### PR TITLE
Apply consistency pass across plugins, resolvers, CLI, and tests

### DIFF
--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 from typing import Sequence
@@ -13,14 +15,14 @@ from ._plugins import (
     apply_ops,
 )
 from ._resolve import resolve_edges, safe_resolve_module, temp_sys_path
-from ._resolvers import exported_roots
+from ._resolvers import PathMap, exported_roots
 from ._symbols import SymbolNode, SymbolTrie
 from ._visitor import SymbolVisitor
 
 logger = logging.getLogger(__name__)
 
 
-def order_paths(paths: dict[Path, list[Path]]) -> list[Path]:
+def order_paths(paths: PathMap) -> list[Path]:
     """Topologically sort base paths so dependencies are processed first.
 
     ``paths`` maps each base directory to the list of other base directories
@@ -38,7 +40,7 @@ def order_paths(paths: dict[Path, list[Path]]) -> list[Path]:
 
 
 def build_symbol_graph(
-    paths: dict[Path, list[Path]],
+    paths: PathMap,
     *,
     plugins: Sequence[EdgePlugin] = (),
     project_root: Path | None = None,
@@ -211,7 +213,7 @@ def _under_any(file: Path, roots: list[Path]) -> bool:
     return False
 
 
-def _infer_project_root(paths: dict[Path, list[Path]]) -> Path:
+def _infer_project_root(paths: PathMap) -> Path:
     bases = list(paths)
     if not bases:
         return Path.cwd()

--- a/dead_cst/_codemod.py
+++ b/dead_cst/_codemod.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import libcst as cst

--- a/dead_cst/_fqn.py
+++ b/dead_cst/_fqn.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from pathlib import PurePath
-from typing import Any, List, Mapping
+from typing import Any, Mapping
 
 from libcst.helpers import ModuleNameAndPackage
 from libcst.metadata import FullyQualifiedNameProvider
@@ -13,7 +15,7 @@ class FixedFullyQualifiedNameProvider(FullyQualifiedNameProvider):
     def gen_cache(
         cls,
         root_path,
-        paths: List[str],
+        paths: list[str],
         **kwargs: Any,
     ) -> Mapping[str, ModuleNameAndPackage]:
         cache = super().gen_cache(root_path, paths, **kwargs)

--- a/dead_cst/_plugins/_core.py
+++ b/dead_cst/_plugins/_core.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Container, Iterable, Iterator, Protocol, Union, runtime_checkable
+from typing import Container, Iterable, Iterator, Protocol, runtime_checkable
 
 import libcst as cst
 import networkx as nx
@@ -208,7 +208,7 @@ class RemoveEdge:
     dst: SymbolNode
 
 
-GraphOp = Union[AddNode, AddEdge, RemoveEdge]
+GraphOp = AddNode | AddEdge | RemoveEdge
 
 
 @runtime_checkable
@@ -261,6 +261,11 @@ def mark_entrypoints(
     yield AddNode(synth, entrypoint=True)
     for target in targets:
         yield AddEdge(synth, target)
+
+
+def simple_name(fqname: str) -> str:
+    """Return the rightmost dotted segment of ``fqname`` (``pkg.mod.f`` -> ``f``)."""
+    return fqname.rpartition(".")[2]
 
 
 def is_name(node: cst.CSTNode | None, value: str) -> bool:

--- a/dead_cst/_plugins/fastapi.py
+++ b/dead_cst/_plugins/fastapi.py
@@ -29,7 +29,7 @@ from ._core import (
 
 # Attribute names FastAPI / APIRouter use to register a callable. Matched as
 # the rightmost attribute of ``@<instance>.<name>(...)``.
-_ROUTE_DECORATORS: frozenset[str] = frozenset(
+_REGISTRATION_DECORATORS: frozenset[str] = frozenset(
     {
         "get",
         "post",
@@ -108,7 +108,7 @@ class FastAPIPlugin:
             instances = find_call_assignments(module, fastapi_imports, _INSTANCE_KINDS)
             if not instances:
                 continue
-            handlers = find_handlers(module, set(instances), _ROUTE_DECORATORS)
+            handlers = find_handlers(module, set(instances), _REGISTRATION_DECORATORS)
 
             module_fqname = module_node.fqname
             for var_name, kind in instances.items():

--- a/dead_cst/_plugins/flask.py
+++ b/dead_cst/_plugins/flask.py
@@ -32,7 +32,7 @@ from ._core import (
 # verb shortcuts (``app.get`` / ``app.post`` / ...), request lifecycle
 # hooks, error handlers, template / context helpers, URL processors, and
 # the ``app_*`` variants Blueprints use to register app-scoped callbacks.
-_ROUTE_DECORATORS: frozenset[str] = frozenset(
+_REGISTRATION_DECORATORS: frozenset[str] = frozenset(
     {
         "route",
         "get",
@@ -129,7 +129,7 @@ class FlaskPlugin:
             instances = find_call_assignments(module, flask_imports, _INSTANCE_KINDS)
             if not instances:
                 continue
-            handlers = find_handlers(module, set(instances), _ROUTE_DECORATORS)
+            handlers = find_handlers(module, set(instances), _REGISTRATION_DECORATORS)
 
             module_fqname = module_node.fqname
             for var_name, kind in instances.items():

--- a/dead_cst/_plugins/init_subclass.py
+++ b/dead_cst/_plugins/init_subclass.py
@@ -33,7 +33,7 @@ from typing import Iterable
 import libcst as cst
 
 from .._symbols import SymbolNode
-from ._core import AddEdge, AddNode, GraphOp, PluginContext, synthetic_node
+from ._core import AddEdge, AddNode, GraphOp, PluginContext, simple_name, synthetic_node
 
 _INIT_SUBCLASS = "__init_subclass__"
 INIT_SUBCLASS_PREFIX = "<__init_subclass__>:"
@@ -172,7 +172,7 @@ def _find_class_def(module: cst.Module, class_node: SymbolNode) -> cst.ClassDef 
     branch of an ``if/else`` defines the same name), the first match
     wins; both share the same MRO for ``__init_subclass__`` purposes.
     """
