### PR TITLE
Detect unreachable branches and surface them as synthetic graph nodes

### DIFF
--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -76,8 +76,19 @@ def build_symbol_graph(
                 for src, dst in visitor.internal_edges:
                     symbol_graph.add_edge(src, dst)
 
+                # Synthetic ``unreachable`` nodes for statically-dead suites.
+                # They live in the graph as orphan sources -- nothing points
+                # at them, so reachability never visits them, but the edges
+                # they own surface which symbols are referenced from inside
+                # dead branches. Existing top-level decl edges are unchanged.
+                for unreachable in visitor.unreachable_nodes:
+                    symbol_graph.add_node(unreachable)
+                for src, dst in visitor.unreachable_internal_edges:
+                    symbol_graph.add_edge(src, dst)
+
                 # collect all the intra module edges
                 import_edges = import_edges | visitor.import_edges
+                import_edges = import_edges | visitor.unreachable_import_edges
 
             # add edges to keep __init__.py files alive
             current_trie.add_module_hierarchy_edges(symbol_graph)

--- a/dead_cst/_branches.py
+++ b/dead_cst/_branches.py
@@ -179,9 +179,7 @@ def make_unreachable_fqname(module_fqname: str, position: CodeRange) -> str:
     )
 
 
-def make_unreachable_node(
-    module_fqname: str, path: Path, position: CodeRange
-) -> SymbolNode:
+def make_unreachable_node(module_fqname: str, path: Path, position: CodeRange) -> SymbolNode:
     """Build the synthetic ``SymbolNode`` for a dead suite.
 
     Reuses ``type="synthetic"`` -- the existing escape hatch for graph

--- a/dead_cst/_branches.py
+++ b/dead_cst/_branches.py
@@ -11,13 +11,24 @@ over those. Anything involving a name lookup (other than the three
 keywords), attribute access, function call, comparison, or other
 dynamic operation returns ``None`` (unknown). Returning ``None`` is
 always the safe default: callers must treat the branch as live.
+
+This module also owns the convention for synthetic graph nodes that
+represent dead suites. The nodes have ``type="synthetic"`` (the
+existing escape hatch in :mod:`dead_cst._symbols`) and a fqname
+prefixed with ``<unreachable ``. ``is_unreachable_node`` is the single
+source of truth for that convention; consumers should never check the
+prefix string themselves.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Sequence
 
 import libcst as cst
+from libcst.metadata import CodeRange
+
+from ._symbols import SymbolNode
 
 
 _KEYWORDS: dict[str, bool] = {
@@ -25,6 +36,8 @@ _KEYWORDS: dict[str, bool] = {
     "False": False,
     "None": False,
 }
+
+_UNREACHABLE_FQNAME_PREFIX = "<unreachable "
 
 
 def evaluate_truthiness(node: cst.BaseExpression) -> bool | None:
@@ -91,50 +104,54 @@ def evaluate_truthiness(node: cst.BaseExpression) -> bool | None:
     return None
 
 
-def unreachable_bodies(stmt: cst.BaseStatement) -> list[Sequence[cst.CSTNode]]:
-    """Return every dead statement-block body inside ``stmt``.
+def unreachable_suites(stmt: cst.BaseStatement) -> list[cst.BaseSuite]:
+    """Return every dead suite inside ``stmt``.
 
     Supports ``cst.If`` (including ``elif`` / ``else`` chains) and
     ``cst.While``. Returns ``[]`` for any other statement type or when
     no branch can be shown to be unreachable.
 
-    The bodies returned are the ``.body`` lists of the dead suites.
-    Each is typed as ``Sequence[cst.CSTNode]`` because libcst's
-    ``BaseSuite.body`` may be ``Sequence[BaseStatement]`` (an indented
-    block) or ``Sequence[BaseSmallStatement]`` (a one-line suite like
-    ``if False: x = 1``).
+    Returns the suite nodes themselves so callers that need source
+    positions (e.g. the visitor) can read them off the node.
     """
     if isinstance(stmt, cst.If):
         return _unreachable_in_if(stmt, branch_taken=False)
     if isinstance(stmt, cst.While):
         truth = evaluate_truthiness(stmt.test)
         if truth is False:
-            return [_suite_body(stmt.body)]
+            return [stmt.body]
         # ``while True:`` exits only via break / return / exception, so
         # the ``else`` clause (which fires on normal exit) never runs.
         if truth is True and stmt.orelse is not None:
-            return [_suite_body(stmt.orelse.body)]
+            return [stmt.orelse.body]
         return []
     return []
 
 
