### PR TITLE
Wholistic simplify pass: shared entrypoint helper, single-source-of-truth prefix constants

### DIFF
--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -159,7 +159,6 @@ def build_symbol_graph(
 
                 import_edges |= visitor.import_edges | visitor.unreachable_import_edges
 
-            # add edges to keep __init__.py files alive
             current_trie.add_module_hierarchy_edges(symbol_graph)
             export_tries[base] = export_trie
 
@@ -173,7 +172,6 @@ def build_symbol_graph(
             for dep in paths.get(base, []):
                 symbol_lookup.merge(export_tries.get(dep, base_tries[dep]))
 
-            # resolve all the import edges
             for src, dst in resolve_edges(import_edges, symbol_lookup, base):
                 symbol_graph.add_edge(src, dst)
 

--- a/dead_cst/_branches.py
+++ b/dead_cst/_branches.py
@@ -15,9 +15,9 @@ always the safe default: callers must treat the branch as live.
 This module also owns the convention for synthetic graph nodes that
 represent dead suites. The nodes have ``type="synthetic"`` (the
 existing escape hatch in :mod:`dead_cst._symbols`) and a fqname
-prefixed with ``<unreachable ``. ``is_unreachable_node`` is the single
-source of truth for that convention; consumers should never check the
-prefix string themselves.
+prefixed with :data:`UNREACHABLE_PREFIX` (``<unreachable>:``).
+``is_unreachable_node`` is the single source of truth for that
+convention; consumers should never check the prefix string themselves.
 """
 
 from __future__ import annotations
@@ -37,7 +37,7 @@ _KEYWORDS: dict[str, bool] = {
     "None": False,
 }
 
-_UNREACHABLE_PREFIX = "<unreachable "
+UNREACHABLE_PREFIX = "<unreachable>:"
 
 
 def evaluate_truthiness(node: cst.BaseExpression) -> bool | None:
@@ -173,7 +173,7 @@ def make_unreachable_fqname(module_fqname: str, position: CodeRange) -> str:
     :func:`is_unreachable_node` to identify these nodes rather than
     string-matching on their fqnames.
     """
-    return f"{_UNREACHABLE_PREFIX}{module_fqname}:{position.start.line}:{position.start.column}>"
+    return f"{UNREACHABLE_PREFIX}{module_fqname}:{position.start.line}:{position.start.column}"
 
 
 def make_unreachable_node(module_fqname: str, path: Path, position: CodeRange) -> SymbolNode:
@@ -183,7 +183,7 @@ def make_unreachable_node(module_fqname: str, path: Path, position: CodeRange) -
     nodes that don't correspond to a top-level declaration -- and
     distinguishes itself by carrying a real source ``position`` (rather
     than the ``SYNTHETIC_POSITION`` sentinel used by entrypoint plugins)
-    plus an ``<unreachable ...>`` fqname prefix.
+    plus the :data:`UNREACHABLE_PREFIX` fqname prefix.
     """
     return SymbolNode(
         fqname=make_unreachable_fqname(module_fqname, position),
@@ -200,4 +200,4 @@ def is_unreachable_node(sym: SymbolNode) -> bool:
     string-match on the fqname directly; the prefix is an implementation
     detail of this module.
     """
-    return sym.type == "synthetic" and sym.fqname.startswith(_UNREACHABLE_PREFIX)
+    return sym.type == "synthetic" and sym.fqname.startswith(UNREACHABLE_PREFIX)

--- a/dead_cst/_branches.py
+++ b/dead_cst/_branches.py
@@ -37,7 +37,7 @@ _KEYWORDS: dict[str, bool] = {
     "None": False,
 }
 
-_UNREACHABLE_FQNAME_PREFIX = "<unreachable "
+_UNREACHABLE_PREFIX = "<unreachable "
 
 
 def evaluate_truthiness(node: cst.BaseExpression) -> bool | None:
@@ -173,10 +173,7 @@ def make_unreachable_fqname(module_fqname: str, position: CodeRange) -> str:
     :func:`is_unreachable_node` to identify these nodes rather than
     string-matching on their fqnames.
     """
-    return (
-        f"{_UNREACHABLE_FQNAME_PREFIX}"
-        f"{module_fqname}:{position.start.line}:{position.start.column}>"
-    )
+    return f"{_UNREACHABLE_PREFIX}{module_fqname}:{position.start.line}:{position.start.column}>"
 
 
 def make_unreachable_node(module_fqname: str, path: Path, position: CodeRange) -> SymbolNode:
@@ -203,4 +200,4 @@ def is_unreachable_node(sym: SymbolNode) -> bool:
     string-match on the fqname directly; the prefix is an implementation
     detail of this module.
     """
-    return sym.type == "synthetic" and sym.fqname.startswith(_UNREACHABLE_FQNAME_PREFIX)
+    return sym.type == "synthetic" and sym.fqname.startswith(_UNREACHABLE_PREFIX)

--- a/dead_cst/_plugins/_core.py
+++ b/dead_cst/_plugins/_core.py
@@ -26,6 +26,20 @@ from .._symbols import SymbolNode, SymbolTrie
 
 SYNTHETIC_POSITION = CodeRange(start=CodePosition(0, 0), end=CodePosition(0, 0))
 
+# Synthetic-node fqname prefixes, consumed by ``importers`` and the path
+# resolver. Anything in :data:`SYNTHETIC_PATH_PREFIXES` is also a valid
+# value for ``Import.path`` -- the analyzer surfaces non-first-party
+# imports as ``[external dist] X`` / ``[external file] X`` /
+# ``[unresolved] X`` so plugins can answer "which files import X?".
+# Stdlib imports (``[stdlib] X``) are *not* surfaced as graph nodes;
+# the prefix exists for the resolver only.
+STDLIB_PREFIX = "[stdlib] "
+EXTERNAL_DIST_PREFIX = "[external dist] "
+EXTERNAL_FILE_PREFIX = "[external file] "
+EXTERNAL_PREFIXES = (EXTERNAL_DIST_PREFIX, EXTERNAL_FILE_PREFIX)
+UNRESOLVED_PREFIX = "[unresolved] "
+SYNTHETIC_PATH_PREFIXES = (*EXTERNAL_PREFIXES, UNRESOLVED_PREFIX)
+
 
 @dataclass
 class PluginContext:
@@ -129,12 +143,8 @@ class PluginContext:
         """
         target_node = self.find_module(target)
         if target_node is None:
-            for tag in (
-                f"[external dist] {target}",
-                f"[external file] {target}",
-                f"[unresolved] {target}",
-            ):
-                node = self._synthetic(tag)
+            for prefix in SYNTHETIC_PATH_PREFIXES:
+                node = self._synthetic(f"{prefix}{target}")
                 if node is not None:
                     target_node = node
                     break

--- a/dead_cst/_plugins/_core.py
+++ b/dead_cst/_plugins/_core.py
@@ -53,12 +53,15 @@ class PluginContext:
     # is fine in practice -- ``importers`` is for prefiltering against
     # the analyzer's already-resolved dep markers.
     _synthetic_index: dict[str, SymbolNode] | None = field(default=None, init=False, repr=False)
-    # Cached materialization of ``base_modules``. Plugins don't add module
-    # nodes during their pass (only the visitor pass does, before plugins
-    # run), so a one-time scan of ``graph.nodes`` is safe to memoize.
+    # Cached materialization of ``base_modules`` / ``base_nodes``. Plugins
+    # may add nodes during their pass (entrypoint synthetics, etc.) but
+    # those are never re-iterated by these helpers; we snapshot once at
+    # first call to keep iteration cheap when ``graph`` accumulates nodes
+    # across bases.
     _base_modules_cache: list[tuple[Path, SymbolNode]] | None = field(
         default=None, init=False, repr=False
     )
+    _base_nodes_cache: list[SymbolNode] | None = field(default=None, init=False, repr=False)
 
     def find_module(self, fqname: str) -> SymbolNode | None:
         node = self.symbol_lookup._get(fqname.split("."))
@@ -89,6 +92,20 @@ class PluginContext:
                 if node.type == "module" and node.path.is_relative_to(self.base)
             ]
         return iter(self._base_modules_cache)
+
+    def base_nodes(self) -> Iterator[SymbolNode]:
+        """Yield every graph node whose path is under :attr:`base`.
+
+        ``graph`` accumulates nodes across bases; plugins that need to
+        iterate "everything in this base" should use this instead of
+        ``ctx.graph.nodes`` so they don't pay O(N) for nodes belonging
+        to sibling bases.
+        """
+        if self._base_nodes_cache is None:
+            self._base_nodes_cache = [
+                node for node in self.graph.nodes if node.path.is_relative_to(self.base)
+            ]
+        return iter(self._base_nodes_cache)
 
     def importers(self, target: str) -> set[Path]:
         """Return paths under :attr:`base` whose imports reach ``target``.

--- a/dead_cst/_plugins/explicit.py
+++ b/dead_cst/_plugins/explicit.py
@@ -11,6 +11,8 @@ from typing import Iterable
 from .._symbols import SymbolNode
 from ._core import GraphOp, PluginContext, mark_entrypoints
 
+EXPLICIT_PREFIX = "<entrypoint>:"
+
 
 @dataclass
 class ExplicitEntrypointPlugin:
@@ -36,7 +38,7 @@ class ExplicitEntrypointPlugin:
         for node in ctx.base_nodes():
             if not self._matches(node, root):
                 continue
-            yield from mark_entrypoints(f"<entrypoint>:{node.fqname}", node.path, [node])
+            yield from mark_entrypoints(f"{EXPLICIT_PREFIX}{node.fqname}", node.path, [node])
 
     def _matches(self, sym: SymbolNode, root: Path) -> bool:
         try:

--- a/dead_cst/_plugins/explicit.py
+++ b/dead_cst/_plugins/explicit.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Iterable
 
 from .._symbols import SymbolNode
-from ._core import AddEdge, AddNode, GraphOp, PluginContext, synthetic_node
+from ._core import GraphOp, PluginContext, mark_entrypoints
 
 
 @dataclass
@@ -33,17 +33,10 @@ class ExplicitEntrypointPlugin:
 
     def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
         root = ctx.project_root
-        for node in ctx.graph.nodes:
-            if not node.path.is_relative_to(ctx.base):
-                continue
+        for node in ctx.base_nodes():
             if not self._matches(node, root):
                 continue
-            synth = synthetic_node(
-                fqname=f"<entrypoint>:{node.fqname}",
-                path=node.path,
-            )
-            yield AddNode(synth, entrypoint=True)
-            yield AddEdge(synth, node)
+            yield from mark_entrypoints(f"<entrypoint>:{node.fqname}", node.path, [node])
 
     def _matches(self, sym: SymbolNode, root: Path) -> bool:
         try:

--- a/dead_cst/_plugins/init_subclass.py
+++ b/dead_cst/_plugins/init_subclass.py
@@ -36,7 +36,7 @@ from .._symbols import SymbolNode
 from ._core import AddEdge, AddNode, GraphOp, PluginContext, synthetic_node
 
 _INIT_SUBCLASS = "__init_subclass__"
-_MARKER_PREFIX = "<__init_subclass__>:"
+INIT_SUBCLASS_PREFIX = "<__init_subclass__>:"
 
 
 @dataclass
@@ -96,7 +96,7 @@ class InitSubclassPlugin:
                 continue
             if _has_init_subclass(class_def):
                 roots[class_node] = synthetic_node(
-                    fqname=f"{_MARKER_PREFIX}{class_node.fqname}",
+                    fqname=f"{INIT_SUBCLASS_PREFIX}{class_node.fqname}",
                     path=class_node.path,
                 )
             module_fqname = class_node.fqname.rsplit(".", 1)[0]

--- a/dead_cst/_plugins/main_block.py
+++ b/dead_cst/_plugins/main_block.py
@@ -9,6 +9,8 @@ import libcst as cst
 
 from ._core import GraphOp, PluginContext, is_name, mark_entrypoints
 
+MAIN_BLOCK_PREFIX = "<__main__>:"
+
 
 @dataclass
 class MainBlockPlugin:
@@ -31,7 +33,9 @@ class MainBlockPlugin:
             module = ctx.parse(path)
             if module is None or not _has_main_block(module):
                 continue
-            yield from mark_entrypoints(f"<__main__>:{module_node.fqname}", path, [module_node])
+            yield from mark_entrypoints(
+                f"{MAIN_BLOCK_PREFIX}{module_node.fqname}", path, [module_node]
+            )
 
 
 def _has_main_block(module: cst.Module) -> bool:

--- a/dead_cst/_plugins/main_block.py
+++ b/dead_cst/_plugins/main_block.py
@@ -7,7 +7,7 @@ from typing import Iterable
 
 import libcst as cst
 
-from ._core import AddEdge, AddNode, GraphOp, PluginContext, synthetic_node
+from ._core import GraphOp, PluginContext, is_name, mark_entrypoints
 
 
 @dataclass
@@ -31,12 +31,7 @@ class MainBlockPlugin:
             module = ctx.parse(path)
             if module is None or not _has_main_block(module):
                 continue
-            synth = synthetic_node(
-                fqname=f"<__main__>:{module_node.fqname}",
-                path=path,
-            )
-            yield AddNode(synth, entrypoint=True)
-            yield AddEdge(synth, module_node)
+            yield from mark_entrypoints(f"<__main__>:{module_node.fqname}", path, [module_node])
 
 
 def _has_main_block(module: cst.Module) -> bool:
@@ -57,13 +52,9 @@ def _is_name_eq_main(expr: cst.BaseExpression) -> bool:
     if not isinstance(op.operator, cst.Equal):
         return False
     left, right = expr.left, op.comparator
-    return (_is_dunder_name(left, "__name__") and _is_string(right, "__main__")) or (
-        _is_string(left, "__main__") and _is_dunder_name(right, "__name__")
+    return (is_name(left, "__name__") and _is_string(right, "__main__")) or (
+        _is_string(left, "__main__") and is_name(right, "__name__")
     )
-
-
-def _is_dunder_name(expr: cst.BaseExpression, name: str) -> bool:
-    return isinstance(expr, cst.Name) and expr.value == name
 
 
 def _is_string(expr: cst.BaseExpression, value: str) -> bool:

--- a/dead_cst/_plugins/module_dunders.py
+++ b/dead_cst/_plugins/module_dunders.py
@@ -6,7 +6,9 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from .._symbols import SymbolNode
-from ._core import AddEdge, AddNode, GraphOp, PluginContext, synthetic_node
+from ._core import GraphOp, PluginContext, mark_entrypoints
+
+DUNDER_PREFIX = "<dunder>:"
 
 
 @dataclass
@@ -24,17 +26,10 @@ class ModuleDundersPlugin:
     name: str = "module_dunders"
 
     def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
-        for node in ctx.graph.nodes:
-            if not node.path.is_relative_to(ctx.base):
-                continue
+        for node in ctx.base_nodes():
             if not _is_module_dunder(node):
                 continue
-            synth = synthetic_node(
-                fqname=f"<dunder>:{node.fqname}",
-                path=node.path,
-            )
-            yield AddNode(synth, entrypoint=True)
-            yield AddEdge(synth, node)
+            yield from mark_entrypoints(f"{DUNDER_PREFIX}{node.fqname}", node.path, [node])
 
 
 def _is_module_dunder(node: SymbolNode) -> bool:

--- a/dead_cst/_plugins/project_scripts.py
+++ b/dead_cst/_plugins/project_scripts.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Iterable
 
 from .._resolvers._core import load_toml
-from ._core import AddEdge, AddNode, GraphOp, PluginContext, synthetic_node
+from ._core import GraphOp, PluginContext, mark_entrypoints
 
 logger = logging.getLogger(__name__)
 
@@ -53,10 +53,4 @@ class ProjectScriptsPlugin:
                     target,
                 )
                 continue
-            synth = synthetic_node(
-                fqname=f"<project.scripts>:{script_name}",
-                path=pyproject,
-            )
-            yield AddNode(synth, entrypoint=True)
-            for target_node in target_nodes:
-                yield AddEdge(synth, target_node)
+            yield from mark_entrypoints(f"<project.scripts>:{script_name}", pyproject, target_nodes)

--- a/dead_cst/_plugins/project_scripts.py
+++ b/dead_cst/_plugins/project_scripts.py
@@ -11,6 +11,8 @@ from typing import Iterable
 from .._resolvers._core import load_toml
 from ._core import GraphOp, PluginContext, mark_entrypoints
 
+PROJECT_SCRIPTS_PREFIX = "<project.scripts>:"
+
 logger = logging.getLogger(__name__)
 
 
@@ -53,4 +55,6 @@ class ProjectScriptsPlugin:
                     target,
                 )
                 continue
-            yield from mark_entrypoints(f"<project.scripts>:{script_name}", pyproject, target_nodes)
+            yield from mark_entrypoints(
+                f"{PROJECT_SCRIPTS_PREFIX}{script_name}", pyproject, target_nodes
+            )

--- a/dead_cst/_plugins/pytest.py
+++ b/dead_cst/_plugins/pytest.py
@@ -12,6 +12,10 @@ import libcst as cst
 from .._symbols import SymbolNode
 from ._core import GraphOp, PluginContext, mark_entrypoints
 
+PYTEST_CONFTEST_PREFIX = "<pytest:conftest>:"
+PYTEST_TESTS_PREFIX = "<pytest:tests>:"
+PYTEST_FIXTURES_PREFIX = "<pytest:fixtures>:"
+
 
 @dataclass
 class PytestPlugin:
@@ -57,12 +61,12 @@ class PytestPlugin:
 
             if filename == "conftest.py":
                 yield from mark_entrypoints(
-                    f"<pytest:conftest>:{module_node.fqname}", path, module_decls
+                    f"{PYTEST_CONFTEST_PREFIX}{module_node.fqname}", path, module_decls
                 )
             elif _is_test_filename(filename):
                 test_decls = [d for d in module_decls if _is_test_decl(d)]
                 yield from mark_entrypoints(
-                    f"<pytest:tests>:{module_node.fqname}", path, test_decls
+                    f"{PYTEST_TESTS_PREFIX}{module_node.fqname}", path, test_decls
                 )
 
             if path not in fixture_candidates:
@@ -79,7 +83,7 @@ class PytestPlugin:
                 if d.type == "function" and d.fqname.rsplit(".", 1)[-1] in fixture_names
             ]
             yield from mark_entrypoints(
-                f"<pytest:fixtures>:{module_node.fqname}", path, fixture_decls
+                f"{PYTEST_FIXTURES_PREFIX}{module_node.fqname}", path, fixture_decls
             )
 
 

