### PR TITLE
Consolidate shared plugin AST helpers into _plugins/_core.py

### DIFF
--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -157,9 +157,7 @@ def build_symbol_graph(
                 for src, dst in visitor.unreachable_internal_edges:
                     symbol_graph.add_edge(src, dst)
 
-                # collect all the intra module edges
-                import_edges = import_edges | visitor.import_edges
-                import_edges = import_edges | visitor.unreachable_import_edges
+                import_edges |= visitor.import_edges | visitor.unreachable_import_edges
 
             # add edges to keep __init__.py files alive
             current_trie.add_module_hierarchy_edges(symbol_graph)

--- a/dead_cst/_plugins/_core.py
+++ b/dead_cst/_plugins/_core.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable, Iterator, Protocol, Union, runtime_checkable
+from typing import Container, Iterable, Iterator, Protocol, Union, runtime_checkable
 
 import libcst as cst
 import networkx as nx
@@ -207,3 +207,115 @@ def apply_ops(graph: nx.DiGraph, ops: Iterable[GraphOp]) -> None:
 def synthetic_node(fqname: str, path: Path) -> SymbolNode:
     """Create a placeholder node plugins can attach edges to."""
     return SymbolNode(fqname=fqname, type="synthetic", path=path, position=SYNTHETIC_POSITION)
+
+
+def mark_entrypoints(
+    seed_fqname: str, path: Path, targets: Iterable[SymbolNode]
+) -> Iterator[GraphOp]:
+    """Emit a synthetic entrypoint node and edges from it to each target.
+
+    Used by plugins that mark a set of decls alive without a natural caller --
+    pytest discovery, unittest discovery, and similar.
+    """
+    targets = list(targets)
+    if not targets:
+        return
+    synth = synthetic_node(fqname=seed_fqname, path=path)
+    yield AddNode(synth, entrypoint=True)
+    for target in targets:
+        yield AddEdge(synth, target)
+
+
+def is_name(node: cst.CSTNode | None, value: str) -> bool:
+    """Return ``True`` if ``node`` is a bare ``Name`` with the given value."""
+    return isinstance(node, cst.Name) and node.value == value
+
+
+def is_from_module(node: cst.ImportFrom, module_name: str) -> bool:
+    """Return ``True`` if ``node`` is ``from <module_name> import ...`` (non-relative)."""
+    return not node.relative and is_name(node.module, module_name)
+
+
+def single_target_assignment(
+    stmt: cst.BaseSmallStatement,
+) -> tuple[str | None, cst.BaseExpression | None]:
+    """Extract ``(name, rhs)`` for ``X = ...`` / ``X: T = ...``; else ``(None, None)``."""
+    if isinstance(stmt, cst.Assign):
+        if len(stmt.targets) != 1:
+            return None, None
+        target = stmt.targets[0].target
+        if isinstance(target, cst.Name):
+            return target.value, stmt.value
+    elif isinstance(stmt, cst.AnnAssign):
+        if isinstance(stmt.target, cst.Name) and stmt.value is not None:
+            return stmt.target.value, stmt.value
+    return None, None
+
+
+def decorator_owner(expr: cst.BaseExpression, valid_attrs: Container[str]) -> str | None:
+    """For ``@X.<attr>(...)`` / ``@X.<attr>`` return ``"X"`` when ``attr`` is in
+    ``valid_attrs`` and ``X`` is a bare ``Name``. Returns ``None`` otherwise."""
+    if isinstance(expr, cst.Call):
+        expr = expr.func
+    if not isinstance(expr, cst.Attribute):
+        return None
+    if expr.attr.value not in valid_attrs:
+        return None
+    if not isinstance(expr.value, cst.Name):
+        return None
+    return expr.value.value
+
+
+def find_handlers(
+    module: cst.Module, instance_vars: Container[str], valid_attrs: Container[str]
+) -> dict[str, list[str]]:
+    """Return ``{instance_var: [handler_func_name, ...]}`` for top-level functions
+    decorated with ``@<instance_var>.<attr>(...)`` where ``attr`` is in ``valid_attrs``."""
+    handlers: dict[str, list[str]] = {}
+    for stmt in module.body:
+        if not isinstance(stmt, cst.FunctionDef):
+            continue
+        for dec in stmt.decorators:
+            owner = decorator_owner(dec.decorator, valid_attrs)
+            if owner is None or owner not in instance_vars:
+                continue
+            handlers.setdefault(owner, []).append(stmt.name.value)
+            break
+    return handlers
+
+
+def collect_module_imports(
+    module: cst.Module, module_name: str, allowed_targets: Container[str]
+) -> dict[str, str]:
+    """Return ``{local_name: target}`` for names imported from ``module_name``.
+
+    Each ``from <module_name> import X [as Y]`` whose ``X`` is in
+    ``allowed_targets`` adds ``{Y or X: X}``. Each ``import <module_name> [as Y]``
+    adds ``{Y or module_name: '<module>'}`` so callers can recognize the bare
+    module-prefixed form (``<module_name>.X(...)``).
+    """
+    bindings: dict[str, str] = {}
+    for stmt in module.body:
+        if not isinstance(stmt, cst.SimpleStatementLine):
+            continue
+        for small in stmt.body:
+            if isinstance(small, cst.ImportFrom):
+                if not is_from_module(small, module_name):
+                    continue
+                if isinstance(small.names, cst.ImportStar):
+                    continue
+                for alias in small.names:
+                    target = alias.name.value if isinstance(alias.name, cst.Name) else None
+                    if target is None or target not in allowed_targets:
+                        continue
+                    local = alias.asname.name.value if alias.asname else target
+                    if isinstance(local, str):
+                        bindings[local] = target
+            elif isinstance(small, cst.Import):
+                for alias in small.names:
+                    if not is_name(alias.name, module_name):
+                        continue
+                    local = alias.asname.name.value if alias.asname else module_name
+                    if isinstance(local, str):
+                        bindings[local] = "<module>"
+    return bindings

--- a/dead_cst/_plugins/click.py
+++ b/dead_cst/_plugins/click.py
@@ -31,11 +31,21 @@ from typing import Iterable
 
 import libcst as cst
 
-from ._core import AddEdge, GraphOp, PluginContext
+from ._core import (
+    AddEdge,
+    GraphOp,
+    PluginContext,
+    collect_module_imports,
+    decorator_owner,
+    find_handlers,
+    single_target_assignment,
+)
 
 # Attribute names a Click ``Group`` uses to register a callable. Matched
 # as the rightmost attribute of ``@<instance>.<name>(...)``.
 _REGISTRATION_DECORATORS: frozenset[str] = frozenset({"command", "group", "result_callback"})
+
+_SUBGROUP_DECORATOR: frozenset[str] = frozenset({"group"})
 
 # Names (as imported from ``click``) that produce a ``Group`` when used
 # as a decorator on a function. ``click.group`` is the function form;
@@ -101,13 +111,13 @@ class ClickPlugin:
             module = ctx.parse(path)
             if module is None:
                 continue
-            click_imports = _collect_click_imports(module)
+            click_imports = collect_module_imports(module, "click", _GROUP_DECORATOR_NAMES)
             if not click_imports:
                 continue
             instances = _find_instances(module, click_imports)
             if not instances:
                 continue
-            handlers = _find_handlers(module, instances)
+            handlers = find_handlers(module, instances, _REGISTRATION_DECORATORS)
 
             module_fqname = module_node.fqname
             for var_name in instances:
@@ -120,49 +130,6 @@ class ClickPlugin:
                             f"{module_fqname}.{handler_name}"
                         ):
                             yield AddEdge(instance_decl, handler_decl)
