### PR TITLE
Add TyperPlugin for command and callback handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ two versions.
   `GraphOp`/`AddNode`/`AddEdge`/`RemoveEdge`, `apply_ops`, `synthetic_node`).
   Built-in plugins: `MainBlockPlugin`, `ProjectScriptsPlugin`,
   `ExplicitEntrypointPlugin`, `ModuleDundersPlugin`, `PytestPlugin`,
-  `FastAPIPlugin`. Third-party plugins register under the `dead_cst.plugins`
-  entry-point group and load via `load_plugin`.
+  `FastAPIPlugin`, `TyperPlugin`. Third-party plugins register under the
+  `dead_cst.plugins` entry-point group and load via `load_plugin`.
 - Path resolver architecture (`PathResolver`, `merge_paths`). Built-in
   resolvers: `VenvResolver`, `PyprojectResolver`, `UvWorkspaceResolver`. Third-
   party resolvers register under `dead_cst.resolvers` and load via
@@ -25,6 +25,12 @@ two versions.
   backends, name-match fallback) to determine which subdirs the build
   backend would actually ship, so internal dirs like `tests/` stay scoped
   to their owning workspace member during cross-member import resolution.
+- `TyperPlugin` (`--plugin typer`): detect top-level `Typer()` instances and
+  emit `instance -> handler` edges for `@app.command(...)` and
+  `@app.callback(...)` decorators. Typer apps are pass-through; reachability
+  is expected through `[project.scripts]` or a `__main__` block, after which
+  every registered command and callback stays alive. Sub-typers that are
+  never `add_typer`'d remain dead.
 - `dead-cst unused-exports` CLI command: report `__all__` entries whose targets
   are kept alive only because they are listed in `__all__`.
 - `dead-cst dependencies` CLI command: list third-party distributions and

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Entrypoint detection is now fully plugin-driven. Builtins:
 | `ModuleDundersPlugin` | Keep top-level dunder variables (`__all__`, `__version__`, etc.) alive (always on) |
 | `PytestPlugin` | Keep pytest-discovered tests, `conftest.py` decls, and `@pytest.fixture` functions alive (`--plugin pytest`) |
 | `FastAPIPlugin` | Detect top-level `FastAPI()` / `APIRouter()` instances; mark `FastAPI` apps as entrypoints and add `instance -> handler` edges for every `@app.get(...)`-style decorator (HTTP methods, websockets, middleware, exception handlers, `on_event`). Routers stay pass-through, so an `APIRouter` that's never `include_router`'d remains dead (`--plugin fastapi`) |
+| `TyperPlugin` | Detect top-level `Typer()` instances and add `instance -> handler` edges for every `@app.command(...)` / `@app.callback(...)` decorator. Typer apps are pass-through (reach them via `[project.scripts]` or `if __name__ == "__main__": app()`), so a sub-typer that's never `add_typer`'d stays dead (`--plugin typer`) |
 
 Write your own by implementing the `EdgePlugin` or `CSTAwareEdgePlugin` protocol; register under the `dead_cst.plugins` entry-point group for CLI discovery.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,10 +33,11 @@ trust work remaining.
 
 ### 2. Finish the framework-aware plugin presets
 
-`PytestPlugin` and `FastAPIPlugin` shipped, but the existential risk is still
-"I tried it and it flagged half my codebase." The remaining common offenders:
+`PytestPlugin`, `FastAPIPlugin`, and `TyperPlugin` shipped, but the
+existential risk is still "I tried it and it flagged half my codebase." The
+remaining common offenders:
 
-- Click / Typer commands and groups
+- Click commands and groups
 - Django URLConf, admin registration, signal handlers, management commands
 - Pydantic validators and field serializers
 - Descriptor-style hooks: `__init_subclass__`, `__set_name__`, dataclass
@@ -127,7 +128,8 @@ Folded down from earlier tiers as they landed:
 
 - Codemod test coverage and import pruning (Tier 1).
 - `from X import *` resolution, pessimistic by default (Tier 1).
-- `PytestPlugin` and `FastAPIPlugin` (Tier 1, partial — see item 2).
+- `PytestPlugin`, `FastAPIPlugin`, and `TyperPlugin` (Tier 1, partial — see
+  item 2).
 - `unused-exports` and `dependencies` CLI commands.
 - Unreachable-branch detection surfaced as synthetic graph nodes.
 - Workspace-aware cross-member import scoping via `exported_roots`.