-def _suite_body(suite: cst.BaseSuite) -> Sequence[cst.CSTNode]:
-    return suite.body
+def unreachable_bodies(stmt: cst.BaseStatement) -> list[Sequence[cst.CSTNode]]:
+    """Return the ``.body`` of every dead suite inside ``stmt``.
+
+    Thin wrapper over :func:`unreachable_suites` for callers that only
+    need the statement list, not the enclosing suite. Each entry is
+    typed as ``Sequence[cst.CSTNode]`` because libcst's
+    ``BaseSuite.body`` may be ``Sequence[BaseStatement]`` (an indented
+    block) or ``Sequence[BaseSmallStatement]`` (a one-line suite like
+    ``if False: x = 1``).
+    """
+    return [suite.body for suite in unreachable_suites(stmt)]
 
 
-def _unreachable_in_if(
-    node: cst.If, branch_taken: bool
-) -> list[Sequence[cst.CSTNode]]:
-    """Walk an ``if`` / ``elif`` / ``else`` chain collecting dead bodies.
+def _unreachable_in_if(node: cst.If, branch_taken: bool) -> list[cst.BaseSuite]:
+    """Walk an ``if`` / ``elif`` / ``else`` chain collecting dead suites.
 
     ``branch_taken`` is ``True`` when an earlier branch in the chain is
     known to fire; everything from this point on is then unreachable.
     """
-    dead: list[Sequence[cst.CSTNode]] = []
+    dead: list[cst.BaseSuite] = []
     truth = None if branch_taken else evaluate_truthiness(node.test)
 
     if branch_taken or truth is False:
-        dead.append(_suite_body(node.body))
+        dead.append(node.body)
 
     next_taken = branch_taken or truth is True
 
@@ -143,7 +160,49 @@ def _unreachable_in_if(
         return dead
     if isinstance(orelse, cst.Else):
         if next_taken:
-            dead.append(_suite_body(orelse.body))
+            dead.append(orelse.body)
         return dead
     dead.extend(_unreachable_in_if(orelse, next_taken))
     return dead
+
+
+def make_unreachable_fqname(module_fqname: str, position: CodeRange) -> str:
+    """Build the fqname for the synthetic node representing a dead suite.
+
+    The format is intentionally fixed: callers should use
+    :func:`is_unreachable_node` to identify these nodes rather than
+    string-matching on their fqnames.
+    """
+    return (
+        f"{_UNREACHABLE_FQNAME_PREFIX}"
+        f"{module_fqname}:{position.start.line}:{position.start.column}>"
+    )
+
+
+def make_unreachable_node(
+    module_fqname: str, path: Path, position: CodeRange
+) -> SymbolNode:
+    """Build the synthetic ``SymbolNode`` for a dead suite.
+
+    Reuses ``type="synthetic"`` -- the existing escape hatch for graph
+    nodes that don't correspond to a top-level declaration -- and
+    distinguishes itself by carrying a real source ``position`` (rather
+    than the ``SYNTHETIC_POSITION`` sentinel used by entrypoint plugins)
+    plus an ``<unreachable ...>`` fqname prefix.
+    """
+    return SymbolNode(
+        fqname=make_unreachable_fqname(module_fqname, position),
+        type="synthetic",
+        path=path,
+        position=position,
+    )
+
+
+def is_unreachable_node(sym: SymbolNode) -> bool:
+    """Predicate: ``True`` iff ``sym`` is a synthetic dead-suite node.
+
+    The only supported way to identify these nodes. Callers should not
+    string-match on the fqname directly; the prefix is an implementation
+    detail of this module.
+    """
+    return sym.type == "synthetic" and sym.fqname.startswith(_UNREACHABLE_FQNAME_PREFIX)

--- a/dead_cst/_branches.py
+++ b/dead_cst/_branches.py
@@ -1,0 +1,149 @@
+"""Static evaluator for conditional truthiness.
+
+Determines, when possible, whether the truthiness of an expression is
+statically known. Used to identify dead branches of ``if`` / ``while``
+statements so callers can prune references that live inside them.
+
+Only handles a small whitelist of literal forms: the ``True`` /
+``False`` / ``None`` keywords, integer / string literals,
+empty-vs-non-empty collection literals, and ``not`` / ``and`` / ``or``
+over those. Anything involving a name lookup (other than the three
+keywords), attribute access, function call, comparison, or other
+dynamic operation returns ``None`` (unknown). Returning ``None`` is
+always the safe default: callers must treat the branch as live.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import libcst as cst
+
+
+_KEYWORDS: dict[str, bool] = {
+    "True": True,
+    "False": False,
+    "None": False,
+}
+
+
+def evaluate_truthiness(node: cst.BaseExpression) -> bool | None:
+    """Best-effort static truthiness for ``node``.
+
+    Returns ``True`` / ``False`` if the value's truthiness is statically
+    determinable, ``None`` otherwise. Never raises.
+    """
+    if isinstance(node, cst.Name):
+        return _KEYWORDS.get(node.value)
+
+    if isinstance(node, cst.Integer):
+        try:
+            return int(node.value, 0) != 0
+        except ValueError:
+            return None
+
+    if isinstance(node, (cst.SimpleString, cst.ConcatenatedString)):
+        try:
+            value = node.evaluated_value
+        except Exception:
+            return None
+        if value is None:
+            return None
+        return bool(value)
+
+    if isinstance(node, (cst.Tuple, cst.List, cst.Set)):
+        for elt in node.elements:
+            if isinstance(elt, cst.StarredElement):
+                return None
+        return len(node.elements) > 0
+
+    if isinstance(node, cst.Dict):
+        for elt in node.elements:
+            if isinstance(elt, cst.StarredDictElement):
+                return None
+        return len(node.elements) > 0
+
+    if isinstance(node, cst.UnaryOperation) and isinstance(node.operator, cst.Not):
+        inner = evaluate_truthiness(node.expression)
+        return None if inner is None else not inner
+
+    if isinstance(node, cst.BooleanOperation):
+        left = evaluate_truthiness(node.left)
+        if isinstance(node.operator, cst.And):
+            if left is False:
+                return False
+            right = evaluate_truthiness(node.right)
+            if right is False:
+                return False
+            if left is True and right is True:
+                return True
+            return None
+        if isinstance(node.operator, cst.Or):
+            if left is True:
+                return True
+            right = evaluate_truthiness(node.right)
+            if right is True:
+                return True
+            if left is False and right is False:
+                return False
+            return None
+
+    return None
+
+
+def unreachable_bodies(stmt: cst.BaseStatement) -> list[Sequence[cst.CSTNode]]:
+    """Return every dead statement-block body inside ``stmt``.
+
+    Supports ``cst.If`` (including ``elif`` / ``else`` chains) and
+    ``cst.While``. Returns ``[]`` for any other statement type or when
+    no branch can be shown to be unreachable.
+
+    The bodies returned are the ``.body`` lists of the dead suites.
+    Each is typed as ``Sequence[cst.CSTNode]`` because libcst's
+    ``BaseSuite.body`` may be ``Sequence[BaseStatement]`` (an indented
+    block) or ``Sequence[BaseSmallStatement]`` (a one-line suite like
+    ``if False: x = 1``).
+    """
+    if isinstance(stmt, cst.If):
+        return _unreachable_in_if(stmt, branch_taken=False)
+    if isinstance(stmt, cst.While):
+        truth = evaluate_truthiness(stmt.test)
+        if truth is False:
+            return [_suite_body(stmt.body)]
+        # ``while True:`` exits only via break / return / exception, so
+        # the ``else`` clause (which fires on normal exit) never runs.
+        if truth is True and stmt.orelse is not None:
+            return [_suite_body(stmt.orelse.body)]
+        return []
+    return []
+
+
+def _suite_body(suite: cst.BaseSuite) -> Sequence[cst.CSTNode]:
+    return suite.body
+
+
+def _unreachable_in_if(
+    node: cst.If, branch_taken: bool
+) -> list[Sequence[cst.CSTNode]]:
+    """Walk an ``if`` / ``elif`` / ``else`` chain collecting dead bodies.
+
+    ``branch_taken`` is ``True`` when an earlier branch in the chain is
+    known to fire; everything from this point on is then unreachable.
+    """
+    dead: list[Sequence[cst.CSTNode]] = []
+    truth = None if branch_taken else evaluate_truthiness(node.test)
+
+    if branch_taken or truth is False:
+        dead.append(_suite_body(node.body))
+
+    next_taken = branch_taken or truth is True
+
+    orelse = node.orelse
+    if orelse is None:
+        return dead
+    if isinstance(orelse, cst.Else):
+        if next_taken:
+            dead.append(_suite_body(orelse.body))
+        return dead
+    dead.extend(_unreachable_in_if(orelse, next_taken))
+    return dead

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -4,7 +4,7 @@ import logging
 from functools import cache
 from importlib.util import resolve_name
 from pathlib import Path
