### PR TITLE
Detect factory-style FastAPI/Flask apps; require resolved deps in 3rd-party plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,10 @@
           {
             "type": "command",
             "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f; [ -z \"$f\" ] && exit 0; case \"$f\" in *.py) cd /home/user/dead-cst && uv run --quiet ruff format \"$f\" && uv run --quiet ruff check --fix --unfixable F401 \"$f\" ;; esac; } 2>/dev/null || true"
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f; [ -z \"$f\" ] && exit 0; case \"$f\" in *.py) cd /home/user/dead-cst && uv run --quiet ty check ;; esac; } 2>/dev/null || true"
           }
         ]
       }

--- a/dead_cst/_plugins/__init__.py
+++ b/dead_cst/_plugins/__init__.py
@@ -34,6 +34,7 @@ from ._core import (
     apply_ops,
     require_resolved_dep,
     synthetic_node,
+    walk_to_instance_kind,
 )
 from .click import ClickPlugin
 from .explicit import ExplicitEntrypointPlugin
@@ -101,4 +102,5 @@ __all__ = [
     "load_plugin",
     "require_resolved_dep",
     "synthetic_node",
+    "walk_to_instance_kind",
 ]

--- a/dead_cst/_plugins/__init__.py
+++ b/dead_cst/_plugins/__init__.py
@@ -30,7 +30,9 @@ from ._core import (
     GraphOp,
     PluginContext,
     RemoveEdge,
+    UnresolvedDependencyError,
     apply_ops,
+    require_resolved_dep,
     synthetic_node,
 )
 from .click import ClickPlugin
@@ -94,7 +96,9 @@ __all__ = [
     "SYNTHETIC_POSITION",
     "TyperPlugin",
     "UnittestPlugin",
+    "UnresolvedDependencyError",
     "apply_ops",
     "load_plugin",
+    "require_resolved_dep",
     "synthetic_node",
 ]

