### PR TITLE
WIP: add PathResolver and EdgePlugin protocols (first pass)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ dead-cst analyze ROOT -e ENTRYPOINT [OPTIONS]
 |---|---|
 | `-e, --entrypoint` | Entrypoint: file path, FQN, or `re:pattern` for regex (repeatable) |
 | `-p, --path` | Search path spec: `base:dep1,dep2` or `base` (repeatable) |
+| `--resolver` | Path resolver to run, e.g. `venv`, `pyproject` (repeatable) |
+| `--plugin` | Edge plugin to run, e.g. `main_block`, `project_scripts` (repeatable) |
 | `--preserve-dunder-all / --no-preserve-dunder-all` | Keep `__all__` variables alive (default: true) |
 | `--format` | Output format: `text` or `json` |
 | `-v, --verbose` | Enable verbose logging |
@@ -74,17 +76,44 @@ dead-cst remove ROOT -e ENTRYPOINT [OPTIONS]
 ## Python API
 
 ```python
+import re
 from pathlib import Path
-from dead_cst import build_symbol_graph, find_reachable, remove_code
+from dead_cst import (
+    build_symbol_graph,
+    ExplicitEntrypointPlugin,
+    MainBlockPlugin,
+    find_reachable,
+    remove_code,
+)
 
 root = Path("./src")
-graph = build_symbol_graph({root: []})
-reachable = find_reachable(graph, root, ["re:.*__main__\\.py"])
+graph = build_symbol_graph(
+    {root: []},
+    plugins=[
+        MainBlockPlugin(),
+        ExplicitEntrypointPlugin(specs=[re.compile(r".*__main__\.py")]),
+    ],
+    project_root=root,
+)
+reachable = find_reachable(graph)
 
 unreachable = graph.subgraph([n for n in graph.nodes if n not in reachable])
 # Inspect unreachable nodes, or remove them:
 remove_code(unreachable, root)
 ```
+
+Entrypoint detection is now fully plugin-driven. Builtins:
+
+| Plugin | Purpose |
+|---|---|
+| `MainBlockPlugin` | Mark modules containing `if __name__ == "__main__":` as entrypoints |
+| `ProjectScriptsPlugin` | Read `pyproject.toml [project.scripts]` and mark each target as an entrypoint |
+| `ExplicitEntrypointPlugin` | Match user-supplied file paths / FQNs / regexes (powers the `-e` flag) |
+| `DunderAllPlugin` | Keep top-level `__all__` variables alive (powers `--preserve-dunder-all`) |
+
+Write your own by implementing the `EdgePlugin` or `CSTAwareEdgePlugin` protocol; register under the `dead_cst.plugins` entry-point group for CLI discovery.
+
+Path resolution is similarly pluggable. `PathResolver` implementations return a `{base: [dep_paths]}` map to feed `build_symbol_graph`. Builtins: `VenvResolver`, `PyprojectResolver`. Third-party resolvers register under `dead_cst.resolvers`.
 
 ## Graph model
 

--- a/dead_cst/__init__.py
+++ b/dead_cst/__init__.py
@@ -1,12 +1,54 @@
 from ._analyze import build_symbol_graph, count_nodes, find_reachable, order_paths
 from ._codemod import remove_code
+from ._plugins import (
+    AddEdge,
+    AddNode,
+    BUILTIN_PLUGINS,
+    CSTAwareEdgePlugin,
+    DunderAllPlugin,
+    EdgePlugin,
+    ExplicitEntrypointPlugin,
+    GraphOp,
+    MainBlockPlugin,
+    PluginContext,
+    ProjectScriptsPlugin,
+    RemoveEdge,
+    load_plugin,
+)
+from ._resolvers import (
+    BUILTIN_RESOLVERS,
+    PathResolver,
+    PyprojectResolver,
+    VenvResolver,
+    load_resolver,
+    merge_paths,
+)
 from ._version import __version__
 
 __all__ = [
     "__version__",
+    "AddEdge",
+    "AddNode",
+    "BUILTIN_PLUGINS",
+    "BUILTIN_RESOLVERS",
+    "CSTAwareEdgePlugin",
+    "DunderAllPlugin",
+    "EdgePlugin",
+    "ExplicitEntrypointPlugin",
+    "GraphOp",
+    "MainBlockPlugin",
+    "PathResolver",
+    "PluginContext",
+    "ProjectScriptsPlugin",
+    "PyprojectResolver",
+    "RemoveEdge",
+    "VenvResolver",
     "build_symbol_graph",
     "count_nodes",
     "find_reachable",
+    "load_plugin",
+    "load_resolver",
+    "merge_paths",
     "order_paths",
     "remove_code",
 ]

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from pathlib import Path
 from typing import Sequence
 
@@ -92,11 +91,13 @@ def build_symbol_graph(
         )
         for plugin in plugins:
             if isinstance(plugin, CSTAwareEdgePlugin):
-                ops = plugin.contribute(ctx, base_managers)
+                ops = list(plugin.contribute(ctx, base_managers))
             elif isinstance(plugin, EdgePlugin):
-                ops = plugin.contribute(ctx)
+                ops = list(plugin.contribute(ctx))
             else:
                 raise TypeError(f"Plugin {plugin!r} does not satisfy EdgePlugin protocol")
+            # Materialize before applying so plugins can iterate ctx.graph.nodes
+            # without tripping "dictionary changed size during iteration".
             apply_ops(symbol_graph, ops)
 
     return symbol_graph
@@ -109,30 +110,22 @@ def _infer_project_root(paths: dict[Path, list[Path]]) -> Path:
     return min(bases, key=lambda p: len(p.parts))
 
 