-
-
-def _collect_click_imports(module: cst.Module) -> dict[str, str]:
-    """Return ``{local_name: target}`` for names imported from ``click``.
-
-    ``target`` is one of ``"group"``, ``"Group"``, or ``"<module>"`` (the
-    whole ``click`` package, for ``import click``).
-    """
-    bindings: dict[str, str] = {}
-    for stmt in module.body:
-        if not isinstance(stmt, cst.SimpleStatementLine):
-            continue
-        for small in stmt.body:
-            if isinstance(small, cst.ImportFrom):
-                if not _is_click_module(small):
-                    continue
-                if isinstance(small.names, cst.ImportStar):
-                    continue
-                for alias in small.names:
-                    target = alias.name.value if isinstance(alias.name, cst.Name) else None
-                    if target not in _GROUP_DECORATOR_NAMES:
-                        continue
-                    local = alias.asname.name.value if alias.asname else target
-                    if isinstance(local, str):
-                        bindings[local] = target
-            elif isinstance(small, cst.Import):
-                for alias in small.names:
-                    if not _is_name(alias.name, "click"):
-                        continue
-                    local = alias.asname.name.value if alias.asname else "click"
-                    if isinstance(local, str):
-                        bindings[local] = "<module>"
-    return bindings
-
-
-def _is_click_module(node: cst.ImportFrom) -> bool:
-    if node.relative:
-        return False
-    return _is_name(node.module, "click")
-
-
-def _is_name(node: cst.CSTNode | None, value: str) -> bool:
-    return isinstance(node, cst.Name) and node.value == value
 
 
 def _find_instances(module: cst.Module, click_imports: dict[str, str]) -> set[str]:
