### PR TITLE
Resolve cross-module imports of branch-bound names via flow analysis

### DIFF
--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -61,6 +61,14 @@ def build_symbol_graph(
                         symbol_graph.add_node(decl)
                         symbol_graph.add_edge(decl, node.module)
                         current_trie.add_declaration(decl)
+                    # Shadowed decls still belong to this module: emit them
+                    # so the graph stays well-formed (every decl has a
+                    # parent-module edge). They aren't re-added to
+                    # ``current_trie`` -- the surviving decl is already there
+                    # and is the one that should win project-wide lookups.
+                    for decl in node.shadowed:
+                        symbol_graph.add_node(decl)
+                        symbol_graph.add_edge(decl, node.module)
                     curr.extend(node.children.values())
 
                 for src, dst in visitor.internal_edges:

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -57,15 +57,16 @@ def build_symbol_graph(
                     if node.module is not None:
                         symbol_graph.add_node(node.module)
                         current_trie.add_declaration(node.module)
-                    for decl in node.declarations.values():
-                        symbol_graph.add_node(decl)
-                        symbol_graph.add_edge(decl, node.module)
-                        current_trie.add_declaration(decl)
+                    for decls in node.declarations.values():
+                        for decl in decls:
+                            symbol_graph.add_node(decl)
+                            symbol_graph.add_edge(decl, node.module)
+                            current_trie.add_declaration(decl)
                     # Shadowed decls still belong to this module: emit them
                     # so the graph stays well-formed (every decl has a
                     # parent-module edge). They aren't re-added to
-                    # ``current_trie`` -- the surviving decl is already there
-                    # and is the one that should win project-wide lookups.
+                    # ``current_trie`` -- only live-at-exit decls should
+                    # win project-wide lookups.
                     for decl in node.shadowed:
                         symbol_graph.add_node(decl)
                         symbol_graph.add_edge(decl, node.module)

--- a/dead_cst/_flow.py
+++ b/dead_cst/_flow.py
@@ -31,7 +31,7 @@ the end-to-end behaviour.
 
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Callable, Sequence
 
 import libcst as cst
 
@@ -46,6 +46,79 @@ def _descendant_ids(node: cst.CSTNode, cache: dict[int, frozenset[int]]) -> froz
     frozen = frozenset(ids)
     cache[key] = frozen
     return frozen
+
+
+def _walk_flow(
+    stmts: Sequence[cst.BaseStatement],
+    incoming: set[cst.CSTNode],
+    referent_set: set[cst.CSTNode],
+    cache: dict[int, frozenset[int]],
+    observe: Callable[[cst.BaseStatement, set[cst.CSTNode]], None] | None,
+) -> set[cst.CSTNode]:
+    """Forward-walk ``stmts`` evolving the live referent set.
+
+    ``observe`` (when supplied) is invoked once per statement with the
+    pre-statement state -- callers use it to capture the state seen by
+    a specific access node nested inside ``stmt``.
+    """
+
+    def _referents_in(node: cst.CSTNode) -> set[cst.CSTNode]:
+        ids = _descendant_ids(node, cache)
+        return {r for r in referent_set if id(r) in ids}
+
+    def _else_flow(
+        orelse: cst.Else | cst.If | None, incoming: set[cst.CSTNode]
+    ) -> set[cst.CSTNode]:
+        if orelse is None:
+            return set(incoming)
+        if isinstance(orelse, cst.Else):
+            return _walk_flow(orelse.body.body, incoming, referent_set, cache, observe)
+        # ``elif`` is an ``If`` in the orelse slot; run it as a nested If.
+        return _walk_flow([orelse], incoming, referent_set, cache, observe)
+
+    state = set(incoming)
+    for stmt in stmts:
+        # Record the state the access sees *before* any bindings in the
+        # same statement take effect. RHS-of-assignment and
+        # expression-statement uses both match that convention.
+        if observe is not None:
+            observe(stmt, state)
+
+        if isinstance(stmt, cst.If):
+            body_end = _walk_flow(stmt.body.body, state, referent_set, cache, observe)
+            orelse_end = _else_flow(stmt.orelse, state)
+            state = body_end | orelse_end
+            continue
+
+        if isinstance(stmt, cst.Try):
+            # Body and each handler both see the pre-try state.
+            body_end = _walk_flow(stmt.body.body, state, referent_set, cache, observe)
+            post = set(body_end)
+            for handler in stmt.handlers:
+                post |= _walk_flow(handler.body.body, state, referent_set, cache, observe)
+            if stmt.orelse is not None:
+                # else runs only on the no-exception path, after body.
+                post = _walk_flow(
+                    stmt.orelse.body.body, body_end, referent_set, cache, observe
+                ) | (post - body_end)
+            if stmt.finalbody is not None:
+                post = _walk_flow(stmt.finalbody.body, post, referent_set, cache, observe)
+            state = post
+            continue
+
+        if isinstance(stmt, (cst.For, cst.While)):
+            body_end = _walk_flow(stmt.body.body, state, referent_set, cache, observe)
+            post = state | body_end
+            if stmt.orelse is not None:
+                post = _walk_flow(stmt.orelse.body.body, post, referent_set, cache, observe)
+            state = post
+            continue
+
+        bindings_here = _referents_in(stmt)
+        if bindings_here:
+            state = bindings_here
+
+    return state
 
 
 def live_referents(
@@ -65,69 +138,28 @@ def live_referents(
     access_id = id(access_node)
     observed: list[set[cst.CSTNode]] = []
 
-    def _referents_in(node: cst.CSTNode) -> set[cst.CSTNode]:
-        ids = _descendant_ids(node, cache)
-        return {r for r in referent_set if id(r) in ids}
+    def _observe(stmt: cst.BaseStatement, state: set[cst.CSTNode]) -> None:
+        if access_id in _descendant_ids(stmt, cache):
+            observed.append(set(state))
 
-    def _contains_access(node: cst.CSTNode) -> bool:
-        return access_id in _descendant_ids(node, cache)
-
-    def _flow(stmts: Sequence[cst.BaseStatement], incoming: set[cst.CSTNode]) -> set[cst.CSTNode]:
-        state = set(incoming)
-        for stmt in stmts:
-            # Record the state the access sees *before* any bindings
-            # in the same statement take effect. RHS-of-assignment and
-            # expression-statement uses both match that convention.
-            if _contains_access(stmt):
-                observed.append(set(state))
-
-            if isinstance(stmt, cst.If):
-                body_end = _flow(stmt.body.body, state)
-                orelse_end = _else_flow(stmt.orelse, state)
-                state = body_end | orelse_end
-                continue
-
-            if isinstance(stmt, cst.Try):
-                # Body and each handler both see the pre-try state.
-                body_end = _flow(stmt.body.body, state)
-                post = set(body_end)
-                for handler in stmt.handlers:
-                    post |= _flow(handler.body.body, state)
-                if stmt.orelse is not None:
-                    # else runs only on the no-exception path, after body.
-                    post = _flow(stmt.orelse.body.body, body_end) | (post - body_end)
-                if stmt.finalbody is not None:
-                    post = _flow(stmt.finalbody.body, post)
-                state = post
-                continue
-
-            if isinstance(stmt, (cst.For, cst.While)):
-                body_end = _flow(stmt.body.body, state)
-                post = state | body_end
-                if stmt.orelse is not None:
-                    post = _flow(stmt.orelse.body.body, post)
-                state = post
-                continue
-
-            bindings_here = _referents_in(stmt)
-            if bindings_here:
-                state = bindings_here
-
-        return state
-
-    def _else_flow(
-        orelse: cst.Else | cst.If | None, incoming: set[cst.CSTNode]
-    ) -> set[cst.CSTNode]:
-        if orelse is None:
-            return set(incoming)
-        if isinstance(orelse, cst.Else):
-            return _flow(orelse.body.body, incoming)
-        # ``elif`` is an ``If`` in the orelse slot; run it as a nested If.
-        return _flow([orelse], incoming)
-
-    _flow(scope_body, set())
+    _walk_flow(scope_body, set(), referent_set, cache, _observe)
 
     result: set[cst.CSTNode] = set()
     for s in observed:
         result |= s
     return result
+
+
+def live_at_exit(
+    scope_body: Sequence[cst.BaseStatement],
+    referent_nodes: Sequence[cst.CSTNode],
+) -> set[cst.CSTNode]:
+    """Return the subset of ``referent_nodes`` live after ``scope_body`` runs.
+
+    Same flow model as :func:`live_referents` but observes the state
+    *after* the last statement, so callers can see which bindings
+    survive to the end of the scope -- e.g. which top-level decls a
+    module exports across all reachable control-flow paths.
+    """
+    cache: dict[int, frozenset[int]] = {}
+    return _walk_flow(scope_body, set(), set(referent_nodes), cache, None)

--- a/dead_cst/_flow.py
+++ b/dead_cst/_flow.py
@@ -98,9 +98,9 @@ def _walk_flow(
                 post |= _walk_flow(handler.body.body, state, referent_set, cache, observe)
             if stmt.orelse is not None:
                 # else runs only on the no-exception path, after body.
-                post = _walk_flow(
-                    stmt.orelse.body.body, body_end, referent_set, cache, observe
-                ) | (post - body_end)
+                post = _walk_flow(stmt.orelse.body.body, body_end, referent_set, cache, observe) | (
+                    post - body_end
+                )
             if stmt.finalbody is not None:
                 post = _walk_flow(stmt.finalbody.body, post, referent_set, cache, observe)
             state = post

--- a/dead_cst/_plugins.py
+++ b/dead_cst/_plugins.py
@@ -52,19 +52,21 @@ class PluginContext:
         node = self.symbol_lookup._get(fqname.split("."))
         return node.module if node else None
 
-    def find_declaration(self, fqname: str) -> SymbolNode | None:
-        """Look up a top-level declaration by dotted name.
+    def find_declarations(self, fqname: str) -> list[SymbolNode]:
+        """Look up top-level declarations by dotted name.
 
         ``pkg.mod.func`` is split into module ``pkg.mod`` and decl ``func``.
-        Returns the declaration's :class:`SymbolNode` or ``None``.
+        Returns every :class:`SymbolNode` bound to ``func`` at module
+        exit -- normally one, but multiple when each branch of a
+        conditional defines the same name. Empty list if nothing matches.
         """
         parts = fqname.split(".")
         for split in range(len(parts) - 1, 0, -1):
             module_parts, decl_name = parts[:split], parts[split]
             node = self.symbol_lookup._get(module_parts)
             if node and node.module and decl_name in node.declarations:
-                return node.declarations[decl_name]
-        return None
+                return list(node.declarations[decl_name])
+        return []
 
 
 @dataclass(frozen=True)
@@ -241,8 +243,11 @@ class ProjectScriptsPlugin:
         for script_name, target in scripts.items():
             module_part, _, decl_part = target.partition(":")
             fqname = f"{module_part}.{decl_part}" if decl_part else module_part
-            target_node = ctx.find_declaration(fqname) or ctx.find_module(module_part)
-            if target_node is None:
+            target_nodes = ctx.find_declarations(fqname)
+            if not target_nodes:
+                module_node = ctx.find_module(module_part)
+                target_nodes = [module_node] if module_node else []
+            if not target_nodes:
                 logger.warning(
                     "ProjectScriptsPlugin: %s -> %r not found in symbol graph",
                     script_name,
@@ -254,7 +259,8 @@ class ProjectScriptsPlugin:
                 path=pyproject,
             )
             yield AddNode(synth, entrypoint=True)
-            yield AddEdge(synth, target_node)
+            for target_node in target_nodes:
+                yield AddEdge(synth, target_node)
 
 
 @dataclass

--- a/dead_cst/_resolve.py
+++ b/dead_cst/_resolve.py
@@ -98,6 +98,16 @@ def resolve_edges(
     import_edges: set[tuple[SymbolNode, Import]], symbol_lookup: SymbolTrie
 ) -> Generator[tuple[SymbolNode, SymbolNode], None, None]:
     third_party = set()
+    emitted: set[tuple[SymbolNode, SymbolNode]] = set()
+
+    def _emit(src: SymbolNode, dst: SymbolNode) -> Generator[
+        tuple[SymbolNode, SymbolNode], None, None
+    ]:
+        key = (src, dst)
+        if key in emitted:
+            return
+        emitted.add(key)
+        yield key
 
     for src, dst in import_edges:
         if not isinstance(dst.path, Path):
@@ -110,69 +120,75 @@ def resolve_edges(
             logger.warning("Failed to resolve import module: %s", dst.module)
             continue
 
-        # add the edge to the module
-        yield src, node.module
+        yield from _emit(src, node.module)
 
         # No decl? the edge points at a module
         if not dst.decl:
             continue
 
-        # resolve the access to the deepest declaration we can find. this will jump through imports
-        parts = dst.decl.split(".")
-        while parts:
+        # Resolve the access to the deepest declaration(s) we can find.
+        # ``node.declarations[name]`` may have multiple entries when each
+        # branch of a conditional binds the same name (``if X: from a
+        # import f else: from b import f``); each one is a separate
+        # continuation, so the walk is a small DFS.
+        worklist: list[tuple[SymbolTrie, list[str]]] = [(node, dst.decl.split("."))]
+        while worklist:
+            cur, parts = worklist.pop()
+            if not parts:
+                continue
             part = parts[0]
 
-            # Try declaration at current node (module or package)
-            if decl := node.declarations.get(part):
-                # We resolved a symbol; emit edge
-                yield src, decl
+            decls = cur.declarations.get(part, [])
+            if decls:
+                for decl in decls:
+                    yield from _emit(src, decl)
 
-                # If it's a concrete decl, we're done (ignore trailing attrs like .build)
-                if decl.type in {"function", "class", "variable"}:
-                    break
+                    # Concrete decl terminates this continuation;
+                    # trailing attrs like ``.build`` are ignored.
+                    if decl.type in {"function", "class", "variable"}:
+                        continue
 
-                # It's an import re-export; follow it but DO NOT advance `i`
-                assert decl.type == "import"
-                assert decl.imports is not None, "import symbol needs Import"
+                    # Import re-export: follow it without advancing
+                    # ``parts`` so the remaining attrs resolve in the
+                    # destination module.
+                    assert decl.type == "import"
+                    assert decl.imports is not None, "import symbol needs Import"
 
-                if not isinstance(decl.imports.path, Path):
-                    if "external" in decl.imports.path:
-                        third_party.add(decl.imports.path)
-                    break
+                    if not isinstance(decl.imports.path, Path):
+                        if "external" in decl.imports.path:
+                            third_party.add(decl.imports.path)
+                        continue
 
-                dest = symbol_lookup._get(decl.imports.module.split("."))
-                if not dest:
-                    logger.warning(
-                        "Failed to resolve import edge: %s + %s via %s in %s (no %s)",
-                        dst.module,
-                        dst.decl,
-                        part,
-                        node.module.fqname,
-                        decl.imports.module,
-                    )
-                    break
+                    dest = symbol_lookup._get(decl.imports.module.split("."))
+                    if not dest:
+                        logger.warning(
+                            "Failed to resolve import edge: %s + %s via %s in %s (no %s)",
+                            dst.module,
+                            dst.decl,
+                            part,
+                            cur.module.fqname,
+                            decl.imports.module,
+                        )
+                        continue
 
-                node = dest
-                parts = parts[1:]
-                if decl.imports.decl:
-                    parts = decl.imports.decl.split(".") + parts
+                    next_parts = parts[1:]
+                    if decl.imports.decl:
+                        next_parts = decl.imports.decl.split(".") + next_parts
+                    worklist.append((dest, next_parts))
                 continue
 
-            # Maybe `part` is a submodule under the current package/module
-            if child := node.children.get(part):
-                node = child
-                parts = parts[1:]
+            # Maybe ``part`` is a submodule under the current package/module
+            if child := cur.children.get(part):
+                worklist.append((child, parts[1:]))
                 continue
 
-            # Give up: neither a decl nor a submodule
             logger.warning(
                 "Failed to resolve import edge: %s + %s via %s in %s",
                 dst.module,
                 dst.decl,
                 part,
-                node.module.fqname,
+                cur.module.fqname,
             )
-            break
 
     for mod in sorted(third_party):
         logger.debug(mod)

--- a/dead_cst/_resolve.py
+++ b/dead_cst/_resolve.py
@@ -100,9 +100,9 @@ def resolve_edges(
     third_party = set()
     emitted: set[tuple[SymbolNode, SymbolNode]] = set()
 
-    def _emit(src: SymbolNode, dst: SymbolNode) -> Generator[
-        tuple[SymbolNode, SymbolNode], None, None
-    ]:
+    def _emit(
+        src: SymbolNode, dst: SymbolNode
+    ) -> Generator[tuple[SymbolNode, SymbolNode], None, None]:
         key = (src, dst)
         if key in emitted:
             return

--- a/dead_cst/_symbols.py
+++ b/dead_cst/_symbols.py
@@ -37,17 +37,29 @@ class SymbolTrie:
     # Module information at this node (if this represents an actual module)
     module: SymbolNode | None = None
 
-    # Declarations in this module (classes, functions, variables, imports)
-    # Keyed by the simple name (not fully qualified)
-    declarations: dict[str, SymbolNode] = field(default_factory=dict)
+    # Declarations in this module, keyed by simple name. A name maps to the
+    # set of decls live at module exit: usually one decl, but multiple when
+    # every branch of a conditional binds the same name (``if X: def f...
+    # else: def f...``). All branches are legitimate runtime values and a
+    # ``from mod import name`` should reach each of them.
+    declarations: dict[str, list[SymbolNode]] = field(default_factory=dict)
 
-    # Decls displaced by a later same-name decl in source order. They still
-    # belong to this module -- the symbol graph needs them so the
-    # ``decl -> module`` parent edge is emitted for shadowed decls too.
+    # Decls strictly displaced by a later same-name decl on every path to
+    # module exit. They still belong to this module -- the symbol graph
+    # needs them so the ``decl -> module`` parent edge is emitted for
+    # shadowed decls too -- but they are not exported.
     shadowed: list[SymbolNode] = field(default_factory=list)
 
     def add_declaration(self, decl: SymbolNode) -> None:
-        """Add a declaration to the trie."""
+        """Add a declaration to the trie.
+
+        For non-module decls this just collects: the trie does not yet
+        know which decls are live at module exit. ``finalize_declarations``
+        partitions same-name decls into ``declarations`` (live exports)
+        and ``shadowed`` (strictly displaced). De-duplicates so the
+        visitor's double-push for ``Assign`` (one push for the LHS name,
+        one for the RHS value) does not register the same decl twice.
+        """
         parts = decl.fqname.split(".")
         match decl.type:
             case "module":
@@ -55,16 +67,33 @@ class SymbolTrie:
                 assert node.module is None, f"Module already exists at this node {decl.path}"
                 node.module = decl
             case _:
-                # Store declarations by their simple name
                 parent, child = parts[:-1], parts[-1]
                 node = self._touch(parent)
                 assert node.module is not None, (
                     f"Module should exist when adding {decl.type} {decl.fqname}"
                 )
-                existing = node.declarations.get(child)
-                if existing is not None and existing != decl:
-                    node.shadowed.append(existing)
-                node.declarations[child] = decl
+                bucket = node.declarations.setdefault(child, [])
+                if decl not in bucket:
+                    bucket.append(decl)
+
+    def finalize_declarations(
+        self,
+        name: str,
+        live: list[SymbolNode],
+        shadowed: list[SymbolNode],
+    ) -> None:
+        """Partition collected decls for ``name`` into live vs shadowed.
+
+        ``live`` is the set of decls that bind ``name`` on at least one
+        path to module exit. ``shadowed`` is the rest. The caller is
+        expected to derive both from a flow-sensitive walk of the
+        module body (see :func:`dead_cst._flow.live_at_exit`).
+        """
+        if live:
+            self.declarations[name] = list(live)
+        else:
+            self.declarations.pop(name, None)
+        self.shadowed.extend(shadowed)
 
     def merge(self, other: SymbolTrie) -> SymbolTrie:
         """Merge another SymbolTrie into this one."""
@@ -77,7 +106,7 @@ class SymbolTrie:
         if other.module:
             assert self.module is None, "Cannot merge module into a node that already has a module"
             self.module = other.module
-            self.declarations = other.declarations.copy()
+            self.declarations = {k: list(v) for k, v in other.declarations.items()}
             self.shadowed = list(other.shadowed)
         return self
 

--- a/dead_cst/_symbols.py
+++ b/dead_cst/_symbols.py
@@ -41,6 +41,11 @@ class SymbolTrie:
     # Keyed by the simple name (not fully qualified)
     declarations: dict[str, SymbolNode] = field(default_factory=dict)
 
+    # Decls displaced by a later same-name decl in source order. They still
+    # belong to this module -- the symbol graph needs them so the
+    # ``decl -> module`` parent edge is emitted for shadowed decls too.
+    shadowed: list[SymbolNode] = field(default_factory=list)
+
     def add_declaration(self, decl: SymbolNode) -> None:
         """Add a declaration to the trie."""
         parts = decl.fqname.split(".")
@@ -56,6 +61,9 @@ class SymbolTrie:
                 assert node.module is not None, (
                     f"Module should exist when adding {decl.type} {decl.fqname}"
                 )
+                existing = node.declarations.get(child)
+                if existing is not None and existing != decl:
+                    node.shadowed.append(existing)
                 node.declarations[child] = decl
 
     def merge(self, other: SymbolTrie) -> SymbolTrie:
@@ -70,6 +78,7 @@ class SymbolTrie:
             assert self.module is None, "Cannot merge module into a node that already has a module"
             self.module = other.module
             self.declarations = other.declarations.copy()
+            self.shadowed = list(other.shadowed)
         return self
 
     def _touch(self, parts: list[str]) -> SymbolTrie:

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -325,9 +325,7 @@ class SymbolVisitor(cst.CSTVisitor):
                 if ref is not None:
                     referent_nodes.append(ref)
 
-            live_ids = {
-                id(n) for n in live_at_exit(list(module_node.body), referent_nodes)
-            }
+            live_ids = {id(n) for n in live_at_exit(list(module_node.body), referent_nodes)}
 
             live_decls: list[SymbolNode] = []
             shadowed_decls: list[SymbolNode] = []

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -22,7 +22,7 @@ from libcst.metadata.scope_provider import (
     ImportAssignment,
 )
 
-from ._flow import live_referents
+from ._flow import live_at_exit, live_referents
 from ._resolve import resolve_import
 from ._symbols import Import, SymbolNode, SymbolTrie
 
@@ -98,6 +98,12 @@ class SymbolVisitor(cst.CSTVisitor):
         self.import_edges: set[tuple[SymbolNode, Import]] = set()
         self.internal_edges: set[tuple[SymbolNode, SymbolNode]] = set()
         self.trie: SymbolTrie = SymbolTrie()
+        # CST node used as the flow-analysis "binding site" for each
+        # top-level decl. Functions/classes use the def itself, variables
+        # use the LHS Name, imports use the ImportAlias. All are
+        # descendants of the containing statement, which is what
+        # ``live_at_exit`` matches against.
+        self.symbol_referent_nodes: dict[SymbolNode, cst.CSTNode] = {}
 
     @property
     def module_node(self) -> SymbolNode:
@@ -140,7 +146,9 @@ class SymbolVisitor(cst.CSTVisitor):
         fqns = self.get_metadata(FullyQualifiedNameProvider, node, default=[])
         pos = self._pos(node)
         for fqn in fqns:
-            self._push_decl(node, SymbolNode(fqn.name, type_, self.path, pos))
+            sym = SymbolNode(fqn.name, type_, self.path, pos)
+            self.symbol_referent_nodes[sym] = node
+            self._push_decl(node, sym)
 
     def _add_variable(self, node: cst.Assign | cst.AnnAssign):
         # Only collect top-level declarations, skip nested ones
@@ -175,6 +183,7 @@ class SymbolVisitor(cst.CSTVisitor):
             pos = self._pos(name)
             for fqn in fqns:
                 sym = SymbolNode(fqn.name, "variable", self.path, pos)
+                self.symbol_referent_nodes[sym] = name
                 name_to_syms.setdefault(name, []).append(sym)
                 if value is not None:
                     value_to_syms.setdefault(value, []).append(sym)
@@ -241,6 +250,7 @@ class SymbolVisitor(cst.CSTVisitor):
                     self._pos(alias),
                     import_info,
                 )
+                self.symbol_referent_nodes[sym] = alias
                 self._push_decl(alias, sym)
 
             # add the import edge to the last decl on the stack
@@ -250,6 +260,9 @@ class SymbolVisitor(cst.CSTVisitor):
         assert not self.decl_stack, "Module node should be the first visited node"
         fqns = self.get_metadata(FullyQualifiedNameProvider, node, default=[])
         sym = SymbolNode(next(iter(fqns)).name, "module", self.path, self._pos(node))
+        # Cache so ``_finalize_module_declarations`` can locate the trie
+        # node after ``on_leave`` has popped the module frame.
+        self._module_fqname = sym.fqname
         self._push_decl(node, sym)
 
     def visit_FunctionDef(self, node: cst.FunctionDef) -> None:
@@ -287,6 +300,46 @@ class SymbolVisitor(cst.CSTVisitor):
 
         self._add_import(module, node)
 
+    def _finalize_module_declarations(self, module_node: cst.Module) -> None:
+        """Partition same-name top-level decls into live / shadowed at exit.
+
+        For names with more than one decl, ask :func:`live_at_exit` which
+        binding sites survive on at least one path to module exit. Live
+        decls stay in ``trie.declarations[name]`` (multi-valued for
+        conditional bindings); the rest move to ``trie.shadowed`` so the
+        graph keeps their parent-module edge but cross-module imports do
+        not reach them.
+        """
+        trie_node = self.trie._get(self._module_fqname.split("."))
+        if trie_node is None:
+            return
+
+        name_decls = {n: list(d) for n, d in trie_node.declarations.items()}
+        for name, decls in name_decls.items():
+            if len(decls) <= 1:
+                continue
+
+            referent_nodes: list[cst.CSTNode] = []
+            for d in decls:
+                ref = self.symbol_referent_nodes.get(d)
+                if ref is not None:
+                    referent_nodes.append(ref)
+
+            live_ids = {
+                id(n) for n in live_at_exit(list(module_node.body), referent_nodes)
+            }
+
+            live_decls: list[SymbolNode] = []
+            shadowed_decls: list[SymbolNode] = []
+            for d in decls:
+                ref = self.symbol_referent_nodes.get(d)
+                if ref is not None and id(ref) in live_ids:
+                    live_decls.append(d)
+                else:
+                    shadowed_decls.append(d)
+
+            trie_node.finalize_declarations(name, live_decls, shadowed_decls)
+
     def on_leave(self, original_node: cst.CSTNode) -> None:
         self.nearest_decls[original_node] = list(self.decl_stack[-1]) if self.decl_stack else []
         for frame in reversed(self.node_to_frames.get(original_node, [])):
@@ -296,6 +349,8 @@ class SymbolVisitor(cst.CSTVisitor):
         # only run once for the Module node
         if not isinstance(original_node, cst.Module):
             return
+
+        self._finalize_module_declarations(original_node)
 
         parent_map = self.metadata[ParentNodeProvider]
         references = set()

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -737,8 +737,10 @@ def test_declarations(build_decl_graph, assert_edges, src, expected_edges):
             # Two distinct ``mod.a`` variable nodes at different
             # positions. The second assignment's RHS genuinely references
             # the first binding -- no cycle in the underlying graph.
-            # Only the last decl (trie survivor) gets a parent edge.
+            # Both decls -- including the shadowed one -- carry a
+            # parent-module edge so the graph stays well-formed.
             {
+                "mod.a@1:0 -> mod",
                 "mod.a@2:0 -> mod",
                 "mod.a@2:0 -> mod.a@1:0",
             },
@@ -751,9 +753,12 @@ def test_declarations(build_decl_graph, assert_edges, src, expected_edges):
             f()
             """,
             # The flow filter drops the shadowed line-1 def at the call
-            # site, so only the surviving ``mod.f@2:0`` appears.
+            # site, so only the surviving ``mod.f@2:0`` is reachable
+            # there. The shadowed ``mod.f@1:0`` still belongs to the
+            # module, so it carries the parent-module edge.
             {
                 "mod -> mod.f@2:0",
+                "mod.f@1:0 -> mod",
                 "mod.f@2:0 -> mod",
             },
             id="function-redefined-creates-two-nodes",
@@ -766,6 +771,7 @@ def test_declarations(build_decl_graph, assert_edges, src, expected_edges):
             """,
             {
                 "mod -> mod.C@2:0",
+                "mod.C@1:0 -> mod",
                 "mod.C@2:0 -> mod",
             },
             id="class-redefined-creates-two-nodes",
@@ -778,11 +784,13 @@ def test_declarations(build_decl_graph, assert_edges, src, expected_edges):
             f()
             """,
             # ``f()`` only reaches the last ``def f`` after filtering.
-            # The shadowed ``mod.f@2:0`` had no outgoing references
-            # anyway, so it drops out of the graph entirely.
+            # The shadowed ``mod.f@2:0`` keeps its parent-module edge so
+            # it stays in the graph as a (now-orphan-from-the-call-site)
+            # decl.
             {
                 "mod -> mod.f@3:0",
                 "mod.a@1:0 -> mod",
+                "mod.f@2:0 -> mod",
                 "mod.f@3:0 -> mod",
                 "mod.f@3:0 -> mod.a@1:0",
             },
@@ -800,6 +808,7 @@ def test_declarations(build_decl_graph, assert_edges, src, expected_edges):
             {
                 "mod -> mod.f@4:0",
                 "mod.dec@1:0 -> mod",
+                "mod.f@2:0 -> mod",
                 "mod.f@4:0 -> mod",
                 "mod.f@4:0 -> mod.dec@1:0",
             },
@@ -818,6 +827,7 @@ def test_declarations(build_decl_graph, assert_edges, src, expected_edges):
             {
                 "mod -> mod.f@1:0",
                 "mod -> mod.f@3:9",
+                "mod.f@1:0 -> mod",
                 "mod.f@3:9 -> mod",
                 "mod.f@3:9 -> mod.g@2:0",
                 "mod.g@2:0 -> mod",
@@ -841,6 +851,7 @@ def test_declarations(build_decl_graph, assert_edges, src, expected_edges):
                 "mod -> mod.f@6:4",
                 "mod.a@1:0 -> mod",
                 "mod.b@2:0 -> mod",
+                "mod.f@4:4 -> mod",
                 "mod.f@4:4 -> mod.a@1:0",
                 "mod.f@6:4 -> mod",
                 "mod.f@6:4 -> mod.b@2:0",
@@ -859,6 +870,7 @@ def test_declarations(build_decl_graph, assert_edges, src, expected_edges):
             {
                 "mod.f@1:0 -> mod",
                 "mod.g@2:0 -> mod",
+                "mod.x@4:4 -> mod",
                 "mod.x@4:4 -> mod.f@1:0",
                 "mod.x@6:4 -> mod",
                 "mod.x@6:4 -> mod.g@2:0",
@@ -895,6 +907,7 @@ def test_redeclarations(build_decl_graph, assert_positional_edges, src, expected
             # it so ``other`` is no longer kept alive by this module.
             {
                 "mod -> mod.f@2:0",
+                "mod.f@1:18 -> mod",
                 "mod.f@1:18 -> other",
                 "mod.f@1:18 -> other.f@1:0",
                 "mod.f@2:0 -> mod",
@@ -912,11 +925,13 @@ def test_redeclarations(build_decl_graph, assert_positional_edges, src, expected
                 """,
             },
             # The shadowing import wins at the call; the shadowed def
-            # at line 1 has no incoming edges and drops from the graph.
+            # at line 1 has no incoming edges and stays in the graph
+            # only via its parent-module edge.
             {
                 "mod -> mod.f@2:18",
                 "mod -> other",
                 "mod -> other.f@1:0",
+                "mod.f@1:0 -> mod",
                 "mod.f@2:18 -> mod",
                 "mod.f@2:18 -> other",
                 "mod.f@2:18 -> other.f@1:0",
@@ -935,6 +950,7 @@ def test_redeclarations(build_decl_graph, assert_positional_edges, src, expected
             },
             {
                 "mod -> mod.f@2:0",
+                "mod.f@1:18 -> mod",
                 "mod.f@1:18 -> other",
                 "mod.f@1:18 -> other.f@1:0",
                 "mod.f@2:0 -> mod",
@@ -963,6 +979,7 @@ def test_redeclarations(build_decl_graph, assert_positional_edges, src, expected
                 "mod -> mod.x@2:14",
                 "mod.x@1:14 -> a",
                 "mod.x@1:14 -> a.x@1:0",
+                "mod.x@1:14 -> mod",
                 "mod.x@2:14 -> b",
                 "mod.x@2:14 -> b.x@1:0",
                 "mod.x@2:14 -> mod",
@@ -988,6 +1005,7 @@ def test_redeclarations(build_decl_graph, assert_positional_edges, src, expected
             {
                 "mod -> mod.f@3:0",
                 "mod.dead_helper@1:0 -> mod",
+                "mod.f@2:0 -> mod",
                 "mod.f@2:0 -> mod.dead_helper@1:0",
                 "mod.f@3:0 -> mod",
             },
@@ -1005,6 +1023,7 @@ def test_redeclarations(build_decl_graph, assert_positional_edges, src, expected
             },
             {
                 "mod -> mod.C@4:0",
+                "mod.C@2:0 -> mod",
                 "mod.C@2:0 -> mod.dead_helper@1:0",
                 "mod.C@4:0 -> mod",
                 "mod.dead_helper@1:0 -> mod",
@@ -1029,7 +1048,9 @@ def test_redeclarations(build_decl_graph, assert_positional_edges, src, expected
                 "mod -> mod.f@5:0",
                 "mod.a@1:0 -> mod",
                 "mod.b@2:0 -> mod",
+                "mod.f@3:0 -> mod",
                 "mod.f@3:0 -> mod.a@1:0",
+                "mod.f@4:0 -> mod",
                 "mod.f@4:0 -> mod.b@2:0",
                 "mod.f@5:0 -> mod",
             },

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -1063,6 +1063,129 @@ def test_shadowed_declarations(build_decl_graph, assert_positional_edges, files,
     assert_positional_edges(graph, expected_edges)
 
 
+@pytest.mark.parametrize(
+    "files, expected_edges",
+    [
+        # Both branches define ``f``; both are live at module exit, so a
+        # cross-module ``from lib import f`` must reach each one.
+        pytest.param(
+            {
+                "lib.py": """
+                if True:
+                    def f(): pass
+                else:
+                    def f(): pass
+                """,
+                "mod.py": """
+                from lib import f
+                f()
+                """,
+            },
+            {
+                "lib.f@2:4 -> lib",
+                "lib.f@4:4 -> lib",
+                "mod -> lib",
+                "mod -> lib.f@2:4",
+                "mod -> lib.f@4:4",
+                "mod -> mod.f@1:16",
+                "mod.f@1:16 -> lib",
+                "mod.f@1:16 -> lib.f@2:4",
+                "mod.f@1:16 -> lib.f@4:4",
+                "mod.f@1:16 -> mod",
+            },
+            id="cross-module-import-of-if-else-binding",
+        ),
+        # Conditional re-export through an intermediate module: each
+        # branch imports from a different upstream, so resolving
+        # ``mod -> compat.f`` forks the worklist into both upstreams.
+        pytest.param(
+            {
+                "a.py": "def f(): pass\n",
+                "b.py": "def f(): pass\n",
+                "compat.py": """
+                if True:
+                    from a import f
+                else:
+                    from b import f
+                """,
+                "mod.py": """
+                from compat import f
+                f()
+                """,
+            },
+            {
+                "a.f@1:0 -> a",
+                "b.f@1:0 -> b",
+                "compat.f@2:18 -> a",
+                "compat.f@2:18 -> a.f@1:0",
+                "compat.f@2:18 -> compat",
+                "compat.f@4:18 -> b",
+                "compat.f@4:18 -> b.f@1:0",
+                "compat.f@4:18 -> compat",
+                "mod -> a.f@1:0",
+                "mod -> b.f@1:0",
+                "mod -> compat",
+                "mod -> compat.f@2:18",
+                "mod -> compat.f@4:18",
+                "mod -> mod.f@1:19",
+                "mod.f@1:19 -> a.f@1:0",
+                "mod.f@1:19 -> b.f@1:0",
+                "mod.f@1:19 -> compat",
+                "mod.f@1:19 -> compat.f@2:18",
+                "mod.f@1:19 -> compat.f@4:18",
+                "mod.f@1:19 -> mod",
+            },
+            id="cross-module-import-through-conditional-reexport",
+        ),
+        # ``try`` body and ``except`` handler both bind ``f``; both are
+        # live at exit (a handler can run before *or* instead of the
+        # body completing), so both must be importable.
+        pytest.param(
+            {
+                "lib.py": """
+                try:
+                    from a import f
+                except ImportError:
+                    def f(): pass
+                """,
+                "a.py": "def f(): pass\n",
+                "mod.py": """
+                from lib import f
+                f()
+                """,
+            },
+            {
+                "a.f@1:0 -> a",
+                "lib.f@2:18 -> a",
+                "lib.f@2:18 -> a.f@1:0",
+                "lib.f@2:18 -> lib",
+                "lib.f@4:4 -> lib",
+                "mod -> a.f@1:0",
+                "mod -> lib",
+                "mod -> lib.f@2:18",
+                "mod -> lib.f@4:4",
+                "mod -> mod.f@1:16",
+                "mod.f@1:16 -> a.f@1:0",
+                "mod.f@1:16 -> lib",
+                "mod.f@1:16 -> lib.f@2:18",
+                "mod.f@1:16 -> lib.f@4:4",
+                "mod.f@1:16 -> mod",
+            },
+            id="try-except-both-branches-exported",
+        ),
+    ],
+)
+def test_branch_bindings_exported(build_decl_graph, assert_positional_edges, files, expected_edges):
+    """Decls bound on every reachable path to module exit are importable.
+
+    Plain shadowing keeps single-survivor semantics, but conditional
+    bindings (``if/else``, ``try/except``, ...) where multiple branches
+    bind the same name should expose every branch to importing modules.
+    """
+    graph = build_decl_graph(files)
+    assert_positional_edges(graph, expected_edges)
+
+
 def test_module_hierarchy_edges(build_decl_graph, assert_edges):
     """Submodules point at their parent package to keep __init__.py alive."""
     graph = build_decl_graph(


### PR DESCRIPTION
## Summary

Two related fixes for how the symbol graph handles top-level decls that share a name within a module.

### 1. Shadowed decls now carry a parent-module edge

`SymbolTrie.declarations` was a `dict[str, SymbolNode]` keyed by simple name, so when two top-level decls shared a name the second one silently overwrote the first. `_analyze.py` walked `node.declarations.values()` to emit `decl -> module` parent edges, so shadowed decls either lost that edge (e.g. `mod.f@1:18` from `from other import f` shadowed by `def f(): pass`) or never made it into the graph at all (e.g. the line-1 `def f` in `def f(): pass / def f(): pass`). The trie now tracks displaced decls in a `shadowed` list, and `_analyze.py` emits the parent-module edge for those too -- they remain unreachable from cross-module lookups but the graph stays well-formed.

### 2. Branch-bound names are exported on every live path

A name bound on multiple control-flow paths to module exit (`if/else`, `try/except`, ...) used to collapse to a single trie entry -- only the last source-order decl. Cross-module `from mod import name` would reach just that one decl, dropping the other branches even though either is a legitimate runtime value.

The existing `_flow.py` walker is reused for this: a new `live_at_exit(scope_body, referent_nodes)` returns the post-state of the scope walk, sharing all the if/try/loop semantics with the existing `live_referents`. The visitor calls it once per multi-decl name in `on_leave` for the module, partitioning same-name top-level decls into:

- `trie.declarations[name]` (now `list[SymbolNode]`) -- live exports across all paths
- `trie.shadowed` -- strictly displaced (graph-visible, but not importable)

The import resolver in `_resolve.py` becomes a small worklist DFS so it can fork through multiple candidates per name. Plain shadowing (one survivor) stays linear; conditional bindings or conditional re-exports (`if X: from a import f else: from b import f`) fork.

Knock-on cleanups:

- `PluginContext.find_declaration` -> `find_declarations` (plural) and `ProjectScriptsPlugin` emits an entrypoint edge per resolved decl.
- `_analyze.py` flattens the list-valued `declarations` when emitting parent-module edges.
- `_resolve.py` dedupes `(src, dst)` so the same edge isn't yielded twice through different worklist branches.

## Test plan

- [x] Existing test suite: 144 pre-existing tests still pass.
- [x] New test class `test_branch_bindings_exported` covers:
  - `cross-module-import-of-if-else-binding` -- both branches importable.
  - `cross-module-import-through-conditional-reexport` -- the resolver forks through a `compat.py` whose `if/else` re-exports from different upstreams.
  - `try-except-both-branches-exported` -- try body and except handler both bind the name.
- [x] Updated 15 existing `test_redeclarations` / `test_shadowed_declarations` cases to assert the new shadowed `-> mod` edges.
- [x] `ruff check` and `ruff format --check` clean.
- [x] Final suite: 147 passed.

https://claude.ai/code/session_013JEHVzVDURYoQy21XdUmcA