### PR TITLE
Prototype flow-sensitive referent filter for redeclaration false positives

### DIFF
--- a/dead_cst/_flow.py
+++ b/dead_cst/_flow.py
@@ -71,9 +71,7 @@ def live_referents(
     def _contains_access(node: cst.CSTNode) -> bool:
         return access_id in _descendant_ids(node, cache)
 
-    def _flow(
-        stmts: Sequence[cst.BaseStatement], incoming: set[cst.CSTNode]
-    ) -> set[cst.CSTNode]:
+    def _flow(stmts: Sequence[cst.BaseStatement], incoming: set[cst.CSTNode]) -> set[cst.CSTNode]:
         state = set(incoming)
         for stmt in stmts:
             # Record the state the access sees *before* any bindings

--- a/dead_cst/_flow.py
+++ b/dead_cst/_flow.py
@@ -1,0 +1,134 @@
+"""Prototype flow-sensitive referent filter (phase 2).
+
+Given a single access and a set of candidate referents that all share
+one lexical scope (which is what ``ScopeProvider`` guarantees -- see
+``tests/test_scope_provider_contract.py``), return the subset that is
+actually live at the access under a control-flow-aware model.
+
+Rules applied during a forward pass over the scope's statement list:
+
+* Sequential: a later binding in the same block kills earlier bindings.
+* ``if`` / ``elif`` / ``else``: each branch sees the pre-``if`` state.
+  The post-``if`` state is the union of each branch's end-state. A
+  missing ``else`` counts as a pass-through branch.
+* ``try`` / ``except`` / ``else`` / ``finally``: body and each handler
+  both see the pre-``try`` state (pessimistic -- an exception can
+  happen before any binding in the body). The post-``try`` state is
+  the union of the body's end-state and each handler's end-state; the
+  ``else`` clause runs after the body on the no-exception path;
+  ``finally`` runs afterwards on all paths.
+* ``for`` / ``while``: the body may execute zero or more times, so the
+  post-loop state is the pre-loop state unioned with the body's
+  end-state. ``else`` runs if the loop exits normally.
+
+Not yet modelled: walrus expressions, ``global`` / ``nonlocal``
+rebindings, exception re-raise edges, ``match`` statements, ``del``.
+This is a prototype -- it is *not* wired into the edge resolution
+pass. See ``tests/test_flow_sensitive_filter.py`` for the cases it
+currently handles.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import libcst as cst
+
+
+def _descendant_ids(node: cst.CSTNode, cache: dict[int, frozenset[int]]) -> frozenset[int]:
+    key = id(node)
+    if key in cache:
+        return cache[key]
+    ids = {key}
+    for child in node.children:
+        ids |= _descendant_ids(child, cache)
+    frozen = frozenset(ids)
+    cache[key] = frozen
+    return frozen
+
+
+def live_referents(
+    scope_body: Sequence[cst.BaseStatement],
+    access_node: cst.CSTNode,
+    referent_nodes: Sequence[cst.CSTNode],
+) -> set[cst.CSTNode]:
+    """Filter ``referent_nodes`` to those live at ``access_node``.
+
+    ``scope_body`` is the ordered statement list of the lexical scope
+    containing the access (``module.body`` for module-level accesses,
+    ``functiondef.body.body`` for a function scope, etc.). The access
+    and every referent must be reachable from ``scope_body``.
+    """
+    cache: dict[int, frozenset[int]] = {}
+    referent_set = set(referent_nodes)
+    access_id = id(access_node)
+    observed: list[set[cst.CSTNode]] = []
+
+    def _referents_in(node: cst.CSTNode) -> set[cst.CSTNode]:
+        ids = _descendant_ids(node, cache)
+        return {r for r in referent_set if id(r) in ids}
+
+    def _contains_access(node: cst.CSTNode) -> bool:
+        return access_id in _descendant_ids(node, cache)
+
+    def _flow(
+        stmts: Sequence[cst.BaseStatement], incoming: set[cst.CSTNode]
+    ) -> set[cst.CSTNode]:
+        state = set(incoming)
+        for stmt in stmts:
+            # Record the state the access sees *before* any bindings
+            # in the same statement take effect. RHS-of-assignment and
+            # expression-statement uses both match that convention.
+            if _contains_access(stmt):
+                observed.append(set(state))
+
+            if isinstance(stmt, cst.If):
+                body_end = _flow(stmt.body.body, state)
+                orelse_end = _else_flow(stmt.orelse, state)
+                state = body_end | orelse_end
+                continue
+
+            if isinstance(stmt, cst.Try):
+                # Body and each handler both see the pre-try state.
+                body_end = _flow(stmt.body.body, state)
+                post = set(body_end)
+                for handler in stmt.handlers:
+                    post |= _flow(handler.body.body, state)
+                if stmt.orelse is not None:
+                    # else runs only on the no-exception path, after body.
+                    post = _flow(stmt.orelse.body.body, body_end) | (post - body_end)
+                if stmt.finalbody is not None:
+                    post = _flow(stmt.finalbody.body, post)
+                state = post
+                continue
+
+            if isinstance(stmt, (cst.For, cst.While)):
+                body_end = _flow(stmt.body.body, state)
+                post = state | body_end
+                if stmt.orelse is not None:
+                    post = _flow(stmt.orelse.body.body, post)
+                state = post
+                continue
+
+            bindings_here = _referents_in(stmt)
+            if bindings_here:
+                state = bindings_here
+
+        return state
+
+    def _else_flow(
+        orelse: cst.Else | cst.If | None, incoming: set[cst.CSTNode]
+    ) -> set[cst.CSTNode]:
+        if orelse is None:
+            return set(incoming)
+        if isinstance(orelse, cst.Else):
+            return _flow(orelse.body.body, incoming)
+        # ``elif`` is an ``If`` in the orelse slot; run it as a nested If.
+        return _flow([orelse], incoming)
+
+    _flow(scope_body, set())
+
+    result: set[cst.CSTNode] = set()
+    for s in observed:
+        result |= s
+    return result

--- a/tests/test_flow_sensitive_filter.py
+++ b/tests/test_flow_sensitive_filter.py
@@ -1,0 +1,337 @@
+"""Unit tests for the phase-2 flow-sensitive filter prototype.
+
+Each case parses a module, asks ``ScopeProvider`` for the access and
+its (multi-)referent list -- the same data the visitor gets today --
+and runs ``live_referents`` over the module body. Cases are organised
+to mirror ``test_limitations.py`` entries: straight-line shadowing,
+branch coexistence, loop bodies, nested scope isolation.
+
+The filter is *not* wired into edge resolution yet; this file only
+demonstrates the rule.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import libcst as cst
+import pytest
+from libcst.metadata import MetadataWrapper, PositionProvider, ScopeProvider
+
+from dead_cst._flow import live_referents
+
+
+def _resolve_access(
+    src: str, name: str, access_line: int
+) -> tuple[cst.Module, cst.CSTNode, list[cst.CSTNode], list[int]]:
+    """Find the access to ``name`` on ``access_line`` and return the
+    module, the access node, the referent nodes, and the list of
+    referent source-line numbers (for readable assertions)."""
+    module = cst.parse_module(textwrap.dedent(src).strip())
+    wrap = MetadataWrapper(module, unsafe_skip_copy=True)
+    scopes = wrap.resolve(ScopeProvider)
+    positions = wrap.resolve(PositionProvider)
+
+    seen: set[int] = set()
+    for scope in set(scopes.values()):
+        for access in scope.accesses:
+            if id(access) in seen:
+                continue
+            seen.add(id(access))
+            if getattr(access.node, "value", None) != name:
+                continue
+            if positions[access.node].start.line != access_line:
+                continue
+            ref_nodes = [r.node for r in access.referents]
+            ref_lines = [positions[n].start.line for n in ref_nodes]
+            return wrap.module, access.node, ref_nodes, ref_lines
+    raise AssertionError(f"no access {name!r} on line {access_line}")
+
+
+def _live_lines(
+    src: str, name: str, access_line: int, *, scope_body: str | None = None
+) -> list[int]:
+    """Run the filter and return the sorted source lines of live referents.
+
+    ``scope_body`` selects which enclosing scope's body to pass in:
+    ``"module"`` (default) for module-level accesses, or
+    ``"function:<fnname>"`` to use that function def's body.
+    """
+    module, access, referents, _ = _resolve_access(src, name, access_line)
+
+    body: list[cst.BaseStatement]
+    if scope_body is None or scope_body == "module":
+        body = list(module.body)
+    elif scope_body.startswith("function:"):
+        fn_name = scope_body.split(":", 1)[1]
+        fn = _find_function(module, fn_name)
+        body = list(fn.body.body)
+    else:  # pragma: no cover - defensive
+        raise ValueError(scope_body)
+
+    wrap = MetadataWrapper(module, unsafe_skip_copy=True)
+    positions = wrap.resolve(PositionProvider)
+    live = live_referents(body, access, referents)
+    return sorted(positions[n].start.line for n in live)
+
+
+def _find_function(module: cst.Module, name: str) -> cst.FunctionDef:
+    for stmt in module.body:
+        if isinstance(stmt, cst.FunctionDef) and stmt.name.value == name:
+            return stmt
+    raise AssertionError(f"function {name!r} not found")
+
+
+# ----------------------------------------------------------------------
+# Straight-line shadowing: the phase-2 target. Each case here
+# corresponds to a false positive documented in test_limitations.py.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src, name, access_line, expected",
+    [
+        pytest.param(
+            """
+            def f(): pass
+            def f(): pass
+            f()
+            """,
+            "f",
+            3,
+            [2],
+            # Was 2 referents; filter drops the shadowed line-1 def.
+            id="redeclared-def-keeps-only-last",
+        ),
+        pytest.param(
+            """
+            def a(): pass
+            def b(): pass
+            def f(): a()
+            def f(): b()
+            def f(): pass
+            f()
+            """,
+            "f",
+            6,
+            [5],
+            id="three-way-chain-keeps-only-last",
+        ),
+        pytest.param(
+            """
+            from other import f
+            def f(): pass
+            f()
+            """,
+            "f",
+            3,
+            [2],
+            id="import-shadowed-by-def-drops-import",
+        ),
+        pytest.param(
+            """
+            def f(): pass
+            from other import f
+            f()
+            """,
+            "f",
+            3,
+            [2],
+            id="def-shadowed-by-import-drops-def",
+        ),
+        pytest.param(
+            """
+            from other import f
+            f = 1
+            print(f)
+            """,
+            "f",
+            3,
+            [2],
+            id="import-rebound-to-constant-drops-import",
+        ),
+        pytest.param(
+            """
+            from a import x
+            from b import x
+            x()
+            """,
+            "x",
+            3,
+            [2],
+            # Even though both imports resolve to different modules,
+            # the second statically kills the first at this access.
+            id="same-alias-two-imports-keeps-last",
+        ),
+    ],
+)
+def test_straight_line_shadowing(
+    src: str, name: str, access_line: int, expected: list[int]
+) -> None:
+    assert _live_lines(src, name, access_line) == expected
+
+
+# ----------------------------------------------------------------------
+# Branch coexistence: phase 2 MUST NOT filter these down. Each case
+# asserts the filter preserves all in-scope referents because neither
+# branch dominates the access.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src, name, access_line, expected",
+    [
+        pytest.param(
+            """
+            if cond:
+                x = 1
+            else:
+                x = 2
+            print(x)
+            """,
+            "x",
+            5,
+            [2, 4],
+            id="if-else-keeps-both-branches",
+        ),
+        pytest.param(
+            """
+            if cond:
+                x = 1
+            elif other:
+                x = 2
+            else:
+                x = 3
+            print(x)
+            """,
+            "x",
+            7,
+            [2, 4, 6],
+            id="elif-chain-keeps-all-branches",
+        ),
+        pytest.param(
+            """
+            x = 0
+            if cond:
+                x = 1
+            print(x)
+            """,
+            "x",
+            4,
+            [1, 3],
+            # No else clause: the pre-if binding survives on the
+            # not-taken path.
+            id="if-without-else-keeps-fallthrough",
+        ),
+        pytest.param(
+            """
+            try:
+                x = 1
+            except Exception:
+                x = 2
+            print(x)
+            """,
+            "x",
+            5,
+            [2, 4],
+            # The optional-import fallback pattern. Both branches
+            # must stay alive.
+            id="try-except-keeps-both-branches",
+        ),
+        pytest.param(
+            """
+            x = 0
+            for i in range(3):
+                x = i
+            print(x)
+            """,
+            "x",
+            4,
+            [1, 3],
+            # Loop body may execute zero times, so the pre-loop
+            # binding survives.
+            id="for-loop-keeps-preloop-and-body",
+        ),
+    ],
+)
+def test_branches_preserved(
+    src: str, name: str, access_line: int, expected: list[int]
+) -> None:
+    assert _live_lines(src, name, access_line) == expected
+
+
+# ----------------------------------------------------------------------
+# Sequential kills across / within branches.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src, name, access_line, expected",
+    [
+        pytest.param(
+            """
+            if cond:
+                x = 1
+            else:
+                x = 2
+            x = 3
+            print(x)
+            """,
+            "x",
+            6,
+            [5],
+            # A post-if rebinding dominates the access and kills both
+            # branch bindings.
+            id="post-if-rebinding-kills-branches",
+        ),
+        pytest.param(
+            """
+            if cond:
+                x = 1
+                x = 2
+            else:
+                x = 3
+            print(x)
+            """,
+            "x",
+            6,
+            [3, 5],
+            # Inside the true branch, the second binding kills the
+            # first; the false branch is unaffected.
+            id="within-branch-shadowing",
+        ),
+    ],
+)
+def test_sequential_and_branch_interaction(
+    src: str, name: str, access_line: int, expected: list[int]
+) -> None:
+    assert _live_lines(src, name, access_line) == expected
+
+
+# ----------------------------------------------------------------------
+# Nested-scope independence. ScopeProvider already filters these down
+# to a single referent, so the filter has nothing to do, but these
+# pin that the prototype is a no-op in those cases.
+# ----------------------------------------------------------------------
+
+
+def test_nested_function_rebinding_does_not_reach_outer_access() -> None:
+    src = """\
+    x = 1
+    def foo():
+        x = 2
+    print(x)
+    """
+    assert _live_lines(src, "x", 4) == [1]
+
+
+def test_shadowed_inner_def_from_inner_use() -> None:
+    # The inner access has one referent already; passing the inner
+    # function's body as the scope keeps that invariant.
+    src = """\
+    def f(): pass
+    def outer():
+        def f(): pass
+        f()
+    """
+    assert _live_lines(src, "f", 4, scope_body="function:outer") == [3]

