### PR TITLE
Fix TypeError on try/finally in flow-sensitive filter

### DIFF
--- a/dead_cst/_flow.py
+++ b/dead_cst/_flow.py
@@ -102,7 +102,7 @@ def _walk_flow(
                     post - body_end
                 )
             if stmt.finalbody is not None:
-                post = _walk_flow(stmt.finalbody.body, post, referent_set, cache, observe)
+                post = _walk_flow(stmt.finalbody.body.body, post, referent_set, cache, observe)
             state = post
             continue
 

--- a/tests/test_flow_sensitive_filter.py
+++ b/tests/test_flow_sensitive_filter.py
@@ -252,6 +252,23 @@ def test_straight_line_shadowing(
             # binding survives.
             id="for-loop-keeps-preloop-and-body",
         ),
+        pytest.param(
+            """
+            x = 1
+            try:
+                x = 2
+            finally:
+                x = 3
+            print(x)
+            """,
+            "x",
+            6,
+            [5],
+            # Regression: try/finally with a use-after used to crash
+            # because finalbody.body is the IndentedBlock itself.
+            # finally runs on every path, so its rebinding dominates.
+            id="try-finally-rebinding-dominates",
+        ),
     ],
 )
 def test_branches_preserved(src: str, name: str, access_line: int, expected: list[int]) -> None:


### PR DESCRIPTION
`Try.finalbody` is a `cst.Finally` whose `.body` is an `IndentedBlock`,
not a list of statements. The `Try` branch of `_walk_flow` was passing
`stmt.finalbody.body` (the `IndentedBlock`) to the recursive call, which
then tried to iterate it and raised. Drill one level further to
`stmt.finalbody.body.body`, matching every other branch in the same
function.

Fixes #26.