### PR TITLE
Add `dependencies` command to list third-party imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ dead-cst why-alive ./src mypackage.some_module.some_function
 
 # Remove dead code (interactive confirmation)
 dead-cst remove ./src -e "re:.*__main__\.py"
+
+# List third-party dependencies imported by the codebase
+dead-cst dependencies ./src
 ```
 
 ## CLI reference
@@ -67,6 +70,24 @@ Report `__all__` entries whose targets would be dead without `__all__`. Useful i
 ```
 dead-cst unused-exports ROOT -e ENTRYPOINT [OPTIONS]
 ```
+
+### `dead-cst dependencies`
+
+List third-party dependencies imported by the codebase. Each base path gets its
+own section. Distributions are reported as `[external dist] <name>`; files
+resolved inside `site-packages` without a matching distribution are reported as
+`[external file] <name>`.
+
+```
+dead-cst dependencies ROOT [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `-p, --path` | Search path spec: `base:dep1,dep2` or `base` (repeatable) |
+| `--resolver` | Path resolver to run, e.g. `venv`, `pyproject` (repeatable) |
+| `--format` | Output format: `text` or `json` |
+| `-v, --verbose` | Enable verbose logging |
 
 ### `dead-cst remove`
 
@@ -137,7 +158,7 @@ A module-level `import` / `from ... import ...` is itself a declaration of type 
 
 - `import *` is not resolved.
 - Dynamic attribute access (`getattr`) and runtime-generated symbols are invisible to static analysis.
-- Only first-party code is analysed; third-party dependencies are treated as opaque.
+- Only first-party code is analysed; third-party dependencies are treated as opaque (they appear as synthetic nodes — see `dead-cst dependencies`).
 - PEP 695 `type` statements are not tracked.
 - `__all__` is followed only when assigned a list/tuple of string literals; dynamic mutation (`__all__.append`, comprehensions, etc.) is not tracked.
 

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -99,7 +99,7 @@ def build_symbol_graph(
                 symbol_lookup.merge(base_tries[sp])
 
             # resolve all the import edges
-            for src, dst in resolve_edges(import_edges, symbol_lookup):
+            for src, dst in resolve_edges(import_edges, symbol_lookup, base):
                 symbol_graph.add_edge(src, dst)
 
     if plugins:

--- a/dead_cst/_resolve.py
+++ b/dead_cst/_resolve.py
@@ -8,6 +8,7 @@ from importlib.machinery import ModuleSpec
 from pathlib import Path
 from typing import Generator
 
+from ._plugins._core import SYNTHETIC_POSITION
 from ._symbols import Import, SymbolNode, SymbolTrie
 
 logger = logging.getLogger(__name__)
@@ -95,9 +96,10 @@ def resolve_import(name: str, search_paths: list[Path]) -> str | Path:
 
 
 def resolve_edges(
-    import_edges: set[tuple[SymbolNode, Import]], symbol_lookup: SymbolTrie
+    import_edges: set[tuple[SymbolNode, Import]],
+    symbol_lookup: SymbolTrie,
+    base: Path,
 ) -> Generator[tuple[SymbolNode, SymbolNode], None, None]:
-    third_party = set()
     emitted: set[tuple[SymbolNode, SymbolNode]] = set()
 
     def _emit(
@@ -109,10 +111,13 @@ def resolve_edges(
         emitted.add(key)
         yield key
 
+    def _synthetic(tag: str) -> SymbolNode:
+        return SymbolNode(fqname=tag, type="synthetic", path=base, position=SYNTHETIC_POSITION)
+
     for src, dst in import_edges:
         if not isinstance(dst.path, Path):
             if "external" in dst.path:
-                third_party.add(dst.path)
+                yield from _emit(src, _synthetic(dst.path))
             continue
 
         node = symbol_lookup._get(dst.module.split("."))
@@ -156,7 +161,7 @@ def resolve_edges(
 
                     if not isinstance(decl.imports.path, Path):
                         if "external" in decl.imports.path:
-                            third_party.add(decl.imports.path)
+                            yield from _emit(src, _synthetic(decl.imports.path))
                         continue
 
                     dest = symbol_lookup._get(decl.imports.module.split("."))
@@ -189,6 +194,3 @@ def resolve_edges(
                 part,
                 cur.module.fqname,
             )
-
-    for mod in sorted(third_party):
-        logger.debug(mod)

--- a/dead_cst/cli.py
+++ b/dead_cst/cli.py
@@ -353,6 +353,60 @@ def _is_dunder_all(node: SymbolNode) -> bool:
     return node.type == "variable" and node.fqname.endswith("__all__")
 
 
+def _is_external_dep(node: SymbolNode) -> bool:
+    return node.type == "synthetic" and node.fqname.startswith("[external ")
+
+
+@app.command()
+def dependencies(
+    root: Annotated[Path, typer.Argument(help="Root directory to analyze.")],
+    path: Annotated[
+        Optional[list[str]],
+        typer.Option("-p", "--path", help="Search path spec: 'base:dep1,dep2' or 'base'."),
+    ] = None,
+    resolver: Annotated[
+        Optional[list[str]],
+        typer.Option("--resolver", help="Path resolver to run (e.g. venv, pyproject)."),
+    ] = None,
+    verbose: Annotated[
+        bool, typer.Option("-v", "--verbose", help="Enable verbose output.")
+    ] = False,
+    output_format: Annotated[
+        OutputFormat, typer.Option("--format", help="Output format.")
+    ] = OutputFormat.text,
+) -> None:
+    """List third-party dependencies imported by the codebase."""
+    setup_logging(verbose)
+    root = root.resolve()
+
+    paths_dict = resolve_paths(root, path or [], resolver or [])
+
+    typer.echo(f"Building symbol graph for {root}...", err=True)
+    graph = build_symbol_graph(paths_dict, project_root=root)
+
+    deps_by_base: dict[Path, list[SymbolNode]] = {base: [] for base in order_paths(paths_dict)}
+    for node in graph.nodes:
+        if not _is_external_dep(node):
+            continue
+        if node.path in deps_by_base:
+            deps_by_base[node.path].append(node)
+
+    if output_format == OutputFormat.json:
+        result = {
+            str(base): sorted(n.fqname for n in nodes) for base, nodes in deps_by_base.items()
+        }
+        typer.echo(json.dumps(result, indent=2))
+        return
+
+    for base, nodes in deps_by_base.items():
+        typer.echo(f"\n{base}:")
+        if not nodes:
+            typer.echo("  (no third-party dependencies found)")
+            continue
+        for node in sorted(nodes, key=lambda n: n.fqname):
+            typer.echo(f"  {node.fqname}")
+
+
 @app.command("unused-exports")
 def unused_exports(
     root: Annotated[Path, typer.Argument(help="Root directory to analyze.")],

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -291,3 +291,24 @@ def test_imports(build_decl_graph, assert_edges, src, expected_extra_edges):
 def test_dunder_all_edges(build_decl_graph, assert_edges, src, expected_extra_edges):
     graph = build_decl_graph({**IMPORT_TEST_FILES, "p/x.py": src})
     assert_edges(graph, IMPORT_BASE_EDGES | expected_extra_edges)
+
+
+def test_third_party_import_creates_synthetic_node(build_decl_graph):
+    graph = build_decl_graph(
+        {
+            "p/__init__.py": "",
+            "p/uses_nx.py": "import networkx as nx\ndef build(): return nx.DiGraph()",
+        }
+    )
+    nx_nodes = {
+        n
+        for n in graph.nodes
+        if n.type == "synthetic" and n.fqname.startswith("[external") and "networkx" in n.fqname
+    }
+    assert nx_nodes, (
+        "expected an external-dep synthetic node for networkx, got "
+        f"{[n.fqname for n in graph.nodes if n.type == 'synthetic']}"
+    )
+
+    edge_srcs = {src.fqname for src, dst in graph.edges if dst in nx_nodes}
+    assert {"p.uses_nx.nx", "p.uses_nx.build"} <= edge_srcs


### PR DESCRIPTION
## Summary

`resolve_edges` already discovered every third-party module imported by the codebase but only logged the set at debug level. This PR turns those into first-class graph members so users can list them and so they participate in the existing graph machinery.

- Each external dep becomes a `SymbolNode(type="synthetic", fqname="[external dist] X" | "[external file] X", path=base)`. Edges from importing decls land on it through `resolve_edges`, deduped by the new `_emit` helper.
- Reuses the existing `"synthetic"` type and the `SYNTHETIC_POSITION` sentinel from `_plugins._core`. The fqname prefix `[external ` distinguishes external-dep synthetics from the unreachable-suite synthetics that already use `<unreachable ...>`.
- New `dead-cst dependencies ROOT` subcommand: lists deps per base in text (default) or `--format json`. Accepts `-p/--path` and `--resolver` for parity with the other commands.
- `count_nodes`, `why-alive`, and graph predecessor walks pick these up for free — `dead-cst why-alive ROOT "[external dist] foo"` now shows every importer.

## Test plan

- [x] `uv run pytest` (286 passed)
- [x] `uv run pre-commit run --all-files`
- [x] Smoke: `dead-cst dependencies` on a scratch package using `networkx`, `libcst`, and `typer` lists all three under `[external dist]`
- [x] Smoke: `--format json` produces the same set keyed by base path
- [ ] Try on a real project with multiple base paths via `-p base1 -p base2`

https://claude.ai/code/session_01W4dKJrv7uSPY5UHP7Gc8QN