### PR TITLE
Simplify duplicated helpers across plugins, resolvers, and CLI

### DIFF
--- a/dead_cst/_plugins/_core.py
+++ b/dead_cst/_plugins/_core.py
@@ -53,6 +53,12 @@ class PluginContext:
     # is fine in practice -- ``importers`` is for prefiltering against
     # the analyzer's already-resolved dep markers.
     _synthetic_index: dict[str, SymbolNode] | None = field(default=None, init=False, repr=False)
+    # Cached materialization of ``base_modules``. Plugins don't add module
+    # nodes during their pass (only the visitor pass does, before plugins
+    # run), so a one-time scan of ``graph.nodes`` is safe to memoize.
+    _base_modules_cache: list[tuple[Path, SymbolNode]] | None = field(
+        default=None, init=False, repr=False
+    )
 
     def find_module(self, fqname: str) -> SymbolNode | None:
         node = self.symbol_lookup._get(fqname.split("."))
@@ -76,9 +82,13 @@ class PluginContext:
 
     def base_modules(self) -> Iterator[tuple[Path, SymbolNode]]:
         """Yield ``(path, module_node)`` for every module under :attr:`base`."""
-        for node in self.graph.nodes:
-            if node.type == "module" and node.path.is_relative_to(self.base):
-                yield node.path, node
+        if self._base_modules_cache is None:
+            self._base_modules_cache = [
+                (node.path, node)
+                for node in self.graph.nodes
+                if node.type == "module" and node.path.is_relative_to(self.base)
+            ]
+        return iter(self._base_modules_cache)
 
     def importers(self, target: str) -> set[Path]:
         """Return paths under :attr:`base` whose imports reach ``target``.
@@ -282,6 +292,60 @@ def find_handlers(
             handlers.setdefault(owner, []).append(stmt.name.value)
             break
     return handlers
+
+
+def matched_attr_call(
+    expr: cst.BaseExpression,
+    imports: dict[str, str],
+    valid_targets: Container[str],
+    *,
+    unwrap_call: bool = True,
+) -> str | None:
+    """Return the matched target name for ``expr`` against ``imports`` / ``valid_targets``.
+
+    Recognizes both forms produced by ``collect_module_imports``:
+
+    * bare ``Name`` (e.g. ``Flask``) where ``imports[name]`` is a real
+      target in ``valid_targets`` (from ``from <mod> import Flask``);
+    * module-prefixed ``Attribute`` (e.g. ``flask.Flask``) where
+      ``imports[<bare module>] == "<module>"`` and the rightmost attr
+      is in ``valid_targets``.
+
+    ``unwrap_call=True`` (default) handles ``Foo(...)`` by inspecting
+    ``.func``; pass ``False`` for callers that have already unwrapped.
+    Returns ``None`` if no match.
+    """
+    if unwrap_call and isinstance(expr, cst.Call):
+        expr = expr.func
+    if isinstance(expr, cst.Name):
+        target = imports.get(expr.value)
+        if target in valid_targets:
+            return target
+    elif isinstance(expr, cst.Attribute) and isinstance(expr.value, cst.Name):
+        if imports.get(expr.value.value) == "<module>":
+            attr = expr.attr.value
+            if attr in valid_targets:
+                return attr
+    return None
+
+
+def find_call_assignments(
+    module: cst.Module, imports: dict[str, str], valid_targets: Container[str]
+) -> dict[str, str]:
+    """Return ``{var_name: target_name}`` for top-level ``X = <call>`` where
+    ``<call>`` matches one of ``valid_targets`` via :func:`matched_attr_call`."""
+    instances: dict[str, str] = {}
+    for stmt in module.body:
+        if not isinstance(stmt, cst.SimpleStatementLine):
+            continue
+        for small in stmt.body:
+            target_name, value = single_target_assignment(small)
+            if target_name is None or not isinstance(value, cst.Call):
+                continue
+            kind = matched_attr_call(value.func, imports, valid_targets, unwrap_call=False)
+            if kind is not None:
+                instances[target_name] = kind
+    return instances
 
 
 def collect_module_imports(

--- a/dead_cst/_plugins/click.py
+++ b/dead_cst/_plugins/click.py
@@ -38,6 +38,7 @@ from ._core import (
     collect_module_imports,
     decorator_owner,
     find_handlers,
+    matched_attr_call,
     single_target_assignment,
 )
 
@@ -150,7 +151,7 @@ def _find_instances(module: cst.Module, click_imports: dict[str, str]) -> set[st
     for stmt in module.body:
         if isinstance(stmt, cst.FunctionDef):
             for dec in stmt.decorators:
-                if _is_group_decorator(dec.decorator, click_imports):
+                if matched_attr_call(dec.decorator, click_imports, _GROUP_DECORATOR_NAMES):
                     instances.add(stmt.name.value)
                     break
         elif isinstance(stmt, cst.SimpleStatementLine):
@@ -158,7 +159,9 @@ def _find_instances(module: cst.Module, click_imports: dict[str, str]) -> set[st
                 target_name, value = single_target_assignment(small)
                 if target_name is None or not isinstance(value, cst.Call):
                     continue
-                if _is_group_constructor(value.func, click_imports):
+                if matched_attr_call(
+                    value.func, click_imports, _GROUP_CONSTRUCTOR_NAMES, unwrap_call=False
+                ):
                     instances.add(target_name)
 
     # Fixpoint: ``@<known_group>.group(...)`` produces a new group; that new
@@ -178,32 +181,3 @@ def _find_instances(module: cst.Module, click_imports: dict[str, str]) -> set[st
                     changed = True
                     break
     return instances
-
-
-def _is_group_decorator(expr: cst.BaseExpression, click_imports: dict[str, str]) -> bool:
-    """Return ``True`` if ``expr`` is ``click.group`` / ``click.Group`` (or
-    aliased / module-prefixed) used as a decorator (with or without a call)."""
-    if isinstance(expr, cst.Call):
-        expr = expr.func
-    if isinstance(expr, cst.Name):
-        return click_imports.get(expr.value) in _GROUP_DECORATOR_NAMES
-    if isinstance(expr, cst.Attribute) and isinstance(expr.value, cst.Name):
-        if click_imports.get(expr.value.value) == "<module>":
-            return expr.attr.value in _GROUP_DECORATOR_NAMES
-    return False
-
-
-def _is_group_constructor(func: cst.BaseExpression, click_imports: dict[str, str]) -> bool:
-    """Return ``True`` if ``func`` denotes a Click ``Group`` constructor.
-
-    Limited to the class form (``click.Group``); the function form
-    (``click.group``) is recognized only as a decorator, since
-    ``X = click.group(...)`` typed on a single line is rare and the class
-    form is the unambiguous spelling for an explicit constructor call.
-    """
-    if isinstance(func, cst.Name):
-        return click_imports.get(func.value) in _GROUP_CONSTRUCTOR_NAMES
-    if isinstance(func, cst.Attribute) and isinstance(func.value, cst.Name):
-        if click_imports.get(func.value.value) == "<module>":
-            return func.attr.value in _GROUP_CONSTRUCTOR_NAMES
-    return False

--- a/dead_cst/_plugins/fastapi.py
+++ b/dead_cst/_plugins/fastapi.py
@@ -17,16 +17,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable
 
-import libcst as cst
-
 from ._core import (
     AddEdge,
     AddNode,
     GraphOp,
     PluginContext,
     collect_module_imports,
+    find_call_assignments,
     find_handlers,
-    single_target_assignment,
 )
 
 # Attribute names FastAPI / APIRouter use to register a callable. Matched as
@@ -107,7 +105,7 @@ class FastAPIPlugin:
             fastapi_imports = collect_module_imports(module, "fastapi", _INSTANCE_KINDS)
             if not fastapi_imports:
                 continue
-            instances = _find_instances(module, fastapi_imports)
+            instances = find_call_assignments(module, fastapi_imports, _INSTANCE_KINDS)
             if not instances:
                 continue
             handlers = find_handlers(module, set(instances), _ROUTE_DECORATORS)
@@ -125,34 +123,3 @@ class FastAPIPlugin:
                             f"{module_fqname}.{handler_name}"
                         ):
                             yield AddEdge(instance_decl, handler_decl)
-
-
-def _find_instances(module: cst.Module, fastapi_imports: dict[str, str]) -> dict[str, str]:
-    """Return ``{var_name: 'FastAPI' | 'APIRouter'}`` for top-level instances."""
-    instances: dict[str, str] = {}
-    for stmt in module.body:
-        if not isinstance(stmt, cst.SimpleStatementLine):
-            continue
-        for small in stmt.body:
-            target_name, value = single_target_assignment(small)
-            if target_name is None or not isinstance(value, cst.Call):
-                continue
-            kind = _classify_call(value.func, fastapi_imports)
-            if kind is not None:
-                instances[target_name] = kind
-    return instances
-
-
-def _classify_call(func: cst.BaseExpression, fastapi_imports: dict[str, str]) -> str | None:
-    """Return ``"FastAPI"`` / ``"APIRouter"`` if ``func`` calls one, else ``None``."""
-    if isinstance(func, cst.Name):
-        target = fastapi_imports.get(func.value)
-        if target in _INSTANCE_KINDS:
-            return target
-    elif isinstance(func, cst.Attribute) and isinstance(func.value, cst.Name):
-        # ``fastapi.FastAPI(...)`` / ``fa.APIRouter(...)``
-        if fastapi_imports.get(func.value.value) == "<module>":
-            attr = func.attr.value
-            if attr in _INSTANCE_KINDS:
-                return attr
-    return None

--- a/dead_cst/_plugins/flask.py
+++ b/dead_cst/_plugins/flask.py
@@ -17,16 +17,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable
 
-import libcst as cst
-
 from ._core import (
     AddEdge,
     AddNode,
     GraphOp,
     PluginContext,
     collect_module_imports,
+    find_call_assignments,
     find_handlers,
-    single_target_assignment,
 )
 
 # Attribute names Flask / Blueprint use to register a callable. Matched as
@@ -128,7 +126,7 @@ class FlaskPlugin:
             flask_imports = collect_module_imports(module, "flask", _INSTANCE_KINDS)
             if not flask_imports:
                 continue
-            instances = _find_instances(module, flask_imports)
+            instances = find_call_assignments(module, flask_imports, _INSTANCE_KINDS)
             if not instances:
                 continue
             handlers = find_handlers(module, set(instances), _ROUTE_DECORATORS)
@@ -146,34 +144,3 @@ class FlaskPlugin:
                             f"{module_fqname}.{handler_name}"
                         ):
                             yield AddEdge(instance_decl, handler_decl)
-
-
-def _find_instances(module: cst.Module, flask_imports: dict[str, str]) -> dict[str, str]:
-    """Return ``{var_name: 'Flask' | 'Blueprint'}`` for top-level instances."""
-    instances: dict[str, str] = {}
-    for stmt in module.body:
-        if not isinstance(stmt, cst.SimpleStatementLine):
-            continue
-        for small in stmt.body:
-            target_name, value = single_target_assignment(small)
-            if target_name is None or not isinstance(value, cst.Call):
-                continue
-            kind = _classify_call(value.func, flask_imports)
-            if kind is not None:
-                instances[target_name] = kind
-    return instances
-
-
-def _classify_call(func: cst.BaseExpression, flask_imports: dict[str, str]) -> str | None:
-    """Return ``"Flask"`` / ``"Blueprint"`` if ``func`` calls one, else ``None``."""
-    if isinstance(func, cst.Name):
-        target = flask_imports.get(func.value)
-        if target in _INSTANCE_KINDS:
-            return target
-    elif isinstance(func, cst.Attribute) and isinstance(func.value, cst.Name):
-        # ``flask.Flask(...)`` / ``fl.Blueprint(...)``
-        if flask_imports.get(func.value.value) == "<module>":
-            attr = func.attr.value
-            if attr in _INSTANCE_KINDS:
-                return attr
-    return None

--- a/dead_cst/_plugins/project_scripts.py
+++ b/dead_cst/_plugins/project_scripts.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
+from .._resolvers._core import load_toml
 from ._core import AddEdge, AddNode, GraphOp, PluginContext, synthetic_node
 
 logger = logging.getLogger(__name__)
@@ -33,16 +34,9 @@ class ProjectScriptsPlugin:
 
     def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
         pyproject = self.pyproject_path or ctx.base / "pyproject.toml"
-        if not pyproject.is_file():
+        data = load_toml(pyproject)
+        if data is None:
             return
-
-        try:
-            import tomllib
-        except ImportError:  # pragma: no cover
-            return
-
-        with pyproject.open("rb") as f:
-            data = tomllib.load(f)
 
         scripts = data.get("project", {}).get("scripts", {})
         for script_name, target in scripts.items():

--- a/dead_cst/_plugins/typer.py
+++ b/dead_cst/_plugins/typer.py
@@ -20,23 +20,20 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable
 
-import libcst as cst
-
 from ._core import (
     AddEdge,
     GraphOp,
     PluginContext,
     collect_module_imports,
+    find_call_assignments,
     find_handlers,
-    single_target_assignment,
 )
 
 # Attribute names ``Typer`` uses to register a callable. Matched as the
 # rightmost attribute of ``@<instance>.<name>(...)``.
 _REGISTRATION_DECORATORS: frozenset[str] = frozenset({"command", "callback"})
 
-_TYPER_CLASS = "Typer"
-_TYPER_TARGETS: frozenset[str] = frozenset({_TYPER_CLASS})
+_TYPER_TARGETS: frozenset[str] = frozenset({"Typer"})
 
 
 @dataclass
@@ -88,7 +85,7 @@ class TyperPlugin:
             typer_imports = collect_module_imports(module, "typer", _TYPER_TARGETS)
             if not typer_imports:
                 continue
-            instances = _find_instances(module, typer_imports)
+            instances = set(find_call_assignments(module, typer_imports, _TYPER_TARGETS))
             if not instances:
                 continue
             handlers = find_handlers(module, instances, _REGISTRATION_DECORATORS)
@@ -104,29 +101,3 @@ class TyperPlugin:
                             f"{module_fqname}.{handler_name}"
                         ):
                             yield AddEdge(instance_decl, handler_decl)
-
-
-def _find_instances(module: cst.Module, typer_imports: dict[str, str]) -> set[str]:
-    """Return the set of top-level names bound to a ``Typer(...)`` call."""
-    instances: set[str] = set()
-    for stmt in module.body:
-        if not isinstance(stmt, cst.SimpleStatementLine):
-            continue
-        for small in stmt.body:
-            target_name, value = single_target_assignment(small)
-            if target_name is None or not isinstance(value, cst.Call):
-                continue
-            if _is_typer_call(value.func, typer_imports):
-                instances.add(target_name)
-    return instances
-
-
-def _is_typer_call(func: cst.BaseExpression, typer_imports: dict[str, str]) -> bool:
-    """Return ``True`` if ``func`` denotes a ``Typer`` constructor."""
-    if isinstance(func, cst.Name):
-        return typer_imports.get(func.value) == _TYPER_CLASS
-    if isinstance(func, cst.Attribute) and isinstance(func.value, cst.Name):
-        # ``typer.Typer(...)`` / ``t.Typer(...)``
-        if typer_imports.get(func.value.value) == "<module>":
-            return func.attr.value == _TYPER_CLASS
-    return False

--- a/dead_cst/_resolvers/_core.py
+++ b/dead_cst/_resolvers/_core.py
@@ -8,7 +8,7 @@ multiple resolvers' outputs.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 PathMap = dict[Path, list[Path]]
 
@@ -18,6 +18,18 @@ class PathResolver(Protocol):
     name: str
 
     def resolve(self, project_root: Path) -> PathMap: ...
+
+
+def load_toml(path: Path) -> dict[str, Any] | None:
+    """Read ``path`` as TOML; ``None`` if the file is missing or tomllib is unavailable."""
+    if not path.is_file():
+        return None
+    try:
+        import tomllib
+    except ImportError:  # pragma: no cover - py<3.11 not supported
+        return None
+    with path.open("rb") as f:
+        return tomllib.load(f)
 
 
 def merge_paths(*maps: PathMap) -> PathMap:

--- a/dead_cst/_resolvers/_exports.py
+++ b/dead_cst/_resolvers/_exports.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ._core import load_toml
+
 
 def exported_roots(base: Path) -> list[Path] | None:
     """Subdirs of ``base`` that are visible to *other* bases at import time.
