### PR TITLE
Configure local version scheme in pyproject.toml instead of CI env

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,6 @@ jobs:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v7
       - run: uv build
-        env:
-          # PyPI and TestPyPI reject PEP 440 local version identifiers (+gSHA),
-          # which hatch-vcs adds to between-tag builds by default.
-          SETUPTOOLS_SCM_OVERRIDES_FOR_DEAD_CST: '{local_scheme = "no-local-version"}'
       - uses: actions/upload-artifact@v4
         with:
           name: dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,12 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "vcs"
+# PyPI and TestPyPI reject PEP 440 local version identifiers (+gSHA),
+# which hatch-vcs adds to between-tag builds by default. hatch-vcs passes
+# raw-options as kwargs to setuptools_scm.get_version, so this is the only
+# place the scheme can be configured — SETUPTOOLS_SCM_OVERRIDES_FOR_* is
+# ignored because that env var is only read by Configuration.from_file().
+raw-options = { local_scheme = "no-local-version" }
 
 [tool.hatch.build.hooks.vcs]
 version-file = "dead_cst/_version.py"


### PR DESCRIPTION
## Summary
Moved the setuptools_scm local version scheme configuration from the CI workflow environment variable to the `pyproject.toml` file, making it a permanent project setting rather than a CI-specific override.

## Changes
- Added `raw-options = { local_scheme = "no-local-version" }` to the `[tool.hatch.version]` section in `pyproject.toml` to configure hatch-vcs to exclude PEP 440 local version identifiers (+gSHA) from between-tag builds
- Removed the `SETUPTOOLS_SCM_OVERRIDES_FOR_DEAD_CST` environment variable from the publish workflow, as the configuration is now handled in the project configuration file

## Details
PyPI and TestPyPI reject PEP 440 local version identifiers, which hatch-vcs adds by default to builds between version tags. By configuring this in `pyproject.toml` via the `raw-options` parameter (which hatch-vcs passes to setuptools_scm), the setting is now centralized and applies consistently across all build environments, eliminating the need for CI-specific environment variable overrides.

https://claude.ai/code/session_01Ra5RJoDRAm36TSd9mvNkf2