--- a/dead_cst/_plugins/unittest.py
+++ b/dead_cst/_plugins/unittest.py
@@ -11,6 +11,8 @@ import libcst as cst
 from .._symbols import SymbolNode
 from ._core import GraphOp, PluginContext, is_from_module, is_name, mark_entrypoints
 
+UNITTEST_PREFIX = "<unittest>:"
+
 # Module-level functions ``unittest`` discovers by name.
 _MODULE_HOOKS: frozenset[str] = frozenset({"setUpModule", "tearDownModule", "load_tests"})
 
@@ -92,7 +94,7 @@ class UnittestPlugin:
             if not targets:
                 continue
 
-            yield from mark_entrypoints(f"<unittest>:{module_node.fqname}", path, targets)
+            yield from mark_entrypoints(f"{UNITTEST_PREFIX}{module_node.fqname}", path, targets)
 
 
 def _collect_unittest_imports(module: cst.Module) -> tuple[set[str], set[str]]:

--- a/dead_cst/_resolve.py
+++ b/dead_cst/_resolve.py
@@ -8,19 +8,20 @@ from importlib.machinery import ModuleSpec
 from pathlib import Path
 from typing import Generator
 
-from ._plugins._core import synthetic_node
+from ._plugins._core import (
+    EXTERNAL_DIST_PREFIX,
+    EXTERNAL_FILE_PREFIX,
+    STDLIB_PREFIX,
+    SYNTHETIC_PATH_PREFIXES,
+    UNRESOLVED_PREFIX,
+    synthetic_node,
+)
 from ._symbols import Import, SymbolNode, SymbolTrie
 
 logger = logging.getLogger(__name__)
 
 STDLIB = Path(sysconfig.get_path("stdlib")).resolve()
 SITE_PACKAGES_MARKERS = ("site-packages", "dist-packages")