@@ -188,7 +155,7 @@ def _find_instances(module: cst.Module, click_imports: dict[str, str]) -> set[st
                     break
         elif isinstance(stmt, cst.SimpleStatementLine):
             for small in stmt.body:
-                target_name, value = _single_target_assignment(small)
+                target_name, value = single_target_assignment(small)
                 if target_name is None or not isinstance(value, cst.Call):
                     continue
                 if _is_group_constructor(value.func, click_imports):
@@ -205,7 +172,7 @@ def _find_instances(module: cst.Module, click_imports: dict[str, str]) -> set[st
             if stmt.name.value in instances:
                 continue
             for dec in stmt.decorators:
-                owner = _registration_decorator_owner(dec.decorator, attr="group")
+                owner = decorator_owner(dec.decorator, _SUBGROUP_DECORATOR)
                 if owner is not None and owner in instances:
                     instances.add(stmt.name.value)
                     changed = True
@@ -240,57 +207,3 @@ def _is_group_constructor(func: cst.BaseExpression, click_imports: dict[str, str
         if click_imports.get(func.value.value) == "<module>":
             return func.attr.value in _GROUP_CONSTRUCTOR_NAMES
     return False
-
-
-def _single_target_assignment(
-    stmt: cst.BaseSmallStatement,
-) -> tuple[str | None, cst.BaseExpression | None]:
-    """Extract ``(name, rhs)`` for ``X = ...`` / ``X: T = ...``; else ``(None, None)``."""
-    if isinstance(stmt, cst.Assign):
-        if len(stmt.targets) != 1:
-            return None, None
-        target = stmt.targets[0].target
-        if isinstance(target, cst.Name):
-            return target.value, stmt.value
-    elif isinstance(stmt, cst.AnnAssign):
-        if isinstance(stmt.target, cst.Name) and stmt.value is not None:
-            return stmt.target.value, stmt.value
-    return None, None
-
-
-def _find_handlers(module: cst.Module, instance_vars: set[str]) -> dict[str, list[str]]:
-    """Return ``{instance_var: [handler_func_name, ...]}`` for decorated handlers."""
-    handlers: dict[str, list[str]] = {}
-    for stmt in module.body:
-        if not isinstance(stmt, cst.FunctionDef):
-            continue
-        for dec in stmt.decorators:
-            owner = _registration_decorator_owner(dec.decorator)
-            if owner is None or owner not in instance_vars:
-                continue
-            handlers.setdefault(owner, []).append(stmt.name.value)
-            break
-    return handlers
-
-
-def _registration_decorator_owner(
-    expr: cst.BaseExpression, *, attr: str | None = None
-) -> str | None:
-    """For ``@X.command(...)`` / ``@X.command`` return ``"X"`` (only when the
-    rightmost attribute is a known Click registration name and ``X`` is a
-    bare ``Name``). Returns ``None`` otherwise.
-
-    When ``attr`` is given, only that specific attribute name is matched
-    (e.g. ``attr="group"`` for sub-group discovery)."""
-    if isinstance(expr, cst.Call):
-        expr = expr.func
-    if not isinstance(expr, cst.Attribute):
-        return None
-    if attr is None:
-        if expr.attr.value not in _REGISTRATION_DECORATORS:
-            return None
-    elif expr.attr.value != attr:
-        return None
-    if not isinstance(expr.value, cst.Name):
-        return None
-    return expr.value.value

--- a/dead_cst/_plugins/fastapi.py
+++ b/dead_cst/_plugins/fastapi.py
@@ -19,7 +19,15 @@ from typing import Iterable
 
 import libcst as cst
 
-from ._core import AddEdge, AddNode, GraphOp, PluginContext
+from ._core import (
+    AddEdge,
+    AddNode,
+    GraphOp,
+    PluginContext,
+    collect_module_imports,
+    find_handlers,
+    single_target_assignment,
+)
 
 # Attribute names FastAPI / APIRouter use to register a callable. Matched as
 # the rightmost attribute of ``@<instance>.<name>(...)``.
@@ -96,13 +104,13 @@ class FastAPIPlugin:
             module = ctx.parse(path)
             if module is None:
                 continue
-            fastapi_imports = _collect_fastapi_imports(module)
+            fastapi_imports = collect_module_imports(module, "fastapi", _INSTANCE_KINDS)
             if not fastapi_imports:
                 continue
             instances = _find_instances(module, fastapi_imports)
             if not instances:
                 continue
-            handlers = _find_handlers(module, set(instances))
+            handlers = find_handlers(module, set(instances), _ROUTE_DECORATORS)
 
             module_fqname = module_node.fqname
             for var_name, kind in instances.items():
@@ -119,49 +127,6 @@ class FastAPIPlugin:
                             yield AddEdge(instance_decl, handler_decl)
 
 
-def _collect_fastapi_imports(module: cst.Module) -> dict[str, str]:
-    """Return ``{local_name: target}`` for names imported from ``fastapi``.
-
-    ``target`` is one of ``"FastAPI"``, ``"APIRouter"``, or ``"<module>"``
-    (the whole ``fastapi`` package, for ``import fastapi``).
-    """
-    bindings: dict[str, str] = {}
-    for stmt in module.body:
-        if not isinstance(stmt, cst.SimpleStatementLine):
-            continue
-        for small in stmt.body:
-            if isinstance(small, cst.ImportFrom):
-                if not _is_fastapi_module(small):
-                    continue
-                if isinstance(small.names, cst.ImportStar):
-                    continue
-                for alias in small.names:
-                    target = alias.name.value if isinstance(alias.name, cst.Name) else None
-                    if target not in _INSTANCE_KINDS:
-                        continue
-                    local = alias.asname.name.value if alias.asname else target
-                    if isinstance(local, str):
-                        bindings[local] = target
-            elif isinstance(small, cst.Import):
-                for alias in small.names:
-                    if not _is_name(alias.name, "fastapi"):
-                        continue
-                    local = alias.asname.name.value if alias.asname else "fastapi"
-                    if isinstance(local, str):
-                        bindings[local] = "<module>"
-    return bindings
-
-
-def _is_fastapi_module(node: cst.ImportFrom) -> bool:
-    if node.relative:
-        return False
-    return _is_name(node.module, "fastapi")
-
-
-def _is_name(node: cst.CSTNode | None, value: str) -> bool:
-    return isinstance(node, cst.Name) and node.value == value
-
-
 def _find_instances(module: cst.Module, fastapi_imports: dict[str, str]) -> dict[str, str]:
     """Return ``{var_name: 'FastAPI' | 'APIRouter'}`` for top-level instances."""
     instances: dict[str, str] = {}
@@ -169,29 +134,13 @@ def _find_instances(module: cst.Module, fastapi_imports: dict[str, str]) -> dict
         if not isinstance(stmt, cst.SimpleStatementLine):
             continue
         for small in stmt.body:
-            target_name, value = _single_target_assignment(small)
+            target_name, value = single_target_assignment(small)
             if target_name is None or not isinstance(value, cst.Call):
                 continue
             kind = _classify_call(value.func, fastapi_imports)
             if kind is not None:
                 instances[target_name] = kind
     return instances
-
-
-def _single_target_assignment(
-    stmt: cst.BaseSmallStatement,
-) -> tuple[str | None, cst.BaseExpression | None]:
-    """Extract ``(name, rhs)`` for ``X = ...`` / ``X: T = ...``; else ``(None, None)``."""
-    if isinstance(stmt, cst.Assign):
-        if len(stmt.targets) != 1:
-            return None, None
-        target = stmt.targets[0].target
-        if isinstance(target, cst.Name):
-            return target.value, stmt.value
-    elif isinstance(stmt, cst.AnnAssign):
-        if isinstance(stmt.target, cst.Name) and stmt.value is not None:
-            return stmt.target.value, stmt.value
-    return None, None
 
 
 def _classify_call(func: cst.BaseExpression, fastapi_imports: dict[str, str]) -> str | None:
@@ -207,33 +156,3 @@ def _classify_call(func: cst.BaseExpression, fastapi_imports: dict[str, str]) ->
             if attr in _INSTANCE_KINDS:
                 return attr
     return None
-
-
-def _find_handlers(module: cst.Module, instance_vars: set[str]) -> dict[str, list[str]]:
-    """Return ``{instance_var: [handler_func_name, ...]}`` for decorated handlers."""
-    handlers: dict[str, list[str]] = {}
-    for stmt in module.body:
-        if not isinstance(stmt, cst.FunctionDef):
-            continue
-        for dec in stmt.decorators:
-            owner = _route_decorator_owner(dec.decorator)
-            if owner is None or owner not in instance_vars:
-                continue
-            handlers.setdefault(owner, []).append(stmt.name.value)
-            break
-    return handlers
-
-
-def _route_decorator_owner(expr: cst.BaseExpression) -> str | None:
-    """For ``@X.get(...)`` / ``@X.get`` return ``"X"`` (only when the rightmost
-    attribute is a known FastAPI registration name and ``X`` is a bare
-    ``Name``). Returns ``None`` otherwise."""
-    if isinstance(expr, cst.Call):
-        expr = expr.func
-    if not isinstance(expr, cst.Attribute):
-        return None
-    if expr.attr.value not in _ROUTE_DECORATORS:
-        return None
-    if not isinstance(expr.value, cst.Name):
-        return None
-    return expr.value.value

--- a/dead_cst/_plugins/flask.py
+++ b/dead_cst/_plugins/flask.py
@@ -19,7 +19,15 @@ from typing import Iterable
 
 import libcst as cst
 
-from ._core import AddEdge, AddNode, GraphOp, PluginContext
+from ._core import (
+    AddEdge,
+    AddNode,
+    GraphOp,
+    PluginContext,
+    collect_module_imports,
+    find_handlers,
+    single_target_assignment,
+)
 
 # Attribute names Flask / Blueprint use to register a callable. Matched as
 # the rightmost attribute of ``@<instance>.<name>(...)``. Includes the HTTP
@@ -117,13 +125,13 @@ class FlaskPlugin:
             module = ctx.parse(path)
             if module is None:
                 continue
-            flask_imports = _collect_flask_imports(module)
+            flask_imports = collect_module_imports(module, "flask", _INSTANCE_KINDS)
             if not flask_imports:
                 continue
             instances = _find_instances(module, flask_imports)
             if not instances:
                 continue
-            handlers = _find_handlers(module, set(instances))
+            handlers = find_handlers(module, set(instances), _ROUTE_DECORATORS)
 
             module_fqname = module_node.fqname
             for var_name, kind in instances.items():
@@ -140,49 +148,6 @@ class FlaskPlugin:
                             yield AddEdge(instance_decl, handler_decl)
 
 
-def _collect_flask_imports(module: cst.Module) -> dict[str, str]:
-    """Return ``{local_name: target}`` for names imported from ``flask``.
-
-    ``target`` is one of ``"Flask"``, ``"Blueprint"``, or ``"<module>"``
-    (the whole ``flask`` package, for ``import flask``).
-    """
-    bindings: dict[str, str] = {}
-    for stmt in module.body:
-        if not isinstance(stmt, cst.SimpleStatementLine):
-            continue
-        for small in stmt.body:
-            if isinstance(small, cst.ImportFrom):
-                if not _is_flask_module(small):
-                    continue
-                if isinstance(small.names, cst.ImportStar):
-                    continue
-                for alias in small.names:
-                    target = alias.name.value if isinstance(alias.name, cst.Name) else None
-                    if target not in _INSTANCE_KINDS:
-                        continue
-                    local = alias.asname.name.value if alias.asname else target
-                    if isinstance(local, str):
-                        bindings[local] = target
-            elif isinstance(small, cst.Import):
-                for alias in small.names:
-                    if not _is_name(alias.name, "flask"):
-                        continue
-                    local = alias.asname.name.value if alias.asname else "flask"
-                    if isinstance(local, str):
-                        bindings[local] = "<module>"
-    return bindings
-
-
-def _is_flask_module(node: cst.ImportFrom) -> bool:
-    if node.relative:
-        return False
-    return _is_name(node.module, "flask")
-
-
-def _is_name(node: cst.CSTNode | None, value: str) -> bool:
-    return isinstance(node, cst.Name) and node.value == value
-
-
 def _find_instances(module: cst.Module, flask_imports: dict[str, str]) -> dict[str, str]:
     """Return ``{var_name: 'Flask' | 'Blueprint'}`` for top-level instances."""
     instances: dict[str, str] = {}
@@ -190,29 +155,13 @@ def _find_instances(module: cst.Module, flask_imports: dict[str, str]) -> dict[s
         if not isinstance(stmt, cst.SimpleStatementLine):
             continue
         for small in stmt.body:
-            target_name, value = _single_target_assignment(small)
+            target_name, value = single_target_assignment(small)
             if target_name is None or not isinstance(value, cst.Call):
                 continue
             kind = _classify_call(value.func, flask_imports)
             if kind is not None:
                 instances[target_name] = kind
     return instances
-
-
-def _single_target_assignment(
-    stmt: cst.BaseSmallStatement,
-) -> tuple[str | None, cst.BaseExpression | None]:
-    """Extract ``(name, rhs)`` for ``X = ...`` / ``X: T = ...``; else ``(None, None)``."""
-    if isinstance(stmt, cst.Assign):
-        if len(stmt.targets) != 1:
-            return None, None
-        target = stmt.targets[0].target
-        if isinstance(target, cst.Name):
-            return target.value, stmt.value
-    elif isinstance(stmt, cst.AnnAssign):
-        if isinstance(stmt.target, cst.Name) and stmt.value is not None:
-            return stmt.target.value, stmt.value
-    return None, None
 
 
 def _classify_call(func: cst.BaseExpression, flask_imports: dict[str, str]) -> str | None:
@@ -228,33 +177,3 @@ def _classify_call(func: cst.BaseExpression, flask_imports: dict[str, str]) -> s
             if attr in _INSTANCE_KINDS:
                 return attr
     return None
-
-
-def _find_handlers(module: cst.Module, instance_vars: set[str]) -> dict[str, list[str]]:
-    """Return ``{instance_var: [handler_func_name, ...]}`` for decorated handlers."""
-    handlers: dict[str, list[str]] = {}
-    for stmt in module.body:
-        if not isinstance(stmt, cst.FunctionDef):
-            continue
-        for dec in stmt.decorators:
-            owner = _route_decorator_owner(dec.decorator)
-            if owner is None or owner not in instance_vars:
-                continue
-            handlers.setdefault(owner, []).append(stmt.name.value)
-            break
-    return handlers
-
-
-def _route_decorator_owner(expr: cst.BaseExpression) -> str | None:
-    """For ``@X.route(...)`` / ``@X.route`` return ``"X"`` (only when the
-    rightmost attribute is a known Flask registration name and ``X`` is a
-    bare ``Name``). Returns ``None`` otherwise."""
-    if isinstance(expr, cst.Call):
-        expr = expr.func
-    if not isinstance(expr, cst.Attribute):
-        return None
-    if expr.attr.value not in _ROUTE_DECORATORS:
-        return None
-    if not isinstance(expr.value, cst.Name):
-        return None
-    return expr.value.value

--- a/dead_cst/_plugins/pytest.py
+++ b/dead_cst/_plugins/pytest.py
@@ -10,7 +10,7 @@ from typing import Iterable
 import libcst as cst
 
 from .._symbols import SymbolNode
-from ._core import AddEdge, AddNode, GraphOp, PluginContext, synthetic_node
+from ._core import GraphOp, PluginContext, mark_entrypoints
 
 
 @dataclass
@@ -56,12 +56,12 @@ class PytestPlugin:
             filename = path.name
 
             if filename == "conftest.py":
-                yield from _mark_entrypoints(
+                yield from mark_entrypoints(
                     f"<pytest:conftest>:{module_node.fqname}", path, module_decls
                 )
             elif _is_test_filename(filename):
                 test_decls = [d for d in module_decls if _is_test_decl(d)]
-                yield from _mark_entrypoints(
+                yield from mark_entrypoints(
                     f"<pytest:tests>:{module_node.fqname}", path, test_decls
                 )
 
@@ -78,7 +78,7 @@ class PytestPlugin:
                 for d in module_decls
                 if d.type == "function" and d.fqname.rsplit(".", 1)[-1] in fixture_names
             ]
-            yield from _mark_entrypoints(
+            yield from mark_entrypoints(
                 f"<pytest:fixtures>:{module_node.fqname}", path, fixture_decls
             )
 
@@ -94,15 +94,6 @@ def _is_test_decl(node: SymbolNode) -> bool:
     if node.type == "class" and simple.startswith("Test"):
         return True
     return False
-
-
-def _mark_entrypoints(seed_fqname: str, path: Path, targets: list[SymbolNode]) -> Iterable[GraphOp]:
-    if not targets:
-        return
-    synth = synthetic_node(fqname=seed_fqname, path=path)
-    yield AddNode(synth, entrypoint=True)
-    for target in targets:
-        yield AddEdge(synth, target)
 
 
 def _find_fixture_names(module: cst.Module) -> set[str]:

--- a/dead_cst/_plugins/typer.py
+++ b/dead_cst/_plugins/typer.py
@@ -22,13 +22,21 @@ from typing import Iterable
 
 import libcst as cst
 
-from ._core import AddEdge, GraphOp, PluginContext
+from ._core import (
+    AddEdge,
+    GraphOp,
+    PluginContext,
+    collect_module_imports,
+    find_handlers,
+    single_target_assignment,
+)
 
 # Attribute names ``Typer`` uses to register a callable. Matched as the
 # rightmost attribute of ``@<instance>.<name>(...)``.
 _REGISTRATION_DECORATORS: frozenset[str] = frozenset({"command", "callback"})
 
 _TYPER_CLASS = "Typer"
+_TYPER_TARGETS: frozenset[str] = frozenset({_TYPER_CLASS})
 
 
 @dataclass
@@ -77,13 +85,13 @@ class TyperPlugin:
             module = ctx.parse(path)
             if module is None:
                 continue
-            typer_imports = _collect_typer_imports(module)
+            typer_imports = collect_module_imports(module, "typer", _TYPER_TARGETS)
             if not typer_imports:
                 continue
             instances = _find_instances(module, typer_imports)
             if not instances:
                 continue
-            handlers = _find_handlers(module, instances)
+            handlers = find_handlers(module, instances, _REGISTRATION_DECORATORS)
 
             module_fqname = module_node.fqname
             for var_name in instances:
@@ -98,49 +106,6 @@ class TyperPlugin:
                             yield AddEdge(instance_decl, handler_decl)
 
 
-def _collect_typer_imports(module: cst.Module) -> dict[str, str]:
-    """Return ``{local_name: target}`` for names imported from ``typer``.
-
-    ``target`` is either ``"Typer"`` or ``"<module>"`` (the whole
-    ``typer`` package, for ``import typer``).
-    """
-    bindings: dict[str, str] = {}
-    for stmt in module.body:
-        if not isinstance(stmt, cst.SimpleStatementLine):
-            continue
-        for small in stmt.body:
-            if isinstance(small, cst.ImportFrom):
-                if not _is_typer_module(small):
-                    continue
-                if isinstance(small.names, cst.ImportStar):
-                    continue
-                for alias in small.names:
-                    target = alias.name.value if isinstance(alias.name, cst.Name) else None
-                    if target != _TYPER_CLASS:
-                        continue
-                    local = alias.asname.name.value if alias.asname else target
-                    if isinstance(local, str):
-                        bindings[local] = _TYPER_CLASS
-            elif isinstance(small, cst.Import):
-                for alias in small.names:
-                    if not _is_name(alias.name, "typer"):
-                        continue
-                    local = alias.asname.name.value if alias.asname else "typer"
-                    if isinstance(local, str):
-                        bindings[local] = "<module>"
-    return bindings
-
-
-def _is_typer_module(node: cst.ImportFrom) -> bool:
-    if node.relative:
-        return False
-    return _is_name(node.module, "typer")
-
-
-def _is_name(node: cst.CSTNode | None, value: str) -> bool:
-    return isinstance(node, cst.Name) and node.value == value
-
-
 def _find_instances(module: cst.Module, typer_imports: dict[str, str]) -> set[str]:
     """Return the set of top-level names bound to a ``Typer(...)`` call."""
     instances: set[str] = set()
@@ -148,28 +113,12 @@ def _find_instances(module: cst.Module, typer_imports: dict[str, str]) -> set[st
         if not isinstance(stmt, cst.SimpleStatementLine):
             continue
         for small in stmt.body:
-            target_name, value = _single_target_assignment(small)
+            target_name, value = single_target_assignment(small)
             if target_name is None or not isinstance(value, cst.Call):
                 continue
             if _is_typer_call(value.func, typer_imports):
                 instances.add(target_name)
     return instances
-
-
-def _single_target_assignment(
-    stmt: cst.BaseSmallStatement,
-) -> tuple[str | None, cst.BaseExpression | None]:
-    """Extract ``(name, rhs)`` for ``X = ...`` / ``X: T = ...``; else ``(None, None)``."""
-    if isinstance(stmt, cst.Assign):
-        if len(stmt.targets) != 1:
-            return None, None
-        target = stmt.targets[0].target
-        if isinstance(target, cst.Name):
-            return target.value, stmt.value
-    elif isinstance(stmt, cst.AnnAssign):
-        if isinstance(stmt.target, cst.Name) and stmt.value is not None:
-            return stmt.target.value, stmt.value
-    return None, None
 
 
 def _is_typer_call(func: cst.BaseExpression, typer_imports: dict[str, str]) -> bool:
@@ -181,33 +130,3 @@ def _is_typer_call(func: cst.BaseExpression, typer_imports: dict[str, str]) -> b
         if typer_imports.get(func.value.value) == "<module>":
             return func.attr.value == _TYPER_CLASS
     return False
-
-
-def _find_handlers(module: cst.Module, instance_vars: set[str]) -> dict[str, list[str]]:
-    """Return ``{instance_var: [handler_func_name, ...]}`` for decorated handlers."""
-    handlers: dict[str, list[str]] = {}
-    for stmt in module.body:
-        if not isinstance(stmt, cst.FunctionDef):
-            continue
-        for dec in stmt.decorators:
-            owner = _registration_decorator_owner(dec.decorator)
-            if owner is None or owner not in instance_vars:
-                continue
-            handlers.setdefault(owner, []).append(stmt.name.value)
-            break
-    return handlers
-
-
-def _registration_decorator_owner(expr: cst.BaseExpression) -> str | None:
-    """For ``@X.command(...)`` / ``@X.command`` return ``"X"`` (only when the
-    rightmost attribute is a known Typer registration name and ``X`` is a
-    bare ``Name``). Returns ``None`` otherwise."""
-    if isinstance(expr, cst.Call):
-        expr = expr.func
-    if not isinstance(expr, cst.Attribute):
-        return None
-    if expr.attr.value not in _REGISTRATION_DECORATORS:
-        return None
-    if not isinstance(expr.value, cst.Name):
-        return None
-    return expr.value.value

--- a/dead_cst/_plugins/unittest.py
+++ b/dead_cst/_plugins/unittest.py
@@ -9,7 +9,7 @@ from typing import Iterable
 import libcst as cst
 
 from .._symbols import SymbolNode
-from ._core import AddEdge, AddNode, GraphOp, PluginContext, synthetic_node
+from ._core import GraphOp, PluginContext, is_from_module, is_name, mark_entrypoints
 
 # Module-level functions ``unittest`` discovers by name.
 _MODULE_HOOKS: frozenset[str] = frozenset({"setUpModule", "tearDownModule", "load_tests"})
@@ -92,14 +92,7 @@ class UnittestPlugin:
             if not targets:
                 continue
 
-            yield from _mark_entrypoints(f"<unittest>:{module_node.fqname}", path, targets)
-
-
-def _mark_entrypoints(seed_fqname: str, path: Path, targets: list[SymbolNode]) -> Iterable[GraphOp]:
-    synth = synthetic_node(fqname=seed_fqname, path=path)
-    yield AddNode(synth, entrypoint=True)
-    for target in targets:
-        yield AddEdge(synth, target)
+            yield from mark_entrypoints(f"<unittest>:{module_node.fqname}", path, targets)
 
 
 def _collect_unittest_imports(module: cst.Module) -> tuple[set[str], set[str]]:
@@ -119,13 +112,13 @@ def _collect_unittest_imports(module: cst.Module) -> tuple[set[str], set[str]]:
         for small in stmt.body:
             if isinstance(small, cst.Import):
                 for alias in small.names:
-                    if not _is_name(alias.name, "unittest"):
+                    if not is_name(alias.name, "unittest"):
                         continue
                     local = alias.asname.name.value if alias.asname else "unittest"
                     if isinstance(local, str):
                         module_aliases.add(local)
             elif isinstance(small, cst.ImportFrom):
-                if small.relative or not _is_name(small.module, "unittest"):
+                if not is_from_module(small, "unittest"):
                     continue
                 if isinstance(small.names, cst.ImportStar):
                     # ``from unittest import *`` brings every public name in,
@@ -172,7 +165,3 @@ def _find_module_hooks(module: cst.Module) -> set[str]:
         for stmt in module.body
         if isinstance(stmt, cst.FunctionDef) and stmt.name.value in _MODULE_HOOKS
     }
-
-
-def _is_name(node: cst.CSTNode | None, value: str) -> bool:
-    return isinstance(node, cst.Name) and node.value == value

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -269,12 +269,8 @@ class SymbolVisitor(cst.CSTVisitor):
                 module_path = f"[unresolved] {top_level}"
                 module_name = full_name
 
-            # if there is an asname, that is the decl being added
-            # and we resolve the entire import
             if alias.asname:
                 decl_name = alias.asname.name
-
-            # if there is not an asname, the first name is the decl
             else:
                 decl_name = alias.name
 
@@ -483,13 +479,12 @@ class SymbolVisitor(cst.CSTVisitor):
                     accessed_attrs = [] if not original_import.decl else [original_import.decl]
 
                     if isinstance(access.node, (cst.Name, cst.Attribute)):
-                        # figure out what is being accessed
-                        prev_access, curr_access = None, access.node
-                        while prev_access := parent_map.get(curr_access):
-                            if not isinstance(prev_access, cst.Attribute):
+                        curr_access = access.node
+                        while parent := parent_map.get(curr_access):
+                            if not isinstance(parent, cst.Attribute):
                                 break
-                            accessed_attrs.append(prev_access.attr.value)
-                            curr_access = prev_access
+                            accessed_attrs.append(parent.attr.value)
+                            curr_access = parent
 
                     # Create the new Import with the specific symbol being accessed
                     resolved_import = Import(


### PR DESCRIPTION
The framework plugins (click, flask, fastapi, typer, unittest, pytest)
each kept their own copy of `_is_name`, `_single_target_assignment`,
`_collect_<framework>_imports`, `_find_handlers`, `_*_decorator_owner`,
and `_mark_entrypoints`. Move parameterized versions to `_plugins/_core.py`
and have each plugin import them. Net -245 lines across the plugin files
with no behavior change (all 445 tests still pass).

Also a few small drive-bys:
- Drop a redundant set-union in `_analyze.py` (`a = a | b; a = a | c`
  -> `a |= b | c`).
- Remove a what-not-why comment in `_visitor.py` and a dead
  `prev_access = None` initializer that's overwritten by the walrus
  on the very next line.