@@ -47,17 +49,9 @@ def exported_roots(base: Path) -> list[Path] | None:
     listed above also fall through.
     """
     base = base.resolve()
-    pyproject = base / "pyproject.toml"
-    if not pyproject.is_file():
+    data = load_toml(base / "pyproject.toml")
+    if data is None:
         return None
-
-    try:
-        import tomllib
-    except ImportError:  # pragma: no cover - py<3.11 not supported
-        return None
-
-    with pyproject.open("rb") as f:
-        data = tomllib.load(f)
 
     if (base / "src").is_dir():
         return [(base / "src").resolve()]

--- a/dead_cst/_resolvers/pyproject.py
+++ b/dead_cst/_resolvers/pyproject.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ._core import PathMap
+from ._core import PathMap, load_toml
 
 
 class PyprojectResolver:
@@ -27,17 +27,9 @@ class PyprojectResolver:
 
     def resolve(self, project_root: Path) -> PathMap:
         project_root = project_root.resolve()
-        pyproject = project_root / "pyproject.toml"
-        if not pyproject.is_file():
+        data = load_toml(project_root / "pyproject.toml")
+        if data is None:
             return {}
-
-        try:
-            import tomllib
-        except ImportError:  # pragma: no cover - py<3.11 not supported
-            return {}
-
-        with pyproject.open("rb") as f:
-            data = tomllib.load(f)
 
         tool = data.get("tool", {}).get("dead-cst", {})
         entries = tool.get("paths")

--- a/dead_cst/_resolvers/uv_workspace.py
+++ b/dead_cst/_resolvers/uv_workspace.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ._core import PathMap
+from ._core import PathMap, load_toml
 
 
 class UvWorkspaceResolver:
@@ -39,17 +39,9 @@ class UvWorkspaceResolver:
 
     def resolve(self, project_root: Path) -> PathMap:
         project_root = project_root.resolve()
-        lock = self.lock_path or project_root / "uv.lock"
-        if not lock.is_file():
+        data = load_toml(self.lock_path or project_root / "uv.lock")
+        if data is None:
             return {}
-
-        try:
-            import tomllib
-        except ImportError:  # pragma: no cover - py<3.11 not supported
-            return {}
-
-        with lock.open("rb") as f:
-            data = tomllib.load(f)
 
         member_dirs: dict[str, Path] = {}
         member_deps: dict[str, list[str]] = {}

--- a/dead_cst/cli.py
+++ b/dead_cst/cli.py
@@ -48,6 +48,14 @@ def parse_entrypoint(ep: str) -> str | re.Pattern[str]:
     return ep
 
 
+def _rel_path(path: Path, root: Path) -> Path:
+    """``path`` made relative to ``root`` if possible, else ``path`` unchanged."""
+    try:
+        return path.relative_to(root)
+    except ValueError:
+        return path
+
+
 def build_plugins(
     *,
     entrypoints: list[str],
@@ -202,23 +210,16 @@ def _output_text(
     if dead_real:
         typer.echo(f"\nDead symbols ({len(dead_real)}):")
         for node in sorted(dead_real, key=lambda n: (str(n.path), n.fqname)):
-            try:
-                rel_path = node.path.relative_to(root)
-            except ValueError:
-                rel_path = node.path
-            typer.echo(f"  {node.fqname} ({node.type}) at {rel_path}")
+            typer.echo(f"  {node.fqname} ({node.type}) at {_rel_path(node.path, root)}")
 
     branches = [n for n in graph.nodes if is_unreachable_node(n)]
     if branches:
         typer.echo(f"\nUnreachable branches ({len(branches)}):")
         for node in sorted(branches, key=lambda n: (str(n.path), n.position.start)):
-            try:
-                rel_path = node.path.relative_to(root)
-            except ValueError:
-                rel_path = node.path
+            rel = _rel_path(node.path, root)
             start = node.position.start
             end = node.position.end
-            typer.echo(f"  {rel_path}:{start.line}:{start.column}-{end.line}:{end.column}")
+            typer.echo(f"  {rel}:{start.line}:{start.column}-{end.line}:{end.column}")
 
 
 def _output_json(
@@ -249,15 +250,11 @@ def _output_json(
     for node in sorted(unreachable.nodes, key=lambda n: (str(n.path), n.fqname)):
         if is_unreachable_node(node):
             continue
-        try:
-            rel_path = str(node.path.relative_to(root))
-        except ValueError:
-            rel_path = str(node.path)
         result["dead_symbols"].append(
             {
                 "fqname": node.fqname,
                 "type": node.type,
-                "path": rel_path,
+                "path": str(_rel_path(node.path, root)),
             }
         )
 
@@ -265,13 +262,9 @@ def _output_json(
         (n for n in graph.nodes if is_unreachable_node(n)),
         key=lambda n: (str(n.path), n.position.start),
     ):
-        try:
-            rel_path = str(node.path.relative_to(root))
-        except ValueError:
-            rel_path = str(node.path)
         result["unreachable_branches"].append(
             {
-                "path": rel_path,
+                "path": str(_rel_path(node.path, root)),
                 "start": {"line": node.position.start.line, "column": node.position.start.column},
                 "end": {"line": node.position.end.line, "column": node.position.end.column},
             }
@@ -323,13 +316,8 @@ def why_alive(
         typer.echo(f"Symbol not found: {fqname}", err=True)
         raise typer.Exit(1)
 
-    try:
-        rel_path = target_node.path.relative_to(root)
-    except ValueError:
-        rel_path = target_node.path
-
     typer.echo(f"\nSymbol: {target_node.fqname} ({target_node.type})")
-    typer.echo(f"Path: {rel_path}")
+    typer.echo(f"Path: {_rel_path(target_node.path, root)}")
     typer.echo(f"In-degree: {graph.in_degree(target_node)}")
     typer.echo("\nPredecessor chain:")
 
@@ -340,11 +328,7 @@ def why_alive(
         if node in seen:
             continue
         seen.add(node)
-        try:
-            node_rel = node.path.relative_to(root)
-        except ValueError:
-            node_rel = node.path
-        typer.echo(f"  <- {node.fqname} ({node.type}) at {node_rel}")
+        typer.echo(f"  <- {node.fqname} ({node.type}) at {_rel_path(node.path, root)}")
         stack.extend(graph.predecessors(node))
 
 
@@ -475,11 +459,7 @@ def unused_exports(
         return
 
     for all_sym in sorted(by_all, key=lambda n: n.fqname):
-        try:
-            rel_path = all_sym.path.relative_to(root)
-        except ValueError:
-            rel_path = all_sym.path
-        typer.echo(f"\n{all_sym.fqname} at {rel_path}:")
+        typer.echo(f"\n{all_sym.fqname} at {_rel_path(all_sym.path, root)}:")
         for sym in sorted(by_all[all_sym], key=lambda n: n.fqname):
             typer.echo(f"  {sym.fqname} ({sym.type})")
 
@@ -542,11 +522,7 @@ def remove(
 
     typer.echo(f"\nDead symbols to remove ({len(removable)}):")
     for node in sorted(removable, key=lambda n: (str(n.path), n.fqname)):
-        try:
-            rel_path = node.path.relative_to(root)
-        except ValueError:
-            rel_path = node.path
-        typer.echo(f"  {node.fqname} ({node.type}) at {rel_path}")
+        typer.echo(f"  {node.fqname} ({node.type}) at {_rel_path(node.path, root)}")
 
     if dry_run:
         typer.echo("\n--dry-run specified, no changes made.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,7 @@ from dead_cst._symbols import SymbolNode
 from dead_cst.cli import (
     _is_dunder_all,
     _is_external_dep,
+    _rel_path,
     app,
     build_plugins,
     parse_entrypoint,
@@ -232,6 +233,20 @@ def test_is_dunder_all(fqname, type_, expected):
 def test_is_external_dep(fqname, type_, expected):
     node = SymbolNode(fqname, type_, Path("/x.py"), _pos())
     assert _is_external_dep(node) is expected
+
+
+def test_rel_path_under_root_is_relativized():
+    assert _rel_path(Path("/a/b/c.py"), Path("/a")) == Path("b/c.py")
+
+
+def test_rel_path_outside_root_returned_unchanged():
+    p = Path("/elsewhere/c.py")
+    assert _rel_path(p, Path("/a")) == p
+
+
+def test_rel_path_equal_to_root_yields_empty(tmp_path):
+    """``Path.relative_to`` of a path against itself is ``Path('.')``."""
+    assert _rel_path(tmp_path, tmp_path) == Path(".")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plugins/test_core.py
+++ b/tests/test_plugins/test_core.py
@@ -1,9 +1,15 @@
 """Tests for the plugin surface itself: empty seeds, registry lookup,