-def find_reachable(
-    graph: nx.DiGraph, root: Path, entrypoints: list[str | Path | re.Pattern]
-) -> set[SymbolNode]:
-    visited = set()
+def find_reachable(graph: nx.DiGraph) -> set[SymbolNode]:
+    """BFS forward from every node tagged as an entrypoint by a plugin.
 
-    def _is_entrypoint(sym: SymbolNode) -> bool:
-        rel = str(sym.path.relative_to(root))
-        for e in entrypoints:
-            if isinstance(e, str):
-                if e == rel or e == sym.fqname:
-                    return True
-            elif isinstance(e, re.Pattern):
-                if e.match(rel):
-                    return True
-        return False
-
-    stack = [e for e in graph.nodes if _is_entrypoint(e)]
+    Plugins mark seeds by setting ``graph.nodes[node]["entrypoint"] = True``
+    (see :func:`dead_cst._plugins.apply_ops`). There is no longer any
+    built-in matching against file paths or FQNs -- that lives in
+    :class:`ExplicitEntrypointPlugin`.
+    """
+    visited: set[SymbolNode] = set()
+    stack = [n for n, attrs in graph.nodes(data=True) if attrs.get("entrypoint")]
     while stack:
         node = stack.pop()
         if node in visited:
             continue
         visited.add(node)
         stack.extend(graph.successors(node))
-
     return visited
 
 

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -1,10 +1,17 @@
 import logging
 import re
 from pathlib import Path
+from typing import Sequence
 
 import networkx as nx
 from libcst.metadata import FullRepoManager, FullyQualifiedNameProvider
 
+from ._plugins import (
+    CSTAwareEdgePlugin,
+    EdgePlugin,
+    PluginContext,
+    apply_ops,
+)
 from ._resolve import resolve_edges, safe_resolve_module, temp_sys_path
 from ._symbols import SymbolNode, SymbolTrie
 from ._visitor import SymbolVisitor
@@ -21,9 +28,16 @@ def order_paths(paths: dict[Path, list[Path]]) -> list[Path]:
     return list(nx.topological_sort(path_order))
 
 
-def build_symbol_graph(paths: dict[Path, list[Path]]) -> nx.DiGraph:
+def build_symbol_graph(
+    paths: dict[Path, list[Path]],
+    *,
+    plugins: Sequence[EdgePlugin | CSTAwareEdgePlugin] = (),
+    project_root: Path | None = None,
+) -> nx.DiGraph:
     symbol_graph = nx.DiGraph()
-    base_tries = dict()
+    base_tries: dict[Path, SymbolTrie] = {}
+    base_managers: dict[Path, FullRepoManager] = {}
+    symbol_lookup: SymbolTrie = SymbolTrie()
     for base in order_paths(paths):
         logger.debug("Processing base path: %s", base)
         search_paths = [base] + paths.get(base, [])
@@ -33,6 +47,7 @@ def build_symbol_graph(paths: dict[Path, list[Path]]) -> nx.DiGraph:
             import_edges = set()
             files = list(sorted(base.rglob("*.py")))
             mgr = FullRepoManager(base, files, {FullyQualifiedNameProvider})
+            base_managers[base] = mgr
             for file in files:
                 wrapper = mgr.get_metadata_wrapper_for_path(file)
                 visitor = SymbolVisitor(file, search_paths)
@@ -67,7 +82,31 @@ def build_symbol_graph(paths: dict[Path, list[Path]]) -> nx.DiGraph:
             for src, dst in resolve_edges(import_edges, symbol_lookup):
                 symbol_graph.add_edge(src, dst)
 
+    if plugins:
+        root = project_root or _infer_project_root(paths)
+        ctx = PluginContext(
+            graph=symbol_graph,
+            symbol_lookup=symbol_lookup,
+            paths=paths,
+            project_root=root,
+        )
+        for plugin in plugins:
+            if isinstance(plugin, CSTAwareEdgePlugin):
+                ops = plugin.contribute(ctx, base_managers)
+            elif isinstance(plugin, EdgePlugin):
+                ops = plugin.contribute(ctx)
+            else:
+                raise TypeError(f"Plugin {plugin!r} does not satisfy EdgePlugin protocol")
+            apply_ops(symbol_graph, ops)
+
     return symbol_graph