-    name = class_node.fqname.rsplit(".", 1)[-1]
+    name = simple_name(class_node.fqname)
     for stmt in module.body:
         if isinstance(stmt, cst.ClassDef) and stmt.name.value == name:
             return stmt

--- a/dead_cst/_plugins/module_dunders.py
+++ b/dead_cst/_plugins/module_dunders.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from .._symbols import SymbolNode
-from ._core import GraphOp, PluginContext, mark_entrypoints
+from ._core import GraphOp, PluginContext, mark_entrypoints, simple_name
 
 DUNDER_PREFIX = "<dunder>:"
 
@@ -36,5 +36,5 @@ def _is_module_dunder(node: SymbolNode) -> bool:
     """True for module-level variables named like ``__xxx__``."""
     if node.type != "variable":
         return False
-    name = node.fqname.rpartition(".")[2]
+    name = simple_name(node.fqname)
     return len(name) > 4 and name.startswith("__") and name.endswith("__")

--- a/dead_cst/_plugins/pytest.py
+++ b/dead_cst/_plugins/pytest.py
@@ -10,7 +10,7 @@ from typing import Iterable
 import libcst as cst
 
 from .._symbols import SymbolNode
-from ._core import GraphOp, PluginContext, mark_entrypoints
+from ._core import GraphOp, PluginContext, mark_entrypoints, simple_name
 
 PYTEST_CONFTEST_PREFIX = "<pytest:conftest>:"
 PYTEST_TESTS_PREFIX = "<pytest:tests>:"
@@ -44,10 +44,8 @@ class PytestPlugin:
 
     def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
         decls_by_path: dict[Path, list[SymbolNode]] = {}
-        for node in ctx.graph.nodes:
-            if node.type in ("function", "class", "variable") and node.path.is_relative_to(
-                ctx.base
-            ):
+        for node in ctx.base_nodes():
+            if node.type in ("function", "class", "variable"):
                 decls_by_path.setdefault(node.path, []).append(node)
 
         # Fixture-branch prefilter: ``@pytest.fixture`` / ``@fixture``