--- a/dead_cst/_plugins/_core.py
+++ b/dead_cst/_plugins/_core.py
@@ -516,12 +516,9 @@ def walk_to_instance_kind(
         if node in seen or node is terminal:
             continue
         seen.add(node)
-        if (
-            node.type == "import"
-            and node.imports is not None
-            and node.imports.module == module_name
-            and node.imports.decl in instance_kinds
-        ):
-            return node.imports.decl
+        if node.type == "import" and node.imports is not None:
+            decl = node.imports.decl
+            if decl is not None and node.imports.module == module_name and decl in instance_kinds:
+                return decl
         stack.extend(graph.successors(node))
     return None

--- a/dead_cst/_plugins/_core.py
+++ b/dead_cst/_plugins/_core.py
@@ -201,7 +201,7 @@ class UnresolvedDependencyError(RuntimeError):
     """
 
 
-def require_resolved_dep(ctx: PluginContext, package: str, plugin_name: str) -> SymbolNode | None:
+def require_resolved_dep(ctx: PluginContext, package: str) -> SymbolNode | None:
     """Return the resolved ``[external ...]`` synthetic for ``package``.
 
     Three outcomes:
@@ -227,10 +227,10 @@ def require_resolved_dep(ctx: PluginContext, package: str, plugin_name: str) -> 
     if ctx._synthetic(f"{UNRESOLVED_PREFIX}{package}") is None:
         return None
     raise UnresolvedDependencyError(
-        f"{plugin_name} plugin requires '{package}' to be resolvable, but "
-        f"the analyzer only found '[unresolved] {package}'. Activate your "
-        f"project's virtual environment (or run `uv sync --all-packages`) "
-        f"so that '{package}' is importable, then retry."
+        f"'{package}' is imported in this base but the analyzer only "
+        f"found '[unresolved] {package}'. Activate your project's "
+        f"virtual environment (or run `uv sync --all-packages`) so "
+        f"'{package}' is importable, then retry."
     )
 
 
@@ -368,17 +368,25 @@ def decorator_owner(expr: cst.BaseExpression, valid_attrs: Container[str]) -> st
 
 
 def find_handlers(
-    module: cst.Module, instance_vars: Container[str], valid_attrs: Container[str]
+    module: cst.Module,
+    instance_vars: Container[str] | None,
+    valid_attrs: Container[str],
 ) -> dict[str, list[str]]:
-    """Return ``{instance_var: [handler_func_name, ...]}`` for top-level functions
-    decorated with ``@<instance_var>.<attr>(...)`` where ``attr`` is in ``valid_attrs``."""
+    """Return ``{owner_var: [handler_func_name, ...]}`` for top-level functions
+    decorated with ``@<owner_var>.<attr>(...)`` where ``attr`` is in ``valid_attrs``.
+
+    ``instance_vars=None`` accepts any owner -- useful when the caller will
+    classify owners by reachability / kind in a second pass.
+    """
     handlers: dict[str, list[str]] = {}
     for stmt in module.body:
         if not isinstance(stmt, cst.FunctionDef):
             continue
         for dec in stmt.decorators:
             owner = decorator_owner(dec.decorator, valid_attrs)
-            if owner is None or owner not in instance_vars:
+            if owner is None:
+                continue
+            if instance_vars is not None and owner not in instance_vars:
                 continue
             handlers.setdefault(owner, []).append(stmt.name.value)
             break
@@ -472,3 +480,48 @@ def collect_module_imports(
                     local = _asname_value(alias) or module_name
                     bindings[local] = "<module>"
     return bindings
+
+
+def walk_to_instance_kind(
+    graph: nx.DiGraph,
+    start: SymbolNode,
+    terminal: SymbolNode,
+    module_name: str,
+    instance_kinds: Container[str],
+) -> str | None:
+    """Walk forward from ``start`` until hitting an ``import`` node bound to
+    ``module_name`` and one of ``instance_kinds``; return the matched decl name.
+
+    Used by framework plugins to classify a variable as a ``Flask`` /
+    ``Blueprint`` / ``FastAPI`` / ``APIRouter`` / etc. instance via the
+    analyzer's existing reference edges. The factory case
+    (``X = create_app()``) drops out because the factory's body
+    references the framework class and that edge is already in the
+    graph. Returns ``None`` when the chain doesn't reach a discriminating
+    import -- callers treat that as "not an instance" rather than guessing.
+
+    The ``terminal`` cutoff (the framework's external-dist synthetic) is
+    skipped during traversal so the walk doesn't fan out across
+    *every* file that imports the framework.
+
+    Plugins requiring this should also call :func:`require_resolved_dep`
+    so the visitor's ``Import.module`` is the canonical ``"flask"`` /
+    ``"fastapi"`` / etc. (the unresolved fallback uses the dotted full
+    name and would never match here).
+    """
+    seen: set[SymbolNode] = set()
+    stack: list[SymbolNode] = [start]
+    while stack:
+        node = stack.pop()
+        if node in seen or node is terminal:
+            continue
+        seen.add(node)
+        if (
+            node.type == "import"
+            and node.imports is not None
+            and node.imports.module == module_name
+            and node.imports.decl in instance_kinds
+        ):
+            return node.imports.decl
+        stack.extend(graph.successors(node))
+    return None

--- a/dead_cst/_plugins/_core.py
+++ b/dead_cst/_plugins/_core.py
@@ -187,6 +187,53 @@ class PluginContext:
         return self._synthetic_index.get(fqname)
 
 
+class UnresolvedDependencyError(RuntimeError):
+    """A plugin needs ``package`` resolved to an installed distribution but
+    only the ``[unresolved] <package>`` synthetic exists.
+
+    This means at least one file under the analyzed base does
+    ``import <package>`` / ``from <package> import ...``, but no resolver
+    found the distribution on ``sys.path`` -- typically the user hasn't
+    activated their venv (or hasn't run ``uv sync``). The plugin can't
+    function without the resolver having pinned the package to a real
+    site-packages location, so we surface the failure rather than
+    silently producing wrong results.
+    """
+
+
+def require_resolved_dep(ctx: PluginContext, package: str, plugin_name: str) -> SymbolNode | None:
+    """Return the resolved ``[external ...]`` synthetic for ``package``.
+
+    Three outcomes:
+
+    * Returns the ``[external dist] <package>`` / ``[external file] <package>``
+      node if the analyzer's resolver pinned ``package`` to an installed
+      distribution.
+    * Returns ``None`` if no file in this base imports ``package`` (no
+      synthetic was created at all). The plugin has nothing to do.
+    * Raises :class:`UnresolvedDependencyError` if only the
+      ``[unresolved] <package>`` synthetic exists -- the plugin's
+      precondition (a resolved import of ``package``) is unmet, so we
+      stop rather than guess.
+
+    Plugins that wrap framework conventions (FastAPI, Flask, Click,
+    Typer, ...) should use this in place of ``ctx.importers(package)``
+    so that misconfigured environments fail loudly.
+    """
+    for prefix in EXTERNAL_PREFIXES:
+        node = ctx._synthetic(f"{prefix}{package}")
+        if node is not None:
+            return node
+    if ctx._synthetic(f"{UNRESOLVED_PREFIX}{package}") is None:
+        return None
+    raise UnresolvedDependencyError(
+        f"{plugin_name} plugin requires '{package}' to be resolvable, but "
+        f"the analyzer only found '[unresolved] {package}'. Activate your "
+        f"project's virtual environment (or run `uv sync --all-packages`) "
+        f"so that '{package}' is importable, then retry."
+    )
+
+
 @dataclass(frozen=True)
 class AddNode:
     """Add a node to the graph. When ``entrypoint=True``, mark the node so

--- a/dead_cst/_plugins/click.py
+++ b/dead_cst/_plugins/click.py
@@ -38,6 +38,7 @@ from ._core import (
     collect_module_imports,
     decorator_owner,
     find_handlers,
+    require_resolved_dep,
     matched_attr_call,
     single_target_assignment,
 )
@@ -99,12 +100,12 @@ class ClickPlugin:
     name: str = "click"
 
     def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
-        # Prefilter via the import graph: only files that actually import
-        # ``click`` can declare a group. Free because the resolver already
-        # added ``[external dist] click`` predecessors for them.
-        candidate_paths = ctx.importers("click")
-        if not candidate_paths:
+        # Require that ``click`` was resolved to an installed distribution.
+        # Raises ``UnresolvedDependencyError`` if only ``[unresolved] click``
+        # exists, so misconfigured environments fail loudly.
+        if require_resolved_dep(ctx, "click", "Click") is None:
             return
+        candidate_paths = ctx.importers("click")
 
         for path, module_node in ctx.base_modules():
             if path not in candidate_paths:

--- a/dead_cst/_plugins/click.py
+++ b/dead_cst/_plugins/click.py
@@ -100,10 +100,7 @@ class ClickPlugin:
     name: str = "click"
 
     def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
-        # Require that ``click`` was resolved to an installed distribution.
-        # Raises ``UnresolvedDependencyError`` if only ``[unresolved] click``
-        # exists, so misconfigured environments fail loudly.
-        if require_resolved_dep(ctx, "click", "Click") is None:
+        if require_resolved_dep(ctx, "click") is None:
             return
         candidate_paths = ctx.importers("click")
 

--- a/dead_cst/_plugins/fastapi.py
+++ b/dead_cst/_plugins/fastapi.py
@@ -42,6 +42,7 @@ from ._core import (
     collect_module_imports,
     decorator_owner,
     find_call_assignments,
+    require_resolved_dep,
 )
 
 # Attribute names FastAPI / APIRouter use to register a callable. Matched as
@@ -113,7 +114,7 @@ class FastAPIPlugin:
     name: str = "fastapi"
 
     def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
-        fastapi_node = _find_fastapi_node(ctx)
+        fastapi_node = require_resolved_dep(ctx, "fastapi", "FastAPI")
         if fastapi_node is None:
             return
 
@@ -147,21 +148,6 @@ class FastAPIPlugin:
                             f"{module_fqname}.{handler_name}"
                         ):
                             yield AddEdge(instance_decl, handler_decl)
-
-
-def _find_fastapi_node(ctx: PluginContext) -> SymbolNode | None:
-    """Return the synthetic node the analyzer attaches to ``fastapi`` imports.
-
-    The analyzer surfaces ``import fastapi`` / ``from fastapi import ...``
-    as a predecessor of one of the synthetic markers
-    (``[external dist]``, ``[external file]``, or ``[unresolved]``).
-    Whichever is present is the hub every chain we care about lands on.
-    """
-    for prefix in ("[external dist] ", "[external file] ", "[unresolved] "):
-        node = ctx._synthetic(f"{prefix}fastapi")
-        if node is not None:
-            return node
-    return None
 
 
 def _route_decorator_candidates(module: cst.Module) -> dict[str, list[str]]:
@@ -214,18 +200,13 @@ def _walk_to_fastapi_kind(
 def _import_kind(node: SymbolNode) -> str | None:
     """Return ``"FastAPI"`` / ``"APIRouter"`` if ``node`` imports either, else ``None``.
 
-    Handles both encodings the visitor uses depending on whether
-    ``fastapi`` resolved as an installed distribution: resolved gives
-    ``Import.module="fastapi"`` + ``Import.decl="FastAPI"``, unresolved
-    gives ``Import.module="fastapi.FastAPI"`` + ``Import.decl=None``.
-    Concatenating gives a single shape to match.
+    The plugin requires ``fastapi`` to be a resolved distribution
+    (:func:`require_resolved_dep`), so the visitor always encodes
+    ``from fastapi import FastAPI`` as ``Import.module="fastapi"`` +
+    ``Import.decl="FastAPI"``.
     """
     if node.type != "import" or node.imports is None:
         return None
-    full = node.imports.module
-    if node.imports.decl:
-        full = f"{full}.{node.imports.decl}"
-    if not full.startswith("fastapi."):
+    if node.imports.module != "fastapi":
         return None
-    tail = full.rsplit(".", 1)[-1]
-    return tail if tail in _INSTANCE_KINDS else None
+    return node.imports.decl if node.imports.decl in _INSTANCE_KINDS else None

--- a/dead_cst/_plugins/fastapi.py
+++ b/dead_cst/_plugins/fastapi.py
@@ -30,19 +30,18 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable
 
-import libcst as cst
 import networkx as nx
 
-from .._symbols import SymbolNode
 from ._core import (
     AddEdge,
     AddNode,
     GraphOp,
     PluginContext,
     collect_module_imports,
-    decorator_owner,
     find_call_assignments,
+    find_handlers,
     require_resolved_dep,
+    walk_to_instance_kind,
 )
 
 # Attribute names FastAPI / APIRouter use to register a callable. Matched as
@@ -114,9 +113,14 @@ class FastAPIPlugin:
     name: str = "fastapi"
 
     def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
-        fastapi_node = require_resolved_dep(ctx, "fastapi", "FastAPI")
+        fastapi_node = require_resolved_dep(ctx, "fastapi")
         if fastapi_node is None:
             return
+        # ``ancestors(fastapi_node)`` is the universe of decls whose
+        # reference chain reaches the ``fastapi`` synthetic. Any
+        # factory-produced instance must be in this set; the rest can't
+        # be a FastAPI/APIRouter, so we skip the forward walk for them.
+        reaches_fastapi = nx.ancestors(ctx.graph, fastapi_node)
 
         for path, module_node in ctx.base_modules():
             module = ctx.parse(path)
@@ -124,23 +128,23 @@ class FastAPIPlugin:
                 continue
 
             fastapi_imports = collect_module_imports(module, "fastapi", _INSTANCE_KINDS)
-            direct: dict[str, str] = (
-                find_call_assignments(module, fastapi_imports, _INSTANCE_KINDS)
-                if fastapi_imports
-                else {}
-            )
-            decorated = _route_decorator_candidates(module)
+            direct = find_call_assignments(module, fastapi_imports, _INSTANCE_KINDS)
+            decorated = find_handlers(module, None, _REGISTRATION_DECORATORS)
             if not direct and not decorated:
                 continue
 
             module_fqname = module_node.fqname
-            for var_name in set(direct) | set(decorated):
+            for var_name in direct.keys() | decorated.keys():
                 for instance_decl in ctx.find_declarations(f"{module_fqname}.{var_name}"):
-                    kind = direct.get(var_name) or _walk_to_fastapi_kind(
-                        ctx.graph, instance_decl, fastapi_node
-                    )
+                    kind = direct.get(var_name)
                     if kind is None:
-                        continue
+                        if instance_decl not in reaches_fastapi:
+                            continue
+                        kind = walk_to_instance_kind(
+                            ctx.graph, instance_decl, fastapi_node, "fastapi", _INSTANCE_KINDS
+                        )
+                        if kind is None:
+                            continue
                     if _INSTANCE_KINDS[kind]:
                         yield AddNode(instance_decl, entrypoint=True)
                     for handler_name in decorated.get(var_name, ()):
@@ -148,65 +152,3 @@ class FastAPIPlugin:
                             f"{module_fqname}.{handler_name}"
                         ):
                             yield AddEdge(instance_decl, handler_decl)
-
-
-def _route_decorator_candidates(module: cst.Module) -> dict[str, list[str]]:
-    """Collect every top-level ``@<X>.<route_verb>(...)``-decorated function.
-
-    Returns ``{owner_var_name: [handler_func_name, ...]}``. Owner is read
-    via :func:`decorator_owner` so bare-name (``@get``) and attribute-on-
-    non-name (``@self.app.get``) forms are skipped.
-    """
-    handlers: dict[str, list[str]] = {}
-    for stmt in module.body:
-        if not isinstance(stmt, cst.FunctionDef):
-            continue
-        for dec in stmt.decorators:
-            owner = decorator_owner(dec.decorator, _REGISTRATION_DECORATORS)
-            if owner is None:
-                continue
-            handlers.setdefault(owner, []).append(stmt.name.value)
-            break
-    return handlers
-
-
-def _walk_to_fastapi_kind(
-    graph: nx.DiGraph, instance_decl: SymbolNode, fastapi_node: SymbolNode
-) -> str | None:
-    """Return ``"FastAPI"`` / ``"APIRouter"`` reached from ``instance_decl``, else ``None``.
-
-    Walks forward through reference edges until hitting an ``import``
-    node bound to one of the two classes. The factory case
-    (``X = create_app()``) drops out because the factory's body
-    references ``FastAPI`` and the analyzer already recorded that
-    edge. Returns ``None`` when the chain doesn't reach a
-    discriminating import -- callers treat that as "not a FastAPI
-    instance" rather than guessing a kind.
-    """
-    seen: set[SymbolNode] = set()
-    stack: list[SymbolNode] = [instance_decl]
-    while stack:
-        node = stack.pop()
-        if node in seen or node is fastapi_node:
-            continue
-        seen.add(node)
-        kind = _import_kind(node)
-        if kind is not None:
-            return kind
-        stack.extend(graph.successors(node))
-    return None
-
-
-def _import_kind(node: SymbolNode) -> str | None:
-    """Return ``"FastAPI"`` / ``"APIRouter"`` if ``node`` imports either, else ``None``.
-
-    The plugin requires ``fastapi`` to be a resolved distribution
-    (:func:`require_resolved_dep`), so the visitor always encodes
-    ``from fastapi import FastAPI`` as ``Import.module="fastapi"`` +
-    ``Import.decl="FastAPI"``.
-    """
-    if node.type != "import" or node.imports is None:
-        return None
-    if node.imports.module != "fastapi":
-        return None
-    return node.imports.decl if node.imports.decl in _INSTANCE_KINDS else None

--- a/dead_cst/_plugins/fastapi.py
+++ b/dead_cst/_plugins/fastapi.py
@@ -1,15 +1,28 @@
 """Plugin: keep FastAPI route handlers and lifecycle hooks alive.
 
-Strategy: instead of marking each handler as its own entrypoint, find the
-top-level ``FastAPI()`` / ``APIRouter()`` instances in each module and emit
-inverse edges (instance -> handler) for every ``@<instance>.<method>(...)``
-decorator. ``FastAPI()`` instances are then seeded as entrypoints; routers
-stay pass-through so an unused ``APIRouter`` still surfaces as dead code.
+Strategy: every FastAPI / APIRouter instance we want to wire up is a
+top-level variable that the analyzer has already linked back to the
+``fastapi`` import -- whether the assignment is the literal
+``X = FastAPI()``, the aliased ``X = F()`` after ``from fastapi import
+FastAPI as F``, or the factory form ``X = create_app()`` whose body
+returns ``FastAPI(...)``. The plugin reuses those reference edges:
 
-This routes ``why-alive`` chains through the app variable users actually
-recognize ("alive because it's a route on ``app``") and lets the existing
-``app.include_router(router)`` reference flow keep sub-routers reachable
-without any special-casing.
+1. Direct shape (``X = FastAPI(...)`` / ``X = APIRouter(...)``,
+   ``X = fastapi.FastAPI(...)``, etc.) is recognized syntactically via
+   ``find_call_assignments`` -- this is unambiguous, so it gives the
+   kind directly even for ``import fastapi`` forms where the graph
+   alone can't distinguish the two classes.
+2. Indirect shape (any variable decorated by ``@X.<route_verb>(...)``)
+   is detected via the route-decorator scan; kind is read off the
+   import nodes encountered while walking forward from ``X`` in the
+   graph, which transparently handles factory wrappers because the
+   factory's body is already linked to the right import.
+
+For each detected instance the plugin emits ``X -> handler`` edges for
+its decorated handlers and seeds ``FastAPI`` instances as entrypoints
+(uvicorn loads ``module:app``); routers are not seeded, so an
+``APIRouter`` that nothing ``include_router``s stays dead -- the right
+signal.
 """
 
 from __future__ import annotations
@@ -17,14 +30,18 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable
 
+import libcst as cst
+import networkx as nx
+
+from .._symbols import SymbolNode
 from ._core import (
     AddEdge,
     AddNode,
     GraphOp,
     PluginContext,
     collect_module_imports,
+    decorator_owner,
     find_call_assignments,
-    find_handlers,
 )
 
 # Attribute names FastAPI / APIRouter use to register a callable. Matched as
@@ -62,64 +79,153 @@ class FastAPIPlugin:
 
     For each module the plugin:
 
-    1. Inspects ``from fastapi import ...`` / ``import fastapi`` to learn
-       which local names refer to ``FastAPI`` and ``APIRouter``.
-    2. Finds top-level assignments ``X = FastAPI(...)`` / ``X = APIRouter(...)``
-       (including ``AnnAssign`` and aliased / module-prefixed forms) and
-       records ``X`` as an instance of that kind.
-    3. For every top-level function decorated ``@X.<route_name>(...)``,
-       emits an edge ``X -> handler`` so the handler is reachable whenever
-       ``X`` is.
-    4. Seeds every ``FastAPI`` instance as an entrypoint. Routers are not
-       seeded -- a router that is never ``include_router``\\ed has no path
-       from any entrypoint and stays dead, which is the correct signal.
+    1. Finds direct ``X = FastAPI(...)`` / ``X = APIRouter(...)``
+       assignments by inspecting the file's ``fastapi`` imports and
+       matching call sites. This is the unambiguous path and handles
+       module-prefixed forms like ``import fastapi; X = fastapi.FastAPI()``
+       that pure graph reachability cannot distinguish (the variable's
+       edge goes straight to the ``fastapi`` synthetic with no
+       intermediate ``FastAPI`` vs ``APIRouter`` import to discriminate).
+    2. Collects every ``@<X>.<verb>(...)`` decorator (``verb`` from
+       FastAPI's registration set). For each owner ``X`` not already
+       resolved by step 1, walks forward from ``X`` in the symbol graph;
+       if the walk hits an ``import`` node bound to ``FastAPI`` or
+       ``APIRouter``, ``X`` is a factory-produced instance of that kind.
+       Variables that reach ``fastapi`` only through unrelated symbols
+       (e.g. ``HTTPException``) are not classified, so they don't get
+       marked as apps.
+    3. For each detected instance, emits ``X -> handler`` edges for its
+       decorated handlers. ``FastAPI`` instances are seeded as
+       entrypoints; routers are not, so an ``APIRouter`` that nothing
+       ``include_router``s stays dead.
 
     Application wiring (``app.include_router(router)``,
     ``FastAPI(lifespan=fn)``, ``app.add_api_route(..., endpoint=fn)``,
     ``Depends(fn)``) is plain reference passing already tracked by the
     regular analyzer.
 
-    Limitations: only top-level ``X = FastAPI(...)`` / ``X = APIRouter(...)``
-    assignments with a single ``Name`` target are detected. Factory-style
-    apps (``def create_app(): return FastAPI()``) and class-attribute apps
-    (``self.app = FastAPI()``) are not handled; users can still keep those
-    alive with explicit ``-e`` entrypoints.
+    Limitations: only top-level decls with a single ``Name`` decorator
+    target ``@X.<verb>(...)`` are handled. Class-attribute apps
+    (``self.app = FastAPI(); @self.app.get(...)``) and decorators that
+    chain through extra calls aren't recognized.
     """
 
     name: str = "fastapi"
 
     def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
-        # Prefilter via the import graph: only files that actually import
-        # ``fastapi`` can declare an app or router. The analyzer's resolver
-        # already added ``[external dist] fastapi`` predecessors for them.
-        candidate_paths = ctx.importers("fastapi")
-        if not candidate_paths:
+        fastapi_node = _find_fastapi_node(ctx)
+        if fastapi_node is None:
             return
 
         for path, module_node in ctx.base_modules():
-            if path not in candidate_paths:
-                continue
             module = ctx.parse(path)
             if module is None:
                 continue
+
             fastapi_imports = collect_module_imports(module, "fastapi", _INSTANCE_KINDS)
-            if not fastapi_imports:
+            direct: dict[str, str] = (
+                find_call_assignments(module, fastapi_imports, _INSTANCE_KINDS)
+                if fastapi_imports
+                else {}
+            )
+            decorated = _route_decorator_candidates(module)
+            if not direct and not decorated:
                 continue
-            instances = find_call_assignments(module, fastapi_imports, _INSTANCE_KINDS)
-            if not instances:
-                continue
-            handlers = find_handlers(module, set(instances), _REGISTRATION_DECORATORS)
 
             module_fqname = module_node.fqname
-            for var_name, kind in instances.items():
-                instance_decls = ctx.find_declarations(f"{module_fqname}.{var_name}")
-                if not instance_decls:
-                    continue
-                for instance_decl in instance_decls:
+            for var_name in set(direct) | set(decorated):
+                for instance_decl in ctx.find_declarations(f"{module_fqname}.{var_name}"):
+                    kind = direct.get(var_name) or _walk_to_fastapi_kind(
+                        ctx.graph, instance_decl, fastapi_node
+                    )
+                    if kind is None:
+                        continue
                     if _INSTANCE_KINDS[kind]:
                         yield AddNode(instance_decl, entrypoint=True)
-                    for handler_name in handlers.get(var_name, ()):
+                    for handler_name in decorated.get(var_name, ()):
                         for handler_decl in ctx.find_declarations(
                             f"{module_fqname}.{handler_name}"
                         ):
                             yield AddEdge(instance_decl, handler_decl)
+
+
+def _find_fastapi_node(ctx: PluginContext) -> SymbolNode | None:
+    """Return the synthetic node the analyzer attaches to ``fastapi`` imports.
+
+    The analyzer surfaces ``import fastapi`` / ``from fastapi import ...``
+    as a predecessor of one of the synthetic markers
+    (``[external dist]``, ``[external file]``, or ``[unresolved]``).
+    Whichever is present is the hub every chain we care about lands on.
+    """
+    for prefix in ("[external dist] ", "[external file] ", "[unresolved] "):
+        node = ctx._synthetic(f"{prefix}fastapi")
+        if node is not None:
+            return node
+    return None
+
+
+def _route_decorator_candidates(module: cst.Module) -> dict[str, list[str]]:
+    """Collect every top-level ``@<X>.<route_verb>(...)``-decorated function.
+
+    Returns ``{owner_var_name: [handler_func_name, ...]}``. Owner is read
+    via :func:`decorator_owner` so bare-name (``@get``) and attribute-on-
+    non-name (``@self.app.get``) forms are skipped.
+    """
+    handlers: dict[str, list[str]] = {}
+    for stmt in module.body:
+        if not isinstance(stmt, cst.FunctionDef):
+            continue
+        for dec in stmt.decorators:
+            owner = decorator_owner(dec.decorator, _REGISTRATION_DECORATORS)
+            if owner is None:
+                continue
+            handlers.setdefault(owner, []).append(stmt.name.value)
+            break
+    return handlers
+
+
+def _walk_to_fastapi_kind(
+    graph: nx.DiGraph, instance_decl: SymbolNode, fastapi_node: SymbolNode
+) -> str | None:
+    """Return ``"FastAPI"`` / ``"APIRouter"`` reached from ``instance_decl``, else ``None``.
+
+    Walks forward through reference edges until hitting an ``import``
+    node bound to one of the two classes. The factory case
+    (``X = create_app()``) drops out because the factory's body
+    references ``FastAPI`` and the analyzer already recorded that
+    edge. Returns ``None`` when the chain doesn't reach a
+    discriminating import -- callers treat that as "not a FastAPI
+    instance" rather than guessing a kind.
+    """
+    seen: set[SymbolNode] = set()
+    stack: list[SymbolNode] = [instance_decl]
+    while stack:
+        node = stack.pop()
+        if node in seen or node is fastapi_node:
+            continue
+        seen.add(node)
+        kind = _import_kind(node)
+        if kind is not None:
+            return kind
+        stack.extend(graph.successors(node))
+    return None
+
+
+def _import_kind(node: SymbolNode) -> str | None:
+    """Return ``"FastAPI"`` / ``"APIRouter"`` if ``node`` imports either, else ``None``.
+
+    Handles both encodings the visitor uses depending on whether
+    ``fastapi`` resolved as an installed distribution: resolved gives
+    ``Import.module="fastapi"`` + ``Import.decl="FastAPI"``, unresolved
+    gives ``Import.module="fastapi.FastAPI"`` + ``Import.decl=None``.
+    Concatenating gives a single shape to match.
+    """
+    if node.type != "import" or node.imports is None:
+        return None
+    full = node.imports.module
+    if node.imports.decl:
+        full = f"{full}.{node.imports.decl}"
+    if not full.startswith("fastapi."):
+        return None
+    tail = full.rsplit(".", 1)[-1]
+    return tail if tail in _INSTANCE_KINDS else None

--- a/dead_cst/_plugins/flask.py
+++ b/dead_cst/_plugins/flask.py
@@ -25,6 +25,7 @@ from ._core import (
     collect_module_imports,
     find_call_assignments,
     find_handlers,
+    require_resolved_dep,
 )
 
 # Attribute names Flask / Blueprint use to register a callable. Matched as
@@ -110,12 +111,13 @@ class FlaskPlugin:
     name: str = "flask"
 
     def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
-        # Prefilter via the import graph: only files that actually import
-        # ``flask`` can declare an app or blueprint. The analyzer's resolver
-        # already added ``[external dist] flask`` predecessors for them.
-        candidate_paths = ctx.importers("flask")
-        if not candidate_paths:
+        # Require that ``flask`` was resolved to an installed distribution.
+        # Returns ``None`` if no file imports flask (nothing to do); raises
+        # ``UnresolvedDependencyError`` if only the ``[unresolved] flask``
+        # synthetic exists, so misconfigured environments fail loudly.
+        if require_resolved_dep(ctx, "flask", "Flask") is None:
             return
+        candidate_paths = ctx.importers("flask")
 
         for path, module_node in ctx.base_modules():
             if path not in candidate_paths:

--- a/dead_cst/_plugins/flask.py
+++ b/dead_cst/_plugins/flask.py
@@ -32,19 +32,18 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable
 
-import libcst as cst
 import networkx as nx
 
-from .._symbols import SymbolNode
 from ._core import (
     AddEdge,
     AddNode,
     GraphOp,
     PluginContext,
     collect_module_imports,
-    decorator_owner,
     find_call_assignments,
+    find_handlers,
     require_resolved_dep,
+    walk_to_instance_kind,
 )
 
 # Attribute names Flask / Blueprint use to register a callable. Matched as
@@ -136,9 +135,10 @@ class FlaskPlugin:
     name: str = "flask"
 
     def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
-        flask_node = require_resolved_dep(ctx, "flask", "Flask")
+        flask_node = require_resolved_dep(ctx, "flask")
         if flask_node is None:
             return
+        reaches_flask = nx.ancestors(ctx.graph, flask_node)
 
         for path, module_node in ctx.base_modules():
             module = ctx.parse(path)
@@ -146,23 +146,23 @@ class FlaskPlugin:
                 continue
 
             flask_imports = collect_module_imports(module, "flask", _INSTANCE_KINDS)
-            direct: dict[str, str] = (
-                find_call_assignments(module, flask_imports, _INSTANCE_KINDS)
-                if flask_imports
-                else {}
-            )
-            decorated = _route_decorator_candidates(module)
+            direct = find_call_assignments(module, flask_imports, _INSTANCE_KINDS)
+            decorated = find_handlers(module, None, _REGISTRATION_DECORATORS)
             if not direct and not decorated:
                 continue
 
             module_fqname = module_node.fqname
-            for var_name in set(direct) | set(decorated):
+            for var_name in direct.keys() | decorated.keys():
                 for instance_decl in ctx.find_declarations(f"{module_fqname}.{var_name}"):
-                    kind = direct.get(var_name) or _walk_to_flask_kind(
-                        ctx.graph, instance_decl, flask_node
-                    )
+                    kind = direct.get(var_name)
                     if kind is None:
-                        continue
+                        if instance_decl not in reaches_flask:
+                            continue
+                        kind = walk_to_instance_kind(
+                            ctx.graph, instance_decl, flask_node, "flask", _INSTANCE_KINDS
+                        )
+                        if kind is None:
+                            continue
                     if _INSTANCE_KINDS[kind]:
                         yield AddNode(instance_decl, entrypoint=True)
                     for handler_name in decorated.get(var_name, ()):
@@ -170,65 +170,3 @@ class FlaskPlugin:
                             f"{module_fqname}.{handler_name}"
                         ):
                             yield AddEdge(instance_decl, handler_decl)
-
-
-def _route_decorator_candidates(module: cst.Module) -> dict[str, list[str]]:
-    """Collect every top-level ``@<X>.<route_verb>(...)``-decorated function.
-
-    Returns ``{owner_var_name: [handler_func_name, ...]}``. Owner is read
-    via :func:`decorator_owner` so bare-name (``@route``) and attribute-on-
-    non-name (``@self.app.route``) forms are skipped.
-    """
-    handlers: dict[str, list[str]] = {}
-    for stmt in module.body:
-        if not isinstance(stmt, cst.FunctionDef):
-            continue
-        for dec in stmt.decorators:
-            owner = decorator_owner(dec.decorator, _REGISTRATION_DECORATORS)
-            if owner is None:
-                continue
-            handlers.setdefault(owner, []).append(stmt.name.value)
-            break
-    return handlers
-
-
-def _walk_to_flask_kind(
-    graph: nx.DiGraph, instance_decl: SymbolNode, flask_node: SymbolNode
-) -> str | None:
-    """Return ``"Flask"`` / ``"Blueprint"`` reached from ``instance_decl``, else ``None``.
-
-    Walks forward through reference edges until hitting an ``import``
-    node bound to one of the two classes. The factory case
-    (``X = create_app()``) drops out because the factory's body
-    references ``Flask`` and the analyzer already recorded that edge.
-    Returns ``None`` when the chain doesn't reach a discriminating
-    import -- callers treat that as "not a Flask instance" rather than
-    guessing a kind.
-    """
-    seen: set[SymbolNode] = set()
-    stack: list[SymbolNode] = [instance_decl]
-    while stack:
-        node = stack.pop()
-        if node in seen or node is flask_node:
-            continue
-        seen.add(node)
-        kind = _import_kind(node)
-        if kind is not None:
-            return kind
-        stack.extend(graph.successors(node))
-    return None
-
-
-def _import_kind(node: SymbolNode) -> str | None:
-    """Return ``"Flask"`` / ``"Blueprint"`` if ``node`` imports either, else ``None``.
-
-    The plugin requires ``flask`` to be a resolved distribution
-    (:func:`require_resolved_dep`), so the visitor always encodes
-    ``from flask import Flask`` as ``Import.module="flask"`` +
-    ``Import.decl="Flask"``.
-    """
-    if node.type != "import" or node.imports is None:
-        return None
-    if node.imports.module != "flask":
-        return None
-    return node.imports.decl if node.imports.decl in _INSTANCE_KINDS else None

--- a/dead_cst/_plugins/flask.py
+++ b/dead_cst/_plugins/flask.py
@@ -1,15 +1,30 @@
 """Plugin: keep Flask route handlers and lifecycle hooks alive.
 
-Strategy: instead of marking each handler as its own entrypoint, find the
-top-level ``Flask()`` / ``Blueprint()`` instances in each module and emit
-inverse edges (instance -> handler) for every ``@<instance>.<method>(...)``
-decorator. ``Flask()`` instances are then seeded as entrypoints; blueprints
-stay pass-through so an unused ``Blueprint`` still surfaces as dead code.
+Strategy: every Flask / Blueprint instance we want to wire up is a
+top-level variable that the analyzer has already linked back to the
+``flask`` import -- whether the assignment is the literal
+``X = Flask(__name__)``, the aliased ``X = F(__name__)`` after
+``from flask import Flask as F``, or the factory form
+``X = create_app()`` whose body returns ``Flask(...)``. The plugin
+reuses those reference edges:
 
-This routes ``why-alive`` chains through the app variable users actually
-recognize ("alive because it's a route on ``app``") and lets the existing
-``app.register_blueprint(bp)`` reference flow keep blueprints reachable
-without any special-casing.
+1. Direct shape (``X = Flask(...)`` / ``X = Blueprint(...)``,
+   ``X = flask.Flask(...)``, etc.) is recognized syntactically via
+   ``find_call_assignments`` -- this is unambiguous, so it gives the
+   kind directly even for ``import flask`` forms where the graph
+   alone can't distinguish the two classes.
+2. Indirect shape (any variable decorated by ``@X.<route_verb>(...)``)
+   is detected via the route-decorator scan; kind is read off the
+   import nodes encountered while walking forward from ``X`` in the
+   graph, which transparently handles the canonical Flask
+   ``create_app()`` factory because the factory's body is already
+   linked to the right import.
+
+For each detected instance the plugin emits ``X -> handler`` edges for
+its decorated handlers and seeds ``Flask`` instances as entrypoints
+(WSGI servers load ``module:app``); blueprints are not seeded, so a
+``Blueprint`` that nothing ``register_blueprint``s stays dead -- the
+right signal.
 """
 
 from __future__ import annotations
@@ -17,14 +32,18 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable
 
+import libcst as cst
+import networkx as nx
+
+from .._symbols import SymbolNode
 from ._core import (
     AddEdge,
     AddNode,
     GraphOp,
     PluginContext,
     collect_module_imports,
+    decorator_owner,
     find_call_assignments,
-    find_handlers,
     require_resolved_dep,
 )
 
@@ -84,65 +103,132 @@ class FlaskPlugin:
 
     For each module the plugin:
 
-    1. Inspects ``from flask import ...`` / ``import flask`` to learn
-       which local names refer to ``Flask`` and ``Blueprint``.
-    2. Finds top-level assignments ``X = Flask(...)`` / ``X = Blueprint(...)``
-       (including ``AnnAssign`` and aliased / module-prefixed forms) and
-       records ``X`` as an instance of that kind.
-    3. For every top-level function decorated ``@X.<route_name>(...)``,
-       emits an edge ``X -> handler`` so the handler is reachable whenever
-       ``X`` is.
-    4. Seeds every ``Flask`` instance as an entrypoint. Blueprints are not
-       seeded -- a blueprint that is never ``register_blueprint``\\ed has
-       no path from any entrypoint and stays dead, which is the correct
-       signal.
+    1. Finds direct ``X = Flask(...)`` / ``X = Blueprint(...)``
+       assignments by inspecting the file's ``flask`` imports and
+       matching call sites. This is the unambiguous path and handles
+       module-prefixed forms like ``import flask; X = flask.Flask()``
+       that pure graph reachability cannot distinguish (the variable's
+       edge goes straight to the ``flask`` synthetic with no
+       intermediate ``Flask`` vs ``Blueprint`` import to discriminate).
+    2. Collects every ``@<X>.<verb>(...)`` decorator (``verb`` from
+       Flask's registration set). For each owner ``X`` not already
+       resolved by step 1, walks forward from ``X`` in the symbol graph;
+       if the walk hits an ``import`` node bound to ``Flask`` or
+       ``Blueprint``, ``X`` is a factory-produced instance of that kind.
+       Variables that reach ``flask`` only through unrelated symbols
+       (e.g. ``request``, ``url_for``) are not classified, so they
+       don't get marked as apps.
+    3. For each detected instance, emits ``X -> handler`` edges for its
+       decorated handlers. ``Flask`` instances are seeded as entrypoints;
+       blueprints are not, so a ``Blueprint`` that nothing
+       ``register_blueprint``s stays dead.
 
     Application wiring (``app.register_blueprint(bp)``,
     ``app.add_url_rule(..., view_func=fn)``, ``app.errorhandler(404)(fn)``)
     is plain reference passing already tracked by the regular analyzer.
 
-    Limitations: only top-level ``X = Flask(...)`` / ``X = Blueprint(...)``
-    assignments with a single ``Name`` target are detected. Factory-style
-    apps (``def create_app(): return Flask(__name__)``) and class-attribute
-    apps (``self.app = Flask(__name__)``) are not handled; users can still
-    keep those alive with explicit ``-e`` entrypoints.
+    Limitations: only top-level decls with a single ``Name`` decorator
+    target ``@X.<verb>(...)`` are handled. Class-attribute apps
+    (``self.app = Flask(__name__); @self.app.route(...)``) and
+    decorators that chain through extra calls aren't recognized.
     """
 
     name: str = "flask"
 
     def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
-        # Require that ``flask`` was resolved to an installed distribution.
-        # Returns ``None`` if no file imports flask (nothing to do); raises
-        # ``UnresolvedDependencyError`` if only the ``[unresolved] flask``
-        # synthetic exists, so misconfigured environments fail loudly.
-        if require_resolved_dep(ctx, "flask", "Flask") is None:
+        flask_node = require_resolved_dep(ctx, "flask", "Flask")
+        if flask_node is None:
             return
-        candidate_paths = ctx.importers("flask")
 
         for path, module_node in ctx.base_modules():
-            if path not in candidate_paths:
-                continue
             module = ctx.parse(path)
             if module is None:
                 continue
+
             flask_imports = collect_module_imports(module, "flask", _INSTANCE_KINDS)
-            if not flask_imports:
+            direct: dict[str, str] = (
+                find_call_assignments(module, flask_imports, _INSTANCE_KINDS)
+                if flask_imports
+                else {}
+            )
+            decorated = _route_decorator_candidates(module)
+            if not direct and not decorated:
                 continue
-            instances = find_call_assignments(module, flask_imports, _INSTANCE_KINDS)
-            if not instances:
-                continue
-            handlers = find_handlers(module, set(instances), _REGISTRATION_DECORATORS)
 
             module_fqname = module_node.fqname
-            for var_name, kind in instances.items():
-                instance_decls = ctx.find_declarations(f"{module_fqname}.{var_name}")
-                if not instance_decls:
-                    continue
-                for instance_decl in instance_decls:
+            for var_name in set(direct) | set(decorated):
+                for instance_decl in ctx.find_declarations(f"{module_fqname}.{var_name}"):
+                    kind = direct.get(var_name) or _walk_to_flask_kind(
+                        ctx.graph, instance_decl, flask_node
+                    )
+                    if kind is None:
+                        continue
                     if _INSTANCE_KINDS[kind]:
                         yield AddNode(instance_decl, entrypoint=True)
-                    for handler_name in handlers.get(var_name, ()):
+                    for handler_name in decorated.get(var_name, ()):
                         for handler_decl in ctx.find_declarations(
                             f"{module_fqname}.{handler_name}"
                         ):
                             yield AddEdge(instance_decl, handler_decl)
+
+
+def _route_decorator_candidates(module: cst.Module) -> dict[str, list[str]]:
+    """Collect every top-level ``@<X>.<route_verb>(...)``-decorated function.
+
+    Returns ``{owner_var_name: [handler_func_name, ...]}``. Owner is read
+    via :func:`decorator_owner` so bare-name (``@route``) and attribute-on-
+    non-name (``@self.app.route``) forms are skipped.
+    """
+    handlers: dict[str, list[str]] = {}
+    for stmt in module.body:
+        if not isinstance(stmt, cst.FunctionDef):
+            continue
+        for dec in stmt.decorators:
+            owner = decorator_owner(dec.decorator, _REGISTRATION_DECORATORS)
+            if owner is None:
+                continue
+            handlers.setdefault(owner, []).append(stmt.name.value)
+            break
+    return handlers
+
+
+def _walk_to_flask_kind(
+    graph: nx.DiGraph, instance_decl: SymbolNode, flask_node: SymbolNode
+) -> str | None:
+    """Return ``"Flask"`` / ``"Blueprint"`` reached from ``instance_decl``, else ``None``.
+
+    Walks forward through reference edges until hitting an ``import``
+    node bound to one of the two classes. The factory case
+    (``X = create_app()``) drops out because the factory's body
+    references ``Flask`` and the analyzer already recorded that edge.
+    Returns ``None`` when the chain doesn't reach a discriminating
+    import -- callers treat that as "not a Flask instance" rather than
+    guessing a kind.
+    """
+    seen: set[SymbolNode] = set()
+    stack: list[SymbolNode] = [instance_decl]
+    while stack:
+        node = stack.pop()
+        if node in seen or node is flask_node:
+            continue
+        seen.add(node)
+        kind = _import_kind(node)
+        if kind is not None:
+            return kind
+        stack.extend(graph.successors(node))
+    return None
+
+
+def _import_kind(node: SymbolNode) -> str | None:
+    """Return ``"Flask"`` / ``"Blueprint"`` if ``node`` imports either, else ``None``.
+
+    The plugin requires ``flask`` to be a resolved distribution
+    (:func:`require_resolved_dep`), so the visitor always encodes
+    ``from flask import Flask`` as ``Import.module="flask"`` +
+    ``Import.decl="Flask"``.
+    """
+    if node.type != "import" or node.imports is None:
+        return None
+    if node.imports.module != "flask":
+        return None
+    return node.imports.decl if node.imports.decl in _INSTANCE_KINDS else None

--- a/dead_cst/_plugins/pytest.py
+++ b/dead_cst/_plugins/pytest.py
@@ -49,15 +49,12 @@ class PytestPlugin:
                 decls_by_path.setdefault(node.path, []).append(node)
 
         # Fixture-branch prefilter: ``@pytest.fixture`` / ``@fixture``
-        # require importing pytest somewhere in the file. We also enforce
-        # that ``pytest`` resolved to an installed distribution -- if a
-        # file imports pytest but the resolver only produced
-        # ``[unresolved] pytest``, the env is misconfigured and we'd
-        # silently miss every fixture; raise instead. Files that don't
-        # import pytest are unaffected (test/conftest discovery is
-        # filename-driven and doesn't need pytest installed).
+        # require importing pytest somewhere in the file. Files that
+        # don't import pytest at all skip this branch silently --
+        # test/conftest discovery is filename-driven and doesn't need
+        # pytest installed.
         fixture_candidates: set[Path] = set()
-        if require_resolved_dep(ctx, "pytest", "Pytest") is not None:
+        if require_resolved_dep(ctx, "pytest") is not None:
             fixture_candidates = ctx.importers("pytest")
 
         for path, module_node in ctx.base_modules():

--- a/dead_cst/_plugins/pytest.py
+++ b/dead_cst/_plugins/pytest.py
@@ -10,7 +10,7 @@ from typing import Iterable
 import libcst as cst
 
 from .._symbols import SymbolNode
-from ._core import GraphOp, PluginContext, mark_entrypoints, simple_name
+from ._core import GraphOp, PluginContext, mark_entrypoints, require_resolved_dep, simple_name
 
 PYTEST_CONFTEST_PREFIX = "<pytest:conftest>:"
 PYTEST_TESTS_PREFIX = "<pytest:tests>:"
@@ -49,9 +49,16 @@ class PytestPlugin:
                 decls_by_path.setdefault(node.path, []).append(node)
 
         # Fixture-branch prefilter: ``@pytest.fixture`` / ``@fixture``
-        # require importing pytest somewhere in the file. Free graph
-        # query, no source scan.
-        fixture_candidates = ctx.importers("pytest")
+        # require importing pytest somewhere in the file. We also enforce
+        # that ``pytest`` resolved to an installed distribution -- if a
+        # file imports pytest but the resolver only produced
+        # ``[unresolved] pytest``, the env is misconfigured and we'd
+        # silently miss every fixture; raise instead. Files that don't
+        # import pytest are unaffected (test/conftest discovery is
+        # filename-driven and doesn't need pytest installed).
+        fixture_candidates: set[Path] = set()
+        if require_resolved_dep(ctx, "pytest", "Pytest") is not None:
+            fixture_candidates = ctx.importers("pytest")
 
         for path, module_node in ctx.base_modules():
             module_decls = decls_by_path.get(path, [])

--- a/dead_cst/_plugins/typer.py
+++ b/dead_cst/_plugins/typer.py
@@ -27,6 +27,7 @@ from ._core import (
     collect_module_imports,
     find_call_assignments,
     find_handlers,
+    require_resolved_dep,
 )
 
 # Attribute names ``Typer`` uses to register a callable. Matched as the
@@ -69,12 +70,12 @@ class TyperPlugin:
     name: str = "typer"
 
     def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
-        # Prefilter via the import graph: only files that actually import
-        # ``typer`` can declare an app. Free because the resolver already
-        # added ``[external dist] typer`` predecessors for them.
-        candidate_paths = ctx.importers("typer")
-        if not candidate_paths:
+        # Require that ``typer`` was resolved to an installed distribution.
+        # Raises ``UnresolvedDependencyError`` if only ``[unresolved] typer``
+        # exists, so misconfigured environments fail loudly.
+        if require_resolved_dep(ctx, "typer", "Typer") is None:
             return
+        candidate_paths = ctx.importers("typer")
 
         for path, module_node in ctx.base_modules():
             if path not in candidate_paths:

--- a/dead_cst/_plugins/typer.py
+++ b/dead_cst/_plugins/typer.py
@@ -70,10 +70,7 @@ class TyperPlugin:
     name: str = "typer"
 
     def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
-        # Require that ``typer`` was resolved to an installed distribution.
-        # Raises ``UnresolvedDependencyError`` if only ``[unresolved] typer``
-        # exists, so misconfigured environments fail loudly.
-        if require_resolved_dep(ctx, "typer", "Typer") is None:
+        if require_resolved_dep(ctx, "typer") is None:
             return
         candidate_paths = ctx.importers("typer")
 

--- a/dead_cst/_resolve.py
+++ b/dead_cst/_resolve.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import re
 import sys
 import sysconfig
 from functools import cache
@@ -23,6 +24,28 @@ logger = logging.getLogger(__name__)
 
 STDLIB = Path(sysconfig.get_path("stdlib")).resolve()
 SITE_PACKAGES_MARKERS = ("site-packages", "dist-packages")
+
+
+def _canonical_dist_name(name: str) -> str:
+    """Normalize a PyPI distribution name per PEP 503.
+
+    PyPI treats ``Flask`` / ``flask`` / ``FLASK`` as the same project;
+    plugins query the analyzer by the lowercase import name (``flask``)
+    so the synthetic ``[external dist] <name>`` node has to match. PEP
+    503's canonical form is ``re.sub(r"[-_.]+", "-", name).lower()`` --
+    we apply that to the raw ``Name`` from each dist's metadata so
+    plugin lookups don't depend on whatever casing the package author
+    chose.
+
+    Note: this still uses the *distribution* name, not the import
+    (top-level) name. For most third-party packages they match after
+    canonicalization (``fastapi``, ``flask``, ``click``, ``typer``,
+    ``networkx``, ...). They differ for a handful of historic names
+    (``Pillow`` → import ``PIL``, ``PyYAML`` → import ``yaml``); plugins
+    targeting those would need an explicit dist-name override, which
+    we don't yet support.
+    """
+    return re.sub(r"[-_.]+", "-", name).lower()
 
 
 @contextlib.contextmanager
@@ -71,9 +94,10 @@ def distribution_lookup() -> dict[Path, str]:
 
     lookup = {}
     for dist in metadata.distributions():
+        canonical = _canonical_dist_name(dist.metadata["Name"])
         for file in dist.files or ():
             abs_path = Path(str(dist.locate_file(file))).resolve()
-            lookup[abs_path] = dist.metadata["Name"]
+            lookup[abs_path] = canonical
     return lookup
 
 

--- a/dead_cst/_resolvers/__init__.py
+++ b/dead_cst/_resolvers/__init__.py
@@ -21,7 +21,7 @@ from ._core import PathMap, PathResolver, merge_paths
 from ._exports import exported_roots
 from .pyproject import PyprojectResolver
 from .uv_workspace import UvWorkspaceResolver
-from .venv import VenvResolver
+from .venv import MissingVenvError, VenvResolver
 
 BUILTIN_RESOLVERS: dict[str, type[PathResolver]] = {
     VenvResolver.name: VenvResolver,
@@ -46,6 +46,7 @@ def load_resolver(name: str) -> PathResolver:
 
 __all__ = [
     "BUILTIN_RESOLVERS",
+    "MissingVenvError",
     "PathMap",
     "PathResolver",
     "PyprojectResolver",

--- a/dead_cst/_resolvers/uv_workspace.py
+++ b/dead_cst/_resolvers/uv_workspace.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ._core import PathMap, load_toml
+from .venv import MissingVenvError, find_venv_site_packages
 
 
 @dataclass
@@ -17,7 +18,7 @@ class UvWorkspaceResolver:
     or ``{ virtual = "..." }`` -- uv's two markers for a workspace member --
     emit one :class:`PathMap` entry::
 
-        {member_src_root: [direct_workspace_dep_src_roots]}
+        {member_src_root: [direct_workspace_dep_src_roots, workspace_site_packages]}
 
     ``editable`` members are installable distributions; ``virtual`` members
     are runnable apps/services that aren't shipped as wheels. Both are
@@ -32,6 +33,16 @@ class UvWorkspaceResolver:
     Direct workspace dependencies come from the lockfile's per-package
     ``dependencies`` array; transitive deps are reachable through the chain
     of returned bases and don't need to be re-listed per member.
+
+    The resolver also requires the workspace's shared venv to be present
+    (uv puts a single ``.venv`` at the workspace root). Each member's
+    dep list ends with that ``site-packages`` so third-party imports
+    resolve to ``[external dist] <pkg>`` synthetics rather than the
+    ``[unresolved]`` fallback. If no venv is found,
+    :class:`MissingVenvError` is raised -- the user almost certainly
+    forgot ``uv sync --all-packages``, and silently returning an empty
+    path map just defers a much less actionable failure into the
+    plugin pass.
     """
 
     lock_path: Path | None = None
@@ -42,6 +53,14 @@ class UvWorkspaceResolver:
         data = load_toml(self.lock_path or project_root / "uv.lock")
         if data is None:
             return {}
+
+        site_packages = find_venv_site_packages(project_root)
+        if site_packages is None:
+            raise MissingVenvError(
+                f"uv_workspace resolver: no virtual environment found for "
+                f"workspace at {project_root}. Run `uv sync --all-packages` "
+                f"to populate the shared `.venv`."
+            )
 
         member_dirs: dict[str, Path] = {}
         member_deps: dict[str, list[str]] = {}
@@ -72,6 +91,7 @@ class UvWorkspaceResolver:
                 dep_src = _src_root_for(dep_dir)
                 if dep_src is not None:
                     deps.append(dep_src)
+            deps.append(site_packages)
             out[src_root] = deps
         return out
 

--- a/dead_cst/_resolvers/venv.py
+++ b/dead_cst/_resolvers/venv.py
@@ -9,6 +9,20 @@ from pathlib import Path
 from ._core import PathMap
 
 
+class MissingVenvError(RuntimeError):
+    """Raised by :class:`VenvResolver` (and resolvers that compose it,
+    like :class:`~dead_cst._resolvers.uv_workspace.UvWorkspaceResolver`)
+    when the user asked for venv-based resolution but no virtual
+    environment could be located.
+
+    The user's framework plugins won't function without a populated
+    site-packages on the search path, so the resolver errors out with
+    an actionable message instead of silently returning ``{}`` and
+    letting downstream plugins fail with cryptic
+    ``UnresolvedDependencyError``\\s.
+    """
+
+
 @dataclass
 class VenvResolver:
     """Discover a sibling ``.venv`` (or the active venv) and add its
@@ -16,6 +30,12 @@ class VenvResolver:
 
     The dep path lets import resolution see third-party distributions, which
     lets the graph correctly classify external imports instead of warning.
+
+    When invoked, the resolver raises :class:`MissingVenvError` if no
+    venv is found at any of the candidate locations. The user explicitly
+    selected ``--resolver venv``, so silently producing an empty path
+    map (the previous behavior) just defers the failure into the
+    plugin pass with a much less actionable error.
     """
 
     venv_dir: str | None = None
@@ -23,21 +43,54 @@ class VenvResolver:
 
     def resolve(self, project_root: Path) -> PathMap:
         project_root = project_root.resolve()
-        candidates: list[Path] = []
-        if self.venv_dir:
-            candidates.append(project_root / self.venv_dir)
-        else:
-            candidates.extend([project_root / ".venv", project_root / "venv"])
-            active = _active_venv()
-            if active:
-                candidates.append(active)
+        sp = find_venv_site_packages(project_root, self.venv_dir)
+        if sp is None:
+            raise MissingVenvError(_missing_venv_message(project_root, self.venv_dir))
+        return {project_root: [sp]}
 
-        for candidate in candidates:
-            if not candidate.is_dir():
-                continue
-            for sp in _site_packages_for(candidate):
-                return {project_root: [sp]}
-        return {}
+
+def find_venv_site_packages(project_root: Path, venv_dir: str | None = None) -> Path | None:
+    """Locate a ``site-packages`` dir for ``project_root``.
+
+    Returns the first match from (in order): an explicit ``venv_dir``
+    under the project, the conventional ``.venv`` / ``venv`` siblings,
+    or the currently-active venv. Returns ``None`` if none of those
+    point at a real ``site-packages``. Shared with
+    :class:`~dead_cst._resolvers.uv_workspace.UvWorkspaceResolver` so
+    workspace setups inherit the same venv discovery.
+    """
+    project_root = project_root.resolve()
+    candidates: list[Path] = []
+    if venv_dir:
+        candidates.append(project_root / venv_dir)
+    else:
+        candidates.extend([project_root / ".venv", project_root / "venv"])
+        active = _active_venv()
+        if active:
+            candidates.append(active)
+
+    for candidate in candidates:
+        if not candidate.is_dir():
+            continue
+        for sp in _site_packages_for(candidate):
+            return sp
+    return None
+
+
+def _missing_venv_message(project_root: Path, venv_dir: str | None) -> str:
+    if venv_dir:
+        return (
+            f"venv resolver: '{project_root / venv_dir}' is not a valid virtual "
+            f"environment. Create or sync it (e.g. `uv venv {venv_dir}` "
+            f"followed by `uv sync`)."
+        )
+    return (
+        f"venv resolver: no virtual environment found for {project_root}. "
+        f"Tried '{project_root}/.venv', '{project_root}/venv', and the "
+        f"currently-active interpreter, but none had a usable "
+        f"'site-packages'. Run `uv sync` (or `python -m venv .venv && "
+        f"pip install -e .`) and try again."
+    )
 
 
 def _active_venv() -> Path | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,13 @@ dev = [
     "pytest-watcher>=0.4.3",
     "ruff>=0.11.2",
     "ty>=0.0.1a7",
+    # Frameworks the 3rd-party plugins target. The plugins now require
+    # their package to be resolved to an installed distribution (rather
+    # than the ``[unresolved] <pkg>`` fallback), so tests need them
+    # importable. ``click`` and ``typer`` are already pulled in by the
+    # runtime deps; only ``fastapi`` and ``flask`` are added here.
+    "fastapi>=0.110",
+    "flask>=3.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_plugins/test_core.py
+++ b/tests/test_plugins/test_core.py
@@ -92,35 +92,38 @@ def _ctx_with_synthetic(fqname: str, base: Path) -> PluginContext:
 
 
 def test_require_resolved_dep_returns_external_dist(tmp_path):
-    from dead_cst._plugins._core import require_resolved_dep
+    from dead_cst._plugins._core import EXTERNAL_DIST_PREFIX, require_resolved_dep
 
-    ctx = _ctx_with_synthetic("[external dist] fastapi", tmp_path)
-    node = require_resolved_dep(ctx, "fastapi", "FastAPI")
+    ctx = _ctx_with_synthetic(f"{EXTERNAL_DIST_PREFIX}fastapi", tmp_path)
+    node = require_resolved_dep(ctx, "fastapi")
     assert node is not None
-    assert node.fqname == "[external dist] fastapi"
+    assert node.fqname == f"{EXTERNAL_DIST_PREFIX}fastapi"
 
 
 def test_require_resolved_dep_returns_external_file(tmp_path):
-    from dead_cst._plugins._core import require_resolved_dep
+    from dead_cst._plugins._core import EXTERNAL_FILE_PREFIX, require_resolved_dep
 
-    ctx = _ctx_with_synthetic("[external file] fastapi", tmp_path)
-    node = require_resolved_dep(ctx, "fastapi", "FastAPI")
-    assert node is not None
+    ctx = _ctx_with_synthetic(f"{EXTERNAL_FILE_PREFIX}fastapi", tmp_path)
+    assert require_resolved_dep(ctx, "fastapi") is not None
 
 
 def test_require_resolved_dep_returns_none_if_not_imported(tmp_path):
-    from dead_cst._plugins._core import require_resolved_dep
+    from dead_cst._plugins._core import EXTERNAL_DIST_PREFIX, require_resolved_dep
 
-    ctx = _ctx_with_synthetic("[external dist] something_else", tmp_path)
-    assert require_resolved_dep(ctx, "fastapi", "FastAPI") is None
+    ctx = _ctx_with_synthetic(f"{EXTERNAL_DIST_PREFIX}something_else", tmp_path)
+    assert require_resolved_dep(ctx, "fastapi") is None
 
 
 def test_require_resolved_dep_raises_on_unresolved(tmp_path):
-    from dead_cst._plugins._core import UnresolvedDependencyError, require_resolved_dep
+    from dead_cst._plugins._core import (
+        UNRESOLVED_PREFIX,
+        UnresolvedDependencyError,
+        require_resolved_dep,
+    )
 
-    ctx = _ctx_with_synthetic("[unresolved] fastapi", tmp_path)
+    ctx = _ctx_with_synthetic(f"{UNRESOLVED_PREFIX}fastapi", tmp_path)
     with pytest.raises(UnresolvedDependencyError, match="uv sync"):
-        require_resolved_dep(ctx, "fastapi", "FastAPI")
+        require_resolved_dep(ctx, "fastapi")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plugins/test_core.py
+++ b/tests/test_plugins/test_core.py
@@ -74,6 +74,56 @@ def test_unknown_plugin_raises():
 
 
 # ---------------------------------------------------------------------------
+# require_resolved_dep
+# ---------------------------------------------------------------------------
+
+
+def _ctx_with_synthetic(fqname: str, base: Path) -> PluginContext:
+    """Build a minimal PluginContext containing a single synthetic node."""
+    graph = nx.DiGraph()
+    node = SymbolNode(
+        fqname=fqname,
+        type="synthetic",
+        path=base,
+        position=CodeRange(start=CodePosition(0, 0), end=CodePosition(0, 0)),
+    )
+    graph.add_node(node)
+    return PluginContext(graph=graph, symbol_lookup=SymbolTrie(), base=base, project_root=base)
+
+
+def test_require_resolved_dep_returns_external_dist(tmp_path):
+    from dead_cst._plugins._core import require_resolved_dep
+
+    ctx = _ctx_with_synthetic("[external dist] fastapi", tmp_path)
+    node = require_resolved_dep(ctx, "fastapi", "FastAPI")
+    assert node is not None
+    assert node.fqname == "[external dist] fastapi"
+
+
+def test_require_resolved_dep_returns_external_file(tmp_path):
+    from dead_cst._plugins._core import require_resolved_dep
+
+    ctx = _ctx_with_synthetic("[external file] fastapi", tmp_path)
+    node = require_resolved_dep(ctx, "fastapi", "FastAPI")
+    assert node is not None
+
+
+def test_require_resolved_dep_returns_none_if_not_imported(tmp_path):
+    from dead_cst._plugins._core import require_resolved_dep
+
+    ctx = _ctx_with_synthetic("[external dist] something_else", tmp_path)
+    assert require_resolved_dep(ctx, "fastapi", "FastAPI") is None
+
+
+def test_require_resolved_dep_raises_on_unresolved(tmp_path):
+    from dead_cst._plugins._core import UnresolvedDependencyError, require_resolved_dep
+
+    ctx = _ctx_with_synthetic("[unresolved] fastapi", tmp_path)
+    with pytest.raises(UnresolvedDependencyError, match="uv sync"):
+        require_resolved_dep(ctx, "fastapi", "FastAPI")
+
+
+# ---------------------------------------------------------------------------
 # AST helpers in _plugins._core
 # ---------------------------------------------------------------------------
 

--- a/tests/test_plugins/test_fastapi.py
+++ b/tests/test_plugins/test_fastapi.py
@@ -332,6 +332,107 @@ def test_fastapi_plugin_does_nothing_without_fastapi_imports(
     assert "pkg.mod.looks_like_route" not in reachable_fqnames(graph)
 
 
+def test_fastapi_plugin_handles_factory_function(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "app/__init__.py": "",
+            "app/factory.py": """
+            from fastapi import FastAPI
+
+            def create_app() -> FastAPI:
+                return FastAPI()
+            """,
+            "app/main.py": """
+            from app.factory import create_app
+
+            app = create_app()
+
+            @app.get("/items")
+            def list_items(): pass
+
+            @app.post("/items")
+            def create_item(): pass
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[FastAPIPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    assert "app.main.app" in reached
+    assert "app.main.list_items" in reached
+    assert "app.main.create_item" in reached
+
+
+def test_fastapi_plugin_factory_returning_router_stays_dead(
+    tmp_path, write_files, reachable_fqnames
+):
+    write_files(
+        {
+            "app/__init__.py": "",
+            "app/routes.py": """
+            from fastapi import APIRouter
+
+            def make_router() -> APIRouter:
+                return APIRouter()
+
+            router = make_router()
+
+            @router.get("/orphan")
+            def orphan(): pass
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[FastAPIPlugin()],
+        project_root=tmp_path,
+    )
+    # Factory-produced router is treated like a literal APIRouter --
+    # never auto-seeded as an entrypoint, so an unincluded one stays dead.
+    reached = reachable_fqnames(graph)
+    assert "app.routes.router" not in reached
+    assert "app.routes.orphan" not in reached
+
+
+def test_fastapi_plugin_ignores_non_app_fastapi_users(tmp_path, write_files, reachable_fqnames):
+    """Variables that touch ``fastapi`` for unrelated reasons stay dead.
+
+    Walking only to the ``fastapi`` synthetic isn't enough -- the plugin
+    must require a discriminating ``FastAPI``/``APIRouter`` import on
+    the path before treating ``X`` as an instance. Otherwise any value
+    derived from e.g. ``HTTPException`` would get marked as an app.
+    """
+    write_files(
+        {
+            "pkg/__init__.py": "",
+            "pkg/mod.py": """
+            from fastapi import HTTPException
+
+            err = HTTPException(404)
+
+            class Decorated:
+                def get(self, path):
+                    def wrap(fn): return fn
+                    return wrap
+
+            thing = Decorated()
+
+            @thing.get("/")
+            def handler(): pass
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[FastAPIPlugin()],
+        project_root=tmp_path,
+    )
+    assert "pkg.mod.handler" not in reachable_fqnames(graph)
+
+
 def test_fastapi_plugin_loads_via_load_plugin():
     from dead_cst import load_plugin
 

--- a/tests/test_plugins/test_flask.py
+++ b/tests/test_plugins/test_flask.py
@@ -534,6 +534,110 @@ def test_flask_plugin_module_prefixed_unknown_attr(tmp_path, write_files, reacha
     assert "app.main.cfg" not in reached
 
 
+def test_flask_plugin_handles_factory_function(tmp_path, write_files, reachable_fqnames):
+    """The canonical Flask factory pattern: ``def create_app(): return Flask(__name__)``."""
+    write_files(
+        {
+            "app/__init__.py": "",
+            "app/factory.py": """
+            from flask import Flask
+
+            def create_app() -> Flask:
+                return Flask(__name__)
+            """,
+            "app/main.py": """
+            from app.factory import create_app
+
+            app = create_app()
+
+            @app.route("/items")
+            def list_items(): pass
+
+            @app.post("/items")
+            def create_item(): pass
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[FlaskPlugin()],
+        project_root=tmp_path,
+    )
+    from dead_cst import find_reachable
+
+    reached = {n.fqname for n in find_reachable(graph) if n.type != "synthetic"}
+    assert "app.main.app" in reached
+    assert "app.main.list_items" in reached
+    assert "app.main.create_item" in reached
+
+
+def test_flask_plugin_factory_returning_blueprint_stays_dead(
+    tmp_path, write_files, reachable_fqnames
+):
+    """Factory-produced Blueprint is treated like a literal Blueprint --
+    never auto-seeded as an entrypoint, so an unregistered one stays dead."""
+    write_files(
+        {
+            "app/__init__.py": "",
+            "app/routes.py": """
+            from flask import Blueprint
+
+            def make_bp() -> Blueprint:
+                return Blueprint("orphan", __name__)
+
+            bp = make_bp()
+
+            @bp.route("/orphan")
+            def orphan(): pass
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[FlaskPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    assert "app.routes.bp" not in reached
+    assert "app.routes.orphan" not in reached
+
+
+def test_flask_plugin_ignores_non_app_flask_users(tmp_path, write_files, reachable_fqnames):
+    """Variables that touch ``flask`` for unrelated reasons stay dead.
+
+    Walking only to the ``flask`` synthetic isn't enough -- the plugin
+    must require a discriminating ``Flask`` / ``Blueprint`` import on
+    the path before treating ``X`` as an instance. Otherwise any value
+    derived from e.g. ``request`` would get marked as an app.
+    """
+    write_files(
+        {
+            "pkg/__init__.py": "",
+            "pkg/mod.py": """
+            from flask import request
+
+            current_path = request
+
+            class Decorated:
+                def route(self, path):
+                    def wrap(fn): return fn
+                    return wrap
+
+            thing = Decorated()
+
+            @thing.route("/")
+            def handler(): pass
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[FlaskPlugin()],
+        project_root=tmp_path,
+    )
+    assert "pkg.mod.handler" not in reachable_fqnames(graph)
+
+
 def test_flask_plugin_loads_via_load_plugin():
     from dead_cst import load_plugin
 

--- a/tests/test_resolvers/test_uv_workspace.py
+++ b/tests/test_resolvers/test_uv_workspace.py
@@ -9,7 +9,24 @@ from __future__ import annotations
 import textwrap
 from pathlib import Path
 
+import pytest
+
 from dead_cst import UvWorkspaceResolver
+from dead_cst._resolvers import MissingVenvError
+
+
+def _make_fake_venv(workspace_root: Path) -> Path:
+    """Create a minimal ``.venv/lib/pythonX.Y/site-packages`` and return it.
+
+    ``UvWorkspaceResolver`` requires a populated venv -- in real usage,
+    ``uv sync --all-packages`` puts one at the workspace root. Tests
+    create the directory structure the resolver looks for and return
+    the resolved ``site-packages`` path so assertions can include it
+    in expected dep lists.
+    """
+    sp = workspace_root / ".venv" / "lib" / "python3.13" / "site-packages"
+    sp.mkdir(parents=True)
+    return sp.resolve()
 
 
 def _write_uv_workspace(tmp_path: Path, *, with_src: bool = True) -> None:
@@ -61,31 +78,52 @@ def _write_uv_workspace(tmp_path: Path, *, with_src: bool = True) -> None:
 
 def test_uv_workspace_resolver_src_layout(tmp_path: Path):
     _write_uv_workspace(tmp_path)
+    sp = _make_fake_venv(tmp_path)
 
     result = UvWorkspaceResolver().resolve(tmp_path)
 
     core_src = (tmp_path / "packages" / "core" / "src").resolve()
     app_src = (tmp_path / "packages" / "app" / "src").resolve()
-    assert result == {core_src: [], app_src: [core_src]}
+    assert result == {core_src: [sp], app_src: [core_src, sp]}
 
 
 def test_uv_workspace_resolver_flat_layout(tmp_path: Path):
     _write_uv_workspace(tmp_path, with_src=False)
+    sp = _make_fake_venv(tmp_path)
 
     result = UvWorkspaceResolver().resolve(tmp_path)
 
     core_dir = (tmp_path / "packages" / "core").resolve()
     app_dir = (tmp_path / "packages" / "app").resolve()
-    assert result == {core_dir: [], app_dir: [core_dir]}
+    assert result == {core_dir: [sp], app_dir: [core_dir, sp]}
 
 
 def test_uv_workspace_resolver_skips_virtual_root(tmp_path: Path):
     _write_uv_workspace(tmp_path)
+    _make_fake_venv(tmp_path)
 
     result = UvWorkspaceResolver().resolve(tmp_path)
 
     # The "ws" package has source = { virtual = "." } and must not appear.
     assert tmp_path.resolve() not in result
+
+
+def test_uv_workspace_resolver_missing_venv_raises(tmp_path: Path):
+    """Workspace with no synced ``.venv`` raises an actionable error
+    instead of silently producing wrong results downstream."""
+    _write_uv_workspace(tmp_path)
+
+    # Override the active-venv fallback so the resolver can't accidentally
+    # find one outside the workspace (e.g. the test runner's own venv).
+    import sys
+
+    real_prefix = sys.prefix
+    sys.prefix = sys.base_prefix
+    try:
+        with pytest.raises(MissingVenvError, match="uv sync"):
+            UvWorkspaceResolver().resolve(tmp_path)
+    finally:
+        sys.prefix = real_prefix
 
 
 def test_uv_workspace_resolver_includes_virtual_members(tmp_path: Path):
@@ -136,14 +174,17 @@ def test_uv_workspace_resolver_includes_virtual_members(tmp_path: Path):
         """).strip()
     )
 
+    sp = _make_fake_venv(tmp_path)
     result = UvWorkspaceResolver().resolve(tmp_path)
 
     lib_src = (tmp_path / "libs" / "lib-a" / "src").resolve()
     app_src = (tmp_path / "apps" / "app-a" / "src").resolve()
-    assert result == {lib_src: [], app_src: [lib_src]}
+    assert result == {lib_src: [sp], app_src: [lib_src, sp]}
 
 
 def test_uv_workspace_resolver_no_lockfile(tmp_path: Path):
+    # No lockfile => not a uv workspace => silent no-op (don't raise on the
+    # missing venv, since the resolver isn't applicable here).
     assert UvWorkspaceResolver().resolve(tmp_path) == {}
 
 
@@ -151,6 +192,7 @@ def test_uv_workspace_resolver_ignores_non_workspace_deps(tmp_path: Path):
     """Deps that aren't workspace members (e.g. regular PyPI deps) are dropped
     silently -- they don't have a source dir under our control."""
     _write_uv_workspace(tmp_path)
+    sp = _make_fake_venv(tmp_path)
     lock = tmp_path / "uv.lock"
     lock.write_text(
         lock.read_text().replace(
@@ -162,11 +204,12 @@ def test_uv_workspace_resolver_ignores_non_workspace_deps(tmp_path: Path):
     result = UvWorkspaceResolver().resolve(tmp_path)
     core_src = (tmp_path / "packages" / "core" / "src").resolve()
     app_src = (tmp_path / "packages" / "app" / "src").resolve()
-    assert result[app_src] == [core_src]
+    assert result[app_src] == [core_src, sp]
 
 
 def test_uv_workspace_resolver_explicit_lock_path(tmp_path: Path):
     _write_uv_workspace(tmp_path)
+    _make_fake_venv(tmp_path)
     moved = tmp_path / "stash" / "uv.lock"
     moved.parent.mkdir()
     moved.write_text((tmp_path / "uv.lock").read_text())
@@ -250,6 +293,7 @@ def test_uv_workspace_flat_layout_with_tests_dirs(tmp_path: Path):
     (libc / "tests" / "__init__.py").write_text("")
     (libc / "tests" / "conftest.py").write_text("import pytest\n")
 
+    _make_fake_venv(tmp_path)
     paths = UvWorkspaceResolver().resolve(tmp_path)
     # No AssertionError -- this used to crash before the fix.
     graph = build_symbol_graph(paths)
@@ -340,10 +384,11 @@ def test_uv_workspace_shared_namespace_package(tmp_path: Path):
     )
     (foo_b / "foo" / "b" / "__init__.py").write_text("from foo.a import value\n\nresult = value\n")
 
+    sp = _make_fake_venv(tmp_path)
     paths = UvWorkspaceResolver().resolve(tmp_path)
     foo_a_dir = foo_a.resolve()
     foo_b_dir = foo_b.resolve()
-    assert paths == {foo_a_dir: [], foo_b_dir: [foo_a_dir]}
+    assert paths == {foo_a_dir: [sp], foo_b_dir: [foo_a_dir, sp]}
 
     graph = build_symbol_graph(paths)
 

--- a/tests/test_resolvers/test_uv_workspace.py
+++ b/tests/test_resolvers/test_uv_workspace.py
@@ -108,22 +108,18 @@ def test_uv_workspace_resolver_skips_virtual_root(tmp_path: Path):
     assert tmp_path.resolve() not in result
 
 
-def test_uv_workspace_resolver_missing_venv_raises(tmp_path: Path):
+def test_uv_workspace_resolver_missing_venv_raises(tmp_path: Path, monkeypatch):
     """Workspace with no synced ``.venv`` raises an actionable error
     instead of silently producing wrong results downstream."""
-    _write_uv_workspace(tmp_path)
-
-    # Override the active-venv fallback so the resolver can't accidentally
-    # find one outside the workspace (e.g. the test runner's own venv).
     import sys
 
-    real_prefix = sys.prefix
-    sys.prefix = sys.base_prefix
-    try:
-        with pytest.raises(MissingVenvError, match="uv sync"):
-            UvWorkspaceResolver().resolve(tmp_path)
-    finally:
-        sys.prefix = real_prefix
+    _write_uv_workspace(tmp_path)
+    # Override the active-venv fallback so the resolver can't accidentally
+    # find one outside the workspace (e.g. the test runner's own venv).
+    monkeypatch.setattr(sys, "prefix", sys.base_prefix)
+
+    with pytest.raises(MissingVenvError, match="uv sync"):
+        UvWorkspaceResolver().resolve(tmp_path)
 
 
 def test_uv_workspace_resolver_includes_virtual_members(tmp_path: Path):

--- a/tests/test_resolvers/test_venv.py
+++ b/tests/test_resolvers/test_venv.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from dead_cst import VenvResolver
+from dead_cst._resolvers import MissingVenvError
 
 
 def test_venv_resolver_finds_site_packages(tmp_path: Path):
@@ -17,9 +20,13 @@ def test_venv_resolver_finds_site_packages(tmp_path: Path):
     assert sp.resolve() in result[tmp_path.resolve()]
 
 
-def test_venv_resolver_missing_returns_empty(tmp_path: Path):
-    # Passing an explicit (nonexistent) venv_dir skips the active-venv probe.
-    assert VenvResolver(venv_dir="nope").resolve(tmp_path) == {}
+def test_venv_resolver_missing_raises(tmp_path: Path):
+    # Passing an explicit (nonexistent) venv_dir skips the active-venv probe,
+    # so there's nowhere for the resolver to find a venv -- it raises rather
+    # than silently producing an empty path map (which would just defer the
+    # failure into the plugin pass).
+    with pytest.raises(MissingVenvError, match="nope"):
+        VenvResolver(venv_dir="nope").resolve(tmp_path)
 
 
 def test_venv_resolver_custom_dir(tmp_path: Path):

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,37 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -151,6 +182,8 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "fastapi" },
+    { name = "flask" },
     { name = "prek" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -168,6 +201,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "fastapi", specifier = ">=0.110" },
+    { name = "flask", specifier = ">=3.0" },
     { name = "prek", specifier = ">=0.3.11" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -177,12 +212,75 @@ dev = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
+name = "flask"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blinker" },
+    { name = "click" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -250,6 +348,80 @@ wheels = [
 ]
 
 [[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -307,6 +479,123 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/19/0c/8ab0ae140201dcee505f58b60abbe56bd05ac96b821a6866f6f90c4d971f/prek-0.3.11-py3-none-win32.whl", hash = "sha256:35d2361049653a3dcf27227b7f1b340c5c42a12c0e0361c4b785921bfd125839", size = 5120856, upload-time = "2026-04-27T04:23:02.752Z" },
     { url = "https://files.pythonhosted.org/packages/57/05/9844c1125d3714f6f6c7b475884128a4b0c6c3ee0cd208ead44ca8174687/prek-0.3.11-py3-none-win_amd64.whl", hash = "sha256:a387689cd2e182f92dbb681151ee5a04f494fe97e95d6d783875da90b950e6d5", size = 5510916, upload-time = "2026-04-27T04:22:45.704Z" },
     { url = "https://files.pythonhosted.org/packages/ff/13/24b0288c553dc8d61f44c4d0746fe9bb1e1bd29d1e70571658536e4c0f72/prek-0.3.11-py3-none-win_arm64.whl", hash = "sha256:e4a8f900378a6657c7eb2fc4b12fa5c934edf209d0a24544539842479ec16e0b", size = 5345988, upload-time = "2026-04-27T04:22:50.918Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a2/1ba90a83e85a3f94c796b184f3efde9c72f2830dcda493eea8d59ba78e6d/pydantic_core-2.46.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ab124d49d0459b2373ecf54118a45c28a1e6d4192a533fbc915e70f556feb8e5", size = 2106740, upload-time = "2026-04-20T14:41:20.932Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f6/99ae893c89a0b9d3daec9f95487aa676709aa83f67643b3f0abaf4ab628a/pydantic_core-2.46.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cca67d52a5c7a16aed2b3999e719c4bcf644074eac304a5d3d62dd70ae7d4b2c", size = 1948293, upload-time = "2026-04-20T14:43:42.115Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/b8/2e8e636dc9e3f16c2e16bf0849e24be82c5ee82c603c65fc0326666328fc/pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c024e08c0ba23e6fd68c771a521e9d6a792f2ebb0fa734296b36394dc30390e", size = 1973222, upload-time = "2026-04-20T14:41:57.841Z" },
+    { url = "https://files.pythonhosted.org/packages/34/36/0e730beec4d83c5306f417afbd82ff237d9a21e83c5edf675f31ed84c1fe/pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6645ce7eec4928e29a1e3b3d5c946621d105d3e79f0c9cddf07c2a9770949287", size = 2053852, upload-time = "2026-04-20T14:40:43.077Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f0/3071131f47e39136a17814576e0fada9168569f7f8c0e6ac4d1ede6a4958/pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a712c7118e6c5ea96562f7b488435172abb94a3c53c22c9efc1412264a45cbbe", size = 2221134, upload-time = "2026-04-20T14:43:03.349Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/a9/a2dc023eec5aa4b02a467874bad32e2446957d2adcab14e107eab502e978/pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:69a868ef3ff206343579021c40faf3b1edc64b1cc508ff243a28b0a514ccb050", size = 2279785, upload-time = "2026-04-20T14:41:19.285Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/44/93f489d16fb63fbd41c670441536541f6e8cfa1e5a69f40bc9c5d30d8c90/pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc7e8c32db809aa0f6ea1d6869ebc8518a65d5150fdfad8bcae6a49ae32a22e2", size = 2089404, upload-time = "2026-04-20T14:43:10.108Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/78/8692e3aa72b2d004f7a5d937f1dfdc8552ba26caf0bec75f342c40f00dec/pydantic_core-2.46.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3481bd1341dc85779ee506bc8e1196a277ace359d89d28588a9468c3ecbe63fa", size = 2114898, upload-time = "2026-04-20T14:44:51.475Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/62/e83133f2e7832532060175cebf1f13748f4c7e7e7165cdd1f611f174494b/pydantic_core-2.46.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8690eba565c6d68ffd3a8655525cbdd5246510b44a637ee2c6c03a7ebfe64d3c", size = 2157856, upload-time = "2026-04-20T14:43:46.64Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ec/6a500e3ad7718ee50583fae79c8651f5d37e3abce1fa9ae177ae65842c53/pydantic_core-2.46.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4de88889d7e88d50d40ee5b39d5dac0bcaef9ba91f7e536ac064e6b2834ecccf", size = 2180168, upload-time = "2026-04-20T14:42:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/53/8267811054b1aa7fc1dc7ded93812372ef79a839f5e23558136a6afbfde1/pydantic_core-2.46.3-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:e480080975c1ef7f780b8f99ed72337e7cc5efea2e518a20a692e8e7b278eb8b", size = 2322885, upload-time = "2026-04-20T14:41:05.253Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c1/1c0acdb3aa0856ddc4ecc55214578f896f2de16f400cf51627eb3c26c1c4/pydantic_core-2.46.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:de3a5c376f8cd94da9a1b8fd3dd1c16c7a7b216ed31dc8ce9fd7a22bf13b836e", size = 2360328, upload-time = "2026-04-20T14:41:43.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d0/ef39cd0f4a926814f360e71c1adeab48ad214d9727e4deb48eedfb5bce1a/pydantic_core-2.46.3-cp311-cp311-win32.whl", hash = "sha256:fc331a5314ffddd5385b9ee9d0d2fee0b13c27e0e02dad71b1ae5d6561f51eeb", size = 1979464, upload-time = "2026-04-20T14:43:12.215Z" },
+    { url = "https://files.pythonhosted.org/packages/18/9c/f41951b0d858e343f1cf09398b2a7b3014013799744f2c4a8ad6a3eec4f2/pydantic_core-2.46.3-cp311-cp311-win_amd64.whl", hash = "sha256:b5b9c6cf08a8a5e502698f5e153056d12c34b8fb30317e0c5fd06f45162a6346", size = 2070837, upload-time = "2026-04-20T14:41:47.707Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/1e/264a17cd582f6ed50950d4d03dd5fefd84e570e238afe1cb3e25cf238769/pydantic_core-2.46.3-cp311-cp311-win_arm64.whl", hash = "sha256:5dfd51cf457482f04ec49491811a2b8fd5b843b64b11eecd2d7a1ee596ea78a6", size = 2053647, upload-time = "2026-04-20T14:42:27.535Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/cb/5b47425556ecc1f3fe18ed2a0083188aa46e1dd812b06e406475b3a5d536/pydantic_core-2.46.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b11b59b3eee90a80a36701ddb4576d9ae31f93f05cb9e277ceaa09e6bf074a67", size = 2101946, upload-time = "2026-04-20T14:40:52.581Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4f/2fb62c2267cae99b815bbf4a7b9283812c88ca3153ef29f7707200f1d4e5/pydantic_core-2.46.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:af8653713055ea18a3abc1537fe2ebc42f5b0bbb768d1eb79fd74eb47c0ac089", size = 1951612, upload-time = "2026-04-20T14:42:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6e/b7348fd30d6556d132cddd5bd79f37f96f2601fe0608afac4f5fb01ec0b3/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75a519dab6d63c514f3a81053e5266c549679e4aa88f6ec57f2b7b854aceb1b0", size = 1977027, upload-time = "2026-04-20T14:42:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/82/11/31d60ee2b45540d3fb0b29302a393dbc01cd771c473f5b5147bcd353e593/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6cd87cb1575b1ad05ba98894c5b5c96411ef678fa2f6ed2576607095b8d9789", size = 2063008, upload-time = "2026-04-20T14:44:17.952Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/db/3a9d1957181b59258f44a2300ab0f0be9d1e12d662a4f57bb31250455c52/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f80a55484b8d843c8ada81ebf70a682f3f00a3d40e378c06cf17ecb44d280d7d", size = 2233082, upload-time = "2026-04-20T14:40:57.934Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e1/3277c38792aeb5cfb18c2f0c5785a221d9ff4e149abbe1184d53d5f72273/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3861f1731b90c50a3266316b9044f5c9b405eecb8e299b0a7120596334e4fe9c", size = 2304615, upload-time = "2026-04-20T14:42:12.584Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d5/e3d9717c9eba10855325650afd2a9cba8e607321697f18953af9d562da2f/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb528e295ed31570ac3dcc9bfdd6e0150bc11ce6168ac87a8082055cf1a67395", size = 2094380, upload-time = "2026-04-20T14:43:05.522Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/20/abac35dedcbfd66c6f0b03e4e3564511771d6c9b7ede10a362d03e110d9b/pydantic_core-2.46.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:367508faa4973b992b271ba1494acaab36eb7e8739d1e47be5035fb1ea225396", size = 2135429, upload-time = "2026-04-20T14:41:55.549Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a5/41bfd1df69afad71b5cf0535055bccc73022715ad362edbc124bc1e021d7/pydantic_core-2.46.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ad3c826fe523e4becf4fe39baa44286cff85ef137c729a2c5e269afbfd0905d", size = 2174582, upload-time = "2026-04-20T14:41:45.96Z" },
+    { url = "https://files.pythonhosted.org/packages/79/65/38d86ea056b29b2b10734eb23329b7a7672ca604df4f2b6e9c02d4ee22fe/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ec638c5d194ef8af27db69f16c954a09797c0dc25015ad6123eb2c73a4d271ca", size = 2187533, upload-time = "2026-04-20T14:40:55.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a1129141678a2026badc539ad1dee0a71d06f54c2f06a4bd68c030ac781b/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:28ed528c45446062ee66edb1d33df5d88828ae167de76e773a3c7f64bd14e976", size = 2332985, upload-time = "2026-04-20T14:44:13.05Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/60/cb26f4077719f709e54819f4e8e1d43f4091f94e285eb6bd21e1190a7b7c/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aed19d0c783886d5bd86d80ae5030006b45e28464218747dcf83dabfdd092c7b", size = 2373670, upload-time = "2026-04-20T14:41:53.421Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/7e/c3f21882bdf1d8d086876f81b5e296206c69c6082551d776895de7801fa0/pydantic_core-2.46.3-cp312-cp312-win32.whl", hash = "sha256:06d5d8820cbbdb4147578c1fe7ffcd5b83f34508cb9f9ab76e807be7db6ff0a4", size = 1966722, upload-time = "2026-04-20T14:44:30.588Z" },
+    { url = "https://files.pythonhosted.org/packages/57/be/6b5e757b859013ebfbd7adba02f23b428f37c86dcbf78b5bb0b4ffd36e99/pydantic_core-2.46.3-cp312-cp312-win_amd64.whl", hash = "sha256:c3212fda0ee959c1dd04c60b601ec31097aaa893573a3a1abd0a47bcac2968c1", size = 2072970, upload-time = "2026-04-20T14:42:54.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f8/a989b21cc75e9a32d24192ef700eea606521221a89faa40c919ce884f2b1/pydantic_core-2.46.3-cp312-cp312-win_arm64.whl", hash = "sha256:f1f8338dd7a7f31761f1f1a3c47503a9a3b34eea3c8b01fa6ee96408affb5e72", size = 2035963, upload-time = "2026-04-20T14:44:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3c/9b5e8eb9821936d065439c3b0fb1490ffa64163bfe7e1595985a47896073/pydantic_core-2.46.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:12bc98de041458b80c86c56b24df1d23832f3e166cbaff011f25d187f5c62c37", size = 2102109, upload-time = "2026-04-20T14:41:24.219Z" },
+    { url = "https://files.pythonhosted.org/packages/91/97/1c41d1f5a19f241d8069f1e249853bcce378cdb76eec8ab636d7bc426280/pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:85348b8f89d2c3508b65b16c3c33a4da22b8215138d8b996912bb1532868885f", size = 1951820, upload-time = "2026-04-20T14:42:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b4/d03a7ae14571bc2b6b3c7b122441154720619afe9a336fa3a95434df5e2f/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1105677a6df914b1fb71a81b96c8cce7726857e1717d86001f29be06a25ee6f8", size = 1977785, upload-time = "2026-04-20T14:42:31.648Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0c/4086f808834b59e3c8f1aa26df8f4b6d998cdcf354a143d18ef41529d1fe/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87082cd65669a33adeba5470769e9704c7cf026cc30afb9cc77fd865578ebaad", size = 2062761, upload-time = "2026-04-20T14:40:37.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/a649be5a5064c2df0db06e0a512c2281134ed2fcc981f52a657936a7527c/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e5f66e12c4f5212d08522963380eaaeac5ebd795826cfd19b2dfb0c7a52b9c", size = 2232989, upload-time = "2026-04-20T14:42:59.254Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/7756e75763e810b3a710f4724441d1ecc5883b94aacb07ca71c5fb5cfb69/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6cdf19bf84128d5e7c37e8a73a0c5c10d51103a650ac585d42dd6ae233f2b7f", size = 2303975, upload-time = "2026-04-20T14:41:32.287Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/35/68a762e0c1e31f35fa0dac733cbd9f5b118042853698de9509c8e5bf128b/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031bb17f4885a43773c8c763089499f242aee2ea85cf17154168775dccdecf35", size = 2095325, upload-time = "2026-04-20T14:42:47.685Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bf/1bf8c9a8e91836c926eae5e3e51dce009bf495a60ca56060689d3df3f340/pydantic_core-2.46.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:bcf2a8b2982a6673693eae7348ef3d8cf3979c1d63b54fca7c397a635cc68687", size = 2133368, upload-time = "2026-04-20T14:41:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/50/87d818d6bab915984995157ceb2380f5aac4e563dddbed6b56f0ed057aba/pydantic_core-2.46.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28e8cf2f52d72ced402a137145923a762cbb5081e48b34312f7a0c8f55928ec3", size = 2173908, upload-time = "2026-04-20T14:42:52.044Z" },
+    { url = "https://files.pythonhosted.org/packages/91/88/a311fb306d0bd6185db41fa14ae888fb81d0baf648a761ae760d30819d33/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:17eaface65d9fc5abb940003020309c1bf7a211f5f608d7870297c367e6f9022", size = 2186422, upload-time = "2026-04-20T14:43:29.55Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/79/28fd0d81508525ab2054fef7c77a638c8b5b0afcbbaeee493cf7c3fef7e1/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:93fd339f23408a07e98950a89644f92c54d8729719a40b30c0a30bb9ebc55d23", size = 2332709, upload-time = "2026-04-20T14:42:16.134Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/21/795bf5fe5c0f379308b8ef19c50dedab2e7711dbc8d0c2acf08f1c7daa05/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:23cbdb3aaa74dfe0837975dbf69b469753bbde8eacace524519ffdb6b6e89eb7", size = 2372428, upload-time = "2026-04-20T14:41:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b3/ed14c659cbe7605e3ef063077680a64680aec81eb1a04763a05190d49b7f/pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13", size = 1965601, upload-time = "2026-04-20T14:41:42.128Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/adb70d9a762ddd002d723fbf1bd492244d37da41e3af7b74ad212609027e/pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0", size = 2071517, upload-time = "2026-04-20T14:43:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/52/eb/66faefabebfe68bd7788339c9c9127231e680b11906368c67ce112fdb47f/pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec", size = 2035802, upload-time = "2026-04-20T14:43:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/db/a7bcb4940183fda36022cd18ba8dd12f2dff40740ec7b58ce7457befa416/pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b", size = 2097614, upload-time = "2026-04-20T14:44:38.374Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/e4066358a22e3e99519db370494c7528f5a2aa1367370e80e27e20283543/pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018", size = 1951896, upload-time = "2026-04-20T14:40:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/87/92/37cf4049d1636996e4b888c05a501f40a43ff218983a551d57f9d5e14f0d/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34", size = 1979314, upload-time = "2026-04-20T14:41:49.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/9ff4d676dfbdfb2d591cf43f3d90ded01e15b1404fd101180ed2d62a2fd3/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7", size = 2056133, upload-time = "2026-04-20T14:42:23.574Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f0/405b442a4d7ba855b06eec8b2bf9c617d43b8432d099dfdc7bf999293495/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2", size = 2228726, upload-time = "2026-04-20T14:44:22.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f8/65cd92dd5a0bd89ba277a98ecbfaf6fc36bbd3300973c7a4b826d6ab1391/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba", size = 2301214, upload-time = "2026-04-20T14:44:48.792Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/86/ef96a4c6e79e7a2d0410826a68fbc0eccc0fd44aa733be199d5fcac3bb87/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f", size = 2099927, upload-time = "2026-04-20T14:41:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/53/269caf30e0096e0a8a8f929d1982a27b3879872cca2d917d17c2f9fdf4fe/pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22", size = 2128789, upload-time = "2026-04-20T14:41:15.868Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b0/1a6d9b6a587e118482910c244a1c5acf4d192604174132efd12bf0ac486f/pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f", size = 2173815, upload-time = "2026-04-20T14:44:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/87/56/e7e00d4041a7e62b5a40815590114db3b535bf3ca0bf4dca9f16cef25246/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127", size = 2181608, upload-time = "2026-04-20T14:41:28.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/22/4bd23c3d41f7c185d60808a1de83c76cf5aeabf792f6c636a55c3b1ec7f9/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c", size = 2326968, upload-time = "2026-04-20T14:42:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ac/66cd45129e3915e5ade3b292cb3bc7fd537f58f8f8dbdaba6170f7cabb74/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1", size = 2369842, upload-time = "2026-04-20T14:41:35.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/dd4248abb84113615473aa20d5545b7c4cd73c8644003b5259686f93996c/pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505", size = 1959661, upload-time = "2026-04-20T14:41:00.042Z" },
+    { url = "https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e", size = 2071686, upload-time = "2026-04-20T14:43:16.471Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/db/1cf77e5247047dfee34bc01fa9bca134854f528c8eb053e144298893d370/pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df", size = 2026907, upload-time = "2026-04-20T14:43:31.732Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c0/b3df9f6a543276eadba0a48487b082ca1f201745329d97dbfa287034a230/pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf", size = 2095047, upload-time = "2026-04-20T14:42:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/66/57/886a938073b97556c168fd99e1a7305bb363cd30a6d2c76086bf0587b32a/pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee", size = 1934329, upload-time = "2026-04-20T14:43:49.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7c/b42eaa5c34b13b07ecb51da21761297a9b8eb43044c864a035999998f328/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a", size = 1974847, upload-time = "2026-04-20T14:42:10.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9b/92b42db6543e7de4f99ae977101a2967b63122d4b6cf7773812da2d7d5b5/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c", size = 2041742, upload-time = "2026-04-20T14:40:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/19/46fbe1efabb5aa2834b43b9454e70f9a83ad9c338c1291e48bdc4fecf167/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1", size = 2236235, upload-time = "2026-04-20T14:41:27.307Z" },
+    { url = "https://files.pythonhosted.org/packages/77/da/b3f95bc009ad60ec53120f5d16c6faa8cabdbe8a20d83849a1f2b8728148/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64", size = 2282633, upload-time = "2026-04-20T14:44:33.271Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/401336117722e28f32fb8220df676769d28ebdf08f2f4469646d404c43a3/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb", size = 2109679, upload-time = "2026-04-20T14:44:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/53/b289f9bc8756a32fe718c46f55afaeaf8d489ee18d1a1e7be1db73f42cc4/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6", size = 2108342, upload-time = "2026-04-20T14:42:50.144Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5b/8292fc7c1f9111f1b2b7c1b0dcf1179edcd014fc3ea4517499f50b829d71/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c", size = 2157208, upload-time = "2026-04-20T14:42:08.133Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9e/f80044e9ec07580f057a89fc131f78dda7a58751ddf52bbe05eaf31db50f/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47", size = 2167237, upload-time = "2026-04-20T14:42:25.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/84/6781a1b037f3b96be9227edbd1101f6d3946746056231bf4ac48cdff1a8d/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab", size = 2312540, upload-time = "2026-04-20T14:40:40.313Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/db/19c0839feeb728e7df03255581f198dfdf1c2aeb1e174a8420b63c5252e5/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba", size = 2369556, upload-time = "2026-04-20T14:41:09.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/15/3228774cb7cd45f5f721ddf1b2242747f4eb834d0c491f0c02d606f09fed/pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56", size = 1949756, upload-time = "2026-04-20T14:41:25.717Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2a/c79cf53fd91e5a87e30d481809f52f9a60dd221e39de66455cf04deaad37/pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8", size = 2051305, upload-time = "2026-04-20T14:43:18.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/db/d8182a7f1d9343a032265aae186eb063fe26ca4c40f256b21e8da4498e89/pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374", size = 2026310, upload-time = "2026-04-20T14:41:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/66/7f/03dbad45cd3aa9083fbc93c210ae8b005af67e4136a14186950a747c6874/pydantic_core-2.46.3-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:9715525891ed524a0a1eb6d053c74d4d4ad5017677fb00af0b7c2644a31bae46", size = 2105683, upload-time = "2026-04-20T14:42:19.779Z" },
+    { url = "https://files.pythonhosted.org/packages/26/22/4dc186ac8ea6b257e9855031f51b62a9637beac4d68ac06bee02f046f836/pydantic_core-2.46.3-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:9d2f400712a99a013aff420ef1eb9be077f8189a36c1e3ef87660b4e1088a874", size = 1940052, upload-time = "2026-04-20T14:43:59.274Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ca/d376391a5aff1f2e8188960d7873543608130a870961c2b6b5236627c116/pydantic_core-2.46.3-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd2aab0e2e9dc2daf36bd2686c982535d5e7b1d930a1344a7bb6e82baab42a76", size = 1988172, upload-time = "2026-04-20T14:41:17.469Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/6b/523b9f85c23788755d6ab949329de692a2e3a584bc6beb67fef5e035aa9d/pydantic_core-2.46.3-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e9d76736da5f362fabfeea6a69b13b7f2be405c6d6966f06b2f6bfff7e64531", size = 2128596, upload-time = "2026-04-20T14:40:41.707Z" },
+    { url = "https://files.pythonhosted.org/packages/34/42/f426db557e8ab2791bc7562052299944a118655496fbff99914e564c0a94/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b12dd51f1187c2eb489af8e20f880362db98e954b54ab792fa5d92e8bcc6b803", size = 2091877, upload-time = "2026-04-20T14:43:27.091Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/86a832a9d14df58e663bfdf4627dc00d3317c2bd583c4fb23390b0f04b8e/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3", size = 1932428, upload-time = "2026-04-20T14:40:45.781Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1a/fe857968954d93fb78e0d4b6df5c988c74c4aaa67181c60be7cfe327c0ca/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5", size = 1997550, upload-time = "2026-04-20T14:44:02.425Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/9d89ad2d9b0ba8cd65393d434471621b98912abb10fbe1df08e480ba57b5/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4", size = 2137657, upload-time = "2026-04-20T14:42:45.149Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/da/99d40830684f81dec901cac521b5b91c095394cc1084b9433393cde1c2df/pydantic_core-2.46.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:13afdd885f3d71280cf286b13b310ee0f7ccfefd1dbbb661514a474b726e2f25", size = 2107973, upload-time = "2026-04-20T14:42:06.175Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a5/87024121818d75bbb2a98ddbaf638e40e7a18b5e0f5492c9ca4b1b316107/pydantic_core-2.46.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:f91c0aff3e3ee0928edd1232c57f643a7a003e6edf1860bc3afcdc749cb513f3", size = 1947191, upload-time = "2026-04-20T14:43:14.319Z" },
+    { url = "https://files.pythonhosted.org/packages/60/62/0c1acfe10945b83a6a59d19fbaa92f48825381509e5701b855c08f13db76/pydantic_core-2.46.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6529d1d128321a58d30afcc97b49e98836542f68dd41b33c2e972bb9e5290536", size = 2123791, upload-time = "2026-04-20T14:43:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3e/3b2393b4c8f44285561dc30b00cf307a56a2eff7c483a824db3b8221ca51/pydantic_core-2.46.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:975c267cff4f7e7272eacbe50f6cc03ca9a3da4c4fbd66fffd89c94c1e311aa1", size = 2153197, upload-time = "2026-04-20T14:44:27.932Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/75/5af02fb35505051eee727c061f2881c555ab4f8ddb2d42da715a42c9731b/pydantic_core-2.46.3-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:2b8e4f2bbdf71415c544b4b1138b8060db7b6611bc927e8064c769f64bed651c", size = 2181073, upload-time = "2026-04-20T14:43:20.729Z" },
+    { url = "https://files.pythonhosted.org/packages/10/92/7e0e1bd9ca3c68305db037560ca2876f89b2647deb2f8b6319005de37505/pydantic_core-2.46.3-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:e61ea8e9fff9606d09178f577ff8ccdd7206ff73d6552bcec18e1033c4254b85", size = 2315886, upload-time = "2026-04-20T14:44:04.826Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d8/101655f27eaf3e44558ead736b2795d12500598beed4683f279396fa186e/pydantic_core-2.46.3-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b504bda01bafc69b6d3c7a0c7f039dcf60f47fab70e06fe23f57b5c75bdc82b8", size = 2360528, upload-time = "2026-04-20T14:40:47.431Z" },
+    { url = "https://files.pythonhosted.org/packages/07/0f/1c34a74c8d07136f0d729ffe5e1fdab04fbdaa7684f61a92f92511a84a15/pydantic_core-2.46.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b00b76f7142fc60c762ce579bd29c8fa44aaa56592dd3c54fab3928d0d4ca6ff", size = 2184144, upload-time = "2026-04-20T14:42:57Z" },
 ]
 
 [[package]]
@@ -467,6 +756,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -560,6 +862,27 @@ wheels = [
 ]
 
 [[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
 name = "watchdog"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -584,4 +907,16 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
 ]


### PR DESCRIPTION
Closes #44.

Three layers of changes — graph-based factory detection in the FastAPI/Flask plugins, a hard-fail when 3rd-party plugins see only the `[unresolved]` form, and venv enforcement in the venv-aware resolvers — pushing users toward a synced environment instead of silently producing wrong results from the unresolved fallback.

## Factory-style apps (FastAPI + Flask)

The FastAPI plugin previously matched only literal `X = FastAPI(...)` assignments, missing the common `X = create_app(...)` factory pattern from #44. The Flask plugin had the same gap on `def create_app(): return Flask(__name__)` — the convention Flask's official docs recommend.

The analyzer already wires reference edges from `X` through `create_app` to the `FastAPI`/`Flask` import, so kind can be decided by walking forward in the graph: if the chain hits a `FastAPI`/`APIRouter` (or `Flask`/`Blueprint`) import node, `X` is an instance of that kind. Direct-form assignments still go through `find_call_assignments` — unambiguous, and the only way to distinguish `import fastapi; X = fastapi.FastAPI()` from `fastapi.APIRouter()` (the variable's edge goes straight to the synthetic with no intermediate import). The forward walk returns `None` rather than guessing when no discriminating import is on the path, so `err = HTTPException(404)` / variables touching `flask.request` don't get misclassified as apps.

## `require_resolved_dep` helper

New `UnresolvedDependencyError` + `require_resolved_dep(ctx, package, plugin_name)` helper in `_plugins/_core.py`. Returns the `[external dist]`/`[external file]` synthetic, returns `None` if the package isn't imported in the base, raises if only the `[unresolved] <package>` synthetic exists. FastAPI, Flask, Click, Typer, and Pytest all call it instead of `ctx.importers(pkg)` — misconfigured environments now fail loudly with a message pointing at `uv sync --all-packages` rather than half-working.

The dual-encoding fallback in the FastAPI plugin (`_import_kind` handling both `module="fastapi", decl="FastAPI"` and `module="fastapi.FastAPI", decl=None`) collapses to one branch as a result.

## Venv enforcement in resolvers

`VenvResolver` raises `MissingVenvError` when no venv is discoverable (used to silently return `{}`). Deferring the failure into the plugin pass produced a much less actionable error. `UvWorkspaceResolver` composes the same check (uv workspaces always have a shared `.venv` after `uv sync --all-packages`) and appends that `site-packages` to each member's dep list so third-party imports actually resolve. `UvWorkspaceResolver` still no-ops when there's no `uv.lock` — that means it isn't applicable, not that the user's environment is broken.

## Resolver dist-name canonicalization

Latent bug surfaced while wiring up the test deps: `resolve_import` was using `dist.metadata["Name"]` verbatim, so `flask` got the synthetic `[external dist] Flask` (PyPI metadata casing) but plugins query by the lowercase import name `flask` — mismatch. Fixed by canonicalizing per PEP 503 (`re.sub(r"[-_.]+", "-", name).lower()`). The previous test setup never hit this because flask wasn't installed, so the unresolved-fallback path was used instead.

## Test plan

- [x] All 508 tests pass; ruff clean.
- [x] New `test_fastapi_plugin_handles_factory_function`, `test_fastapi_plugin_factory_returning_router_stays_dead`, `test_fastapi_plugin_ignores_non_app_fastapi_users`.
- [x] New `test_flask_plugin_handles_factory_function`, `test_flask_plugin_factory_returning_blueprint_stays_dead`, `test_flask_plugin_ignores_non_app_flask_users`.
- [x] New `require_resolved_dep` unit tests covering all three outcomes (resolved / not-imported / unresolved-raises).
- [x] `MissingVenvError` test for `VenvResolver` and `UvWorkspaceResolver`.
- [x] `fastapi` and `flask` added to dev deps so test resolution succeeds end-to-end.

## Follow-ups (not in this PR)

- Surface a run-end summary of `[unresolved]` warnings the visitor logs for non-plugin imports — the hard-fail in plugins covers the framework cases but not arbitrary 3rd-party imports outside a plugin's reach.