+
+
+def _infer_project_root(paths: dict[Path, list[Path]]) -> Path:
+    bases = list(paths)
+    if not bases:
+        return Path.cwd()
+    return min(bases, key=lambda p: len(p.parts))
 
 
 def find_reachable(

--- a/dead_cst/_plugins.py
+++ b/dead_cst/_plugins.py
@@ -1,0 +1,276 @@
+"""Pluggable edge contributors.
+
+An ``EdgePlugin`` adds (and, optionally, removes) nodes and edges in the symbol
+graph after regular analysis is complete. Plugins exist to encode knowledge
+the static analyzer cannot infer from CST alone -- dynamic dispatch, framework
+conventions, entry-point metadata, etc.
+
+Two flavors exist:
+
+* :class:`EdgePlugin` -- receives a :class:`PluginContext` only. Cheap.
+* :class:`CSTAwareEdgePlugin` -- additionally receives the per-base
+  :class:`FullRepoManager` map, letting the plugin re-walk source with
+  libcst metadata providers.
+
+``build_symbol_graph`` iterates the plugin list and dispatches to whichever
+protocol each plugin satisfies (``isinstance``).
+
+Plugins emit :class:`GraphOp` values rather than mutating the graph directly;
+this keeps them easy to test and lets the analyzer report back on what was
+added.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Protocol, Union, runtime_checkable
+
+import libcst as cst
+import networkx as nx
+from libcst.metadata import CodePosition, CodeRange, FullRepoManager
+
+from ._symbols import SymbolNode, SymbolTrie
+
+logger = logging.getLogger(__name__)
+
+SYNTHETIC_POSITION = CodeRange(start=CodePosition(0, 0), end=CodePosition(0, 0))
+
+
+@dataclass
+class PluginContext:
+    """Read-only view of the analyzer state passed to every plugin."""
+
+    graph: nx.DiGraph
+    symbol_lookup: SymbolTrie
+    paths: dict[Path, list[Path]]
+    project_root: Path
+
+    def find_module(self, fqname: str) -> SymbolNode | None:
+        node = self.symbol_lookup._get(fqname.split("."))
+        return node.module if node else None
+
+    def find_declaration(self, fqname: str) -> SymbolNode | None:
+        """Look up a top-level declaration by dotted name.
+
+        ``pkg.mod.func`` is split into module ``pkg.mod`` and decl ``func``.
+        Returns the declaration's :class:`SymbolNode` or ``None``.
+        """
+        parts = fqname.split(".")
+        for split in range(len(parts) - 1, 0, -1):
+            module_parts, decl_name = parts[:split], parts[split]
+            node = self.symbol_lookup._get(module_parts)
+            if node and node.module and decl_name in node.declarations:
+                return node.declarations[decl_name]
+        return None
+
+
+@dataclass(frozen=True)
+class AddNode:
+    """Add a node to the graph. When ``entrypoint=True``, mark the node so
+    :func:`find_reachable` seeds its BFS from it."""
+
+    node: SymbolNode
+    entrypoint: bool = False
+
+
+@dataclass(frozen=True)
+class AddEdge:
+    src: SymbolNode
+    dst: SymbolNode
+
+
+@dataclass(frozen=True)
+class RemoveEdge:
+    src: SymbolNode
+    dst: SymbolNode
+
+
+GraphOp = Union[AddNode, AddEdge, RemoveEdge]
+
+
+@runtime_checkable
+class EdgePlugin(Protocol):
+    name: str
+
+    def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]: ...
+
+
+@runtime_checkable
+class CSTAwareEdgePlugin(Protocol):
+    name: str
+    # marker attribute used by ``isinstance`` to distinguish this protocol from
+    # the plain ``EdgePlugin`` -- runtime_checkable Protocols only look at
+    # attribute presence, not method signatures, so an extra attribute is the
+    # simplest way to disambiguate.
+    cst_aware: bool
+
+    def contribute(
+        self, ctx: PluginContext, managers: dict[Path, FullRepoManager]
+    ) -> Iterable[GraphOp]: ...
+
+
+def apply_ops(graph: nx.DiGraph, ops: Iterable[GraphOp]) -> None:
+    for op in ops:
+        match op:
+            case AddNode(node, entrypoint):
+                graph.add_node(node)
+                if entrypoint:
+                    graph.nodes[node]["entrypoint"] = True
+            case AddEdge(src, dst):
+                graph.add_edge(src, dst)
+            case RemoveEdge(src, dst):
+                if graph.has_edge(src, dst):
+                    graph.remove_edge(src, dst)
+
+
+def synthetic_node(fqname: str, path: Path) -> SymbolNode:
+    """Create a placeholder node plugins can attach edges to."""
+    return SymbolNode(fqname=fqname, type="synthetic", path=path, position=SYNTHETIC_POSITION)
+
+
+@dataclass
+class MainBlockPlugin:
+    """Treat ``if __name__ == "__main__":`` blocks as entrypoints.
+
+    For each module that contains a top-level ``if __name__ == "__main__":``
+    block, emit a synthetic entrypoint node with an edge to the containing
+    module. The module's existing internal edges (collected by the regular
+    visitor) then keep every symbol referenced in the block reachable.
+
+    This is a :class:`CSTAwareEdgePlugin` so it can reuse the
+    :class:`FullRepoManager` instances the analyzer already built rather than
+    re-parsing files.
+    """
+
+    name: str = "main_block"
+    cst_aware: bool = True
+
+    def contribute(
+        self, ctx: PluginContext, managers: dict[Path, FullRepoManager]
+    ) -> Iterable[GraphOp]:
+        modules_by_path: dict[Path, SymbolNode] = {}
+        for node in ctx.graph.nodes:
+            if node.type == "module":
+                modules_by_path[node.path] = node
+
+        for base, mgr in managers.items():
+            for path, module_node in modules_by_path.items():
+                if not path.is_relative_to(base):
+                    continue
+                try:
+                    wrapper = mgr.get_metadata_wrapper_for_path(path)
+                except Exception:
+                    continue
+                if not _has_main_block(wrapper.module):
+                    continue
+                synth = synthetic_node(
+                    fqname=f"<__main__>:{module_node.fqname}",
+                    path=path,
+                )
+                yield AddNode(synth, entrypoint=True)
+                yield AddEdge(synth, module_node)
+
+
+def _has_main_block(module: cst.Module) -> bool:
+    for stmt in module.body:
+        if not isinstance(stmt, cst.If):
+            continue
+        if _is_name_eq_main(stmt.test):
+            return True
+    return False
+
+
+def _is_name_eq_main(expr: cst.BaseExpression) -> bool:
+    if not isinstance(expr, cst.Comparison):
+        return False
+    if len(expr.comparisons) != 1:
+        return False
+    op = expr.comparisons[0]
+    if not isinstance(op.operator, cst.Equal):
+        return False
+    left, right = expr.left, op.comparator
+    return (_is_dunder_name(left, "__name__") and _is_string(right, "__main__")) or (
+        _is_string(left, "__main__") and _is_dunder_name(right, "__name__")
+    )
+
+
+def _is_dunder_name(expr: cst.BaseExpression, name: str) -> bool:
+    return isinstance(expr, cst.Name) and expr.value == name
+
+
+def _is_string(expr: cst.BaseExpression, value: str) -> bool:
+    if isinstance(expr, cst.SimpleString):
+        return expr.evaluated_value == value
+    if isinstance(expr, cst.ConcatenatedString):
+        try:
+            return expr.evaluated_value == value
+        except Exception:
+            return False
+    return False
+
+
+@dataclass
+class ProjectScriptsPlugin:
+    """Treat every ``[project.scripts]`` entry in ``pyproject.toml`` as an
+    entrypoint.
+
+    For each ``name = "pkg.mod:func"`` mapping, look up ``pkg.mod.func`` in the
+    symbol trie and wire a synthetic entrypoint node to it.
+    """
+
+    name: str = "project_scripts"
+    pyproject_path: Path | None = None
+
+    def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
+        pyproject = self.pyproject_path or ctx.project_root / "pyproject.toml"
+        if not pyproject.is_file():
+            return
+
+        try:
+            import tomllib
+        except ImportError:  # pragma: no cover
+            return
+
+        with pyproject.open("rb") as f:
+            data = tomllib.load(f)
+
+        scripts = data.get("project", {}).get("scripts", {})
+        for script_name, target in scripts.items():
+            module_part, _, decl_part = target.partition(":")
+            fqname = f"{module_part}.{decl_part}" if decl_part else module_part
+            target_node = ctx.find_declaration(fqname) or ctx.find_module(module_part)
+            if target_node is None:
+                logger.warning(
+                    "ProjectScriptsPlugin: %s -> %r not found in symbol graph",
+                    script_name,
+                    target,
+                )
+                continue
+            synth = synthetic_node(
+                fqname=f"<project.scripts>:{script_name}",
+                path=pyproject,
+            )
+            yield AddNode(synth, entrypoint=True)
+            yield AddEdge(synth, target_node)
+
+
+BUILTIN_PLUGINS: dict[str, type] = {
+    MainBlockPlugin.name: MainBlockPlugin,
+    ProjectScriptsPlugin.name: ProjectScriptsPlugin,
+}
+
+
+def load_plugin(name: str):
+    """Load a plugin by name. Checks builtins first, then entry points."""
+    if name in BUILTIN_PLUGINS:
+        return BUILTIN_PLUGINS[name]()
+
+    from importlib.metadata import entry_points
+
+    for ep in entry_points(group="dead_cst.plugins"):
+        if ep.name == name:
+            cls = ep.load()
+            return cls()
+    raise KeyError(f"Unknown edge plugin: {name!r}")

--- a/dead_cst/_plugins.py
+++ b/dead_cst/_plugins.py
@@ -23,6 +23,7 @@ added.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, Protocol, Union, runtime_checkable
@@ -256,9 +257,86 @@ class ProjectScriptsPlugin:
             yield AddEdge(synth, target_node)
 
 
+@dataclass
+class ExplicitEntrypointPlugin:
+    """Mark user-specified symbols as entrypoints.
+
+    ``specs`` accepts the same three forms the CLI's ``-e`` flag used to:
+
+    * ``str`` -- matches either an exact fully-qualified name
+      (``pkg.mod.func``) or a file path relative to ``project_root``.
+    * :class:`pathlib.Path` -- matches an exact absolute path.
+    * :class:`re.Pattern` -- matched against the file path relative to
+      ``project_root``.
+
+    For every matching :class:`SymbolNode`, a synthetic entrypoint node is
+    added with an edge pointing at the match.
+    """
+
+    specs: list[str | Path | re.Pattern[str]] = field(default_factory=list)
+    name: str = "explicit"
+
+    def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
+        root = ctx.project_root
+        for node in ctx.graph.nodes:
+            if not self._matches(node, root):
+                continue
+            synth = synthetic_node(
+                fqname=f"<entrypoint>:{node.fqname}",
+                path=node.path,
+            )
+            yield AddNode(synth, entrypoint=True)
+            yield AddEdge(synth, node)
+
+    def _matches(self, sym: SymbolNode, root: Path) -> bool:
+        try:
+            rel = str(sym.path.relative_to(root))
+        except ValueError:
+            rel = str(sym.path)
+        for spec in self.specs:
+            if isinstance(spec, re.Pattern):
+                if spec.match(rel):
+                    return True
+            elif isinstance(spec, Path):
+                if spec == sym.path:
+                    return True
+            elif isinstance(spec, str):
+                if spec == rel or spec == sym.fqname:
+                    return True
+        return False
+
+
+@dataclass
+class DunderAllPlugin:
+    """Keep module-level ``__all__`` variables alive.
+
+    ``__all__`` declares a module's public export list; removing it would be
+    observable even when no source references it. For each top-level
+    ``__all__`` variable, emit a synthetic entrypoint node with an edge to
+    the variable so :func:`find_reachable` preserves it.
+    """
+
+    name: str = "dunder_all"
+
+    def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
+        for node in ctx.graph.nodes:
+            if node.type != "variable":
+                continue
+            if not node.fqname.endswith(".__all__") and node.fqname != "__all__":
+                continue
+            synth = synthetic_node(
+                fqname=f"<__all__>:{node.fqname}",
+                path=node.path,
+            )
+            yield AddNode(synth, entrypoint=True)
+            yield AddEdge(synth, node)
+
+
 BUILTIN_PLUGINS: dict[str, type] = {
     MainBlockPlugin.name: MainBlockPlugin,
     ProjectScriptsPlugin.name: ProjectScriptsPlugin,
+    ExplicitEntrypointPlugin.name: ExplicitEntrypointPlugin,
+    DunderAllPlugin.name: DunderAllPlugin,
 }
 
 

--- a/dead_cst/_resolvers.py
+++ b/dead_cst/_resolvers.py
@@ -1,0 +1,162 @@
+"""Pluggable resolvers that discover sys.path-like search paths for a project.
+
+A ``PathResolver`` takes a project root and returns a ``dict[base, [dep_paths]]``
+in the same shape ``build_symbol_graph`` already consumes. Multiple resolvers
+compose by merging dicts -- see :func:`merge_paths`.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+PathMap = dict[Path, list[Path]]
+
+
+@runtime_checkable
+class PathResolver(Protocol):
+    name: str
+
+    def resolve(self, project_root: Path) -> PathMap: ...
+
+
+def merge_paths(*maps: PathMap) -> PathMap:
+    """Merge multiple ``PathMap``s, unioning dep-path lists per base."""
+    out: PathMap = {}
+    for m in maps:
+        for base, deps in m.items():
+            base = base.resolve()
+            existing = out.setdefault(base, [])
+            for dep in deps:
+                dep = dep.resolve()
+                if dep not in existing and dep != base:
+                    existing.append(dep)
+    return out
+
+
+class VenvResolver:
+    """Discover a sibling ``.venv`` (or the active venv) and add its
+    ``site-packages`` as a dep path of the project root.
+
+    The dep path lets import resolution see third-party distributions, which
+    lets the graph correctly classify external imports instead of warning.
+    """
+
+    name = "venv"
+
+    def __init__(self, venv_dir: str | None = None) -> None:
+        self.venv_dir = venv_dir
+
+    def resolve(self, project_root: Path) -> PathMap:
+        project_root = project_root.resolve()
+        candidates: list[Path] = []
+        if self.venv_dir:
+            candidates.append(project_root / self.venv_dir)
+        else:
+            candidates.extend([project_root / ".venv", project_root / "venv"])
+            active = _active_venv()
+            if active:
+                candidates.append(active)
+
+        for candidate in candidates:
+            if not candidate.is_dir():
+                continue
+            for sp in _site_packages_for(candidate):
+                return {project_root: [sp]}
+        return {}
+
+
+class PyprojectResolver:
+    """Read ``[tool.dead-cst]`` from a project's ``pyproject.toml`` and turn
+    its configured paths into a ``PathMap``.
+
+    Example ``pyproject.toml``::
+
+        [tool.dead-cst]
+        paths = [
+            { base = "src", deps = ["tests"] },
+            { base = "scripts" },
+        ]
+
+    If no section is configured, fall back to the conventional ``src/``
+    layout when present.
+    """
+
+    name = "pyproject"
+
+    def resolve(self, project_root: Path) -> PathMap:
+        project_root = project_root.resolve()
+        pyproject = project_root / "pyproject.toml"
+        if not pyproject.is_file():
+            return {}
+
+        try:
+            import tomllib
+        except ImportError:  # pragma: no cover - py<3.11 not supported
+            return {}
+
+        with pyproject.open("rb") as f:
+            data = tomllib.load(f)
+
+        tool = data.get("tool", {}).get("dead-cst", {})
+        entries = tool.get("paths")
+        if entries:
+            out: PathMap = {}
+            for entry in entries:
+                base = (project_root / entry["base"]).resolve()
+                deps = [(project_root / d).resolve() for d in entry.get("deps", [])]
+                out[base] = deps
+            return out
+
+        src = project_root / "src"
+        if src.is_dir():
+            return {src: []}
+        return {}
+
+
+def _active_venv() -> Path | None:
+    prefix = getattr(sys, "prefix", None)
+    base_prefix = getattr(sys, "base_prefix", prefix)
+    if prefix and prefix != base_prefix:
+        return Path(prefix)
+    return None
+
+
+def _site_packages_for(venv: Path) -> list[Path]:
+    """Return the ``site-packages`` dirs inside a venv, if any."""
+    paths: list[Path] = []
+    lib = venv / "lib"
+    if lib.is_dir():
+        for py in sorted(lib.glob("python*")):
+            sp = py / "site-packages"
+            if sp.is_dir():
+                paths.append(sp)
+    # Windows layout
+    win_sp = venv / "Lib" / "site-packages"
+    if win_sp.is_dir():
+        paths.append(win_sp)
+    return paths
+
+
+BUILTIN_RESOLVERS: dict[str, type[PathResolver]] = {
+    VenvResolver.name: VenvResolver,
+    PyprojectResolver.name: PyprojectResolver,
+}
+
+
+def load_resolver(name: str) -> PathResolver:
+    """Load a resolver by name. Checks builtins first, then entry points."""
+    if name in BUILTIN_RESOLVERS:
+        return BUILTIN_RESOLVERS[name]()
+
+    from importlib.metadata import entry_points
+
+    for ep in entry_points(group="dead_cst.resolvers"):
+        if ep.name == name:
+            cls = ep.load()
+            return cls()
+    raise KeyError(f"Unknown path resolver: {name!r}")

