### PR TITLE
Preserve __future__ imports in ModuleDundersPlugin

### DIFF
--- a/dead_cst/_plugins/module_dunders.py
+++ b/dead_cst/_plugins/module_dunders.py
@@ -1,4 +1,4 @@
-"""Plugin: keep module-level dunder variables alive."""
+"""Plugin: keep module-level dunder variables and ``__future__`` imports alive."""
 
 from __future__ import annotations
 
@@ -13,23 +13,31 @@ DUNDER_PREFIX = "<dunder>:"
 
 @dataclass
 class ModuleDundersPlugin:
-    """Keep module-level dunder variables alive.
+    """Keep module-level dunder variables and ``__future__`` imports alive.
 
     Variables named ``__xxx__`` at module scope (``__all__``, ``__version__``,
     ``__author__``, ``__license__``, ...) are read by external tooling
     (packagers, ``importlib.metadata`` fallbacks, doc generators) so removing
-    them as dead would be observable even when no source references them. For
-    each such top-level variable, emit a synthetic entrypoint node with an
-    edge to it so :func:`find_reachable` preserves it.
+    them as dead would be observable even when no source references them.
+
+    ``from __future__ import ...`` statements are compile-time directives
+    (``annotations``, ``division``, ...): the local binding is never read,
+    but the import itself changes how the surrounding module parses, so
+    rewriting it away is observable. Both kinds get a synthetic entrypoint
+    node with an edge so :func:`find_reachable` preserves them.
     """
 
     name: str = "module_dunders"
 
     def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
         for node in ctx.base_nodes():
-            if not _is_module_dunder(node):
+            if not _is_kept_alive(node):
                 continue
             yield from mark_entrypoints(f"{DUNDER_PREFIX}{node.fqname}", node.path, [node])
+
+
+def _is_kept_alive(node: SymbolNode) -> bool:
+    return _is_module_dunder(node) or _is_future_import(node)
 
 
 def _is_module_dunder(node: SymbolNode) -> bool:
@@ -38,3 +46,10 @@ def _is_module_dunder(node: SymbolNode) -> bool:
         return False
     name = simple_name(node.fqname)
     return len(name) > 4 and name.startswith("__") and name.endswith("__")
+
+
+def _is_future_import(node: SymbolNode) -> bool:
+    """True for module-level ``from __future__ import ...`` bindings."""
+    return (
+        node.type == "import" and node.imports is not None and node.imports.module == "__future__"
+    )

--- a/tests/test_plugins/test_module_dunders.py
+++ b/tests/test_plugins/test_module_dunders.py
@@ -38,6 +38,43 @@ def test_keeps_other_dunders_alive(tmp_path, write_files, reachable_fqnames):
     assert "pkg.unused" not in reached
 
 
+def test_keeps_future_imports_alive(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "pkg/__init__.py": (
+                "from __future__ import annotations\nfrom __future__ import division\nunused = 1\n"
+            ),
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[ModuleDundersPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    # The local bindings of ``from __future__ import X`` are kept alive
+    # even though ``X`` is not a dunder name -- the import itself is a
+    # compile-time directive that can't be rewritten away.
+    assert {"pkg.annotations", "pkg.division"} <= reached
+    assert "pkg.unused" not in reached
+
+
+def test_ignores_non_future_imports_with_plain_names(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "pkg/__init__.py": "from os import path\n",
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[ModuleDundersPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    # Non-``__future__`` imports of plain names stay dead absent another entrypoint.
+    assert "pkg.path" not in reached
+
+
 def test_ignores_non_dunder_underscore_names(tmp_path, write_files, reachable_fqnames):
     write_files(
         {


### PR DESCRIPTION
from __future__ import ... is a compile-time directive: the local
binding is never read, but rewriting the import away changes how the
surrounding module parses. Treat such imports the same as module-level
dunder variables and seed a synthetic entrypoint to keep them alive.