-from typing import Generator, Literal
+from typing import Generator, Literal, Mapping
 
 import libcst as cst
 from libcst.helpers import get_full_name_for_node
@@ -21,6 +21,7 @@ from libcst.metadata.scope_provider import (
     ImportAssignment,
 )
 
+from ._branches import make_unreachable_node, unreachable_suites
 from ._flow import live_at_exit, live_referents
 from ._fqn import FixedFullyQualifiedNameProvider
 from ._resolve import resolve_import
@@ -104,6 +105,15 @@ class SymbolVisitor(cst.CSTVisitor):
         # descendants of the containing statement, which is what
         # ``live_at_exit`` matches against.
         self.symbol_referent_nodes: dict[SymbolNode, cst.CSTNode] = {}
+        # Synthetic graph nodes for statically-unreachable branches.
+        # ``dead_suite_owner`` maps the ``id()`` of each dead suite node
+        # to the synthetic ``SymbolNode`` that "owns" any references
+        # made inside it; ``unreachable_nodes`` is the flat list the
+        # analyzer pulls into the graph.
+        self.unreachable_nodes: list[SymbolNode] = []
+        self.dead_suite_owner: dict[int, SymbolNode] = {}
+        self.unreachable_internal_edges: set[tuple[SymbolNode, SymbolNode]] = set()
+        self.unreachable_import_edges: set[tuple[SymbolNode, Import]] = set()
 
     @property
     def module_node(self) -> SymbolNode:
@@ -277,6 +287,46 @@ class SymbolVisitor(cst.CSTVisitor):
     def visit_AnnAssign(self, node: cst.AnnAssign) -> None:
         self._add_variable(node)
 
+    def visit_If(self, node: cst.If) -> None:
+        self._record_dead_suites(node)
+
+    def visit_While(self, node: cst.While) -> None:
+        self._record_dead_suites(node)
+
+    def _record_dead_suites(self, stmt: cst.BaseStatement) -> None:
+        """Create a synthetic ``unreachable`` graph node for each dead suite.
+
+        Records the suite's ``id()`` so :meth:`_unreachable_owner` can
+        later attribute references made inside the suite to it. Nested
+        dead suites are handled implicitly: we visit outer ``If`` /
+        ``While`` first, then descend, so an inner dead suite registers
+        afterwards and the innermost match wins at lookup time.
+        """
+        for suite in unreachable_suites(stmt):
+            pos = self._pos(suite)
+            if pos is None:
+                continue
+            sym = make_unreachable_node(self.module_node.fqname, self.path, pos)
+            self.unreachable_nodes.append(sym)
+            self.dead_suite_owner[id(suite)] = sym
+
+    def _unreachable_owner(
+        self, node: cst.CSTNode, parent_map: Mapping[cst.CSTNode, object]
+    ) -> SymbolNode | None:
+        """Return the synthetic node owning ``node`` if it lives inside one.
+
+        Walks up via ``ParentNodeProvider`` looking for a recorded dead
+        suite. Returns the innermost match, or ``None`` if ``node`` is
+        not inside any dead suite.
+        """
+        current: object = parent_map.get(node)
+        while isinstance(current, cst.CSTNode):
+            owner = self.dead_suite_owner.get(id(current))
+            if owner is not None:
+                return owner
+            current = parent_map.get(current)
+        return None
+
     def visit_Import(self, node: cst.Import) -> None:
         self._add_import("", node)
 
@@ -368,6 +418,7 @@ class SymbolVisitor(cst.CSTVisitor):
 
         for access, referent in references:
             owner_symbols = self.nearest_decls.get(access.node, [])
+            unreachable_owner = self._unreachable_owner(access.node, parent_map)
             target_node = referent.node
             if isinstance(referent, ImportAssignment):
                 target_node = referent.as_name
@@ -397,6 +448,8 @@ class SymbolVisitor(cst.CSTVisitor):
 
                     for owner_symbol in owner_symbols:
                         self.import_edges.add((owner_symbol, resolved_import))
+                    if unreachable_owner is not None:
+                        self.unreachable_import_edges.add((unreachable_owner, resolved_import))
 
             target_symbols = self.node_to_symbols.get(target_node)
             if not target_symbols:
@@ -415,3 +468,5 @@ class SymbolVisitor(cst.CSTVisitor):
                 for owner_symbol in owner_symbols:
                     if target_symbol != owner_symbol and target_symbol and owner_symbol:
                         self.internal_edges.add((owner_symbol, target_symbol))
+                if unreachable_owner is not None and target_symbol is not None:
+                    self.unreachable_internal_edges.add((unreachable_owner, target_symbol))

