### PR TITLE
Replace pre-commit with prek and add ty type-check hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
           cache-dependency-glob: "**/uv.lock"
       - uses: actions/cache@v5
         with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          path: ~/.cache/prek
+          key: prek-${{ hashFiles('.pre-commit-config.yaml') }}
       - run: uv sync --frozen
-      - run: uv run pre-commit run --show-diff-on-failure --color=always --all-files
+      - run: uv run prek run --show-diff-on-failure --color=always --all-files
         env:
           RUFF_OUTPUT_FORMAT: github
           CONFTEST_OUTPUT: github

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,13 @@ repos:
     rev: 0.7.2
     hooks:
       - id: uv-lock
+
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty check
+        entry: uv run --frozen ty check
+        language: system
+        types_or: [python, pyi]
+        pass_filenames: false
+        require_serial: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ cd dead-cst
 uv sync
 ```
 
-That installs the package in editable mode along with the `dev` group: `pytest`, `ruff`, `pre-commit`, and `ty`.
+That installs the package in editable mode along with the `dev` group: `pytest`, `ruff`, `prek`, and `ty`.
 
 ## Running tests
 
@@ -57,14 +57,14 @@ excluded; see `[tool.coverage.*]` in `pyproject.toml`.
 
 ## Linting and formatting
 
-Ruff (lint + format) and a small set of pre-commit hooks run on every commit.
+Ruff (lint + format), `ty` (type check), and a small set of hooks run on every commit via [`prek`](https://github.com/j178/prek), a fast Rust-based drop-in replacement for `pre-commit` that reads the same `.pre-commit-config.yaml`.
 
 ```bash