-composition across multiple plugins."""
+composition across multiple plugins, plus unit tests for the small
+AST helpers in :mod:`dead_cst._plugins._core`."""
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import libcst as cst
+import networkx as nx
 import pytest
+from libcst.metadata import CodePosition, CodeRange
 
 from dead_cst import (
     MainBlockPlugin,
@@ -11,6 +17,21 @@ from dead_cst import (
     build_symbol_graph,
     find_reachable,
 )
+from dead_cst._plugins._core import (
+    AddEdge,
+    AddNode,
+    PluginContext,
+    collect_module_imports,
+    decorator_owner,
+    find_call_assignments,
+    find_handlers,
+    is_from_module,
+    is_name,
+    mark_entrypoints,
+    matched_attr_call,
+    single_target_assignment,
+)
+from dead_cst._symbols import SymbolNode, SymbolTrie
 
 
 def test_no_plugins_means_nothing_reachable(tmp_path, write_files):
@@ -50,3 +71,257 @@ def test_unknown_plugin_raises():
 
     with pytest.raises(KeyError):
         load_plugin("does-not-exist")
+
+
+# ---------------------------------------------------------------------------
+# AST helpers in _plugins._core
+# ---------------------------------------------------------------------------
+
+
+def _parse(src: str) -> cst.Module:
+    import textwrap
+
+    return cst.parse_module(textwrap.dedent(src).strip() + "\n")
+
+
+def _pos() -> CodeRange:
+    return CodeRange(start=CodePosition(0, 0), end=CodePosition(0, 0))
+
+
+@pytest.mark.parametrize(
+    "expr, value, expected",
+    [
+        ("foo", "foo", True),
+        ("foo", "bar", False),
+        ("foo.bar", "foo", False),  # Attribute, not Name
+        ("foo()", "foo", False),  # Call, not Name
+    ],
+)
+def test_is_name(expr, value, expected):
+    node = cst.parse_expression(expr)
+    assert is_name(node, value) is expected
+
+
+def test_is_name_handles_none():
+    assert is_name(None, "anything") is False
+
+
+@pytest.mark.parametrize(
+    "src, module_name, expected",
+    [
+        ("from flask import Flask", "flask", True),
+        ("from flask import Flask", "fastapi", False),
+        ("from .pkg import x", "pkg", False),  # relative
+        ("from a.b import c", "a", False),  # dotted module name -- not a bare Name
+    ],
+)
+def test_is_from_module(src, module_name, expected):
+    module = _parse(src)
+    stmt = module.body[0].body[0]
+    assert isinstance(stmt, cst.ImportFrom)
+    assert is_from_module(stmt, module_name) is expected
+
+
+@pytest.mark.parametrize(
+    "src, expected_name, expected_rhs",
+    [
+        ("x = 1", "x", "1"),
+        ("x: int = 1", "x", "1"),
+        ("x, y = 1, 2", None, None),  # tuple target
+        ("x = y = 1", None, None),  # chained assign -> 2 targets
+        ("x: int", None, None),  # AnnAssign without value
+        ("foo.bar = 1", None, None),  # not a bare Name target
+    ],
+)
+def test_single_target_assignment(src, expected_name, expected_rhs):
+    module = _parse(src)
+    stmt = module.body[0].body[0]
+    name, rhs = single_target_assignment(stmt)
+    assert name == expected_name
+    if expected_rhs is None:
+        assert rhs is None
+    else:
+        assert rhs is not None
+        assert cst.Module([]).code_for_node(rhs).strip() == expected_rhs
+
+
+def test_single_target_assignment_rejects_non_assign():
+    module = _parse("def f(): pass")
+    stmt = module.body[0]
+    assert single_target_assignment(stmt) == (None, None)
+
+
+@pytest.mark.parametrize(
+    "expr, valid, expected",
+    [
+        ("app.route", {"route"}, "app"),
+        ("app.route(...)", {"route"}, "app"),  # Call unwrapped
+        ("app.route", {"get"}, None),  # attr not in valid
+        ("app.route.sub", {"route"}, None),  # owner not bare Name
+        ("route", {"route"}, None),  # bare Name, no owner
+    ],
+)
+def test_decorator_owner(expr, valid, expected):
+    node = cst.parse_expression(expr)
+    assert decorator_owner(node, valid) == expected
+
+
+def test_find_handlers_collects_per_instance():
+    module = _parse(
+        """
+        @app.route("/a")
+        def a(): pass
+
+        @app.get("/b")
+        def b(): pass
+
+        @other.route("/c")
+        def c(): pass
+
+        @app.unknown("/d")
+        def d(): pass
+        """
+    )
+    handlers = find_handlers(module, {"app", "other"}, {"route", "get"})
+    assert handlers == {"app": ["a", "b"], "other": ["c"]}
+
+
+def test_find_handlers_skips_non_top_level_functions():
+    module = _parse(
+        """
+        class C:
+            @app.route("/a")
+            def a(self): pass
+        """
+    )
+    assert find_handlers(module, {"app"}, {"route"}) == {}
+
+
+def test_find_handlers_one_decorator_per_function_max():
+    """If a function has multiple matching decorators, count it once per first match."""
+    module = _parse(
+        """
+        @app.route("/a")
+        @app.get("/a")
+        def a(): pass
+        """
+    )
+    handlers = find_handlers(module, {"app"}, {"route", "get"})
+    assert handlers == {"app": ["a"]}
+
+
+def test_collect_module_imports_from_form():
+    module = _parse(
+        """
+        from flask import Flask, Blueprint as BP, Other
+        """
+    )
+    bindings = collect_module_imports(module, "flask", {"Flask", "Blueprint"})
+    assert bindings == {"Flask": "Flask", "BP": "Blueprint"}
+
+
+def test_collect_module_imports_module_form():
+    module = _parse("import flask as fl")
+    bindings = collect_module_imports(module, "flask", {"Flask"})
+    assert bindings == {"fl": "<module>"}
+
+
+def test_collect_module_imports_skips_other_modules_and_star():
+    module = _parse(
+        """
+        from other import Flask
+        from flask import *
+        """
+    )
+    assert collect_module_imports(module, "flask", {"Flask"}) == {}
+
+
+def test_mark_entrypoints_emits_synthetic_node_and_edges(tmp_path):
+    target = SymbolNode("pkg.f", "function", tmp_path / "f.py", _pos())
+    ops = list(mark_entrypoints("seed", tmp_path / "p.toml", [target]))
+    assert len(ops) == 2
+    assert isinstance(ops[0], AddNode)
+    assert ops[0].entrypoint is True
+    assert ops[0].node.fqname == "seed"
+    assert isinstance(ops[1], AddEdge)
+    assert ops[1].src is ops[0].node
+    assert ops[1].dst is target
+
+
+def test_mark_entrypoints_empty_targets_yields_nothing():
+    assert list(mark_entrypoints("seed", Path("/x"), [])) == []
+
+
+@pytest.mark.parametrize(
+    "expr, imports, valid, expected",
+    [
+        ("Flask()", {"Flask": "Flask"}, {"Flask", "Blueprint"}, "Flask"),
+        ("BP()", {"BP": "Blueprint"}, {"Flask", "Blueprint"}, "Blueprint"),
+        ("flask.Flask()", {"flask": "<module>"}, {"Flask", "Blueprint"}, "Flask"),
+        ("Flask()", {"Flask": "Other"}, {"Flask"}, None),  # binding maps elsewhere
+        ("flask.Flask()", {"flask": "<module>"}, {"Blueprint"}, None),  # attr not valid
+        ("flask.sub.Flask()", {"flask": "<module>"}, {"Flask"}, None),  # nested attr
+        ("Other()", {"Flask": "Flask"}, {"Flask"}, None),  # unknown name
+    ],
+)
+def test_matched_attr_call_unwraps_call(expr, imports, valid, expected):
+    node = cst.parse_expression(expr)
+    assert matched_attr_call(node, imports, valid) == expected
+
+
+def test_matched_attr_call_no_unwrap():
+    """With ``unwrap_call=False`` a Call expression itself does not match -- callers
+    must hand in the func directly."""
+    call = cst.parse_expression("Flask()")
+    assert matched_attr_call(call, {"Flask": "Flask"}, {"Flask"}, unwrap_call=False) is None
+    assert matched_attr_call(call.func, {"Flask": "Flask"}, {"Flask"}, unwrap_call=False) == "Flask"
+
+
+def test_find_call_assignments():
+    module = _parse(
+        """
+        app = Flask(__name__)
+        bp: Blueprint = Blueprint("bp", __name__)
+        app2 = flask.Flask()
+        not_a_target = SomethingElse()
+        x, y = Flask(), Flask()  # multi-target -- ignored
+        """
+    )
+    imports = {"Flask": "Flask", "Blueprint": "Blueprint", "flask": "<module>"}
+    assignments = find_call_assignments(module, imports, {"Flask", "Blueprint"})
+    assert assignments == {"app": "Flask", "bp": "Blueprint", "app2": "Flask"}
+
+
+def test_find_call_assignments_ignores_non_call_rhs():
+    module = _parse(
+        """
+        x = Flask  # bare reference, not a call
+        y = 1
+        """
+    )
+    assert find_call_assignments(module, {"Flask": "Flask"}, {"Flask"}) == {}
+
+
+# ---------------------------------------------------------------------------
+# PluginContext: base_modules() caches its first scan
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_context_base_modules_caches_first_scan(tmp_path):
+    base = tmp_path
+    inside = SymbolNode("pkg.a", "module", base / "a.py", _pos())
+    outside = SymbolNode("other.b", "module", tmp_path.parent / "other.py", _pos())
+    graph = nx.DiGraph()
+    graph.add_node(inside)
+    graph.add_node(outside)
+
+    ctx = PluginContext(graph=graph, symbol_lookup=SymbolTrie(), base=base, project_root=base)
+    first = list(ctx.base_modules())
+    assert first == [(inside.path, inside)]
+
+    # Adding a module-typed node after the first call must not appear -- the
+    # cache is intentional, so plugins see a stable snapshot.
+    late = SymbolNode("pkg.late", "module", base / "late.py", _pos())
+    graph.add_node(late)
+    second = list(ctx.base_modules())
+    assert second == first

--- a/tests/test_resolvers/test_core.py
+++ b/tests/test_resolvers/test_core.py
@@ -13,6 +13,7 @@ from dead_cst import (
     load_resolver,
     merge_paths,
 )
+from dead_cst._resolvers._core import load_toml
 
 
 def test_merge_paths_unions_deps():
@@ -38,3 +39,28 @@ def test_load_resolver_known():
 def test_load_resolver_unknown_raises():
     with pytest.raises(KeyError):
         load_resolver("does-not-exist")
+
+
+def test_load_toml_returns_parsed_data(tmp_path):
+    p = tmp_path / "x.toml"
+    p.write_text('[project]\nname = "x"\n')
+    assert load_toml(p) == {"project": {"name": "x"}}
+
+
+def test_load_toml_missing_file_returns_none(tmp_path):
+    assert load_toml(tmp_path / "missing.toml") is None
+
+
+def test_load_toml_directory_returns_none(tmp_path):
+    """``is_file()`` is False for a directory, so we get None rather than IsADirectoryError."""
+    assert load_toml(tmp_path) is None
+
+
+def test_load_toml_invalid_syntax_propagates(tmp_path):
+    """Bad TOML is a programmer/config error -- callers see the parse exception."""
+    import tomllib
+
+    p = tmp_path / "bad.toml"
+    p.write_text("this is = not = valid\n")
+    with pytest.raises(tomllib.TOMLDecodeError):
+        load_toml(p)


### PR DESCRIPTION
Consolidate four near-duplicate patterns that had accumulated as the
plugin and resolver families grew, with no behavior change (445 tests
still pass). Net -96 lines.

- ``load_toml(path)`` in ``_resolvers/_core.py`` replaces four copies
  of the ``Path.is_file() / try import tomllib / open / load`` boilerplate
  in ``pyproject.py``, ``uv_workspace.py``, ``_exports.py``, and
  ``_plugins/project_scripts.py``.
- ``matched_attr_call(expr, imports, valid_targets)`` and
  ``find_call_assignments(module, imports, valid_targets)`` in
  ``_plugins/_core.py`` replace flask's, fastapi's, and typer's
  per-plugin ``_classify_call`` / ``_is_typer_call`` / ``_find_instances``
  helpers, and click's ``_is_group_decorator`` / ``_is_group_constructor``.
  After consolidation flask/fastapi/typer hold only their plugin class.
- ``_rel_path(path, root)`` helper in ``cli.py`` replaces six
  copies of the ``try: path.relative_to(root) except ValueError: path``
  pattern across ``analyze``, ``why-alive``, ``unused-exports``, and
  ``remove`` commands.
- ``PluginContext.base_modules()`` caches its first scan of
  ``ctx.graph.nodes``; subsequent plugin calls reuse the materialized
  list instead of re-walking the graph each time.