### PR TITLE
docs: tier 1 documentation pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,92 @@
+# Changelog
+
+All notable changes to `dead-cst` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Until the first stable release the public API and CLI may change between any
+two versions.
+
+## [Unreleased]
+
+### Added
+- Edge plugin architecture (`EdgePlugin`, `CSTAwareEdgePlugin`, `PluginContext`,
+  `GraphOp`/`AddNode`/`AddEdge`/`RemoveEdge`, `apply_ops`, `synthetic_node`).
+  Built-in plugins: `MainBlockPlugin`, `ProjectScriptsPlugin`,
+  `ExplicitEntrypointPlugin`, `ModuleDundersPlugin`, `PytestPlugin`,
+  `FastAPIPlugin`. Third-party plugins register under the `dead_cst.plugins`
+  entry-point group and load via `load_plugin`.
+- Path resolver architecture (`PathResolver`, `merge_paths`). Built-in
+  resolvers: `VenvResolver`, `PyprojectResolver`, `UvWorkspaceResolver`. Third-
+  party resolvers register under `dead_cst.resolvers` and load via
+  `load_resolver`.
+- `exported_roots(base)` in `dead_cst._resolvers`: inspect a base's
+  `pyproject.toml` (src-layout, hatchling/setuptools/poetry/pdm/flit
+  backends, name-match fallback) to determine which subdirs the build
+  backend would actually ship, so internal dirs like `tests/` stay scoped
+  to their owning workspace member during cross-member import resolution.
+- `dead-cst unused-exports` CLI command: report `__all__` entries whose targets
+  are kept alive only because they are listed in `__all__`.
+- `dead-cst dependencies` CLI command: list third-party distributions and
+  files imported by the codebase, surfaced as synthetic
+  `[external dist] <name>` / `[external file] <name>` graph nodes.
+- `dead-cst analyze` now reports unreachable branches (`if False:`,
+  raise-only suites, etc.) alongside dead symbols, in both the text and JSON
+  output formats.
+- `--resolver` and `--plugin` flags on `analyze`, `why-alive`, `unused-exports`,
+  and `remove` for selecting path resolvers and edge plugins.
+- Position-aware shadowing in the codemod: same-name decls in different
+  branches are tracked by `(fqname, position)` so a shadowed dead binding no
+  longer drags its live sibling out with it.
+- Import pruning in `dead-cst remove`: when the last local user of an import
+  is deleted, the import line is removed via libcst's `RemoveImportsVisitor`.
+- Pre-release notice in the README and a `position` field on `SymbolNode`.
+- `ROADMAP.md` with a stack-ranked plan from alpha to 1.0.
+- Public-API docstrings across `build_symbol_graph`, `find_reachable`,
+  `count_nodes`, `order_paths`, `remove_code`, and the package `__init__`.
+- `CONTRIBUTING.md` and `CHANGELOG.md`.
+
+### Changed
+- `find_reachable(graph)` no longer takes an entrypoints argument. Entrypoints
+  are seeded by plugins via `graph.nodes[node]["entrypoint"] = True`, so the
+  reachability walk is purely graph-driven.
+- `build_symbol_graph` now accepts `plugins=` and `project_root=` keyword
+  arguments and runs the plugin pipeline before returning. Per-consumer
+  lookup tries are now scoped via `exported_roots`, so a workspace member's
+  internal `tests/` package is no longer visible to its dependents.
+- `_resolvers.py` was split into a `_resolvers/` package mirroring
+  `_plugins/` (one submodule per built-in resolver, plus `_core.py` and
+  `_exports.py`). Public imports from `dead_cst` and `dead_cst._resolvers`
+  are unchanged.
+- `--preserve-dunder-all` removed; dunder preservation is provided by
+  `ModuleDundersPlugin`, which is always registered by the CLI and covers
+  every module-level `__xxx__` variable, not just `__all__`.
+- `SymbolTrie.merge` softened from a hard assertion to a first-wins-with-
+  warning when two members declare the same module, so the analyzer logs
+  a clear message instead of crashing on residual collisions.
+
+### Fixed
+- `try/finally` no longer raises `TypeError` in the flow-sensitive filter
+  (`_flow.py`): `Try.finalbody` is a `cst.Finally` whose `.body` is an
+  `IndentedBlock`, so the recursive walk now drills one level further to
+  match every other branch.
+
+## [0.1.0] - Initial release
+
+### Added
+- Symbol-level reachability analysis built on LibCST's
+  `FullyQualifiedNameProvider` and `ScopeProvider`.
+- Resolution of relative imports, aliased imports, and re-export chains
+  through `__init__.py`.
+- `dead-cst analyze` CLI for reporting unreachable symbols, with `text` and
+  `json` output formats.
+- `dead-cst why-alive` CLI for explaining why a symbol is kept alive.
+- `dead-cst remove` CLI that rewrites files in place via a LibCST codemod.
+- Multi-package / monorepo support via the `-p base:dep1,dep2` search-path
+  spec, with topological ordering of bases.
+- Public Python API: `build_symbol_graph`, `find_reachable`, `count_nodes`,
+  `order_paths`, `remove_code`.
+- `py.typed` marker for downstream type-checking.
+
+[Unreleased]: https://github.com/lpetre/dead-cst/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/lpetre/dead-cst/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,125 @@
+# Contributing to dead-cst
+
+Thanks for your interest. `dead-cst` is small and pre-release — bug reports with minimal repros, real-world test cases, and PRs are all welcome. Expect APIs and CLI flags to keep moving until the first stable release. See [`ROADMAP.md`](ROADMAP.md) for the planned trajectory.
+
+## Development setup
+
+`dead-cst` uses [uv](https://github.com/astral-sh/uv) for environment management.
+
+```bash
+git clone https://github.com/lpetre/dead-cst
+cd dead-cst
+uv sync
+```
+
+That installs the package in editable mode along with the `dev` group: `pytest`, `ruff`, `pre-commit`, and `ty`.
+
+## Running tests
+
+```bash
+uv run pytest
+```
+
+For a tight inner loop while editing the visitor, resolver, or a plugin, `pytest-watcher` is in the dev group:
+
+```bash
+uv run ptw
+```
+
+## Linting and formatting
+
+Ruff (lint + format) and a small set of pre-commit hooks run on every commit.
+
+```bash
+uv run pre-commit install        # one-time, sets up the git hook
+uv run pre-commit run --all-files
+```
+
+CI runs `pre-commit run --all-files` on every push and pull request, so running it locally before committing avoids round-trips.
+
+## Project layout
+
+```
+dead_cst/
+  __init__.py            # public API surface
+  _analyze.py            # build_symbol_graph, find_reachable, count_nodes, order_paths
+  _codemod.py            # remove_code -- LibCST transformer + import pruner
+  _resolve.py            # import resolution (stdlib / first-party / third-party)
+  _resolvers/            # path resolvers:
+    venv.py              #   sibling .venv -> site-packages
+    pyproject.py         #   [tool.dead-cst] paths or src/ fallback
+    uv_workspace.py      #   uv.lock workspace members + inter-member deps
+    _exports.py          #   exported_roots: hide internal dirs from consumers
+  _symbols.py            # SymbolNode, SymbolTrie data classes
+  _visitor.py            # SymbolVisitor -- walks each file and emits symbols + edges
+  _flow.py               # flow-sensitive live-at-exit analysis for shadowing
+  _branches.py           # statically-dead suite detection
+  _fqn.py                # FullyQualifiedNameProvider patches / wrappers
+  _plugins/              # edge plugins:
+    main_block.py        #   if __name__ == "__main__"
+    project_scripts.py   #   pyproject.toml [project.scripts]
+    explicit.py          #   user-supplied -e specs
+    module_dunders.py    #   __all__, __version__, ...
+    pytest.py            #   conftest, test_*.py, @pytest.fixture
+    fastapi.py           #   FastAPI / APIRouter route handlers
+  cli.py                 # Typer entrypoints: analyze, why-alive, unused-exports,
+                         #                    dependencies, remove
+tests/                   # pytest suite, fixture-driven from inline source snippets
+```
+
+Modules prefixed with `_` are internal; only the names re-exported from `dead_cst/__init__.py` are part of the supported API. Within the package, plugins and resolvers are stable extension points — see below.
+
+## Adding a plugin
+
+A plugin is any class that satisfies `EdgePlugin` (or `CSTAwareEdgePlugin` if it needs LibCST metadata). Implement `name: str` and a `contribute(ctx)` method that yields `AddNode`, `AddEdge`, or `RemoveEdge` ops.
+
+```python
+from dead_cst import AddEdge, AddNode, GraphOp, PluginContext, synthetic_node
+
+class FlaskRoutesPlugin:
+    name = "flask_routes"
+
+    def contribute(self, ctx: PluginContext):
+        for node in ctx.graph.nodes:
+            ...  # detect @app.route handlers and emit AddNode(..., entrypoint=True)
+```
+
+Built-in plugins live in `dead_cst/_plugins/<name>.py`; out-of-tree plugins register under the `dead_cst.plugins` entry-point group:
+
+```toml
+[project.entry-points."dead_cst.plugins"]
+flask_routes = "myproj.plugins:FlaskRoutesPlugin"
+```
+
+`FastAPIPlugin` is a good full-featured reference — it walks each module's CST, recognises the `FastAPI()` / `APIRouter()` instance pattern, and wires `instance -> handler` edges through decorator detection.
+
+## Adding a resolver
+
+A resolver implements `PathResolver`: a `name: str` attribute and a `resolve(project_root)` method returning a `{base: [dep_paths]}` dict. Built-in resolvers live in `_resolvers.py`; third-party resolvers register under `dead_cst.resolvers`.
+
+## Adding a test
+
+Tests use the `build_decl_graph` fixture (in `tests/conftest.py`), which writes a dict of `{filename: source}` to a tmpdir, runs `build_symbol_graph` on it, and returns the resulting graph. The `assert_edges` fixture compares edges as `"src.fqname -> dst.fqname"` strings.
+
+```python
+def test_something(build_decl_graph, assert_edges):
+    graph = build_decl_graph({"mod.py": "def a(): pass\na()"})
+    assert_edges(graph, {"mod.a -> mod", "mod -> mod.a"})
+```
+
+Plugin tests follow the same pattern in `tests/test_plugins/`. For codemod regressions, `tests/test_codemod.py` writes a source snippet, runs `remove_code`, and asserts on the rewritten text.
+
+## Reporting bugs
+
+A good bug report contains a minimal `.py` file (or pair of files) and the entrypoint flag you ran, plus the actual vs. expected dead-symbol output. The smaller the repro, the faster it gets fixed.
+
+## Pull requests
+
+- Keep PRs focused — one logical change per PR.
+- Add or update tests for behaviour changes.
+- Run `pre-commit run --all-files` and `pytest` before pushing.
+- If your change is user-visible, add an entry to `CHANGELOG.md` under `[Unreleased]`.
+
+## Releasing
+
+Releases are tag-driven. Pushing a `vX.Y.Z` tag triggers `.github/workflows/publish.yml`, which builds the package with `uv build` and publishes to PyPI via OIDC. The version is read from the tag by `hatch-vcs`, so no manual version bumps in source files are needed.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,22 @@ A module-level `import` / `from ... import ...` is itself a declaration of type 
 - PEP 695 `type` statements are not tracked.
 - `__all__` is followed only when assigned a list/tuple of string literals; dynamic mutation (`__all__.append`, comprehensions, etc.) is not tracked.
 
+## Development
+
+```bash
+git clone https://github.com/lpetre/dead-cst
+cd dead-cst
+uv sync
+uv run pytest
+uv run pre-commit run --all-files
+```
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev guide, [`CHANGELOG.md`](CHANGELOG.md) for release notes, and [`ROADMAP.md`](ROADMAP.md) for the stack-ranked plan toward 1.0.
+
 ## TODO
 
 - Host API documentation on Read the Docs.
+
+## License
+
+MIT — see [`LICENSE`](LICENSE).

--- a/dead_cst/__init__.py
+++ b/dead_cst/__init__.py
@@ -1,3 +1,33 @@
+"""Dead code analysis for Python using LibCST.
+
+`dead-cst` builds a symbol-level reachability graph of a Python codebase and
+reports (or removes) anything not reachable from a configurable set of
+entrypoints.
+
+The public API has three layers:
+
+* :func:`build_symbol_graph` parses every ``.py`` file under each base in a
+  ``{base: [dep_paths]}`` map and returns a :class:`networkx.DiGraph` of
+  :class:`SymbolNode` instances. Edges encode "keeps alive" relationships.
+* Edge plugins (:class:`MainBlockPlugin`, :class:`ProjectScriptsPlugin`,
+  :class:`ExplicitEntrypointPlugin`, :class:`ModuleDundersPlugin`,
+  :class:`PytestPlugin`, :class:`FastAPIPlugin`) extend the graph with edges
+  that pure CST analysis can't infer -- entry points, framework conventions,
+  dynamic dispatch. Custom plugins implement the :class:`EdgePlugin` or
+  :class:`CSTAwareEdgePlugin` protocol.
+* Path resolvers (:class:`VenvResolver`, :class:`PyprojectResolver`,
+  :class:`UvWorkspaceResolver`) discover the ``{base: [dep_paths]}`` map
+  itself from a project root, so callers don't have to hand-build it.
+
+After plugins run, :func:`find_reachable` walks successors from every node
+tagged with ``entrypoint=True`` and returns the live set;
+:func:`remove_code` rewrites source files in place to delete the rest via
+a LibCST codemod that preserves surrounding formatting.
+
+See the README for the CLI, the entrypoint and search-path specs, and the
+limitations of static analysis.
+"""
+
 from ._analyze import build_symbol_graph, count_nodes, find_reachable, order_paths
 from ._codemod import remove_code
 from ._plugins import (

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -21,6 +21,14 @@ logger = logging.getLogger(__name__)
 
 
 def order_paths(paths: dict[Path, list[Path]]) -> list[Path]:
+    """Topologically sort base paths so dependencies are processed first.
+
+    ``paths`` maps each base directory to the list of other base directories
+    it imports from (added to ``sys.path`` while it is processed). The
+    returned order ensures that when a base is processed every base it
+    depends on has already contributed its symbols to the lookup tables, so
+    cross-package import resolution sees them.
+    """
     path_order = nx.DiGraph()
     for base, search_paths in paths.items():
         path_order.add_node(base)
@@ -35,6 +43,47 @@ def build_symbol_graph(
     plugins: Sequence[EdgePlugin | CSTAwareEdgePlugin] = (),
     project_root: Path | None = None,
 ) -> nx.DiGraph:
+    """Build a directed reachability graph of every top-level symbol under ``paths``.
+
+    Each ``.py`` file under each base in ``paths`` is parsed with LibCST;
+    modules, classes, functions, top-level variables, and module-level imports
+    become :class:`SymbolNode` graph nodes. Edges encode "keeps alive"
+    relationships:
+
+    * a reference points at its referent,
+    * a declaration points at its containing module,
+    * a submodule points at its parent package, and
+    * synthetic ``unreachable`` nodes own edges into symbols referenced from
+      statically-dead suites (``if False:``, ``raise``-only branches, ...) so
+      those references don't keep the targets alive.
+
+    Third-party imports are surfaced as synthetic ``[external dist] <name>``
+    / ``[external file] <name>`` nodes so callers can audit the
+    project's dependency surface (see the ``dependencies`` CLI command).
+
+    Parameters
+    ----------
+    paths:
+        Mapping from base directory to its first-party search-path
+        dependencies. For a single-package project, pass ``{root: []}``. For
+        a monorepo, list the dependencies so they're added to ``sys.path``
+        and resolved as first-party. ``order_paths`` orders the bases.
+    plugins:
+        Sequence of :class:`EdgePlugin` / :class:`CSTAwareEdgePlugin`
+        instances run after analysis. Plugins emit :class:`AddNode`,
+        :class:`AddEdge`, and :class:`RemoveEdge` ops; ``AddNode(...,
+        entrypoint=True)`` seeds :func:`find_reachable`.
+    project_root:
+        Project root used by plugins for path-relative matching and for
+        locating ``pyproject.toml``. If omitted, inferred as the shortest
+        path in ``paths``.
+
+    Returns
+    -------
+    networkx.DiGraph
+        Nodes are :class:`SymbolNode` instances; entrypoint seeds carry
+        ``graph.nodes[node]["entrypoint"] = True``.
+    """
     symbol_graph = nx.DiGraph()
     base_tries: dict[Path, SymbolTrie] = {}
     export_tries: dict[Path, SymbolTrie] = {}
@@ -182,6 +231,14 @@ def find_reachable(graph: nx.DiGraph) -> set[SymbolNode]:
 
 
 def count_nodes(graph: nx.DiGraph, prefix: Path | None) -> dict[str, int]:
+    """Count nodes in ``graph`` by ``SymbolNode.type``, optionally restricted by path.
+
+    If ``prefix`` is given, only nodes whose ``path`` is under ``prefix`` are
+    counted -- useful for per-base summaries when several packages are
+    analysed together. Includes the synthetic ``"synthetic"`` type contributed
+    by plugins and third-party-dep markers; the CLI suppresses that key when
+    rendering summaries.
+    """
     counts = {}
     for node in graph.nodes:
         if prefix and not node.path.is_relative_to(prefix):

--- a/dead_cst/_codemod.py
+++ b/dead_cst/_codemod.py
@@ -74,6 +74,26 @@ def _import_remove_args(node: SymbolNode) -> tuple[str, str | None, str | None]:
 
 
 def remove_code(G: nx.Graph, base: Path) -> None:
+    """Delete every symbol in ``G`` from the source files under ``base``.
+
+    Modules are removed by unlinking the file. Functions, classes, and
+    top-level variables are dropped by a LibCST transformer matching on
+    ``(fqname, position)`` so a shadowed dead binding does not drag its
+    live sibling out with it. Surviving statements, comments, and
+    formatting around the deletions are preserved.
+
+    Imports are handled in a second pass via libcst's
+    :class:`RemoveImportsVisitor`, which walks scopes itself and skips
+    anything still referenced (defensive -- the graph already classifies
+    these as dead, but the scope check is cheap insurance).
+
+    ``G`` is typically the unreachable subgraph of the graph from
+    :func:`build_symbol_graph`; only the nodes are inspected, edges are
+    ignored. Symbols whose path is not under ``base`` are skipped, so call
+    once per base when analysing several packages together. The
+    transformation is destructive -- back the files up first, or run on a
+    clean working tree.
+    """
     by_file: dict[Path, list[SymbolNode]] = {}
     for node in G.nodes:
         if not node.path.is_relative_to(base):


### PR DESCRIPTION
Rewrite the README for a public release: add a "why dead-cst" pitch, a worked
CLI output example, a "how it works" walkthrough of the symbol graph, and
expanded explanations of entrypoints and search-path specs. Clarify which
entrypoint forms find_reachable actually accepts (str / re.Pattern; Path was
in the type signature but not handled).

Add public-API docstrings on build_symbol_graph, find_reachable, count_nodes,
order_paths, and remove_code, plus a module docstring on the package.

Add CHANGELOG.md (Keep-a-Changelog) seeded with the 0.1.0 surface, and
CONTRIBUTING.md with the uv-based dev quick start, project layout, and the
test-fixture pattern.