### PR TITLE
Disambiguate dead decls by position to handle shadowing

### DIFF
--- a/dead_cst/_codemod.py
+++ b/dead_cst/_codemod.py
@@ -4,22 +4,28 @@ import libcst as cst
 import networkx as nx
 from libcst.codemod import CodemodContext
 from libcst.codemod.visitors import RemoveImportsVisitor
-from libcst.metadata import FullRepoManager, QualifiedNameSource
+from libcst.metadata import CodeRange, FullRepoManager, PositionProvider, QualifiedNameSource
 
 from ._fqn import FixedFullyQualifiedNameProvider
 from ._symbols import SymbolNode
 
 
 class RemoveDeadSymbols(cst.CSTTransformer):
-    METADATA_DEPENDENCIES = (FixedFullyQualifiedNameProvider,)
+    METADATA_DEPENDENCIES = (FixedFullyQualifiedNameProvider, PositionProvider)
 
-    def __init__(self, dead_fqnames: set[str]):
-        self.dead_fqnames = dead_fqnames
+    def __init__(self, dead_decls: set[tuple[str, CodeRange]]):
+        # ``(fqname, position)`` pairs. The position disambiguates same-name
+        # decls so a shadowed dead binding does not drag its live sibling
+        # out with it (and vice versa).
+        self.dead_decls = dead_decls
 
     def _should_remove(self, node: cst.CSTNode) -> bool:
         fqnames = self.get_metadata(FixedFullyQualifiedNameProvider, node, default=[])
+        pos = self.get_metadata(PositionProvider, node, default=None)
         return any(
-            qn.name in self.dead_fqnames for qn in fqnames if qn.source == QualifiedNameSource.LOCAL
+            (qn.name, pos) in self.dead_decls
+            for qn in fqnames
+            if qn.source == QualifiedNameSource.LOCAL
         )
 
     def leave_FunctionDef(self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef):
@@ -35,13 +41,7 @@ class RemoveDeadSymbols(cst.CSTTransformer):
     def leave_Assign(self, original_node: cst.Assign, updated_node: cst.Assign):
         new_targets = []
         for orig_target, new_target in zip(original_node.targets, updated_node.targets):
-            target_node = orig_target.target
-            fqnames = self.get_metadata(FixedFullyQualifiedNameProvider, target_node, default=[])
-            if not any(
-                qn.name in self.dead_fqnames
-                for qn in fqnames
-                if qn.source == QualifiedNameSource.LOCAL
-            ):
+            if not self._should_remove(orig_target.target):
                 new_targets.append(new_target)
 
         if not new_targets:
@@ -50,12 +50,7 @@ class RemoveDeadSymbols(cst.CSTTransformer):
         return updated_node.with_changes(targets=new_targets)
 
     def leave_AnnAssign(self, original_node: cst.AnnAssign, updated_node: cst.AnnAssign):
-        fqnames = self.get_metadata(
-            FixedFullyQualifiedNameProvider, original_node.target, default=[]
-        )
-        if any(
-            qn.name in self.dead_fqnames for qn in fqnames if qn.source == QualifiedNameSource.LOCAL
-        ):
+        if self._should_remove(original_node.target):
             return cst.RemoveFromParent()
         return updated_node
 
@@ -99,8 +94,8 @@ def remove_code(G: nx.Graph, base: Path) -> None:
         # Pass 1: drop dead defs / classes / variables. Imports they
         # used to reference become eligible for removal in pass 2.
         wrapper = mgr.get_metadata_wrapper_for_path(path)
-        dead_fqnames = {n.fqname for n in nodes if n.type != "import"}
-        result = wrapper.visit(RemoveDeadSymbols(dead_fqnames))
+        dead_decls = {(n.fqname, n.position) for n in nodes if n.type != "import"}
+        result = wrapper.visit(RemoveDeadSymbols(dead_decls))
 
         # Pass 2: hand the dead-import set to libcst's stock import
         # remover. It walks scopes itself, so it'll skip anything still

--- a/tests/test_codemod.py
+++ b/tests/test_codemod.py
@@ -38,14 +38,21 @@ def _normalise(s: str) -> str:
 
 @pytest.fixture
 def apply_transformer(tmp_path):
-    """Write ``src`` to ``tmp_path/mod.py`` and run ``RemoveDeadSymbols``."""
+    """Write ``src`` to ``tmp_path/mod.py`` and run ``RemoveDeadSymbols``.
+
+    Resolves each requested FQN to its ``(fqname, position)`` pair via the
+    symbol graph so the codemod's position-aware matching has the data it
+    needs.
+    """
 
     def _apply(src: str, dead_fqnames: set[str]) -> str:
         path = tmp_path / "mod.py"
         path.write_text(_normalise(src))
+        graph = build_symbol_graph({tmp_path: []})
+        dead_decls = {(n.fqname, n.position) for n in graph.nodes if n.fqname in dead_fqnames}
         mgr = FullRepoManager(str(tmp_path), [str(path)], {FixedFullyQualifiedNameProvider})
         wrapper: MetadataWrapper = mgr.get_metadata_wrapper_for_path(str(path))
-        return wrapper.visit(RemoveDeadSymbols(dead_fqnames)).code
+        return wrapper.visit(RemoveDeadSymbols(dead_decls)).code
 
     return _apply
 

--- a/tests/test_codemod.py
+++ b/tests/test_codemod.py
@@ -58,6 +58,28 @@ def apply_transformer(tmp_path):
 
 
 @pytest.fixture