--- a/dead_cst/__init__.py
+++ b/dead_cst/__init__.py
@@ -11,10 +11,11 @@ The public API has three layers:
   :class:`SymbolNode` instances. Edges encode "keeps alive" relationships.
 * Edge plugins (:class:`MainBlockPlugin`, :class:`ProjectScriptsPlugin`,
   :class:`ExplicitEntrypointPlugin`, :class:`ModuleDundersPlugin`,
-  :class:`PytestPlugin`, :class:`FastAPIPlugin`) extend the graph with edges
-  that pure CST analysis can't infer -- entry points, framework conventions,
-  dynamic dispatch. Custom plugins implement the :class:`EdgePlugin` or
-  :class:`CSTAwareEdgePlugin` protocol.
+  :class:`PytestPlugin`, :class:`FastAPIPlugin`, :class:`TyperPlugin`)
+  extend the graph with edges that pure CST analysis can't infer --
+  entry points, framework conventions, dynamic dispatch. Custom plugins
+  implement the :class:`EdgePlugin` or :class:`CSTAwareEdgePlugin`
+  protocol.
 * Path resolvers (:class:`VenvResolver`, :class:`PyprojectResolver`,
   :class:`UvWorkspaceResolver`) discover the ``{base: [dep_paths]}`` map
   itself from a project root, so callers don't have to hand-build it.
