### PR TITLE
Refactor CI/CD pipeline and improve version handling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,50 @@
-name: Publish to PyPI
+name: Publish
 
 on:
   push:
+    branches: [main]
     tags: ["v*"]
 
 permissions:
   id-token: write
+  contents: read
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
-    environment: pypi
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v7
       - run: uv build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,10 @@ jobs:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v7
       - run: uv build
+        env:
+          # PyPI and TestPyPI reject PEP 440 local version identifiers (+gSHA),
+          # which hatch-vcs adds to between-tag builds by default.
+          SETUPTOOLS_SCM_OVERRIDES_FOR_DEAD_CST: '{local_scheme = "no-local-version"}'
       - uses: actions/upload-artifact@v4
         with:
           name: dist

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Python dead code analysis using [libcst](https://github.com/Instagram/LibCST).
 
 `dead-cst` builds a full symbol graph of your Python codebase, walks from your entrypoints, and reports (or removes) anything unreachable.
 
+> **Pre-release software.** `dead-cst` is in early alpha. APIs, CLI flags, and output formats may change without notice, and bugs are expected. Do not run `dead-cst remove` against code that isn't committed to version control.
+
 ## Installation
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "vcs"
-# PyPI and TestPyPI reject PEP 440 local version identifiers (+gSHA),
-# which hatch-vcs adds to between-tag builds by default.
-raw-options = { local_scheme = "no-local-version" }
 
 [tool.hatch.build.hooks.vcs]
 version-file = "dead_cst/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "vcs"
+# PyPI and TestPyPI reject PEP 440 local version identifiers (+gSHA),
+# which hatch-vcs adds to between-tag builds by default.
 raw-options = { local_scheme = "no-local-version" }
 
 [tool.hatch.build.hooks.vcs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "vcs"
+raw-options = { local_scheme = "no-local-version" }
 
 [tool.hatch.build.hooks.vcs]
 version-file = "dead_cst/_version.py"


### PR DESCRIPTION
## Summary
This PR refactors the GitHub Actions publish workflow to separate build and publish steps, and improves version scheme configuration for VCS-based versioning.

## Key Changes

### CI/CD Pipeline Refactoring
- Split the monolithic `publish` job into three separate jobs:
  - `build`: Compiles the distribution artifacts and uploads them as workflow artifacts
  - `publish-testpypi`: Publishes to TestPyPI on pushes to main branch
  - `publish-pypi`: Publishes to PyPI on version tags (v*)
- Added conditional logic to ensure TestPyPI publishes only on main branch pushes and PyPI publishes only on version tags
- Introduced artifact passing between jobs using `upload-artifact` and `download-artifact` actions
- Added `contents: read` permission for improved security

### Version Handling
- Added `raw-options = { local_scheme = "no-local-version" }` to the Hatch VCS version configuration to prevent local version identifiers from being appended to version strings

## Implementation Details
- The workflow now triggers on both main branch pushes and version tags, allowing for continuous deployment to TestPyPI and release deployments to PyPI
- Build artifacts are cached as workflow artifacts, enabling efficient reuse across multiple publish jobs
- The separation of concerns makes the workflow more maintainable and allows for independent scaling of build and publish operations

https://claude.ai/code/session_01Crxtn7e41EiAggfcCmgSuA