--- a/tests/test_flow_sensitive_filter.py
+++ b/tests/test_flow_sensitive_filter.py
@@ -254,9 +254,7 @@ def test_straight_line_shadowing(
         ),
     ],
 )
-def test_branches_preserved(
-    src: str, name: str, access_line: int, expected: list[int]
-) -> None:
+def test_branches_preserved(src: str, name: str, access_line: int, expected: list[int]) -> None:
     assert _live_lines(src, name, access_line) == expected
 
 

--- a/tests/test_scope_provider_contract.py
+++ b/tests/test_scope_provider_contract.py
@@ -144,3 +144,116 @@ def test_scope_provider_returns_all_in_scope_bindings(
     for discarding the dead ones.
     """
     assert _access_referents(src, name) == expected
+
+
+@pytest.mark.parametrize(
+    "src, name, expected",
+    [
+        pytest.param(
+            """
+            x = 1
+            def foo():
+                x = 2
+            print(x)
+            """,
+            "x",
+            [(4, [("Assignment", 1)])],
+            id="rebind-in-nested-function-does-not-leak-to-outer",
+        ),
+        pytest.param(
+            """
+            x = 1
+            def foo():
+                print(x)
+            """,
+            "x",
+            [(3, [("Assignment", 1)])],
+            id="outer-binding-visible-from-inner-scope",
+        ),
+        pytest.param(
+            """
+            def f(): pass
+            def outer():
+                def f(): pass
+                f()
+            """,
+            "f",
+            [(4, [("Assignment", 3)])],
+            id="inner-def-shadows-outer-for-inner-uses",
+        ),
+        pytest.param(
+            """
+            x = 1
+            [x for x in range(3)]
+            print(x)
+            """,
+            "x",
+            [
+                (2, [("Assignment", 2)]),
+                (3, [("Assignment", 1)]),
+            ],
+            # Comprehensions get their own scope in Py3. The outer
+            # ``print(x)`` correctly resolves to ``x = 1`` even though
+            # a comprehension rebound ``x`` between them.
+            id="comprehension-variable-does-not-leak",
+        ),
+        pytest.param(
+            """
+            if cond:
+                x = 1
+            else:
+                x = 2
+            print(x)
+            """,
+            "x",
+            [(5, [("Assignment", 2), ("Assignment", 4)])],
+            # ``if`` is not a new scope and neither branch dominates
+            # the other -- both bindings are valid at the access.
+            # Any phase-2 filter that drops either edge here is wrong.
+            id="if-else-branches-both-correct",
+        ),
+        pytest.param(
+            """
+            try:
+                x = 1
+            except Exception:
+                x = 2
+            print(x)
+            """,
+            "x",
+            [(5, [("Assignment", 2), ("Assignment", 4)])],
+            # Same structural story as if/else, and the pattern most
+            # likely to appear in real code (optional-import fallbacks).
+            id="try-except-branches-both-correct",
+        ),
+        pytest.param(
+            """
+            def foo():
+                x = 1
+                x = 2
+                print(x)
+            """,
+            "x",
+            [(4, [("Assignment", 2), ("Assignment", 3)])],
+            # Proves the shadowing case occurs inside function scopes
+            # too, not just at module level. Phase 2 must drop the
+            # edge to line 2.
+            id="same-function-scope-shadowing",
+        ),
+    ],
+)
+def test_scope_provider_respects_nesting(
+    src: str, name: str, expected: list[tuple[int, list[tuple[str, int]]]]
+) -> None:
+    """ScopeProvider already filters by lexical scope.
+
+    Nesting boundaries (functions, comprehensions) are respected:
+    rebindings in a nested scope never appear as referents for an
+    access in a containing scope, and shadowed outer bindings do not
+    appear for an access in a nested scope. Conversely, ``if`` /
+    ``try`` are NOT new scopes, so their branch bindings both surface
+    -- and when neither branch dominates the access, both are the
+    correct answer. This means phase-2 filtering is a dominator
+    question within a single scope, not a cross-scope one.
+    """
+    assert _access_referents(src, name) == expected

--- a/tests/test_scope_provider_contract.py
+++ b/tests/test_scope_provider_contract.py
@@ -1,0 +1,146 @@
+"""Unit tests for the LibCST metadata contract the visitor relies on.
+
+The redeclaration false positives in ``test_limitations.py`` all have
+the same root cause: ``ScopeProvider`` returns every in-scope binding a
+name could refer to, flow-insensitively, and the visitor currently
+edges to all of them. These tests pin that contract directly, without
+going through ``build_symbol_graph``, so it's obvious when phase 2
+(flow-sensitive referent filtering) changes either our own behaviour
+or LibCST's.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import libcst as cst
+import pytest
+from libcst.metadata import MetadataWrapper, PositionProvider, ScopeProvider
+
+
+def _access_referents(src: str, name: str) -> list[tuple[int, list[tuple[str, int]]]]:
+    """Return ``[(access_line, [(referent_type, referent_line), ...]), ...]``
+    for every access to ``name`` in ``src``, sorted by access line.
+
+    Referent lists are sorted so tests don't depend on LibCST's
+    internal iteration order.
+    """
+    wrap = MetadataWrapper(cst.parse_module(textwrap.dedent(src).strip()))
+    scopes = wrap.resolve(ScopeProvider)
+    positions = wrap.resolve(PositionProvider)
+
+    seen: set[int] = set()
+    results: list[tuple[int, list[tuple[str, int]]]] = []
+    for scope in set(scopes.values()):
+        for access in scope.accesses:
+            if id(access) in seen:
+                continue
+            seen.add(id(access))
+            if getattr(access.node, "value", None) != name:
+                continue
+            access_line = positions[access.node].start.line
+            refs = sorted(
+                (type(r).__name__, positions[r.node].start.line) for r in access.referents
+            )
+            results.append((access_line, refs))
+    return sorted(results)
+
+
+@pytest.mark.parametrize(
+    "src, name, expected",
+    [
+        pytest.param(
+            """
+            def f(): pass
+            f()
+            """,
+            "f",
+            [(2, [("Assignment", 1)])],
+            id="single-binding-yields-one-referent",
+        ),
+        pytest.param(
+            """
+            def f(): pass
+            def f(): pass
+            f()
+            """,
+            "f",
+            [(3, [("Assignment", 1), ("Assignment", 2)])],
+            # Mirrors ``dead-function-body-kept-alive`` in test_limitations.
+            # ScopeProvider hands the call both defs even though only
+            # line 2 is reachable at runtime.
+            id="redeclared-def-yields-all-bindings",
+        ),
+        pytest.param(
+            """
+            from other import f
+            def f(): pass
+            f()
+            """,
+            "f",
+            [(3, [("Assignment", 2), ("ImportAssignment", 1)])],
+            # Mirrors ``import-shadowed-by-function-keeps-import-alive``.
+            id="import-shadowed-by-def-yields-both",
+        ),
+        pytest.param(
+            """
+            def f(): pass
+            from other import f
+            f()
+            """,
+            "f",
+            [(3, [("Assignment", 1), ("ImportAssignment", 2)])],
+            # Mirrors ``function-shadowed-by-import-keeps-function-alive``.
+            id="def-shadowed-by-import-yields-both",
+        ),
+        pytest.param(
+            """
+            from a import x
+            from b import x
+            x()
+            """,
+            "x",
+            [(3, [("ImportAssignment", 1), ("ImportAssignment", 2)])],
+            # Mirrors ``two-imports-same-alias-both-kept-alive``.
+            id="same-alias-from-two-modules-yields-both",
+        ),
+        pytest.param(
+            """
+            from other import f
+            f = 1
+            print(f)
+            """,
+            "f",
+            [(3, [("Assignment", 2), ("ImportAssignment", 1)])],
+            # Mirrors ``import-rebound-to-constant-keeps-import-alive``.
+            id="import-rebound-to-constant-yields-both",
+        ),
+        pytest.param(
+            """
+            def a(): pass
+            def b(): pass
+            def f(): a()
+            def f(): b()
+            def f(): pass
+            f()
+            """,
+            "f",
+            [(6, [("Assignment", 3), ("Assignment", 4), ("Assignment", 5)])],
+            # Mirrors ``chain-of-shadowed-functions-keeps-all-bodies-alive``.
+            # Demonstrates this scales past two: every prior binding is
+            # a valid referent regardless of how far back it was.
+            id="chain-of-redeclared-defs-yields-all",
+        ),
+    ],
+)
+def test_scope_provider_returns_all_in_scope_bindings(
+    src: str, name: str, expected: list[tuple[int, list[tuple[str, int]]]]
+) -> None:
+    """ScopeProvider is flow-insensitive.
+
+    Every binding of ``name`` reachable in the access's scope appears in
+    ``access.referents``, even those that have been shadowed by a later
+    rebinding. Phase-2 filtering in the visitor is what's responsible
+    for discarding the dead ones.
+    """
+    assert _access_referents(src, name) == expected


### PR DESCRIPTION
## Summary

Groundwork for resolving the `test_redeclaration_limitation` false positives in `tests/test_limitations.py`. All seven of those cases share one root cause: LibCST's `ScopeProvider` is flow-insensitive, so an access whose name has been rebound returns *every* in-scope binding as a referent, and the visitor edges to all of them — keeping shadowed imports and dead function bodies alive.

This PR is pure groundwork. It does **not** change edge resolution; behaviour is unchanged and every existing test still passes. Wiring the filter into `_visitor.py` is a follow-up.

## What's here

- **`tests/test_scope_provider_contract.py`** — 14 parametrized unit tests that go straight to `ScopeProvider`, with no `build_symbol_graph` dependency. First group pins the multi-referent behaviour for each redeclaration id in `test_limitations.py`. Second group pins that `ScopeProvider` already handles lexical scope correctly — nested functions, comprehensions, and shadowed outer bindings never pollute an access in another scope, while `if`/`try` branches (which are not new scopes) correctly surface both branch bindings. Conclusion: phase 2 is a dominator question within one scope, no nesting-depth tracking required.

- **`dead_cst/_flow.py`** — prototype `live_referents(scope_body, access, referents)` function. Forward dataflow pass over a statement list. Sequential bindings replace the state; `if`/`elif`/`else` and `try`/`except`/`else`/`finally` merge branch end-states; `for`/`while` bodies may execute zero times so the pre-loop state survives. Not imported by any production code in this PR.

- **`tests/test_flow_sensitive_filter.py`** — 15 parametrized tests exercising the prototype end-to-end (parse → `ScopeProvider` → filter). Covers all six redeclaration ids from `test_limitations.py` (each reduces to a single live referent), branch-coexistence cases that must not over-prune (`if`/`else`, `elif`, `if` without `else`, `try`/`except`, `for` with pre-loop binding), within-branch and post-branch shadowing interactions, and nested-scope no-op sanity checks.

## What's NOT here (follow-up)

- Calling `live_referents` from `_visitor.py`'s `on_leave` (the edge fan-out at lines 292–340).
- Migrating the seven `test_redeclaration_limitation` cases — they will flip to failing once the filter is wired, so they'll move into `test_declarations.py` / `test_imports.py` with corrected expected edge sets.
- Filter gaps the prototype doesn't model yet: `del`, `global`/`nonlocal`, walrus, `match`, exception re-raise edges. Worth tightening before flipping the switch.

## Test plan

- [x] `uv run pytest` — 124 passed, 0 failed
- [x] `test_limitations.py` unchanged (documents unchanged behaviour)
- [x] Prototype module is not imported anywhere outside its own tests (`git grep _flow dead_cst/`)

https://claude.ai/code/session_015dpsGdebpagxwcApzqebhV