@@ -45,6 +46,7 @@ from ._plugins import (
     ProjectScriptsPlugin,
     PytestPlugin,
     RemoveEdge,
+    TyperPlugin,
     load_plugin,
 )
 from ._resolvers import (
@@ -77,6 +79,7 @@ __all__ = [
     "PyprojectResolver",
     "PytestPlugin",
     "RemoveEdge",
+    "TyperPlugin",
     "UvWorkspaceResolver",
     "VenvResolver",
     "build_symbol_graph",

--- a/dead_cst/_plugins/__init__.py
+++ b/dead_cst/_plugins/__init__.py
@@ -44,6 +44,7 @@ from .main_block import MainBlockPlugin
 from .module_dunders import ModuleDundersPlugin
 from .project_scripts import ProjectScriptsPlugin
 from .pytest import PytestPlugin
+from .typer import TyperPlugin
 
 BUILTIN_PLUGINS: dict[str, type] = {
     MainBlockPlugin.name: MainBlockPlugin,
@@ -52,6 +53,7 @@ BUILTIN_PLUGINS: dict[str, type] = {
     ModuleDundersPlugin.name: ModuleDundersPlugin,
     PytestPlugin.name: PytestPlugin,
     FastAPIPlugin.name: FastAPIPlugin,
+    TyperPlugin.name: TyperPlugin,
 }
 
 
@@ -85,6 +87,7 @@ __all__ = [
     "PytestPlugin",
     "RemoveEdge",
     "SYNTHETIC_POSITION",
+    "TyperPlugin",
     "apply_ops",
     "load_plugin",
     "synthetic_node",

--- a/dead_cst/_plugins/typer.py
+++ b/dead_cst/_plugins/typer.py
@@ -1,0 +1,229 @@
+"""Plugin: keep Typer command and callback handlers alive.
+
+Strategy: find top-level ``Typer()`` instances in each module and emit
+inverse edges (instance -> handler) for every ``@<instance>.command(...)``
+and ``@<instance>.callback(...)`` decorator. Typer instances are *not*
+seeded as entrypoints; reachability is expected to flow through
+``[project.scripts]`` (handled by :class:`ProjectScriptsPlugin`) or an
+``if __name__ == "__main__": app()`` block (handled by
+:class:`MainBlockPlugin`). Sub-typers attached via ``app.add_typer(sub)``
+are kept alive through the ordinary reference tracked on that call.
+
+This routes ``why-alive`` chains through the Typer app variable users
+recognize ("alive because it's a command on ``app``") and lets a
+sub-typer that's never ``add_typer``'d surface as dead code, mirroring
+the behavior of :class:`FastAPIPlugin` for ``APIRouter``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import libcst as cst
+from libcst.metadata import FullRepoManager
+
+from .._symbols import SymbolNode
+from ._core import AddEdge, GraphOp, PluginContext
+
+# Attribute names ``Typer`` uses to register a callable. Matched as the
+# rightmost attribute of ``@<instance>.<name>(...)``.
+_REGISTRATION_DECORATORS: frozenset[str] = frozenset({"command", "callback"})
+
+_TYPER_CLASS = "Typer"
+
+
+@dataclass
+class TyperPlugin:
+    """Wire Typer command and callback handlers through their app instance.
+
+    For each module the plugin:
+
+    1. Inspects ``from typer import ...`` / ``import typer`` to learn
+       which local names refer to ``Typer``.
+    2. Finds top-level assignments ``X = Typer(...)`` (including
+       ``AnnAssign`` and aliased / module-prefixed forms) and records
+       ``X`` as a Typer instance.
+    3. For every top-level function decorated ``@X.command(...)`` or
+       ``@X.callback(...)``, emits an edge ``X -> handler`` so the
+       handler is reachable whenever ``X`` is.
+
+    Typer instances are not auto-marked as entrypoints. The expected
+    wiring is ``[project.scripts]`` (``ProjectScriptsPlugin`` seeds
+    ``module:app``) or an ``if __name__ == "__main__": app()`` block
+    (``MainBlockPlugin``); both paths make the instance reachable, after
+    which this plugin's edges keep its commands alive. Sub-typers added
+    via ``app.add_typer(sub)`` are reached through the regular reference
+    tracking on that call.
+
+    Limitations: only top-level ``X = Typer(...)`` assignments with a
+    single ``Name`` target are detected. Factory-style apps
+    (``def make_app(): return Typer()``) and class-attribute apps
+    (``self.app = Typer()``) are not handled; users can still keep those
+    alive with explicit ``-e`` entrypoints.
+
+    This is a :class:`CSTAwareEdgePlugin` because detection needs the
+    original CST.
+    """
+
+    name: str = "typer"
+    cst_aware: bool = True
+
+    def contribute(
+        self, ctx: PluginContext, managers: dict[Path, FullRepoManager]
+    ) -> Iterable[GraphOp]:
+        modules_by_path: dict[Path, SymbolNode] = {}
+        for node in ctx.graph.nodes:
+            if node.type == "module":
+                modules_by_path[node.path] = node
+
+        for path, module_node in modules_by_path.items():
+            wrapper = _wrapper_for(path, managers)
+            if wrapper is None:
+                continue
+            typer_imports = _collect_typer_imports(wrapper.module)
+            if not typer_imports:
+                continue
+            instances = _find_instances(wrapper.module, typer_imports)
+            if not instances:
+                continue
+            handlers = _find_handlers(wrapper.module, instances)
+
+            module_fqname = module_node.fqname
+            for var_name in instances:
+                instance_decls = ctx.find_declarations(f"{module_fqname}.{var_name}")
+                if not instance_decls:
+                    continue
+                for instance_decl in instance_decls:
+                    for handler_name in handlers.get(var_name, ()):
+                        for handler_decl in ctx.find_declarations(
+                            f"{module_fqname}.{handler_name}"
+                        ):
+                            yield AddEdge(instance_decl, handler_decl)
+
+
+def _wrapper_for(path: Path, managers: dict[Path, FullRepoManager]):
+    for base, mgr in managers.items():
+        if not path.is_relative_to(base):
+            continue
+        try:
+            return mgr.get_metadata_wrapper_for_path(path)
+        except Exception:
+            return None
+    return None
+
+
+def _collect_typer_imports(module: cst.Module) -> dict[str, str]:
+    """Return ``{local_name: target}`` for names imported from ``typer``.
+
+    ``target`` is either ``"Typer"`` or ``"<module>"`` (the whole
+    ``typer`` package, for ``import typer``).
+    """
+    bindings: dict[str, str] = {}
+    for stmt in module.body:
+        if not isinstance(stmt, cst.SimpleStatementLine):
+            continue
+        for small in stmt.body:
+            if isinstance(small, cst.ImportFrom):
+                if not _is_typer_module(small):
+                    continue
+                if isinstance(small.names, cst.ImportStar):
+                    continue
+                for alias in small.names:
+                    target = alias.name.value if isinstance(alias.name, cst.Name) else None
+                    if target != _TYPER_CLASS:
+                        continue
+                    local = alias.asname.name.value if alias.asname else target
+                    if isinstance(local, str):
+                        bindings[local] = _TYPER_CLASS
+            elif isinstance(small, cst.Import):
+                for alias in small.names:
+                    if not _is_name(alias.name, "typer"):
+                        continue
+                    local = alias.asname.name.value if alias.asname else "typer"
+                    if isinstance(local, str):
+                        bindings[local] = "<module>"
+    return bindings
+
+
+def _is_typer_module(node: cst.ImportFrom) -> bool:
+    if node.relative:
+        return False
+    return _is_name(node.module, "typer")
+
+
+def _is_name(node: cst.CSTNode | None, value: str) -> bool:
+    return isinstance(node, cst.Name) and node.value == value
+
+
+def _find_instances(module: cst.Module, typer_imports: dict[str, str]) -> set[str]:
+    """Return the set of top-level names bound to a ``Typer(...)`` call."""
+    instances: set[str] = set()
+    for stmt in module.body:
+        if not isinstance(stmt, cst.SimpleStatementLine):
+            continue
+        for small in stmt.body:
+            target_name, value = _single_target_assignment(small)
+            if target_name is None or not isinstance(value, cst.Call):
+                continue
+            if _is_typer_call(value.func, typer_imports):
+                instances.add(target_name)
+    return instances
+
+
+def _single_target_assignment(
+    stmt: cst.BaseSmallStatement,
+) -> tuple[str | None, cst.BaseExpression | None]:
+    """Extract ``(name, rhs)`` for ``X = ...`` / ``X: T = ...``; else ``(None, None)``."""
+    if isinstance(stmt, cst.Assign):
+        if len(stmt.targets) != 1:
+            return None, None
+        target = stmt.targets[0].target
+        if isinstance(target, cst.Name):
+            return target.value, stmt.value
+    elif isinstance(stmt, cst.AnnAssign):
+        if isinstance(stmt.target, cst.Name) and stmt.value is not None:
+            return stmt.target.value, stmt.value
+    return None, None
+
+
+def _is_typer_call(func: cst.BaseExpression, typer_imports: dict[str, str]) -> bool:
+    """Return ``True`` if ``func`` denotes a ``Typer`` constructor."""
+    if isinstance(func, cst.Name):
+        return typer_imports.get(func.value) == _TYPER_CLASS
+    if isinstance(func, cst.Attribute) and isinstance(func.value, cst.Name):
+        # ``typer.Typer(...)`` / ``t.Typer(...)``
+        if typer_imports.get(func.value.value) == "<module>":
+            return func.attr.value == _TYPER_CLASS
+    return False
+
+
+def _find_handlers(module: cst.Module, instance_vars: set[str]) -> dict[str, list[str]]:
+    """Return ``{instance_var: [handler_func_name, ...]}`` for decorated handlers."""
+    handlers: dict[str, list[str]] = {}
+    for stmt in module.body:
+        if not isinstance(stmt, cst.FunctionDef):
+            continue
+        for dec in stmt.decorators:
+            owner = _registration_decorator_owner(dec.decorator)
+            if owner is None or owner not in instance_vars:
+                continue
+            handlers.setdefault(owner, []).append(stmt.name.value)
+            break
+    return handlers
+
+
+def _registration_decorator_owner(expr: cst.BaseExpression) -> str | None:
+    """For ``@X.command(...)`` / ``@X.command`` return ``"X"`` (only when the
+    rightmost attribute is a known Typer registration name and ``X`` is a
+    bare ``Name``). Returns ``None`` otherwise."""
+    if isinstance(expr, cst.Call):
+        expr = expr.func
+    if not isinstance(expr, cst.Attribute):
+        return None
+    if expr.attr.value not in _REGISTRATION_DECORATORS:
+        return None
+    if not isinstance(expr.value, cst.Name):
+        return None
+    return expr.value.value

--- a/tests/test_plugins/test_typer.py
+++ b/tests/test_plugins/test_typer.py
@@ -1,0 +1,449 @@
+"""Tests for :class:`TyperPlugin`."""
+
+from __future__ import annotations
+
+from dead_cst import (
+    ExplicitEntrypointPlugin,
+    MainBlockPlugin,
+    TyperPlugin,
+    build_symbol_graph,
+)
+
+
+def test_typer_plugin_marks_command_handlers(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/main.py": """
+            import typer
+
+            app = typer.Typer()
+
+            @app.command()
+            def hello(): pass
+
+            @app.command("bye")
+            def goodbye(): pass
+
+            @app.callback()
+            def root(): pass
+
+            def helper(): pass
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), TyperPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    assert "cli.main.app" in reached
+    assert "cli.main.hello" in reached
+    assert "cli.main.goodbye" in reached
+    assert "cli.main.root" in reached
+    # Undecorated helper not referenced by any handler stays dead
+    assert "cli.main.helper" not in reached
+
+
+def test_typer_plugin_keeps_handler_dependencies_alive(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/models.py": """
+            class Item:
+                pass
+
+            class Unused:
+                pass
+            """,
+            "cli/main.py": """
+            from typer import Typer
+            from cli.models import Item
+
+            app = Typer()
+
+            def build_item() -> Item:
+                return Item()
+
+            @app.command()
+            def show():
+                return build_item()
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), TyperPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    assert "cli.main.show" in reached
+    # Symbols transitively referenced from the handler stay alive
+    assert "cli.main.build_item" in reached
+    assert "cli.models.Item" in reached
+    # Unrelated module symbol is still dead
+    assert "cli.models.Unused" not in reached
+
+
+def test_typer_plugin_reachable_via_explicit_entrypoint(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/main.py": """
+            from typer import Typer
+
+            app = Typer()
+
+            @app.command()
+            def hello(): pass
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[ExplicitEntrypointPlugin(specs=["cli.main.app"]), TyperPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    assert "cli.main.app" in reached
+    assert "cli.main.hello" in reached
+
+
+def test_typer_plugin_does_not_seed_entrypoint(tmp_path, write_files, reachable_fqnames):
+    """Without an external reach (no main block, no project.scripts, no -e),
+    the Typer instance itself stays dead -- and so do its commands. Mirrors
+    the ``APIRouter`` behavior in :class:`FastAPIPlugin`."""
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/main.py": """
+            from typer import Typer
+
+            app = Typer()
+
+            @app.command()
+            def orphan(): pass
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[TyperPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    assert "cli.main.app" not in reached
+    assert "cli.main.orphan" not in reached
+
+
+def test_typer_plugin_unused_subapp_stays_dead(tmp_path, write_files, reachable_fqnames):
+    """A sub-Typer that's never ``add_typer``'d has no path from the root
+    app and stays dead, along with its commands."""
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/sub.py": """
+            from typer import Typer
+
+            sub = Typer()
+
+            @sub.command()
+            def orphan(): pass
+            """,
+            "cli/main.py": """
+            from typer import Typer
+
+            app = Typer()
+
+            @app.command()
+            def hello(): pass
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), TyperPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    assert "cli.main.hello" in reached
+    assert "cli.sub.sub" not in reached
+    assert "cli.sub.orphan" not in reached
+
+
+def test_typer_plugin_subapp_reachable_via_add_typer(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/sub.py": """
+            from typer import Typer
+
+            sub = Typer()
+
+            @sub.command()
+            def index(): pass
+
+            @sub.command()
+            def things(): pass
+            """,
+            "cli/main.py": """
+            from typer import Typer
+            from cli.sub import sub
+
+            app = Typer()
+            app.add_typer(sub, name="sub")
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), TyperPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    assert "cli.main.app" in reached
+    assert "cli.sub.sub" in reached
+    assert "cli.sub.index" in reached
+    assert "cli.sub.things" in reached
+
+
+def test_typer_plugin_handles_aliased_class_import(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/main.py": """
+            from typer import Typer as T
+
+            app = T()
+
+            @app.command()
+            def hello(): pass
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), TyperPlugin()],
+        project_root=tmp_path,
+    )
+    assert "cli.main.hello" in reachable_fqnames(graph)
+
+
+def test_typer_plugin_handles_aliased_module_import(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/main.py": """
+            import typer as ty
+
+            app = ty.Typer()
+
+            @app.command()
+            def hello(): pass
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), TyperPlugin()],
+        project_root=tmp_path,
+    )
+    assert "cli.main.hello" in reachable_fqnames(graph)
+
+
+def test_typer_plugin_handles_annotated_assignment(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/main.py": """
+            import typer
+
+            app: typer.Typer = typer.Typer()
+
+            @app.command()
+            def hello(): pass
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), TyperPlugin()],
+        project_root=tmp_path,
+    )
+    assert "cli.main.hello" in reachable_fqnames(graph)
+
+
+def test_typer_plugin_ignores_bare_decorators(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "pkg/__init__.py": "",
+            "pkg/mod.py": """
+            from typer import Typer
+
+            app = Typer()
+
+            def command(fn):
+                return fn
+
+            @command
+            def looks_like_command(): pass
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), TyperPlugin()],
+        project_root=tmp_path,
+    )
+    # Bare ``@command`` (no attribute access) is not a Typer registration --
+    # matching it would clobber unrelated decorators with the same name.
+    assert "pkg.mod.looks_like_command" not in reachable_fqnames(graph)
+
+
+def test_typer_plugin_ignores_unrelated_decorators(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "pkg/__init__.py": "",
+            "pkg/mod.py": """
+            class Thing:
+                def command(self, fn):
+                    return fn
+
+            t = Thing()
+
+            @t.command
+            def not_a_command(): pass
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[TyperPlugin()],
+        project_root=tmp_path,
+    )
+    # ``t`` isn't a ``Typer`` instance, so its ``.command`` decorator is ignored.
+    assert "pkg.mod.not_a_command" not in reachable_fqnames(graph)
+
+
+def test_typer_plugin_does_nothing_without_typer_imports(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "pkg/__init__.py": "",
+            "pkg/mod.py": """
+            class App:
+                def command(self):
+                    def wrap(fn): return fn
+                    return wrap
+
+            app = App()
+
+            @app.command()
+            def looks_like_command(): pass
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[TyperPlugin()],
+        project_root=tmp_path,
+    )
+    # ``app`` here is not a Typer instance -- no ``typer`` import in scope.
+    assert "pkg.mod.looks_like_command" not in reachable_fqnames(graph)
+
+
+def test_typer_plugin_multiple_instances_in_one_module(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/main.py": """
+            from typer import Typer
+
+            app = Typer()
+            other = Typer()
+
+            @app.command()
+            def from_app(): pass
+
+            @other.command()
+            def from_other(): pass
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), TyperPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    # ``app`` is reached via the main block; its command is alive.
+    assert "cli.main.from_app" in reached
+    # ``other`` is never reached, so its command stays dead -- handler edges
+    # are scoped to their own instance.
+    assert "cli.main.other" not in reached
+    assert "cli.main.from_other" not in reached
+
+
+def test_typer_plugin_ignores_import_star(tmp_path, write_files, reachable_fqnames):
+    """``from typer import *`` doesn't bind ``Typer`` for the plugin's
+    purposes. The ``import *`` analyzer logic is pessimistic enough on its
+    own; the plugin shouldn't infer Typer wiring from the star import."""
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/main.py": """
+            from typer import *
+
+            app = Typer()
+
+            @app.command()
+            def hello(): pass
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), TyperPlugin()],
+        project_root=tmp_path,
+    )
+    # No instance edge from ``app`` to ``hello`` because the plugin ignores
+    # star imports. ``hello`` is not referenced by anything reachable.
+    assert "cli.main.hello" not in reachable_fqnames(graph)
+
+
+def test_typer_plugin_loads_via_load_plugin():
+    from dead_cst import load_plugin
+
+    plugin = load_plugin("typer")
+    assert isinstance(plugin, TyperPlugin)
+    assert plugin.name == "typer"


### PR DESCRIPTION
Mirrors FastAPIPlugin: detects top-level `Typer()` instances and emits
`instance -> handler` edges for every `@app.command(...)` and
`@app.callback(...)` decorator. Typer apps are pass-through; users wire
them through `[project.scripts]` or a `__main__` block, after which the
plugin keeps the registered commands alive. Sub-typers that are never
`add_typer`'d stay dead.