+def apply_transformer_at_lines(tmp_path):
+    """Run ``RemoveDeadSymbols`` keyed on ``(fqname, start_line)`` pairs.
+
+    Used by shadowing cases where the same FQN binds at multiple
+    positions; the FQN-only fixture above cannot disambiguate them.
+    """
+
+    def _apply(src: str, dead: set[tuple[str, int]]) -> str:
+        path = tmp_path / "mod.py"
+        path.write_text(_normalise(src))
+        graph = build_symbol_graph({tmp_path: []})
+        dead_decls = {
+            (n.fqname, n.position) for n in graph.nodes if (n.fqname, n.position.start.line) in dead
+        }
+        mgr = FullRepoManager(str(tmp_path), [str(path)], {FixedFullyQualifiedNameProvider})
+        wrapper: MetadataWrapper = mgr.get_metadata_wrapper_for_path(str(path))
+        return wrapper.visit(RemoveDeadSymbols(dead_decls)).code
+
+    return _apply
+
+
+@pytest.fixture
 def run_remove_code(tmp_path):
     """Materialise ``files`` under ``tmp_path``, run ``remove_code``, return paths.
 
@@ -407,6 +429,128 @@ def run_remove_code(tmp_path):
 )
 def test_remove_dead_symbols(apply_transformer, src, dead_fqnames, expected):
     assert apply_transformer(src, dead_fqnames) == _normalise(expected)
+
+
+# ---------------------------------------------------------------------------
+# RemoveDeadSymbols -- shadowing (same FQN, multiple positions)
+#
+# The codemod keys on ``(fqname, position)``, so a dead shadowed binding
+# does not drag its live sibling out, and a live binding can be removed
+# without touching a shadowed predecessor that happens to share its
+# name. ``dead`` is a set of ``(fqname, start_line)`` pairs; lines are
+# 1-based and counted from the first non-blank line of the dedented
+# source (matching ``_normalise``).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src, dead, expected",
+    [
+        pytest.param(
+            """
+            def f(): return 1
+            def f(): return 2
+            """,
+            {("mod.f", 1)},
+            """
+            def f(): return 2
+            """,
+            id="shadowed-function-removed-keeps-live",
+        ),
+        pytest.param(
+            """
+            def f(): return 1
+            def f(): return 2
+            """,
+            {("mod.f", 2)},
+            """
+            def f(): return 1
+            """,
+            id="live-function-removed-keeps-shadowed",
+        ),
+        pytest.param(
+            """
+            def f(): return 1
+            def f(): return 2
+            def f(): return 3
+            """,
+            {("mod.f", 2)},
+            """
+            def f(): return 1
+            def f(): return 3
+            """,
+            id="middle-of-three-shadowed-removed",
+        ),
+        pytest.param(
+            """
+            class C:
+                a = 1
+            class C:
+                b = 2
+            """,
+            {("mod.C", 1)},
+            """
+            class C:
+                b = 2
+            """,
+            id="shadowed-class-removed",
+        ),
+        pytest.param(
+            """
+            x = 1
+            x = 2
+            """,
+            {("mod.x", 1)},
+            """
+            x = 2
+            """,
+            id="shadowed-variable-removed",
+        ),
+        pytest.param(
+            """
+            x: int = 1
+            x: str = "y"
+            """,
+            {("mod.x", 1)},
+            """
+            x: str = "y"
+            """,
+            id="shadowed-ann-assign-removed",
+        ),
+        pytest.param(
+            """
+            if cond:
+                def f(): return 1
+            else:
+                def f(): return 2
+            """,
+            {("mod.f", 2)},
+            """
+            if cond:
+                pass
+            else:
+                def f(): return 2
+            """,
+            id="conditional-branch-def-removed-leaves-pass",
+        ),
+        pytest.param(
+            """
+            def f(): return 1
+            def f(): return 2
+            def keep(): pass
+            """,
+            {("mod.f", 1), ("mod.f", 2)},
+            """
+            def keep(): pass
+            """,
+            id="all-same-name-decls-removed",
+        ),
+    ],
+)
+def test_remove_dead_symbols_disambiguates_by_position(
+    apply_transformer_at_lines, src, dead, expected
+):
+    assert apply_transformer_at_lines(src, dead) == _normalise(expected)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`RemoveDeadSymbols` keyed on FQN strings, so two top-level decls
sharing a name (e.g. a shadowed `def f` followed by a live one) were
indistinguishable: marking either as dead removed both. The symbol
graph already separates live from shadowed bindings, but the codemod
threw that away when it dropped down to the CST.

## Changes

- `RemoveDeadSymbols` now takes `set[tuple[str, CodeRange]]` and
  depends on `PositionProvider`. The `_should_remove` helper checks
  the `(fqname, position)` pair on each candidate node; tuple/list
  unpacking targets still fall through unchanged because their
  position is the pattern range, not any single decl's position.
- `remove_code` builds the pair set straight from each `SymbolNode`
  (it already carries `fqname` and `position`).
- New `apply_transformer_at_lines` test fixture resolves
  `(fqname, start_line)` pairs through the symbol graph so shadowing
  cases are readable in the parametrize table.
- 8 new test cases in `test_remove_dead_symbols_disambiguates_by_position`:
  shadowed-only / live-only removal for `def`, `class`, `Assign`,
  `AnnAssign`; middle-of-three same-name function; if/else branches
  where both bindings are live; all same-name decls removed alongside
  an unrelated keep.

## Test plan
- [x] `uv run pytest` -- 272 passed
- [x] Manual check: in `def f: return 1; def f: return 2`, removing
  only the first leaves the second intact, and vice versa.