--- a/dead_cst/cli.py
+++ b/dead_cst/cli.py
@@ -14,6 +14,7 @@ import networkx as nx
 import typer
 
 from . import build_symbol_graph, count_nodes, find_reachable, order_paths, remove_code
+from ._branches import is_unreachable_node
 from ._plugins import (
     CSTAwareEdgePlugin,
     DunderAllPlugin,
@@ -189,6 +190,12 @@ def _output_text(
         total_counts = count_nodes(graph, base)
         unreachable_counts = count_nodes(unreachable, base)
         for kind in sorted(total_counts):
+            # Synthetic nodes (entrypoint sentinels, dead-suite markers)
+            # don't represent user-visible declarations; reporting them
+            # as "dead" alongside functions/classes would be misleading.
+            # Dead-suite nodes get their own section below.
+            if kind == "synthetic":
+                continue
             total = total_counts[kind]
             dead = unreachable_counts.get(kind, 0)
             if dead > 0:
@@ -196,15 +203,27 @@ def _output_text(
             else:
                 typer.echo(f"  {kind}: {total} total")
 
-    dead_count = unreachable.number_of_nodes()
-    if dead_count > 0:
-        typer.echo(f"\nDead symbols ({dead_count}):")
-        for node in sorted(unreachable.nodes, key=lambda n: (str(n.path), n.fqname)):
+    dead_real = [n for n in unreachable.nodes if not is_unreachable_node(n)]
+    if dead_real:
+        typer.echo(f"\nDead symbols ({len(dead_real)}):")
+        for node in sorted(dead_real, key=lambda n: (str(n.path), n.fqname)):
             try:
                 rel_path = node.path.relative_to(root)
             except ValueError:
                 rel_path = node.path
             typer.echo(f"  {node.fqname} ({node.type}) at {rel_path}")
+
+    branches = [n for n in graph.nodes if is_unreachable_node(n)]
+    if branches:
+        typer.echo(f"\nUnreachable branches ({len(branches)}):")
+        for node in sorted(branches, key=lambda n: (str(n.path), n.position.start)):
+            try:
+                rel_path = node.path.relative_to(root)
+            except ValueError:
+                rel_path = node.path
+            start = node.position.start
+            end = node.position.end
+            typer.echo(f"  {rel_path}:{start.line}:{start.column}-{end.line}:{end.column}")
 
 
 def _output_json(
@@ -216,18 +235,25 @@ def _output_json(
     result: dict = {
         "summary": {},
         "dead_symbols": [],
+        "unreachable_branches": [],
     }
 
     for base in order_paths(paths_dict):
         base_str = str(base)
         total_counts = count_nodes(graph, base)
         unreachable_counts = count_nodes(unreachable, base)
+        # Same rationale as the text output: synthetic nodes are reported
+        # via ``unreachable_branches`` (and entrypoint sentinels), not as
+        # part of the per-kind summary.
         result["summary"][base_str] = {
             kind: {"total": total_counts[kind], "dead": unreachable_counts.get(kind, 0)}
             for kind in total_counts
+            if kind != "synthetic"
         }
 
     for node in sorted(unreachable.nodes, key=lambda n: (str(n.path), n.fqname)):
+        if is_unreachable_node(node):
+            continue
         try:
             rel_path = str(node.path.relative_to(root))
         except ValueError:
@@ -237,6 +263,22 @@ def _output_json(
                 "fqname": node.fqname,
                 "type": node.type,
                 "path": rel_path,
+            }
+        )
+
+    for node in sorted(
+        (n for n in graph.nodes if is_unreachable_node(n)),
+        key=lambda n: (str(n.path), n.position.start),
+    ):
+        try:
+            rel_path = str(node.path.relative_to(root))
+        except ValueError:
+            rel_path = str(node.path)
+        result["unreachable_branches"].append(
+            {
+                "path": rel_path,
+                "start": {"line": node.position.start.line, "column": node.position.start.column},
+                "end": {"line": node.position.end.line, "column": node.position.end.column},
             }
         )
 
@@ -361,12 +403,18 @@ def remove(
 
     unreachable_graph = graph.subgraph([n for n in graph.nodes if n not in reachable])
 
-    if unreachable_graph.number_of_nodes() == 0:
+    # Synthetic ``unreachable`` nodes are reported by ``analyze`` but
+    # not yet removable by ``remove`` -- the codemod doesn't know how to
+    # delete an arbitrary suite. Filter them out of the listing so we
+    # don't promise something we don't deliver.
+    removable = [n for n in unreachable_graph.nodes if not is_unreachable_node(n)]
+
+    if not removable:
         typer.echo("No dead code found.")
         return
 
-    typer.echo(f"\nDead symbols to remove ({unreachable_graph.number_of_nodes()}):")
-    for node in sorted(unreachable_graph.nodes, key=lambda n: (str(n.path), n.fqname)):
+    typer.echo(f"\nDead symbols to remove ({len(removable)}):")
+    for node in sorted(removable, key=lambda n: (str(n.path), n.fqname)):
         try:
             rel_path = node.path.relative_to(root)
         except ValueError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import networkx as nx
 import pytest
 
 from dead_cst import build_symbol_graph
+from dead_cst._branches import is_unreachable_node
 
 
 @pytest.fixture
@@ -22,11 +23,26 @@ def build_decl_graph(tmp_path):
     return _make_graph
 
 
+def _has_unreachable_endpoint(edge) -> bool:
+    src, dst = edge
+    return is_unreachable_node(src) or is_unreachable_node(dst)
+
+
 @pytest.fixture
 def assert_edges():
     def _check(graph: nx.DiGraph, expected_edges: set[str]):
-        """Compare visitor.internal_edges to expected 'a -> b' strings."""
-        actual_edges = {f"{src.fqname} -> {dst.fqname}" for src, dst in graph.edges}
+        """Compare visitor.internal_edges to expected 'a -> b' strings.
+
+        Edges touching synthetic ``unreachable`` nodes are excluded so
+        these "real symbol graph" assertions don't churn whenever a new
+        ``if False:`` / ``if True:`` test case is added. Tests covering
+        unreachable behavior should use ``assert_unreachable_edges``.
+        """
+        actual_edges = {
+            f"{src.fqname} -> {dst.fqname}"
+            for src, dst in graph.edges
+            if not _has_unreachable_endpoint((src, dst))
+        }
         assert actual_edges == expected_edges
 
     return _check
@@ -40,7 +56,8 @@ def assert_positional_edges():
     (module nodes keep their bare fqname). Use this for tests where
     multiple top-level decls share a fqname -- e.g. redeclarations and
     shadowing -- so the per-textual-decl identity is visible in the
-    assertion.
+    assertion. Synthetic ``unreachable`` nodes are filtered out for the
+    same reason as :func:`assert_edges`.
     """
 
     def _fmt(sym):
@@ -52,7 +69,33 @@ def assert_positional_edges():
         return f"{sym.fqname}@{start.line}:{start.column}"
 
     def _check(graph: nx.DiGraph, expected_edges: set[str]):
-        actual_edges = {f"{_fmt(src)} -> {_fmt(dst)}" for src, dst in graph.edges}
+        actual_edges = {
+            f"{_fmt(src)} -> {_fmt(dst)}"
+            for src, dst in graph.edges
+            if not _has_unreachable_endpoint((src, dst))
+        }
         assert actual_edges == expected_edges
+
+    return _check
+
+
+@pytest.fixture
+def assert_unreachable_edges():
+    """Assert on edges originating from synthetic ``unreachable`` nodes.
+
+    Format: ``"<line:col> -> target.fqname"``. Per-suite location is the
+    only useful identifier for the source side; the target is rendered
+    by fqname. Edges that don't originate from an unreachable node are
+    ignored.
+    """
+
+    def _check(graph: nx.DiGraph, expected_edges: set[str]):
+        actual = set()
+        for src, dst in graph.edges:
+            if not is_unreachable_node(src):
+                continue
+            start = src.position.start
+            actual.add(f"<{start.line}:{start.column}> -> {dst.fqname}")
+        assert actual == expected_edges
 
     return _check

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -1,0 +1,329 @@
+"""Unit tests for the conditional truthiness evaluator.
+
+The evaluator is intentionally narrow: it only handles literal forms
+that can be decided without any name lookup or runtime state. Tests
+are organised into three groups:
+
+* ``evaluate_truthiness`` on individual expressions, covering the
+  whitelist (``True`` / ``False`` / ``None``, ints, strings, empty vs
+  non-empty collections, ``not`` / ``and`` / ``or``).
+* ``evaluate_truthiness`` on expressions that must return ``None``
+  (any name lookup, attribute, call, comparison, f-string, etc.).
+* ``unreachable_bodies`` on ``if`` / ``while`` statements, including
+  ``elif`` chains and the asymmetric handling of ``while True:``.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Sequence
+
+import libcst as cst
+import pytest
+
+from dead_cst._branches import evaluate_truthiness, unreachable_bodies
+
+
+def _expr(src: str) -> cst.BaseExpression:
+    """Parse ``src`` as a single expression statement and return its value."""
+    module = cst.parse_module(src)
+    stmt = module.body[0]
+    assert isinstance(stmt, cst.SimpleStatementLine)
+    expr = stmt.body[0]
+    assert isinstance(expr, cst.Expr)
+    return expr.value
+
+
+def _stmt(src: str) -> cst.BaseStatement:
+    """Parse ``src`` and return its first top-level statement."""
+    return cst.parse_module(textwrap.dedent(src).strip()).body[0]
+
+
+def _bodies_as_code(bodies: list[Sequence[cst.CSTNode]]) -> list[str]:
+    """Stringify each dead body as concatenated source for assertions."""
+    module = cst.Module([])
+    return [
+        "".join(module.code_for_node(s) for s in body).strip() for body in bodies
+    ]
+
+
+# ----------------------------------------------------------------------
+# evaluate_truthiness: positive cases (statically determinable).
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src, expected",
+    [
+        ("True", True),
+        ("False", False),
+        ("None", False),
+        ("0", False),
+        ("1", True),
+        ("42", True),
+        ("0x0", False),
+        ("0xff", True),
+        ("0b0", False),
+        ("0b1", True),
+        ('""', False),
+        ('"x"', True),
+        ('b""', False),
+        ('b"x"', True),
+        ('"a" "b"', True),
+        ('"" ""', False),
+        ("()", False),
+        ("(1,)", True),
+        ("[]", False),
+        ("[1]", True),
+        ("{}", False),
+        ("{1: 2}", True),
+        ("{1, 2}", True),
+        ("not True", False),
+        ("not False", True),
+        ("not 0", True),
+        ("not not 1", True),
+        ("True and True", True),
+        ("True and False", False),
+        ("False and unknown", False),
+        ("True or False", True),
+        ("False or False", False),
+        ("True or unknown", True),
+        ("not (True and False)", True),
+    ],
+)
+def test_evaluate_truthiness_known(src: str, expected: bool) -> None:
+    assert evaluate_truthiness(_expr(src)) is expected
+
+
+# ----------------------------------------------------------------------
+# evaluate_truthiness: anything outside the whitelist must return None.
+# Returning None means callers treat the branch as live -- the safe
+# default. Each entry here would be unsound to fold.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "x",
+        "TYPE_CHECKING",
+        "obj.attr",
+        "f()",
+        "1 == 1",
+        "1 < 2",
+        "1 is 1",
+        "1.0",
+        "0.0",
+        'f"x"',
+        "[*xs]",
+        "{**d}",
+        "(1, *xs)",
+        "x and y",
+        "x or y",
+        "not x",
+        "True and x",
+        "False or x",
+    ],
+)
+def test_evaluate_truthiness_unknown(src: str) -> None:
+    assert evaluate_truthiness(_expr(src)) is None
+
+
+# ----------------------------------------------------------------------
+# unreachable_bodies: simple ``if`` / ``while``.
+# ----------------------------------------------------------------------
+
+
+def test_if_false_marks_body_dead() -> None:
+    stmt = _stmt(
+        """
+        if False:
+            x = 1
+        """
+    )
+    assert _bodies_as_code(unreachable_bodies(stmt)) == ["x = 1"]
+
+
+def test_if_true_marks_else_dead() -> None:
+    stmt = _stmt(
+        """
+        if True:
+            x = 1
+        else:
+            x = 2
+        """
+    )
+    assert _bodies_as_code(unreachable_bodies(stmt)) == ["x = 2"]
+
+
+def test_if_true_without_else_has_no_dead_body() -> None:
+    stmt = _stmt(
+        """
+        if True:
+            x = 1
+        """
+    )
+    assert unreachable_bodies(stmt) == []
+
+
+def test_if_unknown_returns_no_dead_bodies() -> None:
+    stmt = _stmt(
+        """
+        if cond:
+            x = 1
+        else:
+            x = 2
+        """
+    )
+    assert unreachable_bodies(stmt) == []
+
+
+def test_if_false_with_else_marks_only_body() -> None:
+    stmt = _stmt(
+        """
+        if False:
+            x = 1
+        else:
+            x = 2
+        """
+    )
+    assert _bodies_as_code(unreachable_bodies(stmt)) == ["x = 1"]
+
+
+# ----------------------------------------------------------------------
+# unreachable_bodies: elif chains.
+# ----------------------------------------------------------------------
+
+
+def test_elif_after_true_branch_all_dead() -> None:
+    stmt = _stmt(
+        """
+        if True:
+            a = 1
+        elif other:
+            b = 2
+        else:
+            c = 3
+        """
+    )
+    assert _bodies_as_code(unreachable_bodies(stmt)) == ["b = 2", "c = 3"]
+
+
+def test_elif_with_false_first_branch_only_first_dead() -> None:
+    stmt = _stmt(
+        """
+        if False:
+            a = 1
+        elif cond:
+            b = 2
+        else:
+            c = 3
+        """
+    )
+    assert _bodies_as_code(unreachable_bodies(stmt)) == ["a = 1"]
+
+
+def test_elif_false_in_middle_marks_only_that_branch() -> None:
+    stmt = _stmt(
+        """
+        if cond:
+            a = 1
+        elif False:
+            b = 2
+        else:
+            c = 3
+        """
+    )
+    assert _bodies_as_code(unreachable_bodies(stmt)) == ["b = 2"]
+
+
+def test_elif_true_kills_following_branches_even_when_outer_unknown() -> None:
+    # When the head ``if`` is dynamic but a later elif is statically
+    # True, the True branch is reachable (when no earlier test fires)
+    # and any branches after it can never run.
+    stmt = _stmt(
+        """
+        if cond:
+            a = 1
+        elif True:
+            b = 2
+        elif other:
+            c = 3
+        else:
+            d = 4
+        """
+    )
+    assert _bodies_as_code(unreachable_bodies(stmt)) == ["c = 3", "d = 4"]
+
+
+def test_all_branches_false_keeps_else_live() -> None:
+    stmt = _stmt(
+        """
+        if False:
+            a = 1
+        elif False:
+            b = 2
+        else:
+            c = 3
+        """
+    )
+    assert _bodies_as_code(unreachable_bodies(stmt)) == ["a = 1", "b = 2"]
+
+
+# ----------------------------------------------------------------------
+# unreachable_bodies: ``while``.
+# ----------------------------------------------------------------------
+
+
+def test_while_false_marks_body_dead() -> None:
+    stmt = _stmt(
+        """
+        while False:
+            x = 1
+        """
+    )
+    assert _bodies_as_code(unreachable_bodies(stmt)) == ["x = 1"]
+
+
+def test_while_true_with_else_marks_else_dead() -> None:
+    # ``else`` on a loop runs only on normal exit; ``while True:`` never
+    # exits normally, so the else clause is unreachable.
+    stmt = _stmt(
+        """
+        while True:
+            x = 1
+        else:
+            y = 2
+        """
+    )
+    assert _bodies_as_code(unreachable_bodies(stmt)) == ["y = 2"]
+
+
+def test_while_true_without_else_has_no_dead_body() -> None:
+    stmt = _stmt(
+        """
+        while True:
+            x = 1
+        """
+    )
+    assert unreachable_bodies(stmt) == []
+
+
+def test_while_unknown_returns_no_dead_bodies() -> None:
+    stmt = _stmt(
+        """
+        while cond:
+            x = 1
+        """
+    )
+    assert unreachable_bodies(stmt) == []
+
+
+# ----------------------------------------------------------------------
+# unreachable_bodies: non-conditional statements are passed through.
+# ----------------------------------------------------------------------
+
+
+def test_unsupported_statement_returns_empty() -> None:
+    stmt = _stmt("x = 1")
+    assert unreachable_bodies(stmt) == []

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -42,9 +42,7 @@ def _stmt(src: str) -> cst.BaseStatement:
 def _bodies_as_code(bodies: list[Sequence[cst.CSTNode]]) -> list[str]:
     """Stringify each dead body as concatenated source for assertions."""
     module = cst.Module([])
-    return [
-        "".join(module.code_for_node(s) for s in body).strip() for body in bodies
-    ]
+    return ["".join(module.code_for_node(s) for s in body).strip() for body in bodies]
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_unreachable_branches.py
+++ b/tests/test_unreachable_branches.py
@@ -1,0 +1,280 @@
+"""End-to-end tests for synthetic ``unreachable`` graph nodes.
+
+When the visitor sees a statically-dead ``if`` / ``while`` suite (per
+:mod:`dead_cst._branches`) it creates a synthetic ``SymbolNode`` with
+``type="synthetic"`` and a fqname prefixed with ``<unreachable ``.
+Every reference made from inside that suite gets a parallel edge
+``synthetic -> referent`` -- the original ``enclosing-decl -> referent``
+edge is left in place. The synthetic node is an orphan (no incoming
+edges) so reachability never visits it; the parallel edges are purely
+for surfacing.
+
+These tests exercise the integration end-to-end through
+``build_symbol_graph``: visitor creation of nodes, attribution of
+references inside dead suites, and behavior across nested suites and
+import references.
+"""
+
+from __future__ import annotations
+
+import networkx as nx
+
+from dead_cst._branches import is_unreachable_node
+
+
+def _unreachable_nodes(graph: nx.DiGraph) -> list:
+    return sorted(
+        (n for n in graph.nodes if is_unreachable_node(n)),
+        key=lambda n: (str(n.path), n.position.start.line, n.position.start.column),
+    )
+
+
+def test_if_false_creates_synthetic_node(build_decl_graph):
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            def helper(): pass
+            if False:
+                helper()
+            """
+        }
+    )
+    branches = _unreachable_nodes(graph)
+    assert len(branches) == 1
+    suite = branches[0]
+    assert suite.type == "synthetic"
+    # Fqname is opaque; identification goes through is_unreachable_node.
+    assert is_unreachable_node(suite)
+    # libcst positions an ``IndentedBlock`` at its first statement, not
+    # at the ``if`` keyword. Pin both line and column to lock down the
+    # convention surfacing relies on.
+    assert suite.position.start.line == 3
+    assert suite.position.start.column == 4
+
+
+def test_if_true_marks_else_as_unreachable(build_decl_graph):
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            def helper(): pass
+            if True:
+                helper()
+            else:
+                helper()
+            """
+        }
+    )
+    assert len(_unreachable_nodes(graph)) == 1
+
+
+def test_unknown_condition_creates_no_synthetic_node(build_decl_graph):
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            def helper(): pass
+            if cond:
+                helper()
+            else:
+                helper()
+            """
+        }
+    )
+    assert _unreachable_nodes(graph) == []
+
+
+def test_unreachable_node_has_edge_to_internal_referent(
+    build_decl_graph, assert_unreachable_edges
+):
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            def helper(): pass
+            if False:
+                helper()
+            """
+        }
+    )
+    # Position is the body's first statement.
+    assert_unreachable_edges(graph, {"<3:4> -> mod.helper"})
+
+
+def test_unreachable_node_has_edge_to_import_referent(
+    build_decl_graph, assert_unreachable_edges
+):
+    # Reference to an imported name from inside a dead suite produces
+    # the same edge fan-out as a reference from a live decl: the local
+    # import decl, the upstream module, and the resolved target.
+    graph = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "def helper(): pass",
+            "pkg/b.py": """
+            from pkg.a import helper
+            if False:
+                helper()
+            """,
+        }
+    )
+    assert_unreachable_edges(
+        graph,
+        {
+            "<3:4> -> pkg.b.helper",
+            "<3:4> -> pkg.a",
+            "<3:4> -> pkg.a.helper",
+        },
+    )
+
+
+def test_original_edges_are_preserved_when_branch_is_dead(
+    build_decl_graph, assert_edges
+):
+    # The "real symbol graph" still contains the enclosing-module ->
+    # helper edge. The unreachable-edge filtering in ``assert_edges``
+    # ensures this assertion is unaffected by the synthetic node.
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            def helper(): pass
+            if False:
+                helper()
+            """
+        }
+    )
+    assert_edges(
+        graph,
+        {
+            "mod.helper -> mod",
+            "mod -> mod.helper",
+        },
+    )
+
+
+def test_nested_dead_suites_create_separate_synthetic_nodes(build_decl_graph):
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            def a(): pass
+            def b(): pass
+            if False:
+                a()
+                if False:
+                    b()
+            """
+        }
+    )
+    branches = _unreachable_nodes(graph)
+    assert len(branches) == 2
+
+
+def test_nested_dead_suite_attributes_to_innermost(
+    build_decl_graph, assert_unreachable_edges
+):
+    # ``a()`` is inside the outer dead suite only; ``b()`` is inside
+    # both, but the innermost suite owns it.
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            def a(): pass
+            def b(): pass
+            if False:
+                a()
+                if False:
+                    b()
+            """
+        }
+    )
+    assert_unreachable_edges(
+        graph,
+        {
+            "<4:4> -> mod.a",
+            "<6:8> -> mod.b",
+        },
+    )
+
+
+def test_while_false_creates_synthetic_node(build_decl_graph, assert_unreachable_edges):
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            def helper(): pass
+            while False:
+                helper()
+            """
+        }
+    )
+    assert_unreachable_edges(graph, {"<3:4> -> mod.helper"})
+
+
+def test_while_true_else_is_unreachable(build_decl_graph, assert_unreachable_edges):
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            def helper(): pass
+            while True:
+                pass
+            else:
+                helper()
+            """
+        }
+    )
+    assert_unreachable_edges(graph, {"<5:4> -> mod.helper"})
+
+
+def test_synthetic_nodes_are_unreachable_from_entrypoints(build_decl_graph):
+    # No incoming edges, so reachability skips them. Critical so the
+    # parallel edges do not accidentally keep symbols alive.
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            def helper(): pass
+            if False:
+                helper()
+            """
+        }
+    )
+    suite = _unreachable_nodes(graph)[0]
+    assert graph.in_degree(suite) == 0
+
+
+def test_decls_inside_dead_branch_remain_in_graph(build_decl_graph, assert_edges):
+    # Per the design decision: top-level decls defined inside a dead
+    # branch keep their normal node + edges. The synthetic node coexists
+    # with them; pruning is a follow-up.
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            if False:
+                def foo(): pass
+            """
+        }
+    )
+    fqnames = {n.fqname for n in graph.nodes if not is_unreachable_node(n)}
+    assert "mod.foo" in fqnames
+    assert_edges(
+        graph,
+        {
+            "mod.foo -> mod",
+        },
+    )
+
+
+def test_elif_false_in_chain_creates_synthetic_for_only_dead_branch(
+    build_decl_graph, assert_unreachable_edges
+):
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            def a(): pass
+            def b(): pass
+            def c(): pass
+            if cond:
+                a()
+            elif False:
+                b()
+            else:
+                c()
+            """
+        }
+    )
+    # Only the ``elif False:`` body is unreachable.
+    assert_unreachable_edges(graph, {"<7:4> -> mod.b"})