-uv run pre-commit install        # one-time, sets up the git hook
-uv run pre-commit run --all-files
+uv run prek install        # one-time, sets up the git hook
+uv run prek run --all-files
 ```
 
-CI runs `pre-commit run --all-files` on every push and pull request, so running it locally before committing avoids round-trips.
+CI runs `prek run --all-files` on every push and pull request, so running it locally before committing avoids round-trips.
 
 ## Project layout
 
@@ -146,7 +146,7 @@ A good bug report contains a minimal `.py` file (or pair of files) and the entry
 
 - Keep PRs focused — one logical change per PR.
 - Add or update tests for behaviour changes.
-- Run `pre-commit run --all-files` and `pytest` before pushing.
+- Run `prek run --all-files` and `pytest` before pushing.
 - If your change is user-visible, add an entry to `CHANGELOG.md` under `[Unreleased]`.
 
 ## Releasing

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ git clone https://github.com/lpetre/dead-cst
 cd dead-cst
 uv sync
 uv run pytest
-uv run pre-commit run --all-files
+uv run prek run --all-files
 ```
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev guide, [`CHANGELOG.md`](CHANGELOG.md) for release notes, and [`ROADMAP.md`](ROADMAP.md) for the stack-ranked plan toward 1.0.

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -103,12 +103,14 @@ def build_symbol_graph(
             export_roots = exported_roots(base)
             import_edges = set()
             files = list(sorted(base.rglob("*.py")))
-            mgr = FullRepoManager(base, files, {FixedFullyQualifiedNameProvider})
+            mgr = FullRepoManager(
+                str(base), [str(f) for f in files], {FixedFullyQualifiedNameProvider}
+            )
             # Stash the modules the visitor pass parses so plugins can reuse
             # them via ``ctx.parse(path)`` without re-reading or re-parsing.
             base_modules: dict[Path, cst.Module] | None = {} if plugins else None
             for file in files:
-                wrapper = mgr.get_metadata_wrapper_for_path(file)
+                wrapper = mgr.get_metadata_wrapper_for_path(str(file))
                 if base_modules is not None:
                     base_modules[file] = wrapper.module
                 visitor = SymbolVisitor(file, search_paths)

--- a/dead_cst/_codemod.py
+++ b/dead_cst/_codemod.py
@@ -108,14 +108,14 @@ def remove_code(G: nx.Graph, base: Path) -> None:
             case "module":
                 node.path.unlink()
 
-    mgr = FullRepoManager(base, by_file.keys(), {FixedFullyQualifiedNameProvider})
+    mgr = FullRepoManager(str(base), [str(p) for p in by_file], {FixedFullyQualifiedNameProvider})
     for path, nodes in sorted(by_file.items(), key=lambda x: x):
         if not path.exists():
             continue
 
         # Pass 1: drop dead defs / classes / variables. Imports they
         # used to reference become eligible for removal in pass 2.
-        wrapper = mgr.get_metadata_wrapper_for_path(path)
+        wrapper = mgr.get_metadata_wrapper_for_path(str(path))
         dead_decls = {(n.fqname, n.position) for n in nodes if n.type != "import"}
         result = wrapper.visit(RemoveDeadSymbols(dead_decls))
 

--- a/dead_cst/_flow.py
+++ b/dead_cst/_flow.py
@@ -35,6 +35,14 @@ from typing import Callable, Sequence
 
 import libcst as cst
 
+# A suite's `.body` is `Sequence[BaseStatement] | Sequence[BaseSmallStatement]`
+# depending on whether it's an `IndentedBlock` or a `SimpleStatementSuite`
+# (the one-line `def f(): pass` form). Flow analysis treats small statements
+# as plain bindings -- none of the compound-statement isinstance checks
+# match -- so accepting both shapes keeps a single code path.
+_StmtSeq = Sequence[cst.BaseStatement] | Sequence[cst.BaseSmallStatement]
+_Stmt = cst.BaseStatement | cst.BaseSmallStatement
+
 
 def _descendant_ids(node: cst.CSTNode, cache: dict[int, frozenset[int]]) -> frozenset[int]:
     key = id(node)
@@ -49,11 +57,11 @@ def _descendant_ids(node: cst.CSTNode, cache: dict[int, frozenset[int]]) -> froz
 
 
 def _walk_flow(
-    stmts: Sequence[cst.BaseStatement],
+    stmts: _StmtSeq,
     incoming: set[cst.CSTNode],
     referent_set: set[cst.CSTNode],
     cache: dict[int, frozenset[int]],
-    observe: Callable[[cst.BaseStatement, set[cst.CSTNode]], None] | None,
+    observe: Callable[[_Stmt, set[cst.CSTNode]], None] | None,
 ) -> set[cst.CSTNode]:
     """Forward-walk ``stmts`` evolving the live referent set.
 
@@ -138,7 +146,7 @@ def live_referents(
     access_id = id(access_node)
     observed: list[set[cst.CSTNode]] = []
 
-    def _observe(stmt: cst.BaseStatement, state: set[cst.CSTNode]) -> None:
+    def _observe(stmt: _Stmt, state: set[cst.CSTNode]) -> None:
         if access_id in _descendant_ids(stmt, cache):
             observed.append(set(state))
 

--- a/dead_cst/_plugins/_core.py
+++ b/dead_cst/_plugins/_core.py
@@ -278,6 +278,18 @@ def is_from_module(node: cst.ImportFrom, module_name: str) -> bool:
     return not node.relative and is_name(node.module, module_name)
 
 
+def _asname_value(alias: cst.ImportAlias) -> str | None:
+    """Return ``alias.asname.name.value`` when it's a bare ``Name``, else ``None``.
+
+    ``AsName.name`` is typed ``Name | Tuple | List`` to share with ``with``-statement
+    unpacking, but in import contexts only ``Name`` is legal.
+    """
+    if alias.asname is None:
+        return None
+    name = alias.asname.name
+    return name.value if isinstance(name, cst.Name) else None
+
+
 def single_target_assignment(
     stmt: cst.BaseSmallStatement,
 ) -> tuple[str | None, cst.BaseExpression | None]:
@@ -351,7 +363,7 @@ def matched_attr_call(
         expr = expr.func
     if isinstance(expr, cst.Name):
         target = imports.get(expr.value)
-        if target in valid_targets:
+        if target is not None and target in valid_targets:
             return target
     elif isinstance(expr, cst.Attribute) and isinstance(expr.value, cst.Name):
         if imports.get(expr.value.value) == "<module>":
@@ -404,14 +416,12 @@ def collect_module_imports(
                     target = alias.name.value if isinstance(alias.name, cst.Name) else None
                     if target is None or target not in allowed_targets:
                         continue
-                    local = alias.asname.name.value if alias.asname else target
-                    if isinstance(local, str):
-                        bindings[local] = target
+                    local = _asname_value(alias) or target
+                    bindings[local] = target
             elif isinstance(small, cst.Import):
                 for alias in small.names:
                     if not is_name(alias.name, module_name):
                         continue
-                    local = alias.asname.name.value if alias.asname else module_name
-                    if isinstance(local, str):
-                        bindings[local] = "<module>"
+                    local = _asname_value(alias) or module_name
+                    bindings[local] = "<module>"
     return bindings

--- a/dead_cst/_plugins/unittest.py
+++ b/dead_cst/_plugins/unittest.py
@@ -9,7 +9,15 @@ from typing import Iterable
 import libcst as cst
 
 from .._symbols import SymbolNode
-from ._core import GraphOp, PluginContext, is_from_module, is_name, mark_entrypoints, simple_name
+from ._core import (
+    GraphOp,
+    PluginContext,
+    _asname_value,
+    is_from_module,
+    is_name,
+    mark_entrypoints,
+    simple_name,
+)
 
 UNITTEST_PREFIX = "<unittest>:"
 
@@ -114,9 +122,7 @@ def _collect_unittest_imports(module: cst.Module) -> tuple[set[str], set[str]]:
                 for alias in small.names:
                     if not is_name(alias.name, "unittest"):
                         continue
-                    local = alias.asname.name.value if alias.asname else "unittest"
-                    if isinstance(local, str):
-                        module_aliases.add(local)
+                    module_aliases.add(_asname_value(alias) or "unittest")
             elif isinstance(small, cst.ImportFrom):
                 if not is_from_module(small, "unittest"):
                     continue
@@ -129,9 +135,7 @@ def _collect_unittest_imports(module: cst.Module) -> tuple[set[str], set[str]]:
                     target = alias.name.value if isinstance(alias.name, cst.Name) else None
                     if target not in _TEST_BASE_CLASSES:
                         continue
-                    local = alias.asname.name.value if alias.asname else target
-                    if isinstance(local, str):
-                        base_aliases.add(local)
+                    base_aliases.add(_asname_value(alias) or target)
     return module_aliases, base_aliases
 
 

--- a/dead_cst/_resolve.py
+++ b/dead_cst/_resolve.py
@@ -71,8 +71,8 @@ def distribution_lookup() -> dict[Path, str]:
 
     lookup = {}
     for dist in metadata.distributions():
-        for file in dist.files:
-            abs_path = Path(dist.locate_file(file)).resolve()
+        for file in dist.files or ():
+            abs_path = Path(str(dist.locate_file(file))).resolve()
             lookup[abs_path] = dist.metadata["Name"]
     return lookup
 
@@ -126,7 +126,7 @@ def resolve_edges(
             continue
 
         node = symbol_lookup._get(dst.module.split("."))
-        if not node:
+        if not node or node.module is None:
             logger.warning("Failed to resolve import module: %s", dst.module)
             continue
 
@@ -183,7 +183,7 @@ def resolve_edges(
                             dst.module,
                             dst.decl,
                             part,
-                            cur.module.fqname,
+                            cur.module.fqname if cur.module else "<no module>",
                             decl.imports.module,
                         )
                         continue
@@ -204,5 +204,5 @@ def resolve_edges(
                 dst.module,
                 dst.decl,
                 part,
-                cur.module.fqname,
+                cur.module.fqname if cur.module else "<no module>",
             )

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -4,7 +4,7 @@ import logging
 from functools import cache
 from importlib.util import resolve_name
 from pathlib import Path
-from typing import Generator, Literal, Mapping
+from typing import Generator, Literal, Mapping, cast
 
 import libcst as cst
 from libcst.helpers import get_full_name_for_node
@@ -14,11 +14,12 @@ from libcst.metadata import (
     ScopeProvider,
 )
 from libcst.metadata.scope_provider import (
-    BuiltinAssignment,
+    Assignment,
     ClassScope,
     FunctionScope,
     GlobalScope,
     ImportAssignment,
+    Scope,
 )
 
 from ._branches import make_unreachable_node, unreachable_suites
@@ -121,7 +122,7 @@ class SymbolVisitor(cst.CSTVisitor):
         return self.decl_stack[0][0]
 
     @cache
-    def resolve_import(self, name: str) -> str | Path:
+    def resolve_import(self, name: str) -> str | Path | None:
         return resolve_import(name, self.search_paths)
 
     def _push_decl(self, node: cst.CSTNode, decl: SymbolNode):
@@ -187,11 +188,11 @@ class SymbolVisitor(cst.CSTVisitor):
         else:
             targets = [node.target]
 
-        # For `x: T` (AnnAssign without a value) treat the annotation as the
-        # rhs so references inside it are attributed to the new symbol.
+        # For `x: T` (AnnAssign without a value) treat the annotation expression
+        # as the rhs so references inside it are attributed to the new symbol.
         rhs = node.value
         if rhs is None and isinstance(node, cst.AnnAssign):
-            rhs = node.annotation
+            rhs = node.annotation.annotation
 
         # Flatten each top-level target against the rhs into (name, value) pairs.
         # For chained assignment ``b = c = f`` every target shares the same rhs.
@@ -237,18 +238,27 @@ class SymbolVisitor(cst.CSTVisitor):
     def _add_import(self, from_prefix: str, node: cst.Import | cst.ImportFrom) -> None:
         current_decl = self.decl_stack[-1][-1] if self.decl_stack else None
 
-        module_path, module_name = None, None
+        module_path: str | Path | None = None
+        module_name: str | None = None
         if from_prefix:
-            module_path = self.resolve_import(from_prefix)
-            module_name = from_prefix if module_path else None
+            if path := self.resolve_import(from_prefix):
+                module_path = path
+                module_name = from_prefix
 
+        # ``visit_ImportFrom`` routes ``from X import *`` to ``_add_star_import``,
+        # so by the time we get here ``names`` is always the alias sequence form.
+        assert not isinstance(node.names, cst.ImportStar)
         for alias in reversed(node.names):
             alias_name = get_full_name_for_node(alias.name)
+            # alias.name is always Name | Attribute, both of which produce a
+            # dotted-name string; the helper only returns None for unsupported
+            # node types we never see here.
+            assert alias_name is not None
             full_name = f"{from_prefix}.{alias_name}" if from_prefix else alias_name
 
             if resolved := self.resolve_import(full_name):
                 module_path = resolved
-                module_name = full_name if module_path else None
+                module_name = full_name
 
             if not module_path:
                 code = cst.Module([]).code_for_node(alias)
@@ -263,6 +273,7 @@ class SymbolVisitor(cst.CSTVisitor):
                 top_level = full_name.split(".", 1)[0]
                 module_path = f"{UNRESOLVED_PREFIX}{top_level}"
                 module_name = full_name
+            assert module_name is not None
 
             if alias.asname:
                 decl_name = alias.asname.name
@@ -443,9 +454,15 @@ class SymbolVisitor(cst.CSTVisitor):
 
         parent_map = self.metadata[ParentNodeProvider]
         references = set()
-        for scope in set(self.metadata[ScopeProvider].values()):
+        # ScopeProvider's metadata is typed loosely upstream; the values are
+        # always ``Scope`` instances.
+        scopes = cast("set[Scope]", set(self.metadata[ScopeProvider].values()))
+        for scope in scopes:
             for access in scope.accesses:
-                referents = [r for r in access.referents if not isinstance(r, BuiltinAssignment)]
+                # ``Assignment`` and ``BuiltinAssignment`` are the only
+                # ``BaseAssignment`` subclasses; selecting ``Assignment``
+                # excludes builtins and gives us a typed ``.node``.
+                referents = [r for r in access.referents if isinstance(r, Assignment)]
                 if len(referents) > 1:
                     body = self._scope_body(referents[0].scope, original_node)
                     if body is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ version-file = "dead_cst/_version.py"
 
 [dependency-groups]
 dev = [
-    "pre-commit>=4.2.0",
+    "prek>=0.3.11",
     "pytest>=8.4.1",
     "pytest-cov>=5.0.0",
     "pytest-watcher>=0.4.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,10 @@ docstring-code-format = true
 
 [tool.ruff.lint.isort]
 known-first-party = ["dead_cst"]
+
+[tool.ty.src]
+# Type-check only the package itself. Tests, examples, and the workspace
+# fixtures intentionally exercise untyped LibCST internals and the
+# unresolved-import case the analyzer is meant to detect, so they aren't
+# meaningful targets for ty.
+include = ["dead_cst"]

--- a/uv.lock
+++ b/uv.lock
@@ -16,15 +16,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cfgv"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -160,7 +151,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "pre-commit" },
+    { name = "prek" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-watcher" },
@@ -177,39 +168,12 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "prek", specifier = ">=0.3.11" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-watcher", specifier = ">=0.4.3" },
     { name = "ruff", specifier = ">=0.11.2" },
     { name = "ty", specifier = ">=0.0.1a7" },
-]
-
-[[package]]
-name = "distlib"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
-]
-
-[[package]]
-name = "filelock"
-version = "3.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075, upload-time = "2025-03-14T07:11:40.47Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215, upload-time = "2025-03-14T07:11:39.145Z" },
-]
-
-[[package]]
-name = "identify"
-version = "2.6.12"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/88/d193a27416618628a5eea64e3223acd800b40749a96ffb322a9b55a49ed1/identify-2.6.12.tar.gz", hash = "sha256:d8de45749f1efb108badef65ee8386f0f7bb19a7f26185f74de6367bffbaf0e6", size = 99254, upload-time = "2025-05-23T20:37:53.3Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/cd/18f8da995b658420625f7ef13f037be53ae04ec5ad33f9b718240dcfd48c/identify-2.6.12-py2.py3-none-any.whl", hash = "sha256:ad9672d5a72e0d2ff7c5c8809b62dfa60458626352fb0eb7b55e69bdc45334a2", size = 99145, upload-time = "2025-05-23T20:37:51.495Z" },
 ]
 
 [[package]]
@@ -304,30 +268,12 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.9.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
-]
-
-[[package]]
-name = "platformdirs"
-version = "4.3.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload-time = "2025-05-07T22:47:42.121Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload-time = "2025-05-07T22:47:40.376Z" },
 ]
 
 [[package]]
@@ -340,19 +286,27 @@ wheels = [
 ]
 
 [[package]]
-name = "pre-commit"
-version = "4.2.0"
+name = "prek"
+version = "0.3.11"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cfgv" },
-    { name = "identify" },
-    { name = "nodeenv" },
-    { name = "pyyaml" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/08/39/679ca9b26c7bb2999ff122d50faa301e49af82ca9c066ec061cfbc0c6784/pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146", size = 193424, upload-time = "2025-03-18T21:35:20.987Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/60/5b980c70525ca5f0d17942d8eae13b399051aa384413366fe5df229712ea/prek-0.3.11.tar.gz", hash = "sha256:c4cf77848009503c58d80ff216e32af45b63ea49652bb5546748c1ebfd4d9847", size = 433440, upload-time = "2026-04-27T04:22:59.923Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/74/a88bf1b1efeae488a0c0b7bdf71429c313722d1fc0f377537fbe554e6180/pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd", size = 220707, upload-time = "2025-03-18T21:35:19.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/2a/3392fa7d1fd1ce538915baa7597e7203bbe888367a8b15bfd51ca74d4714/prek-0.3.11-py3-none-linux_armv6l.whl", hash = "sha256:787e605716cfdc86ec01e7c5cf62799f39c28d49de5e37d75595c8e6248cb0f3", size = 5423112, upload-time = "2026-04-27T04:22:52.659Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b0/3fc653b30b70d6c2714fc56bcfe1c2439437fc38f60b72bc300603ace4cd/prek-0.3.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ef1f37187ca52d75ba9c46b53007476c4eab2c3f11bd23defd57a81c62d90442", size = 5801382, upload-time = "2026-04-27T04:23:04.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/46/39aedc7843c3703f1f43b686622e4f8cd123e03b87a163e5c8f2fbd56cda/prek-0.3.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e0d0828a1b50447502ea1be3f5a84da474fdca558cd5d76a1a5205169bb808c7", size = 5370817, upload-time = "2026-04-27T04:22:49.277Z" },
+    { url = "https://files.pythonhosted.org/packages/15/83/df5f3aeacbdea96a88c4f06c98d3932469711fed4e3bf5b703dd6507abe7/prek-0.3.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:bf49464b526ee36d2130baf60ab9580560bfaa60efd2997328e6d6671e209014", size = 5621405, upload-time = "2026-04-27T04:23:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f2/e32c9720747a327669863a4f92d05b9e6fadb851e903b0d7310a97c956a4/prek-0.3.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac344529f0d34757c7c95f65e66b9f6440a691f826eaf43f503247bd22023558", size = 5339780, upload-time = "2026-04-27T04:22:47.614Z" },
+    { url = "https://files.pythonhosted.org/packages/29/2e/0e2f71b63bc2e5372575d5c1574b0666d2f90d30da51ed706a32cbf465a0/prek-0.3.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:83672d963f249e2f246d3bec97f8fd2e8032e70da0a7d9acb2fa38af76dd82d2", size = 5735277, upload-time = "2026-04-27T04:23:12.437Z" },
+    { url = "https://files.pythonhosted.org/packages/09/46/88abf51ac88eeff1ad2fe7d1797ca1fea43eb1ac1ddb8331463ac5b27ed2/prek-0.3.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef70957195d2896a30dd849e64f88344df7bb51af9c950cf16bd11519e7424b0", size = 6622420, upload-time = "2026-04-27T04:23:05.982Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b6/592028a45b084a68b76c7edef909c789d1c96b26761388f63659beef7166/prek-0.3.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4f0cc07d2cdb5fe2882015d5fdafc9af98b4c560d4caa1ae948caeab4341b79", size = 6020038, upload-time = "2026-04-27T04:22:54.367Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/e97f55a1645a2e9becffeee28892ad8bb66cd144dabfa4392ea8e2674bbe/prek-0.3.11-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d7554b436dae2ec97f4351a46817e3561657244307d1c0915f355b859f4fab71", size = 5622539, upload-time = "2026-04-27T04:23:01.314Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e2/f3119eef6b621782ad216a86d449609858ea34c57cf4a40fc6dc80556d7e/prek-0.3.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:caba5d635a5b64b7ac64d903f29b043ca5b0d9d9693543a0ef331ade89e6ad3f", size = 5440681, upload-time = "2026-04-27T04:23:07.422Z" },
+    { url = "https://files.pythonhosted.org/packages/04/62/22dd4f59a47654faeebe74651182ecc48d436542646cc92723052dfd9a45/prek-0.3.11-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:c95a63f19dde48e84b70bd63a235670834af15fa4df8b85d8b7894dd5bc419a9", size = 5314773, upload-time = "2026-04-27T04:22:57.912Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/94/a8361462acb8d8f5b8505255b95ffbfc2ee0872a79b4e066eb330692f7be/prek-0.3.11-py3-none-musllinux_1_1_i686.whl", hash = "sha256:7353b45f44a386c676fe96ba72a5ee326b676f789339f405cf6f1d69a1707194", size = 5596208, upload-time = "2026-04-27T04:23:09.08Z" },
+    { url = "https://files.pythonhosted.org/packages/04/0c/5f065b86bbeb9977074a055d8a05e90c7201f6c4c7032dada61739b5f8cb/prek-0.3.11-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:39f4e86176ccbb70c098df6abbc8e36c1d86cb81281abe92fb79dcd572418214", size = 6132833, upload-time = "2026-04-27T04:22:56.054Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/8ab0ae140201dcee505f58b60abbe56bd05ac96b821a6866f6f90c4d971f/prek-0.3.11-py3-none-win32.whl", hash = "sha256:35d2361049653a3dcf27227b7f1b340c5c42a12c0e0361c4b785921bfd125839", size = 5120856, upload-time = "2026-04-27T04:23:02.752Z" },
+    { url = "https://files.pythonhosted.org/packages/57/05/9844c1125d3714f6f6c7b475884128a4b0c6c3ee0cd208ead44ca8174687/prek-0.3.11-py3-none-win_amd64.whl", hash = "sha256:a387689cd2e182f92dbb681151ee5a04f494fe97e95d6d783875da90b950e6d5", size = 5510916, upload-time = "2026-04-27T04:22:45.704Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/13/24b0288c553dc8d61f44c4d0746fe9bb1e1bd29d1e70571658536e4c0f72/prek-0.3.11-py3-none-win_arm64.whl", hash = "sha256:e4a8f900378a6657c7eb2fc4b12fa5c934edf209d0a24544539842479ec16e0b", size = 5345988, upload-time = "2026-04-27T04:22:50.918Z" },
 ]
 
 [[package]]
@@ -603,20 +557,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/b6/3e681d3b6bb22647509bdbfdd18055d5adc0dce5c5585359fa46ff805fdc/typer-0.24.0.tar.gz", hash = "sha256:f9373dc4eff901350694f519f783c29b6d7a110fc0dcc11b1d7e353b85ca6504", size = 118380, upload-time = "2026-02-16T22:08:48.496Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/d0/4da85c2a45054bb661993c93524138ace4956cb075a7ae0c9d1deadc331b/typer-0.24.0-py3-none-any.whl", hash = "sha256:5fc435a9c8356f6160ed6e85a6301fdd6e3d8b2851da502050d1f92c5e9eddc8", size = 56441, upload-time = "2026-02-16T22:08:47.535Z" },
-]
-
-[[package]]
-name = "virtualenv"
-version = "20.33.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "platformdirs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/60/4f20960df6c7b363a18a55ab034c8f2bcd5d9770d1f94f9370ec104c1855/virtualenv-20.33.1.tar.gz", hash = "sha256:1b44478d9e261b3fb8baa5e74a0ca3bc0e05f21aa36167bf9cbf850e542765b8", size = 6082160, upload-time = "2025-08-05T16:10:55.605Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/ff/ded57ac5ff40a09e6e198550bab075d780941e0b0f83cbeabd087c59383a/virtualenv-20.33.1-py3-none-any.whl", hash = "sha256:07c19bc66c11acab6a5958b815cbcee30891cd1c2ccf53785a28651a0d8d8a67", size = 6060362, upload-time = "2025-08-05T16:10:52.81Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Switch the dev tool from `pre-commit` to `prek`, a Rust-based drop-in
that reads the same `.pre-commit-config.yaml` but is materially faster
and ships as a single binary. Wire `ty check` in as a local hook so
type checking runs alongside the existing ruff and uv-lock hooks. CI
cache key, README, and CONTRIBUTING are updated to match.