--- a/dead_cst/_symbols.py
+++ b/dead_cst/_symbols.py
@@ -18,7 +18,7 @@ class Import:
 @dataclass(frozen=True, slots=True)
 class SymbolNode:
     fqname: str
-    type: Literal["module", "class", "function", "variable", "import"]
+    type: Literal["module", "class", "function", "variable", "import", "synthetic"]
     path: Path
     position: CodeRange
     imports: Import | None = None

--- a/dead_cst/cli.py
+++ b/dead_cst/cli.py
@@ -14,6 +14,14 @@ import networkx as nx
 import typer
 
 from . import build_symbol_graph, count_nodes, find_reachable, order_paths, remove_code
+from ._plugins import (
+    CSTAwareEdgePlugin,
+    DunderAllPlugin,
+    EdgePlugin,
+    ExplicitEntrypointPlugin,
+    load_plugin,
+)
+from ._resolvers import load_resolver, merge_paths
 from ._symbols import SymbolNode
 
 app = typer.Typer(help="Dead code analysis for Python using libcst.")
@@ -37,6 +45,41 @@ def parse_entrypoint(ep: str) -> str | re.Pattern[str]:
     if ep.startswith("re:"):
         return re.compile(ep[3:])
     return ep
+
+
+def build_plugins(
+    *,
+    entrypoints: list[str],
+    plugin_names: list[str],
+    preserve_dunder_all: bool,
+) -> list[EdgePlugin | CSTAwareEdgePlugin]:
+    """Compose the plugin list from CLI flags.
+
+    Order: user-specified plugins first, then ``DunderAllPlugin`` (if
+    enabled), then ``ExplicitEntrypointPlugin`` with the ``-e`` specs.
+    ``-e`` runs last so it can hang entrypoints off any synthetic nodes
+    contributed upstream.
+    """
+    plugins: list[EdgePlugin | CSTAwareEdgePlugin] = []
+    for name in plugin_names:
+        plugins.append(load_plugin(name))
+    if preserve_dunder_all:
+        plugins.append(DunderAllPlugin())
+    if entrypoints:
+        specs = [parse_entrypoint(ep) for ep in entrypoints]
+        plugins.append(ExplicitEntrypointPlugin(specs=specs))
+    return plugins
+
+
+def resolve_paths(
+    root: Path, path_specs: list[str], resolver_names: list[str]
+) -> dict[Path, list[Path]]:
+    """Merge ``-p`` specs and ``--resolver`` outputs into a single path map."""
+    explicit = parse_paths(root, path_specs) if path_specs else {}
+    resolved_maps = [load_resolver(name).resolve(root) for name in resolver_names]
+    if not explicit and not resolved_maps:
+        return {root: []}
+    return merge_paths(explicit, *resolved_maps)
 
 
 def parse_paths(root: Path, paths_str: list[str]) -> dict[Path, list[Path]]:
@@ -82,16 +125,24 @@ def main(
 def analyze(
     root: Annotated[Path, typer.Argument(help="Root directory to analyze.")],
     entrypoint: Annotated[
-        list[str],
+        Optional[list[str]],
         typer.Option(
             "-e",
             "--entrypoint",
             help="Entrypoint: file path, FQN, or 're:pattern' for regex.",
         ),
-    ],
+    ] = None,
     path: Annotated[
         Optional[list[str]],
         typer.Option("-p", "--path", help="Search path spec: 'base:dep1,dep2' or 'base'."),
+    ] = None,
+    resolver: Annotated[
+        Optional[list[str]],
+        typer.Option("--resolver", help="Path resolver to run (e.g. venv, pyproject)."),
+    ] = None,
+    plugin: Annotated[
+        Optional[list[str]],
+        typer.Option("--plugin", help="Edge plugin to run (e.g. main_block, project_scripts)."),
     ] = None,
     preserve_dunder_all: Annotated[bool, typer.Option(help="Keep __all__ variables alive.")] = True,
     verbose: Annotated[
@@ -105,18 +156,16 @@ def analyze(
     setup_logging(verbose)
     root = root.resolve()
 
-    paths_dict = parse_paths(root, path or [])
+    paths_dict = resolve_paths(root, path or [], resolver or [])
 
     typer.echo(f"Building symbol graph for {root}...", err=True)
-    graph = build_symbol_graph(paths_dict)
-
-    eps = [parse_entrypoint(ep) for ep in entrypoint]
-    reachable = find_reachable(graph, root, eps)
-
-    if preserve_dunder_all:
-        for node in graph.nodes:
-            if node.fqname.endswith("__all__") and node.type == "variable":
-                reachable.add(node)
+    plugins = build_plugins(
+        entrypoints=entrypoint or [],
+        plugin_names=plugin or [],
+        preserve_dunder_all=preserve_dunder_all,
+    )
+    graph = build_symbol_graph(paths_dict, plugins=plugins, project_root=root)
+    reachable = find_reachable(graph)
 
     unreachable_graph = graph.subgraph([n for n in graph.nodes if n not in reachable])
 
@@ -202,6 +251,15 @@ def why_alive(
         Optional[list[str]],
         typer.Option("-p", "--path", help="Search path spec: 'base:dep1,dep2' or 'base'."),
     ] = None,
+    resolver: Annotated[
+        Optional[list[str]],
+        typer.Option("--resolver", help="Path resolver to run (e.g. venv, pyproject)."),
+    ] = None,
+    plugin: Annotated[
+        Optional[list[str]],
+        typer.Option("--plugin", help="Edge plugin to run (e.g. main_block, project_scripts)."),
+    ] = None,
+    preserve_dunder_all: Annotated[bool, typer.Option(help="Keep __all__ variables alive.")] = True,
     verbose: Annotated[
         bool, typer.Option("-v", "--verbose", help="Enable verbose output.")
     ] = False,
@@ -210,10 +268,15 @@ def why_alive(
     setup_logging(verbose)
     root = root.resolve()
 
-    paths_dict = parse_paths(root, path or [])
+    paths_dict = resolve_paths(root, path or [], resolver or [])
 
     typer.echo(f"Building symbol graph for {root}...", err=True)
-    graph = build_symbol_graph(paths_dict)
+    plugins = build_plugins(
+        entrypoints=[],
+        plugin_names=plugin or [],
+        preserve_dunder_all=preserve_dunder_all,
+    )
+    graph = build_symbol_graph(paths_dict, plugins=plugins, project_root=root)
 
     target_node: SymbolNode | None = None
     for node in graph.nodes:
@@ -254,16 +317,24 @@ def why_alive(
 def remove(
     root: Annotated[Path, typer.Argument(help="Root directory to analyze.")],
     entrypoint: Annotated[
-        list[str],
+        Optional[list[str]],
         typer.Option(
             "-e",
             "--entrypoint",
             help="Entrypoint: file path, FQN, or 're:pattern' for regex.",
         ),
-    ],
+    ] = None,
     path: Annotated[
         Optional[list[str]],
         typer.Option("-p", "--path", help="Search path spec: 'base:dep1,dep2' or 'base'."),
+    ] = None,
+    resolver: Annotated[
+        Optional[list[str]],
+        typer.Option("--resolver", help="Path resolver to run (e.g. venv, pyproject)."),
+    ] = None,
+    plugin: Annotated[
+        Optional[list[str]],
+        typer.Option("--plugin", help="Edge plugin to run (e.g. main_block, project_scripts)."),
     ] = None,
     preserve_dunder_all: Annotated[bool, typer.Option(help="Keep __all__ variables alive.")] = True,
     verbose: Annotated[
@@ -277,18 +348,16 @@ def remove(
     setup_logging(verbose)
     root = root.resolve()
 
-    paths_dict = parse_paths(root, path or [])
+    paths_dict = resolve_paths(root, path or [], resolver or [])
 
     typer.echo(f"Building symbol graph for {root}...", err=True)
-    graph = build_symbol_graph(paths_dict)
-
-    eps = [parse_entrypoint(ep) for ep in entrypoint]
-    reachable = find_reachable(graph, root, eps)
-
-    if preserve_dunder_all:
-        for node in graph.nodes:
-            if node.fqname.endswith("__all__") and node.type == "variable":
-                reachable.add(node)
+    plugins = build_plugins(
+        entrypoints=entrypoint or [],
+        plugin_names=plugin or [],
+        preserve_dunder_all=preserve_dunder_all,
+    )
+    graph = build_symbol_graph(paths_dict, plugins=plugins, project_root=root)
+    reachable = find_reachable(graph)
 
     unreachable_graph = graph.subgraph([n for n in graph.nodes if n not in reachable])
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,197 @@
+"""Tests for the edge-plugin surface and the builtin plugins."""
+
+from __future__ import annotations
+
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from dead_cst import (
+    DunderAllPlugin,
+    ExplicitEntrypointPlugin,
+    MainBlockPlugin,
+    ProjectScriptsPlugin,
+    build_symbol_graph,
+    find_reachable,
+)
+
+
+def _write(tmp_path: Path, files: dict[str, str]) -> None:
+    for name, src in files.items():
+        p = tmp_path / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(textwrap.dedent(src).strip() + "\n")
+
+
+def _reachable_fqnames(graph) -> set[str]:
+    return {n.fqname for n in find_reachable(graph) if n.type != "synthetic"}
+
+
+def test_no_plugins_means_nothing_reachable(tmp_path):
+    _write(tmp_path, {"pkg/__init__.py": "", "pkg/a.py": "def f(): pass"})
+    graph = build_symbol_graph({tmp_path: []})
+    assert find_reachable(graph) == set()
+
+
+def test_explicit_entrypoint_by_fqname(tmp_path):
+    _write(tmp_path, {"pkg/__init__.py": "", "pkg/a.py": "def f(): pass"})
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[ExplicitEntrypointPlugin(specs=["pkg.a.f"])],
+        project_root=tmp_path,
+    )
+    assert "pkg.a.f" in _reachable_fqnames(graph)
+
+
+def test_explicit_entrypoint_by_relpath(tmp_path):
+    _write(tmp_path, {"pkg/__init__.py": "", "pkg/a.py": "def f(): pass"})
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[ExplicitEntrypointPlugin(specs=["pkg/a.py"])],
+        project_root=tmp_path,
+    )
+    assert {"pkg.a", "pkg.a.f"} <= _reachable_fqnames(graph)
+
+
+def test_explicit_entrypoint_by_regex(tmp_path):
+    _write(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            "pkg/entry.py": "from .a import f\nf()",
+            "pkg/a.py": "def f(): pass",
+        },
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[ExplicitEntrypointPlugin(specs=[re.compile(r".*entry\.py")])],
+        project_root=tmp_path,
+    )
+    reached = _reachable_fqnames(graph)
+    assert "pkg.entry" in reached
+    assert "pkg.a.f" in reached
+
+
+def test_main_block_plugin_marks_module_entrypoint(tmp_path):
+    _write(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            "pkg/script.py": """
+            def main(): pass
+            def unused(): pass
+            if __name__ == "__main__":
+                main()
+            """,
+            "pkg/other.py": "def g(): pass",
+        },
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin()],
+        project_root=tmp_path,
+    )
+    reached = _reachable_fqnames(graph)
+    assert "pkg.script" in reached
+    assert "pkg.script.main" in reached
+    # `unused` has no reference from inside __main__, so stays dead
+    assert "pkg.script.unused" not in reached
+    # modules without a main block are not entrypoints
+    assert "pkg.other" not in reached
+
+
+def test_main_block_reversed_comparison(tmp_path):
+    _write(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            "pkg/script.py": """
+            def main(): pass
+            if "__main__" == __name__:
+                main()
+            """,
+        },
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin()],
+        project_root=tmp_path,
+    )
+    assert "pkg.script" in _reachable_fqnames(graph)
+
+
+def test_project_scripts_plugin(tmp_path):
+    _write(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            "pkg/cli.py": "def main(): pass",
+            "pyproject.toml": """
+            [project]
+            name = "x"
+            [project.scripts]
+            mytool = "pkg.cli:main"
+            """,
+        },
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[ProjectScriptsPlugin()],
+        project_root=tmp_path,
+    )
+    assert "pkg.cli.main" in _reachable_fqnames(graph)
+
+
+def test_dunder_all_plugin_keeps_all_alive(tmp_path):
+    _write(
+        tmp_path,
+        {
+            "pkg/__init__.py": '__all__ = ["a"]\na = 1',
+        },
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[DunderAllPlugin()],
+        project_root=tmp_path,
+    )
+    reached = _reachable_fqnames(graph)
+    assert "pkg.__all__" in reached
+    # the listed symbol itself is *not* followed -- only __all__ stays alive.
+    assert "pkg.a" not in reached
+
+
+def test_plugins_compose(tmp_path):
+    _write(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            "pkg/cli.py": "def main(): pass",
+            "pkg/runner.py": """
+            import pkg.cli
+            if __name__ == "__main__":
+                pkg.cli.main()
+            """,
+            "pyproject.toml": """
+            [project]
+            name = "x"
+            [project.scripts]
+            mytool = "pkg.cli:main"
+            """,
+        },
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), ProjectScriptsPlugin()],
+        project_root=tmp_path,
+    )
+    reached = _reachable_fqnames(graph)
+    assert {"pkg.runner", "pkg.cli", "pkg.cli.main"} <= reached
+
+
+def test_unknown_plugin_raises():
+    from dead_cst import load_plugin
+
+    with pytest.raises(KeyError):
+        load_plugin("does-not-exist")

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -1,0 +1,96 @@
+"""Tests for :mod:`dead_cst._resolvers`."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from dead_cst import (
+    PyprojectResolver,
+    VenvResolver,
+    load_resolver,
+    merge_paths,
+)
+
+
+def test_venv_resolver_finds_site_packages(tmp_path: Path):
+    venv = tmp_path / ".venv"
+    sp = venv / "lib" / "python3.13" / "site-packages"
+    sp.mkdir(parents=True)
+
+    result = VenvResolver().resolve(tmp_path)
+    assert tmp_path.resolve() in result
+    assert sp.resolve() in result[tmp_path.resolve()]
+
+
+def test_venv_resolver_missing_returns_empty(tmp_path: Path):
+    # Passing an explicit (nonexistent) venv_dir skips the active-venv probe.
+    assert VenvResolver(venv_dir="nope").resolve(tmp_path) == {}
+
+
+def test_venv_resolver_custom_dir(tmp_path: Path):
+    venv = tmp_path / "envs" / "myenv"
+    sp = venv / "lib" / "python3.12" / "site-packages"
+    sp.mkdir(parents=True)
+
+    result = VenvResolver(venv_dir="envs/myenv").resolve(tmp_path)
+    assert sp.resolve() in result[tmp_path.resolve()]
+
+
+def test_pyproject_resolver_reads_paths_section(tmp_path: Path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent("""
+            [project]
+            name = "x"
+
+            [tool.dead-cst]
+            paths = [
+              { base = "src", deps = ["tests"] }
+            ]
+        """).strip()
+    )
+
+    result = PyprojectResolver().resolve(tmp_path)
+    assert result == {
+        (tmp_path / "src").resolve(): [(tmp_path / "tests").resolve()],
+    }
+
+
+def test_pyproject_resolver_src_layout_fallback(tmp_path: Path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "x"\n')
+
+    result = PyprojectResolver().resolve(tmp_path)
+    assert result == {(tmp_path / "src").resolve(): []}
+
+
+def test_pyproject_resolver_no_pyproject(tmp_path: Path):
+    assert PyprojectResolver().resolve(tmp_path) == {}
+
+
+def test_merge_paths_unions_deps():
+    base = Path("/a")
+    d1 = Path("/b")
+    d2 = Path("/c")
+    result = merge_paths({base: [d1]}, {base: [d2]}, {base: [d1]})
+    assert result == {base: [d1, d2]}
+
+
+def test_merge_paths_drops_self():
+    base = Path("/a")
+    result = merge_paths({base: [base]})
+    assert result == {base: []}
+
+
+def test_load_resolver_known():
+    assert isinstance(load_resolver("venv"), VenvResolver)
+    assert isinstance(load_resolver("pyproject"), PyprojectResolver)
+
+
+def test_load_resolver_unknown_raises():
+    with pytest.raises(KeyError):
+        load_resolver("does-not-exist")


### PR DESCRIPTION
Introduces pluggable search-path resolution (Venv/Pyproject builtins)
and an edge-plugin surface (EdgePlugin + CSTAwareEdgePlugin), wired into
build_symbol_graph. Design still in flux: the single-ENTRYPOINT node
refactor is pending.

https://claude.ai/code/session_01VVL6oY5ETjEGaV1dh141UP