--- a/tests/test_unreachable_branches.py
+++ b/tests/test_unreachable_branches.py
@@ -82,9 +82,7 @@ def test_unknown_condition_creates_no_synthetic_node(build_decl_graph):
     assert _unreachable_nodes(graph) == []
 
 
-def test_unreachable_node_has_edge_to_internal_referent(
-    build_decl_graph, assert_unreachable_edges
-):
+def test_unreachable_node_has_edge_to_internal_referent(build_decl_graph, assert_unreachable_edges):
     graph = build_decl_graph(
         {
             "mod.py": """
@@ -98,9 +96,7 @@ def test_unreachable_node_has_edge_to_internal_referent(
     assert_unreachable_edges(graph, {"<3:4> -> mod.helper"})
 
 
-def test_unreachable_node_has_edge_to_import_referent(
-    build_decl_graph, assert_unreachable_edges
-):
+def test_unreachable_node_has_edge_to_import_referent(build_decl_graph, assert_unreachable_edges):
     # Reference to an imported name from inside a dead suite produces
     # the same edge fan-out as a reference from a live decl: the local
     # import decl, the upstream module, and the resolved target.
@@ -125,9 +121,7 @@ def test_unreachable_node_has_edge_to_import_referent(
     )
 
 
-def test_original_edges_are_preserved_when_branch_is_dead(
-    build_decl_graph, assert_edges
-):
+def test_original_edges_are_preserved_when_branch_is_dead(build_decl_graph, assert_edges):
     # The "real symbol graph" still contains the enclosing-module ->
     # helper edge. The unreachable-edge filtering in ``assert_edges``
     # ensures this assertion is unaffected by the synthetic node.
@@ -166,9 +160,7 @@ def test_nested_dead_suites_create_separate_synthetic_nodes(build_decl_graph):
     assert len(branches) == 2
 
 
-def test_nested_dead_suite_attributes_to_innermost(
-    build_decl_graph, assert_unreachable_edges
-):
+def test_nested_dead_suite_attributes_to_innermost(build_decl_graph, assert_unreachable_edges):
     # ``a()`` is inside the outer dead suite only; ``b()`` is inside
     # both, but the innermost suite owns it.
     graph = build_decl_graph(


### PR DESCRIPTION
## Summary

Adds the first half of conditional-aware dead-code analysis: a literal-only truthiness evaluator, plus integration that turns each statically-dead suite into a synthetic graph node so the surface report can name it. Edge pruning and codemod removal are deliberately out of scope for this PR -- the synthetic nodes are pure metadata that future PRs build on.

### `dead_cst/_branches.py` (new)

- `evaluate_truthiness(expr) -> bool | None` -- folds a small whitelist of literal forms (`True` / `False` / `None`, ints, simple/concatenated strings, empty-vs-non-empty `tuple` / `list` / `set` / `dict`, and `not` / `and` / `or` over those) into a static bool. Anything outside the whitelist (name lookups, attributes, calls, comparisons, f-strings, starred elements, floats) returns `None`. Short-circuit eval is sound: `False and unknown` -> `False`, `True or unknown` -> `True`.
- `unreachable_suites(stmt)` / `unreachable_bodies(stmt)` -- for `cst.If` (with full elif/else chain support) and `cst.While`, returns the suites that can be statically shown dead. Walks elif chains so a True branch kills everything after it (even when the head test is dynamic), and captures the `while True: ... else:` case where the else clause cannot fire.
- `make_unreachable_node` / `is_unreachable_node` -- factory + predicate for the synthetic graph nodes. Reuses the existing `type="synthetic"` escape hatch and tags fqnames with an `<unreachable ...>` prefix; `is_unreachable_node` is the only supported way to identify them so callers never depend on the prefix string.

### Visitor / analyzer wiring

- `SymbolVisitor.visit_If` / `visit_While` records each dead suite and creates one synthetic `SymbolNode` per suite, positioned at the suite's real `CodeRange`.
- During edge resolution, references made inside a dead suite get a parallel edge `synthetic -> referent` (covers both internal and import references). The original `enclosing-decl -> referent` edges are left in place, so reachability semantics for real symbols are unchanged in this PR.
- The synthetic node has zero in-edges, so `find_reachable` never visits it -- the parallel edges are pure metadata for surfacing.

### CLI surfacing

- `dead-cst analyze` text output gains an "Unreachable branches" section listing each dead suite's file and line range. The per-kind summary suppresses the `synthetic` row so entrypoint sentinels and dead-suite markers don't get folded into dead-symbol counts.
- `--format json` adds an `unreachable_branches` array with start/end positions per branch.
- `dead-cst remove` filters synthetic nodes out of its listing, since the codemod doesn't yet know how to delete a suite -- that's the natural follow-up.

### Tests

- `tests/test_branches.py` -- 67 unit tests for the evaluator: known-truthiness expressions, the must-be-`None` boundary, and `unreachable_bodies` over `if` / `elif` / `else` and `while`.
- `tests/test_unreachable_branches.py` -- 13 end-to-end tests for the graph integration: node creation, internal/import edge attribution, nested-suite ownership (innermost wins), elif chains, `while False` / `while True else`, and the invariant that synthetic nodes have zero in-degree.
- Existing `assert_edges` / `assert_positional_edges` fixtures filter unreachable-touching edges so the "real symbol graph" assertions stay focused; a new `assert_unreachable_edges` fixture covers the new behavior.

## Test plan

- [x] `uv run pytest` -- 236 passing
- [x] `uv run ruff check dead_cst/ tests/` -- clean
- [x] `uv run ruff format --check dead_cst/ tests/` -- clean
- [x] Smoke-tested `dead-cst analyze` on a temp project containing an `if False:` block; confirmed text and JSON output both surface the branch with correct file/line ranges.

https://claude.ai/code/session_018kymTQtNJ8dokc6yV3tzk8