### PR TITLE
fix: handle AnnAssign without value in SymbolVisitor

### DIFF
--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -87,6 +87,12 @@ class SymbolVisitor(cst.CSTVisitor):
         else:
             targets = [node.target]
 
+        # For `x: T` (AnnAssign without a value) treat the annotation as the
+        # rhs so references inside it are attributed to the new symbol.
+        rhs = node.value
+        if rhs is None and isinstance(node, cst.AnnAssign):
+            rhs = node.annotation
+
         value_to_syms = {}
         for target in reversed(targets):
             full_name = get_full_name_for_node(target)
@@ -98,11 +104,11 @@ class SymbolVisitor(cst.CSTVisitor):
             if isinstance(target, cst.Tuple):
                 names = [t.value for t in target.elements]
 
-            values = [node.value]
+            values = [rhs]
 
             # this can happen with unpacking, e.g. `a, b = (1, 2)`
-            if len(names) > len(values) and isinstance(node.value, cst.Tuple):
-                values = [v.value for v in node.value.elements]
+            if len(names) > len(values) and isinstance(rhs, cst.Tuple):
+                values = [v.value for v in rhs.elements]
 
             if len(names) > len(values) and len(values) == 1:
                 # This can happen with unpacking, e.g. `a, b = f()`
@@ -117,9 +123,9 @@ class SymbolVisitor(cst.CSTVisitor):
                     self._push_decl(name, sym)
                     value_to_syms.setdefault(value, []).append(sym)
 
-        values = [node.value]
-        if isinstance(node.value, cst.Tuple):
-            values += [v.value for v in node.value.elements]
+        values = [rhs] if rhs is not None else []
+        if isinstance(rhs, cst.Tuple):
+            values += [v.value for v in rhs.elements]
 
         for value in reversed(values):
             if syms := value_to_syms.get(value):

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -302,6 +302,18 @@ import pytest
         ),
         pytest.param(
             """
+            T = int
+            x: T
+            """,
+            {
+                "mod.T -> mod",
+                "mod.x -> mod",
+                "mod.x -> mod.T",
+            },
+            id="annotated-assign-without-value",
+        ),
+        pytest.param(
+            """
             a, b = 1, 2
             c, d = a, b
             """,

--- a/tests/test_limitations.py
+++ b/tests/test_limitations.py
@@ -133,16 +133,3 @@ import pytest
 def test_limitation(build_decl_graph, assert_edges, files, expected_edges):
     graph = build_decl_graph(files)
     assert_edges(graph, expected_edges)
-
-
-@pytest.mark.xfail(
-    raises=AssertionError,
-    strict=True,
-    reason=(
-        "AnnAssign without a value (e.g. `x: T`) triggers a stack-balance"
-        " assertion in SymbolVisitor._add_variable. Once fixed, promote"
-        " this into the positive declaration suite."
-    ),
-)
-def test_ann_assign_without_value_crashes(build_decl_graph):
-    build_decl_graph({"mod.py": "T = int\nx: T\n"})


### PR DESCRIPTION
`x: T` (an AnnAssign with no value) triggered a stack-balance
assertion in `SymbolVisitor._add_variable` because a decl was pushed
onto the stack keyed on `None` and never popped. Treat the annotation
as the rhs when there is no value so references inside the annotation
are attributed to the new symbol, and promote the former xfail test
into the positive declaration suite.

https://claude.ai/code/session_01AFwSnsJCqDEeKVHgEYhWVc