### PR TITLE
Resolve `from m import *` by fanning out to all target decls

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ A module-level `import` / `from ... import ...` is itself a declaration of type 
 
 ## Limitations
 
-- `import *` is not resolved.
+- `import *` is treated pessimistically: every top-level declaration in the target module is considered used by the importing module.
 - Dynamic attribute access (`getattr`) and runtime-generated symbols are invisible to static analysis.
 - Only first-party code is analysed; third-party dependencies are treated as opaque (they appear as synthetic nodes — see `dead-cst dependencies`).
 - PEP 695 `type` statements are not tracked.

--- a/dead_cst/_resolve.py
+++ b/dead_cst/_resolve.py
@@ -127,6 +127,13 @@ def resolve_edges(
 
         yield from _emit(src, node.module)
 
+        # Star import: fan out to every top-level declaration in the target module
+        if dst.star:
+            for decls in node.declarations.values():
+                for decl in decls:
+                    yield from _emit(src, decl)
+            continue
+
         # No decl? the edge points at a module
         if not dst.decl:
             continue

--- a/dead_cst/_symbols.py
+++ b/dead_cst/_symbols.py
@@ -16,6 +16,7 @@ class Import:
     path: Path | str
     module: str
     decl: str | None = None
+    star: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -364,10 +364,6 @@ class SymbolVisitor(cst.CSTVisitor):
         self._add_import("", node)
 
     def visit_ImportFrom(self, node: cst.ImportFrom) -> None:
-        # FIXME support import star
-        if isinstance(node.names, cst.ImportStar):
-            return
-
         module = ""
         if node.module:
             module = get_full_name_for_node(node.module) or ""
@@ -380,6 +376,10 @@ class SymbolVisitor(cst.CSTVisitor):
 
             prefix = "." * len(node.relative)
             module = resolve_name(f"{prefix}{module}", current_package)
+
+        if isinstance(node.names, cst.ImportStar):
+            self._add_star_import(module)
+            return
 
         self._add_import(module, node)
 
@@ -420,6 +420,16 @@ class SymbolVisitor(cst.CSTVisitor):
                     shadowed_decls.append(d)
 
             trie_node.finalize_declarations(name, live_decls, shadowed_decls)
+
+    def _add_star_import(self, module: str) -> None:
+        module_path = self.resolve_import(module) if module else None
+        if not module_path:
+            logger.warning(
+                "Failed to resolve star import: 'from %s import *' in %s", module, self.path
+            )
+            return
+        star = Import(path=module_path, module=module, star=True)
+        self.import_edges.add((self.decl_stack[-1][-1], star))
 
     def on_leave(self, original_node: cst.CSTNode) -> None:
         self.nearest_decls[original_node] = list(self.decl_stack[-1]) if self.decl_stack else []

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -10,7 +10,7 @@ import pytest
 
 IMPORT_TEST_FILES = {
     "p/__init__.py": "",
-    "p/functions.py": "def f(): pass",
+    "p/functions.py": "def f(): pass\ndef g(): pass",
     "p/classes.py": "class C(): pass",
     "p/chain.py": "from . import functions",
 }
@@ -27,6 +27,7 @@ IMPORT_BASE_EDGES = frozenset(
         "p.classes.C -> p.classes",
         "p.functions -> p",
         "p.functions.f -> p.functions",
+        "p.functions.g -> p.functions",
         "p.x -> p",
     }
 )
@@ -215,6 +216,16 @@ IMPORT_BASE_EDGES = frozenset(
                 "p.x.p -> p.x",
             },
             id="import-package-then-dotted-access",
+        ),
+        pytest.param(
+            "from p.functions import *\ndef a(): f()",
+            {
+                "p.x -> p.functions",
+                "p.x -> p.functions.f",
+                "p.x -> p.functions.g",
+                "p.x.a -> p.x",
+            },
+            id="star-import-fans-out-to-all-decls",
         ),
     ],
 )

--- a/tests/test_limitations.py
+++ b/tests/test_limitations.py
@@ -34,13 +34,19 @@ import pytest
                 def a(): g()
                 """,
             },
-            # ``import *`` is deliberately skipped. ``mod.a`` should
-            # point at ``other.g`` but the reference cannot be resolved.
+            # ``from other import *`` is fanned out at the module level,
+            # so ``mod`` points at every top-level decl in ``other``.
+            # Per-access resolution is still missing: ideally
+            # ``mod.a -> other.g`` would also be present, but
+            # ScopeProvider cannot bind the bare ``g`` reference back to
+            # the star import.
             {
+                "mod -> other",
+                "mod -> other.g",
                 "mod.a -> mod",
                 "other.g -> other",
             },
-            id="star-import-not-resolved",
+            id="star-import-fans-out-but-misses-per-access-edge",
         ),
         pytest.param(
             {


### PR DESCRIPTION
## Summary

`from m import *` was previously dropped from the symbol graph (early
return in `visit_ImportFrom` with a `FIXME`). This PR wires star imports
in pessimistically: at the importing module we add an edge to the target
module plus a fan-out edge to every top-level declaration the target
module exports, so star-imported symbols are no longer reported as dead.

## Why pessimistic?

The visitor relies on libcst's `ScopeProvider` to bind name accesses to
their declarations. `ScopeProvider` cannot see the names brought in by
`from m import *` — there is no `Assignment` to point at — so per-access
edges (e.g. `mod.a -> other.g` for `def a(): g()` following a star
import) remain unavailable. Treating the whole target module as used
by the importing module is a conservative substitute that keeps the
analysis sound for code that uses star imports without requiring a
second pass to recover the names individually. A more precise
implementation would manually scan unresolved name accesses and match
them against each star-imported module's public symbols; that's left
for a follow-up.

## Changes

- `_symbols.py`: add `star: bool = False` to `Import`.
- `_visitor.py`: replace the star-import early-return with
  `_add_star_import`, which resolves the target module and records a
  star-flagged `Import` edge from the enclosing decl.
- `_resolve.py`: when resolving a star edge, emit the module edge plus
  one edge per declaration in the target module's `SymbolTrie`.
- `tests/test_imports.py`: add a star-import case (and a second decl
  `g` in the shared fixture so the fan-out is observable).
- `tests/test_limitations.py`: rewrite `star-import-not-resolved` to
  reflect the new fan-out and the still-missing per-access edge.
- `README.md`: update the limitations bullet to describe the new
  pessimistic behaviour.

## Test plan

- [x] `uv run pytest tests/` — 310 passed
- [x] `uv run ruff check dead_cst tests` — clean