### PR TITLE
Include virtual workspace members in UvWorkspaceResolver (closes #32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ two versions.
   (`_flow.py`): `Try.finalbody` is a `cst.Finally` whose `.body` is an
   `IndentedBlock`, so the recursive walk now drills one level further to
   match every other branch.
+- `UvWorkspaceResolver` now picks up workspace members whose lockfile entry
+  uses `source = { virtual = "..." }` (uv's marker for runnable apps/services
+  that don't ship as wheels), not just `editable` ones. The workspace root
+  itself (`virtual = "."`) is still skipped.
 
 ## [0.1.0] - Initial release
 

--- a/dead_cst/_resolvers/uv_workspace.py
+++ b/dead_cst/_resolvers/uv_workspace.py
@@ -12,9 +12,16 @@ class UvWorkspaceResolver:
     together using uv's resolved dependency graph.
 
     For each ``[[package]]`` entry whose ``source`` is ``{ editable = "..." }``
-    -- uv's marker for a workspace member -- emit one :class:`PathMap` entry::
+    or ``{ virtual = "..." }`` -- uv's two markers for a workspace member --
+    emit one :class:`PathMap` entry::
 
         {member_src_root: [direct_workspace_dep_src_roots]}
+
+    ``editable`` members are installable distributions; ``virtual`` members
+    are runnable apps/services that aren't shipped as wheels. Both are
+    first-party code that needs to be analyzed. The workspace root itself
+    (``virtual = "."``) is skipped -- it's a container that holds
+    ``[tool.uv.workspace]``, not a member.
 
     The src root for a member is ``<member_dir>/src`` if that directory
     exists, else ``<member_dir>`` itself (matching the convention
@@ -48,11 +55,16 @@ class UvWorkspaceResolver:
         member_deps: dict[str, list[str]] = {}
         for pkg in data.get("package", []):
             source = pkg.get("source") or {}
-            editable = source.get("editable")
-            if editable is None:
+            location = source.get("editable") or source.get("virtual")
+            if location is None:
+                continue
+            member_dir = (project_root / location).resolve()
+            # The workspace root itself appears as ``virtual = "."``; it's a
+            # container for ``[tool.uv.workspace]``, not a member to analyze.
+            if member_dir == project_root:
                 continue
             name = pkg["name"]
-            member_dirs[name] = (project_root / editable).resolve()
+            member_dirs[name] = member_dir
             member_deps[name] = [d["name"] for d in pkg.get("dependencies", [])]
 
         out: PathMap = {}

--- a/tests/test_resolvers/test_uv_workspace.py
+++ b/tests/test_resolvers/test_uv_workspace.py
@@ -88,6 +88,61 @@ def test_uv_workspace_resolver_skips_virtual_root(tmp_path: Path):
     assert tmp_path.resolve() not in result
 
 
+def test_uv_workspace_resolver_includes_virtual_members(tmp_path: Path):
+    """Virtual members (apps/services that don't ship as wheels) are first-party
+    code and must be analyzed alongside editable members.
+
+    Regression for the silent drop documented in issue #32: a workspace mixing
+    ``apps/*`` (virtual) with ``libs/*`` (editable) used to skip the apps,
+    causing libraries whose only consumers were apps to be reported as dead.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent("""
+            [project]
+            name = "ws"
+            version = "0.0.0"
+            [tool.uv.workspace]
+            members = ["apps/*", "libs/*"]
+        """).strip()
+    )
+    for kind, name in (("apps", "app-a"), ("libs", "lib-a")):
+        (tmp_path / kind / name / "src" / name.replace("-", "_")).mkdir(parents=True)
+    (tmp_path / "uv.lock").write_text(
+        textwrap.dedent("""
+            version = 1
+            revision = 3
+            requires-python = ">=3.11"
+
+            [manifest]
+            members = ["app-a", "lib-a", "ws"]
+
+            [[package]]
+            name = "app-a"
+            version = "0.0.0"
+            source = { virtual = "apps/app-a" }
+            dependencies = [
+                { name = "lib-a" },
+            ]
+
+            [[package]]
+            name = "lib-a"
+            version = "0.0.0"
+            source = { editable = "libs/lib-a" }
+
+            [[package]]
+            name = "ws"
+            version = "0.0.0"
+            source = { virtual = "." }
+        """).strip()
+    )
+
+    result = UvWorkspaceResolver().resolve(tmp_path)
+
+    lib_src = (tmp_path / "libs" / "lib-a" / "src").resolve()
+    app_src = (tmp_path / "apps" / "app-a" / "src").resolve()
+    assert result == {lib_src: [], app_src: [lib_src]}
+
+
 def test_uv_workspace_resolver_no_lockfile(tmp_path: Path):
     assert UvWorkspaceResolver().resolve(tmp_path) == {}
 


### PR DESCRIPTION
uv workspaces can mix editable members (libs that ship as wheels) and
virtual members (apps/services that don't). The resolver only accepted
source.editable, silently dropping virtual members from analysis -- and
libraries whose only consumers were apps got reported as 100% dead.

Accept either source.editable or source.virtual, while still skipping
the workspace root itself (virtual = ".") which is a container for
[tool.uv.workspace], not a member to analyze.