@@ -80,7 +78,7 @@ class PytestPlugin:
             fixture_decls = [
                 d
                 for d in module_decls
-                if d.type == "function" and d.fqname.rsplit(".", 1)[-1] in fixture_names
+                if d.type == "function" and simple_name(d.fqname) in fixture_names
             ]
             yield from mark_entrypoints(
                 f"{PYTEST_FIXTURES_PREFIX}{module_node.fqname}", path, fixture_decls
@@ -92,7 +90,7 @@ def _is_test_filename(name: str) -> bool:
 
 
 def _is_test_decl(node: SymbolNode) -> bool:
-    simple = node.fqname.rsplit(".", 1)[-1]
+    simple = simple_name(node.fqname)
     if node.type == "function" and simple.startswith("test_"):
         return True
     if node.type == "class" and simple.startswith("Test"):

--- a/dead_cst/_plugins/unittest.py
+++ b/dead_cst/_plugins/unittest.py
@@ -9,7 +9,7 @@ from typing import Iterable
 import libcst as cst
 
 from .._symbols import SymbolNode
-from ._core import GraphOp, PluginContext, is_from_module, is_name, mark_entrypoints
+from ._core import GraphOp, PluginContext, is_from_module, is_name, mark_entrypoints, simple_name
 
 UNITTEST_PREFIX = "<unittest>:"
 
@@ -54,9 +54,7 @@ class UnittestPlugin:
         # ``Import.module`` field instead of an ``[external dist]`` marker.
         candidate_paths: set[Path] = set()
         decls_by_path: dict[Path, list[SymbolNode]] = {}
-        for node in ctx.graph.nodes:
-            if not node.path.is_relative_to(ctx.base):
-                continue
+        for node in ctx.base_nodes():
             if node.type in ("function", "class"):
                 decls_by_path.setdefault(node.path, []).append(node)
             elif (
@@ -90,7 +88,7 @@ class UnittestPlugin:
                 continue
 
             module_decls = decls_by_path.get(path, [])
-            targets = [d for d in module_decls if d.fqname.rsplit(".", 1)[-1] in wanted]
+            targets = [d for d in module_decls if simple_name(d.fqname) in wanted]
             if not targets:
                 continue
 

--- a/dead_cst/_resolve.py
+++ b/dead_cst/_resolve.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import logging
 import os
@@ -75,7 +77,7 @@ def distribution_lookup() -> dict[Path, str]:
     return lookup
 
 
-def resolve_import(name: str, search_paths: list[Path]) -> str | Path:
+def resolve_import(name: str, search_paths: list[Path]) -> str | Path | None:
     spec = safe_resolve_module(name)
     if spec is None:
         return None

--- a/dead_cst/_resolvers/pyproject.py
+++ b/dead_cst/_resolvers/pyproject.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 from ._core import PathMap, load_toml
 
 
+@dataclass
 class PyprojectResolver:
     """Read ``[tool.dead-cst]`` from a project's ``pyproject.toml`` and turn
     its configured paths into a ``PathMap``.
@@ -23,7 +25,7 @@ class PyprojectResolver:
     layout when present.
     """
 
-    name = "pyproject"
+    name: str = "pyproject"
 
     def resolve(self, project_root: Path) -> PathMap:
         project_root = project_root.resolve()

--- a/dead_cst/_resolvers/uv_workspace.py
+++ b/dead_cst/_resolvers/uv_workspace.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 from ._core import PathMap, load_toml
 
 
+@dataclass
 class UvWorkspaceResolver:
     """Discover workspace members from ``uv.lock`` and wire their source roots
     together using uv's resolved dependency graph.
@@ -32,10 +34,8 @@ class UvWorkspaceResolver:
     of returned bases and don't need to be re-listed per member.
     """
 
-    name = "uv_workspace"
-
-    def __init__(self, lock_path: Path | None = None) -> None:
-        self.lock_path = lock_path
+    lock_path: Path | None = None
+    name: str = "uv_workspace"
 
     def resolve(self, project_root: Path) -> PathMap:
         project_root = project_root.resolve()

--- a/dead_cst/_resolvers/venv.py
+++ b/dead_cst/_resolvers/venv.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from ._core import PathMap
 
 
+@dataclass
 class VenvResolver:
     """Discover a sibling ``.venv`` (or the active venv) and add its
     ``site-packages`` as a dep path of the project root.
@@ -16,10 +18,8 @@ class VenvResolver:
     lets the graph correctly classify external imports instead of warning.
     """
 
-    name = "venv"
-
-    def __init__(self, venv_dir: str | None = None) -> None:
-        self.venv_dir = venv_dir
+    venv_dir: str | None = None
+    name: str = "venv"
 
     def resolve(self, project_root: Path) -> PathMap:
         project_root = project_root.resolve()

--- a/dead_cst/cli.py
+++ b/dead_cst/cli.py
@@ -8,7 +8,7 @@ import re
 import sys
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 import networkx as nx
 import typer
@@ -23,7 +23,7 @@ from ._plugins import (
 )
 from ._plugins._core import EXTERNAL_PREFIXES
 from ._plugins.module_dunders import DUNDER_PREFIX
-from ._resolvers import load_resolver, merge_paths
+from ._resolvers import PathMap, load_resolver, merge_paths
 from ._symbols import SymbolNode
 
 
@@ -79,9 +79,7 @@ def build_plugins(
     return plugins
 
 
-def resolve_paths(
-    root: Path, path_specs: list[str], resolver_names: list[str]
-) -> dict[Path, list[Path]]:
+def resolve_paths(root: Path, path_specs: list[str], resolver_names: list[str]) -> PathMap:
     """Merge ``-p`` specs and ``--resolver`` outputs into a single path map."""
     explicit = parse_paths(root, path_specs) if path_specs else {}
     resolved_maps = [load_resolver(name).resolve(root) for name in resolver_names]
@@ -90,7 +88,7 @@ def resolve_paths(
     return merge_paths(explicit, *resolved_maps)
 
 
-def parse_paths(root: Path, paths_str: list[str]) -> dict[Path, list[Path]]:
+def parse_paths(root: Path, paths_str: list[str]) -> PathMap:
     """Parse path specifications into the paths dict format.
 
     Format: "base:dep1,dep2,dep3" or just "base" for no dependencies.
@@ -122,7 +120,7 @@ def version_callback(value: bool) -> None:
 @app.callback()
 def main(
     version: Annotated[
-        Optional[bool],
+        bool | None,
         typer.Option("--version", callback=version_callback, is_eager=True, help="Show version."),
     ] = None,
 ) -> None:
@@ -133,7 +131,7 @@ def main(
 def analyze(
     root: Annotated[Path, typer.Argument(help="Root directory to analyze.")],
     entrypoint: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option(
             "-e",
             "--entrypoint",
@@ -141,15 +139,15 @@ def analyze(
         ),
     ] = None,
     path: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option("-p", "--path", help="Search path spec: 'base:dep1,dep2' or 'base'."),
     ] = None,
     resolver: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option("--resolver", help="Path resolver to run (e.g. venv, pyproject)."),
     ] = None,
     plugin: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option("--plugin", help="Edge plugin to run (e.g. main_block, project_scripts)."),
     ] = None,
     verbose: Annotated[
@@ -188,7 +186,7 @@ def _output_text(
     graph: nx.DiGraph,
     unreachable: nx.DiGraph,
     root: Path,
-    paths_dict: dict[Path, list[Path]],
+    paths_dict: PathMap,
 ) -> None:
     for base in order_paths(paths_dict):
         typer.echo(f"\n{base}:")
@@ -242,7 +240,7 @@ def _output_json(
     graph: nx.DiGraph,
     unreachable: nx.DiGraph,
     root: Path,
-    paths_dict: dict[Path, list[Path]],
+    paths_dict: PathMap,
 ) -> None:
     result: dict = {
         "summary": {},
@@ -290,15 +288,15 @@ def why_alive(
     root: Annotated[Path, typer.Argument(help="Root directory to analyze.")],
     fqname: Annotated[str, typer.Argument(help="Fully qualified name of the symbol to check.")],
     path: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option("-p", "--path", help="Search path spec: 'base:dep1,dep2' or 'base'."),
     ] = None,
     resolver: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option("--resolver", help="Path resolver to run (e.g. venv, pyproject)."),
     ] = None,
     plugin: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option("--plugin", help="Edge plugin to run (e.g. main_block, project_scripts)."),
     ] = None,
     verbose: Annotated[
@@ -356,11 +354,11 @@ def _is_external_dep(node: SymbolNode) -> bool:
 def dependencies(
     root: Annotated[Path, typer.Argument(help="Root directory to analyze.")],
     path: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option("-p", "--path", help="Search path spec: 'base:dep1,dep2' or 'base'."),
     ] = None,
     resolver: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option("--resolver", help="Path resolver to run (e.g. venv, pyproject)."),
     ] = None,
     verbose: Annotated[
@@ -406,7 +404,7 @@ def dependencies(
 def unused_exports(
     root: Annotated[Path, typer.Argument(help="Root directory to analyze.")],
     entrypoint: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option(
             "-e",
             "--entrypoint",
@@ -414,15 +412,15 @@ def unused_exports(
         ),
     ] = None,
     path: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option("-p", "--path", help="Search path spec: 'base:dep1,dep2' or 'base'."),
     ] = None,
     resolver: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option("--resolver", help="Path resolver to run (e.g. venv, pyproject)."),
     ] = None,
     plugin: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option("--plugin", help="Edge plugin to run (e.g. main_block, project_scripts)."),
     ] = None,
     verbose: Annotated[
@@ -480,7 +478,7 @@ def unused_exports(
 def remove(
     root: Annotated[Path, typer.Argument(help="Root directory to analyze.")],
     entrypoint: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option(
             "-e",
             "--entrypoint",
@@ -488,15 +486,15 @@ def remove(
         ),
     ] = None,
     path: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option("-p", "--path", help="Search path spec: 'base:dep1,dep2' or 'base'."),
     ] = None,
     resolver: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option("--resolver", help="Path resolver to run (e.g. venv, pyproject)."),
     ] = None,
     plugin: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option("--plugin", help="Edge plugin to run (e.g. main_block, project_scripts)."),
     ] = None,
     verbose: Annotated[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import textwrap
 
 import networkx as nx
-
 import pytest
 
 from dead_cst import build_symbol_graph
@@ -9,15 +8,29 @@ from dead_cst._branches import is_unreachable_node
 
 
 @pytest.fixture
+def write_files(tmp_path):
+    """Write a ``{relpath: source}`` mapping under ``tmp_path``.
+
+    Each value is dedented and stripped, with a trailing newline appended,
+    matching the inline-source convention used across the test suite.
+    """
+
+    def _write(files: dict[str, str]) -> None:
+        for name, src in files.items():
+            p = tmp_path / name
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(textwrap.dedent(src).strip() + "\n")
+
+    return _write
+
+
+@pytest.fixture
 def build_decl_graph(tmp_path):
     def _make_graph(files: dict[str, str]) -> nx.DiGraph:
-        # Write each file to the temporary directory
         for filename, content in files.items():
             full_path = tmp_path / filename
             full_path.parent.mkdir(parents=True, exist_ok=True)
             full_path.write_text(textwrap.dedent(content).strip())
-
-        # Build the declaration graph
         return build_symbol_graph({tmp_path: []})
 
     return _make_graph

--- a/tests/test_plugins/conftest.py
+++ b/tests/test_plugins/conftest.py
@@ -2,28 +2,9 @@
 
 from __future__ import annotations
 
-import textwrap
-
 import pytest
 
 from dead_cst import find_reachable
-
-
-@pytest.fixture
-def write_files(tmp_path):
-    """Write a ``{relpath: source}`` mapping under ``tmp_path``.
-
-    Each value is dedented and stripped, with a trailing newline appended,
-    matching the inline-source convention used across these tests.
-    """
-
-    def _write(files: dict[str, str]) -> None:
-        for name, src in files.items():
-            p = tmp_path / name
-            p.parent.mkdir(parents=True, exist_ok=True)
-            p.write_text(textwrap.dedent(src).strip() + "\n")
-
-    return _write
 
 
 @pytest.fixture


### PR DESCRIPTION
* Type annotations: drop legacy `Optional[X]` / `Union[A,B,C]` / `typing.List`
  in favor of `X | None`, `A | B | C`, and `list[X]` to match the rest
  of the package.
* Add `from __future__ import annotations` to `_fqn.py`, `_analyze.py`,
  `_resolve.py`, and `_codemod.py` for parity with every other module.
* Fix `resolve_import`'s return type to include `None`, which it already
  returns on unresolved imports.
* Convert resolvers to `@dataclass` (with `name: str` annotated)
  matching the plugin pattern.
* Use the `PathMap` alias in `_analyze.py` and `cli.py` instead of
  spelling `dict[Path, list[Path]]` longhand.
* Promote `simple_name(fqname)` into `_plugins/_core.py` and replace
  three different inlined `rsplit`/`rpartition` idioms across plugins.
* Switch `pytest.py` and `unittest.py` to `ctx.base_nodes()` instead of
  hand-rolling `is_relative_to(ctx.base)` filters over `graph.nodes`.
* Rename FastAPI/Flask `_ROUTE_DECORATORS` to `_REGISTRATION_DECORATORS`
  for parity with Click/Typer.
* Promote the `write_files` fixture from `tests/test_plugins/conftest.py`
  to the top-level `tests/conftest.py` so non-plugin tests can reuse it.