-
-STDLIB_PREFIX = "[stdlib] "
-EXTERNAL_DIST_PREFIX = "[external dist] "
-EXTERNAL_FILE_PREFIX = "[external file] "
-UNRESOLVED_PREFIX = "[unresolved] "
-SYNTHETIC_PATH_PREFIXES = ("[external", "[unresolved")
 
 
 @contextlib.contextmanager

--- a/dead_cst/_resolve.py
+++ b/dead_cst/_resolve.py
@@ -8,13 +8,19 @@ from importlib.machinery import ModuleSpec
 from pathlib import Path
 from typing import Generator
 
-from ._plugins._core import SYNTHETIC_POSITION
+from ._plugins._core import synthetic_node
 from ._symbols import Import, SymbolNode, SymbolTrie
 
 logger = logging.getLogger(__name__)
 
 STDLIB = Path(sysconfig.get_path("stdlib")).resolve()
 SITE_PACKAGES_MARKERS = ("site-packages", "dist-packages")
+
+STDLIB_PREFIX = "[stdlib] "
+EXTERNAL_DIST_PREFIX = "[external dist] "
+EXTERNAL_FILE_PREFIX = "[external file] "
+UNRESOLVED_PREFIX = "[unresolved] "
+SYNTHETIC_PATH_PREFIXES = ("[external", "[unresolved")
 
 
 @contextlib.contextmanager
@@ -76,18 +82,18 @@ def resolve_import(name: str, search_paths: list[Path]) -> str | Path:
     if spec.origin is None:
         return None
     if spec.origin in {"built-in", "frozen"}:
-        return f"[stdlib] {name}"
+        return f"{STDLIB_PREFIX}{name}"
     path = Path(spec.origin).resolve()
     if path.is_relative_to(STDLIB):
-        return f"[stdlib] {name}"
+        return f"{STDLIB_PREFIX}{name}"
 
     lookup = distribution_lookup()
     if dist := lookup.get(path):
-        return f"[external dist] {dist}"
+        return f"{EXTERNAL_DIST_PREFIX}{dist}"
 
     path_str = str(path)
     if any(m in path_str for m in SITE_PACKAGES_MARKERS):
-        return f"[external file] {name}"
+        return f"{EXTERNAL_FILE_PREFIX}{name}"
 
     for search in search_paths:
         if path.is_relative_to(search):
@@ -111,13 +117,10 @@ def resolve_edges(
         emitted.add(key)
         yield key
 
-    def _synthetic(tag: str) -> SymbolNode:
-        return SymbolNode(fqname=tag, type="synthetic", path=base, position=SYNTHETIC_POSITION)
-
     for src, dst in import_edges:
         if not isinstance(dst.path, Path):
-            if dst.path.startswith(("[external", "[unresolved")):
-                yield from _emit(src, _synthetic(dst.path))
+            if dst.path.startswith(SYNTHETIC_PATH_PREFIXES):
+                yield from _emit(src, synthetic_node(dst.path, base))
             continue
 
         node = symbol_lookup._get(dst.module.split("."))
@@ -167,8 +170,8 @@ def resolve_edges(
                     assert decl.imports is not None, "import symbol needs Import"
 
                     if not isinstance(decl.imports.path, Path):
-                        if decl.imports.path.startswith(("[external", "[unresolved")):
-                            yield from _emit(src, _synthetic(decl.imports.path))
+                        if decl.imports.path.startswith(SYNTHETIC_PATH_PREFIXES):
+                            yield from _emit(src, synthetic_node(decl.imports.path, base))
                         continue
 
                     dest = symbol_lookup._get(decl.imports.module.split("."))

--- a/dead_cst/_resolve.py
+++ b/dead_cst/_resolve.py
@@ -13,7 +13,6 @@ from ._plugins._core import (
     EXTERNAL_FILE_PREFIX,
     STDLIB_PREFIX,
     SYNTHETIC_PATH_PREFIXES,
-    UNRESOLVED_PREFIX,
     synthetic_node,
 )
 from ._symbols import Import, SymbolNode, SymbolTrie

--- a/dead_cst/_resolvers/_core.py
+++ b/dead_cst/_resolvers/_core.py
@@ -21,14 +21,20 @@ class PathResolver(Protocol):
 
 
 def load_toml(path: Path) -> dict[str, Any] | None:
-    """Read ``path`` as TOML; ``None`` if the file is missing or tomllib is unavailable."""
-    if not path.is_file():
-        return None
+    """Read ``path`` as TOML; ``None`` if the file is missing or tomllib is unavailable.
+
+    Bad TOML is a programmer/config error and propagates as
+    :class:`tomllib.TOMLDecodeError`.
+    """
     try:
         import tomllib
     except ImportError:  # pragma: no cover - py<3.11 not supported
         return None
-    with path.open("rb") as f:
+    try:
+        f = path.open("rb")
+    except OSError:
+        return None
+    with f:
         return tomllib.load(f)
 
 

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -24,6 +24,7 @@ from libcst.metadata.scope_provider import (
 from ._branches import make_unreachable_node, unreachable_suites
 from ._flow import live_at_exit, live_referents
 from ._fqn import FixedFullyQualifiedNameProvider
+from ._plugins._core import UNRESOLVED_PREFIX
 from ._resolve import resolve_import
 from ._symbols import Import, SymbolNode, SymbolTrie
 
@@ -260,7 +261,7 @@ class SymbolVisitor(cst.CSTVisitor):
                 # ``importers("fastapi")`` finds them all. Reachability is
                 # unaffected (the synthetic has no outbound edges).
                 top_level = full_name.split(".", 1)[0]
-                module_path = f"[unresolved] {top_level}"
+                module_path = f"{UNRESOLVED_PREFIX}{top_level}"
                 module_name = full_name
 
             if alias.asname:

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -37,10 +37,8 @@ def _dotted_name_parts(
         full = f"{prefix}{node.value}" if prefix else node.value
         yield full, node
     elif isinstance(node, cst.Attribute):
-        # Recurse on the value first
         for nm, n in _dotted_name_parts(prefix, node.value):
             yield nm, n
-        # then append this attribute to the last prefix
         full = f"{nm}.{node.attr.value}"
         yield full, node.attr
 
@@ -91,7 +89,6 @@ class SymbolVisitor(cst.CSTVisitor):
     def __init__(self, path: Path, search_paths: list[Path]):
         self.path = path
         self.search_paths = search_paths
-        self.node_to_symbols: dict[cst.CSTNode, list[SymbolNode]] = {}
         self.node_to_frames: dict[cst.CSTNode, list[list[SymbolNode]]] = {}
         self.decl_stack: list[list[SymbolNode]] = []
         self.nearest_decls: dict[cst.CSTNode, list[SymbolNode]] = {}
@@ -139,7 +136,6 @@ class SymbolVisitor(cst.CSTVisitor):
         is attributed to both.
         """
         frame = list(decls)
-        self.node_to_symbols.setdefault(node, []).extend(frame)
         self.node_to_frames.setdefault(node, []).append(frame)
         self.decl_stack.append(frame)
         for d in frame:
@@ -150,7 +146,6 @@ class SymbolVisitor(cst.CSTVisitor):
         node: cst.CSTNode,
         type_: Literal["module", "class", "function", "variable"],
     ):
-        # Only collect top-level declarations, skip nested ones
         if len(self.decl_stack) > 1:
             return
 
@@ -183,7 +178,6 @@ class SymbolVisitor(cst.CSTVisitor):
         return names
 
     def _add_variable(self, node: cst.Assign | cst.AnnAssign):
-        # Only collect top-level declarations, skip nested ones
         if len(self.decl_stack) > 1:
             return
 
@@ -274,7 +268,6 @@ class SymbolVisitor(cst.CSTVisitor):
             else:
                 decl_name = alias.name
 
-            # add the import lookup so we can resolve it in on_leave
             self.import_lookup[decl_name] = import_info = Import(
                 path=module_path,
                 module=module_name,
@@ -285,11 +278,11 @@ class SymbolVisitor(cst.CSTVisitor):
                 ),
             )
 
-            # get the first name of the decl, eg 'google' for 'google.cloud'
+            # ``import google.cloud`` binds ``google`` in the local scope; the
+            # decl is stored under that bare name, not the dotted path.
             while isinstance(decl_name, cst.Attribute):
                 decl_name = decl_name.value
 
-            # add a decl if the import is in the module context
             if current_decl and current_decl.type == "module":
                 sym = SymbolNode(
                     f"{self.module_node.fqname}.{decl_name.value}",
@@ -301,7 +294,6 @@ class SymbolVisitor(cst.CSTVisitor):
                 self.symbol_referent_nodes[sym] = alias
                 self._push_decl(alias, sym)
 
-            # add the import edge to the last decl on the stack
             self.import_edges.add((self.decl_stack[-1][-1], import_info))
 
     def visit_Module(self, node: cst.Module) -> None:
@@ -498,7 +490,9 @@ class SymbolVisitor(cst.CSTVisitor):
                     if unreachable_owner is not None:
                         self.unreachable_import_edges.add((unreachable_owner, resolved_import))
 
-            target_symbols = self.node_to_symbols.get(target_node)
+            target_symbols = [
+                s for frame in self.node_to_frames.get(target_node, ()) for s in frame
+            ]
             if not target_symbols:
                 fallback = self.nearest_decls.get(target_node, [])
                 target_symbols = fallback[:1]
@@ -520,7 +514,7 @@ class SymbolVisitor(cst.CSTVisitor):
 
         # Resolve __all__ string references to declarations in the current module
         if self.dunder_all_refs:
-            module_sym = self.node_to_symbols[original_node][0]
+            module_sym = self.node_to_frames[original_node][0][0]
             module_trie = self.trie._get(module_sym.fqname.split("."))
             if module_trie is not None:
                 for owner, names in self.dunder_all_refs:

--- a/dead_cst/cli.py
+++ b/dead_cst/cli.py
@@ -21,6 +21,7 @@ from ._plugins import (
     ModuleDundersPlugin,
     load_plugin,
 )
+from ._plugins.module_dunders import DUNDER_PREFIX
 from ._resolvers import load_resolver, merge_paths
 from ._symbols import SymbolNode
 
@@ -206,13 +207,12 @@ def _output_text(
             else:
                 typer.echo(f"  {kind}: {total} total")
 
-    dead_real = [n for n in unreachable.nodes if not is_unreachable_node(n)]
+    dead_real, branches = _partition_unreachable(unreachable)
     if dead_real:
         typer.echo(f"\nDead symbols ({len(dead_real)}):")
         for node in sorted(dead_real, key=lambda n: (str(n.path), n.fqname)):
             typer.echo(f"  {node.fqname} ({node.type}) at {_rel_path(node.path, root)}")
 
-    branches = [n for n in graph.nodes if is_unreachable_node(n)]
     if branches:
         typer.echo(f"\nUnreachable branches ({len(branches)}):")
         for node in sorted(branches, key=lambda n: (str(n.path), n.position.start)):
@@ -220,6 +220,21 @@ def _output_text(
             start = node.position.start
             end = node.position.end
             typer.echo(f"  {rel}:{start.line}:{start.column}-{end.line}:{end.column}")
+
+
+def _partition_unreachable(
+    unreachable: nx.DiGraph,
+) -> tuple[list[SymbolNode], list[SymbolNode]]:
+    """Split ``unreachable.nodes`` into ``(dead_real, branches)`` in one pass.
+
+    Synthetic dead-suite nodes are orphan sources -- never visited by
+    reachability -- so they always land in ``unreachable``.
+    """
+    dead_real: list[SymbolNode] = []
+    branches: list[SymbolNode] = []
+    for n in unreachable.nodes:
+        (branches if is_unreachable_node(n) else dead_real).append(n)
+    return dead_real, branches
 
 
 def _output_json(
@@ -247,9 +262,8 @@ def _output_json(
             if kind != "synthetic"
         }
 
-    for node in sorted(unreachable.nodes, key=lambda n: (str(n.path), n.fqname)):
-        if is_unreachable_node(node):
-            continue
+    dead_real, branches = _partition_unreachable(unreachable)
+    for node in sorted(dead_real, key=lambda n: (str(n.path), n.fqname)):
         result["dead_symbols"].append(
             {
                 "fqname": node.fqname,
@@ -258,10 +272,7 @@ def _output_json(
             }
         )
 
-    for node in sorted(
-        (n for n in graph.nodes if is_unreachable_node(n)),
-        key=lambda n: (str(n.path), n.position.start),
-    ):
+    for node in sorted(branches, key=lambda n: (str(n.path), n.position.start)):
         result["unreachable_branches"].append(
             {
                 "path": str(_rel_path(node.path, root)),
@@ -440,7 +451,7 @@ def unused_exports(
         [
             (s, d)
             for s, d in graph.edges
-            if _is_dunder_all(d) and s.type == "synthetic" and s.fqname.startswith("<dunder>:")
+            if _is_dunder_all(d) and s.type == "synthetic" and s.fqname.startswith(DUNDER_PREFIX)
         ]
     )
     reachable_without_all = find_reachable(pruned)

--- a/dead_cst/cli.py
+++ b/dead_cst/cli.py
@@ -21,6 +21,7 @@ from ._plugins import (
     ModuleDundersPlugin,
     load_plugin,
 )
+from ._plugins._core import EXTERNAL_PREFIXES
 from ._plugins.module_dunders import DUNDER_PREFIX
 from ._resolvers import load_resolver, merge_paths
 from ._symbols import SymbolNode
@@ -348,7 +349,7 @@ def _is_dunder_all(node: SymbolNode) -> bool:
 
 
 def _is_external_dep(node: SymbolNode) -> bool:
-    return node.type == "synthetic" and node.fqname.startswith("[external ")
+    return node.type == "synthetic" and node.fqname.startswith(EXTERNAL_PREFIXES)
 
 
 @app.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,7 @@ from dead_cst._symbols import SymbolNode
 from dead_cst.cli import (
     _is_dunder_all,
     _is_external_dep,
+    _partition_unreachable,
     _rel_path,
     app,
     build_plugins,
@@ -247,6 +248,28 @@ def test_rel_path_outside_root_returned_unchanged():
 def test_rel_path_equal_to_root_yields_empty(tmp_path):
     """``Path.relative_to`` of a path against itself is ``Path('.')``."""
     assert _rel_path(tmp_path, tmp_path) == Path(".")
+
+
+def test_partition_unreachable_splits_synthetic_branches_from_real():
+    import networkx as nx
+
+    real = SymbolNode("pkg.f", "function", Path("/a.py"), _pos())
+    branch = SymbolNode("<unreachable pkg.a:5:0>", "synthetic", Path("/a.py"), _pos())
+    entrypoint_synth = SymbolNode("<entrypoint>:pkg.f", "synthetic", Path("/a.py"), _pos())
+
+    g = nx.DiGraph()
+    for n in (real, branch, entrypoint_synth):
+        g.add_node(n)
+
+    dead_real, branches = _partition_unreachable(g)
+    assert dead_real == [real, entrypoint_synth]
+    assert branches == [branch]
+
+
+def test_partition_unreachable_empty_graph_returns_empty_lists():
+    import networkx as nx
+
+    assert _partition_unreachable(nx.DiGraph()) == ([], [])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,11 +21,14 @@ import pytest
 from libcst.metadata import CodePosition, CodeRange
 from typer.testing import CliRunner
 
+from dead_cst._branches import UNREACHABLE_PREFIX
 from dead_cst._plugins import (
     ExplicitEntrypointPlugin,
     MainBlockPlugin,
     ModuleDundersPlugin,
 )
+from dead_cst._plugins._core import EXTERNAL_DIST_PREFIX
+from dead_cst._plugins.explicit import EXPLICIT_PREFIX
 from dead_cst._symbols import SymbolNode
 from dead_cst.cli import (
     _is_dunder_all,
@@ -226,8 +229,8 @@ def test_is_dunder_all(fqname, type_, expected):
 @pytest.mark.parametrize(
     "fqname, type_, expected",
     [
-        pytest.param("[external dist] networkx", "synthetic", True, id="external-synthetic"),
-        pytest.param("<entrypoint>:foo", "synthetic", False, id="entrypoint-synthetic"),
+        pytest.param(f"{EXTERNAL_DIST_PREFIX}networkx", "synthetic", True, id="external-synthetic"),
+        pytest.param(f"{EXPLICIT_PREFIX}foo", "synthetic", False, id="entrypoint-synthetic"),
         pytest.param("pkg.foo", "function", False, id="real-function"),
     ],
 )
@@ -254,8 +257,8 @@ def test_partition_unreachable_splits_synthetic_branches_from_real():
     import networkx as nx
 
     real = SymbolNode("pkg.f", "function", Path("/a.py"), _pos())
-    branch = SymbolNode("<unreachable pkg.a:5:0>", "synthetic", Path("/a.py"), _pos())
-    entrypoint_synth = SymbolNode("<entrypoint>:pkg.f", "synthetic", Path("/a.py"), _pos())
+    branch = SymbolNode(f"{UNREACHABLE_PREFIX}pkg.a:5:0", "synthetic", Path("/a.py"), _pos())
+    entrypoint_synth = SymbolNode(f"{EXPLICIT_PREFIX}pkg.f", "synthetic", Path("/a.py"), _pos())
 
     g = nx.DiGraph()
     for n in (real, branch, entrypoint_synth):

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -8,6 +8,8 @@ the fixture so individual cases only list the edges they introduce.
 
 import pytest
 
+from dead_cst._plugins._core import EXTERNAL_PREFIXES
+
 IMPORT_TEST_FILES = {
     "p/__init__.py": "",
     "p/functions.py": "def f(): pass\ndef g(): pass",
@@ -314,7 +316,9 @@ def test_third_party_import_creates_synthetic_node(build_decl_graph):
     nx_nodes = {
         n
         for n in graph.nodes
-        if n.type == "synthetic" and n.fqname.startswith("[external") and "networkx" in n.fqname
+        if n.type == "synthetic"
+        and n.fqname.startswith(EXTERNAL_PREFIXES)
+        and "networkx" in n.fqname
     }
     assert nx_nodes, (
         "expected an external-dep synthetic node for networkx, got "

--- a/tests/test_plugins/test_core.py
+++ b/tests/test_plugins/test_core.py
@@ -325,3 +325,24 @@ def test_plugin_context_base_modules_caches_first_scan(tmp_path):
     graph.add_node(late)
     second = list(ctx.base_modules())
     assert second == first
+
+
+def test_plugin_context_base_nodes_filters_to_base_and_caches(tmp_path):
+    base = tmp_path
+    inside_mod = SymbolNode("pkg", "module", base / "__init__.py", _pos())
+    inside_fn = SymbolNode("pkg.f", "function", base / "a.py", _pos())
+    outside = SymbolNode("other.b", "module", tmp_path.parent / "other.py", _pos())
+    graph = nx.DiGraph()
+    for n in (inside_mod, inside_fn, outside):
+        graph.add_node(n)
+
+    ctx = PluginContext(graph=graph, symbol_lookup=SymbolTrie(), base=base, project_root=base)
+    first = sorted(ctx.base_nodes(), key=lambda n: n.fqname)
+    assert first == [inside_mod, inside_fn]
+
+    # Cached: nodes added after the first scan don't appear, even when their
+    # path is under ``base``.
+    late = SymbolNode("pkg.late", "function", base / "late.py", _pos())
+    graph.add_node(late)
+    second = sorted(ctx.base_nodes(), key=lambda n: n.fqname)
+    assert second == first

--- a/tests/test_plugins/test_init_subclass.py
+++ b/tests/test_plugins/test_init_subclass.py
@@ -8,6 +8,7 @@ from dead_cst import (
     MainBlockPlugin,
     build_symbol_graph,
 )
+from dead_cst._plugins.init_subclass import INIT_SUBCLASS_PREFIX
 
 
 def test_init_subclass_keeps_subclass_alive_via_parent(tmp_path, write_files, reachable_fqnames):
@@ -358,11 +359,11 @@ def test_init_subclass_marker_in_predecessor_chain(tmp_path, write_files):
     foo = next(n for n in graph.nodes if n.fqname == "pkg.impls.Foo")
     preds = list(graph.predecessors(foo))
     marker = next(
-        (p for p in preds if p.type == "synthetic" and p.fqname.startswith("<__init_subclass__>:")),
+        (p for p in preds if p.type == "synthetic" and p.fqname.startswith(INIT_SUBCLASS_PREFIX)),
         None,
     )
     assert marker is not None, f"expected a marker predecessor, got {preds!r}"
-    assert marker.fqname == "<__init_subclass__>:pkg.base.Plugin"
+    assert marker.fqname == f"{INIT_SUBCLASS_PREFIX}pkg.base.Plugin"
 
     marker_preds = list(graph.predecessors(marker))
     parent = next(p for p in marker_preds if p.fqname == "pkg.base.Plugin")

--- a/tests/test_unreachable_branches.py
+++ b/tests/test_unreachable_branches.py
@@ -2,7 +2,7 @@
 
 When the visitor sees a statically-dead ``if`` / ``while`` suite (per
 :mod:`dead_cst._branches`) it creates a synthetic ``SymbolNode`` with
-``type="synthetic"`` and a fqname prefixed with ``<unreachable ``.
+``type="synthetic"`` and a fqname prefixed with ``<unreachable>:``.
 Every reference made from inside that suite gets a parallel edge
 ``synthetic -> referent`` -- the original ``enclosing-decl -> referent``
 edge is left in place. The synthetic node is an orphan (no incoming


### PR DESCRIPTION
A wholistic cleanup pass: three review agents (reuse, quality, efficiency) audited the package; this PR applies the high-confidence findings, then a follow-up consistency pass pulls every synthetic-fqname prefix into a named constant.

## Plugin and analyzer cleanup

- Route every entrypoint plugin (`main_block`, `module_dunders`, `explicit`, `project_scripts`) through the shared `mark_entrypoints` helper instead of hand-rolling `AddNode`/`AddEdge` pairs.
- Add `PluginContext.base_nodes()` so plugins iterating "everything under this base" don't re-scan sibling bases' accumulated nodes.
- Replace `_resolve.py`'s `_synthetic` closure with the existing `synthetic_node` helper.
- Replace `main_block`'s `_is_dunder_name` with `_core.is_name`.
- Drop the redundant `SymbolVisitor.node_to_symbols` dict; derive from `node_to_frames` at the two read sites.

## CLI / I/O

- Single-pass partition of `unreachable.nodes` in CLI output (was two separate scans across text + JSON paths).
- Drop the TOCTOU `is_file()` pre-check in `load_toml`; open and catch `OSError` instead. `TOMLDecodeError` still propagates.

## Synthetic-fqname prefixes — single source of truth

Every `<kind>:` and `[kind] ` literal across the codebase used to be a mix of named constants and inline strings scattered across producer and consumer sites. They now all live in one place per kind, with consumers reaching in via the constant:

| Family | Constant | Pattern |
|---|---|---|
| Plugin entrypoint | `DUNDER_PREFIX` | `<dunder>:` |
| | `MAIN_BLOCK_PREFIX` | `<__main__>:` |
| | `EXPLICIT_PREFIX` | `<entrypoint>:` |
| | `PROJECT_SCRIPTS_PREFIX` | `<project.scripts>:` |
| | `UNITTEST_PREFIX` | `<unittest>:` |
| | `PYTEST_{CONFTEST,TESTS,FIXTURES}_PREFIX` | `<pytest:kind>:` |
| | `INIT_SUBCLASS_PREFIX` | `<__init_subclass__>:` |
| Dead suite | `UNREACHABLE_PREFIX` | `<unreachable>:` |
| Path marker | `STDLIB_PREFIX` / `EXTERNAL_DIST_PREFIX` / `EXTERNAL_FILE_PREFIX` / `UNRESOLVED_PREFIX` | `[kind] ` |
| | `EXTERNAL_PREFIXES` (tuple) | both external subtypes |
| | `SYNTHETIC_PATH_PREFIXES` (tuple) | every non-first-party marker |

The dead-suite fqname was reshaped to match the `<kind>:identifier` family: `<unreachable {fqname}:{line}:{col}>` → `<unreachable>:{fqname}:{line}:{col}` (drops the trailing `>` and the leading-space-after-kind). This is a pre-release fqname format change; the public `is_unreachable_node` predicate hides the format from callers.

Tests now reach in via the constants instead of hardcoding fqname strings — including a fix to `test_imports.py` which used `"[external"` (no trailing space) where the producer always writes `"[external dist] "` / `"[external file] "`.

## New helper coverage

- `test_plugin_context_base_nodes_filters_to_base_and_caches` for `PluginContext.base_nodes()`.
- `test_partition_unreachable_*` (two tests) for `cli._partition_unreachable`.

## Test plan

- [x] `uv run pytest -x -q` — 495/495 pass
- [x] Smoke tests on `examples/simple-app` and `examples/scripts-and-all`

https://claude.ai/code/session_01E7gkEkbfMjCqR6Ep883nB4