### PR TITLE
Release v0.1.0: Initial alpha release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,3 +48,21 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: dist/*
+          prerelease: true
+          fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,55 +9,72 @@ two versions.
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-04-28
+
+Initial alpha release. `dead-cst` is pre-1.0 software: the public Python API,
+CLI flags, and output formats may change without notice between any two
+versions until the first stable release.
+
 ### Added
-- `InitSubclassPlugin` (`--plugin init_subclass`): detect classes that define
-  `__init_subclass__` and route reachability through a synthetic marker node
-  `<__init_subclass__>:<parent.fqname>` with edges
-  `parent -> marker -> subclass` for every transitive first-party subclass.
-  Registry-pattern subclasses stay alive whenever the parent class does;
-  the marker shows up in `why-alive` chains as a labeled breadcrumb.
-  Parents are pass-through, so a registry base nobody else uses still
-  surfaces as dead code.
-- Edge plugin architecture (`EdgePlugin`, `CSTAwareEdgePlugin`, `PluginContext`,
-  `GraphOp`/`AddNode`/`AddEdge`/`RemoveEdge`, `apply_ops`, `synthetic_node`).
-  Built-in plugins: `MainBlockPlugin`, `ProjectScriptsPlugin`,
-  `ExplicitEntrypointPlugin`, `ModuleDundersPlugin`, `PytestPlugin`,
-  `FastAPIPlugin`, `FlaskPlugin`, `TyperPlugin`, `ClickPlugin`,
-  `InitSubclassPlugin`. Third-party plugins register under the
-  `dead_cst.plugins` entry-point group and load via `load_plugin`.
-- Path resolver architecture (`PathResolver`, `merge_paths`). Built-in
-  resolvers: `VenvResolver`, `PyprojectResolver`, `UvWorkspaceResolver`. Third-
-  party resolvers register under `dead_cst.resolvers` and load via
-  `load_resolver`.
-- `exported_roots(base)` in `dead_cst._resolvers`: inspect a base's
-  `pyproject.toml` (src-layout, hatchling/setuptools/poetry/pdm/flit
-  backends, name-match fallback) to determine which subdirs the build
-  backend would actually ship, so internal dirs like `tests/` stay scoped
-  to their owning workspace member during cross-member import resolution.
-- `TyperPlugin` (`--plugin typer`): detect top-level `Typer()` instances and
-  emit `instance -> handler` edges for `@app.command(...)` and
-  `@app.callback(...)` decorators. Typer apps are pass-through; reachability
-  is expected through `[project.scripts]` or a `__main__` block, after which
-  every registered command and callback stays alive. Sub-typers that are
-  never `add_typer`'d remain dead.
-- `FlaskPlugin` (`--plugin flask`): detect top-level `Flask()` / `Blueprint()`
-  instances and emit `instance -> handler` edges for `@app.route(...)`,
-  HTTP-verb shortcuts (`@app.get(...)`, ...), request-lifecycle hooks
-  (`before_request`, `after_request`, `teardown_*`), error handlers,
-  template helpers (`context_processor`, `template_filter`, ...), and URL
-  processors. `Flask` apps are seeded as entrypoints (WSGI servers load
-  `module:app`); `Blueprint`s stay pass-through, so a blueprint never
-  `register_blueprint`'d remains dead, mirroring the `APIRouter` behavior
-  in `FastAPIPlugin`.
-- `ClickPlugin` (`--plugin click`): detect top-level Click `Group` instances
-  (functions decorated `@click.group(...)` / `@click.Group(...)`,
+- Symbol-level reachability analysis built on LibCST's
+  `FullyQualifiedNameProvider` and `ScopeProvider`.
+- Resolution of relative imports, aliased imports, and re-export chains
+  through `__init__.py`.
+- `dead-cst analyze` CLI for reporting unreachable symbols and unreachable
+  branches (`if False:`, raise-only suites, etc.), with `text` and `json`
+  output formats.
+- `dead-cst why-alive` CLI for explaining why a symbol is kept alive.
+- `dead-cst remove` CLI that rewrites files in place via a LibCST codemod,
+  with import pruning when the last local user of an import is deleted and
+  position-aware shadowing so a shadowed dead binding no longer drags its
+  live sibling out with it.
+- `dead-cst unused-exports` CLI command: report `__all__` entries whose
+  targets are kept alive only because they are listed in `__all__`.
+- `dead-cst dependencies` CLI command: list third-party distributions and
+  files imported by the codebase, surfaced as synthetic
+  `[external dist] <name>` / `[external file] <name>` graph nodes.
+- Multi-package / monorepo support via the `-p base:dep1,dep2` search-path
+  spec, with topological ordering of bases.
+- Edge plugin architecture (`EdgePlugin`, `CSTAwareEdgePlugin`,
+  `PluginContext`, `GraphOp`/`AddNode`/`AddEdge`/`RemoveEdge`, `apply_ops`,
+  `synthetic_node`). Built-in plugins: `MainBlockPlugin`,
+  `ProjectScriptsPlugin`, `ExplicitEntrypointPlugin`, `ModuleDundersPlugin`,
+  `PytestPlugin`, `FastAPIPlugin`, `FlaskPlugin`, `TyperPlugin`,
+  `ClickPlugin`, `UnittestPlugin`, `InitSubclassPlugin`. Third-party
+  plugins register under the `dead_cst.plugins` entry-point group and load
+  via `load_plugin`.
+- `PytestPlugin` (`--plugin pytest`): keep pytest-discovered tests,
+  `conftest.py` decls, and `@pytest.fixture` functions alive.
+- `FastAPIPlugin` (`--plugin fastapi`): detect top-level `FastAPI()` and
+  `APIRouter()` instances (including factory-style apps), mark `FastAPI`
+  apps as entrypoints, and emit `instance -> handler` edges for
+  `@app.get(...)`-style decorators (HTTP methods, websockets, middleware,
+  exception handlers, `on_event`). Routers stay pass-through, so an
+  `APIRouter` that's never `include_router`'d remains dead.
+- `FlaskPlugin` (`--plugin flask`): detect top-level `Flask()` /
+  `Blueprint()` instances (including factory-style apps) and emit
+  `instance -> handler` edges for `@app.route(...)`, HTTP-verb shortcuts,
+  request-lifecycle hooks (`before_request`, `after_request`,
+  `teardown_*`), error handlers, template helpers (`context_processor`,
+  `template_filter`, ...), and URL processors. `Flask` apps are seeded as
+  entrypoints (WSGI servers load `module:app`); `Blueprint`s stay
+  pass-through, so a blueprint never `register_blueprint`'d remains dead,
+  mirroring the `APIRouter` behavior in `FastAPIPlugin`.
+- `TyperPlugin` (`--plugin typer`): detect top-level `Typer()` instances
+  and emit `instance -> handler` edges for `@app.command(...)` and
+  `@app.callback(...)` decorators. Typer apps are pass-through;
+  reachability is expected through `[project.scripts]` or a `__main__`
+  block, after which every registered command and callback stays alive.
+  Sub-typers that are never `add_typer`'d remain dead.
+- `ClickPlugin` (`--plugin click`): detect top-level Click `Group`
+  instances (functions decorated `@click.group(...)` / `@click.Group(...)`,
   `X = click.Group(...)` constructor calls, and inline sub-groups
   registered via `@<group>.group(...)`, all resolved via fixpoint so a
-  chain of nested groups is fully discovered) and emit `instance ->
-  handler` edges for `@<group>.command(...)`, `@<group>.group(...)`, and
-  `@<group>.result_callback(...)` decorators. Click groups stay
-  pass-through; reachability is expected through `[project.scripts]` or a
-  `__main__` block, mirroring `TyperPlugin`.
+  chain of nested groups is fully discovered) and emit
+  `instance -> handler` edges for `@<group>.command(...)`,
+  `@<group>.group(...)`, and `@<group>.result_callback(...)` decorators.
+  Click groups stay pass-through; reachability is expected through
+  `[project.scripts]` or a `__main__` block, mirroring `TyperPlugin`.
 - `UnittestPlugin` (`--plugin unittest`): mark stdlib `unittest.TestCase`
   and `unittest.IsolatedAsyncioTestCase` subclasses, plus module-level
   `setUpModule` / `tearDownModule` / `load_tests` hooks, as entrypoints.
@@ -69,72 +86,37 @@ two versions.
   entrypoint or coverage from `PytestPlugin`'s filename heuristics.
   `from unittest import *`-only files are skipped (the resolver doesn't
   surface stdlib star imports as graph nodes); use a non-star import.
-- `dead-cst unused-exports` CLI command: report `__all__` entries whose targets
-  are kept alive only because they are listed in `__all__`.
-- `dead-cst dependencies` CLI command: list third-party distributions and
-  files imported by the codebase, surfaced as synthetic
-  `[external dist] <name>` / `[external file] <name>` graph nodes.
-- `dead-cst analyze` now reports unreachable branches (`if False:`,
-  raise-only suites, etc.) alongside dead symbols, in both the text and JSON
-  output formats.
-- `--resolver` and `--plugin` flags on `analyze`, `why-alive`, `unused-exports`,
-  and `remove` for selecting path resolvers and edge plugins.
-- Position-aware shadowing in the codemod: same-name decls in different
-  branches are tracked by `(fqname, position)` so a shadowed dead binding no
-  longer drags its live sibling out with it.
-- Import pruning in `dead-cst remove`: when the last local user of an import
-  is deleted, the import line is removed via libcst's `RemoveImportsVisitor`.
-- Pre-release notice in the README and a `position` field on `SymbolNode`.
-- `ROADMAP.md` with a stack-ranked plan from alpha to 1.0.
-- Public-API docstrings across `build_symbol_graph`, `find_reachable`,
-  `count_nodes`, `order_paths`, `remove_code`, and the package `__init__`.
-- `CONTRIBUTING.md` and `CHANGELOG.md`.
-
-### Changed
-- `find_reachable(graph)` no longer takes an entrypoints argument. Entrypoints
-  are seeded by plugins via `graph.nodes[node]["entrypoint"] = True`, so the
-  reachability walk is purely graph-driven.
-- `build_symbol_graph` now accepts `plugins=` and `project_root=` keyword
-  arguments and runs the plugin pipeline before returning. Per-consumer
-  lookup tries are now scoped via `exported_roots`, so a workspace member's
-  internal `tests/` package is no longer visible to its dependents.
-- `_resolvers.py` was split into a `_resolvers/` package mirroring
-  `_plugins/` (one submodule per built-in resolver, plus `_core.py` and
-  `_exports.py`). Public imports from `dead_cst` and `dead_cst._resolvers`
-  are unchanged.
-- `--preserve-dunder-all` removed; dunder preservation is provided by
-  `ModuleDundersPlugin`, which is always registered by the CLI and covers
-  every module-level `__xxx__` variable, not just `__all__`.
-- `SymbolTrie.merge` softened from a hard assertion to a first-wins-with-
-  warning when two members declare the same module, so the analyzer logs
-  a clear message instead of crashing on residual collisions.
-
-### Fixed
-- `try/finally` no longer raises `TypeError` in the flow-sensitive filter
-  (`_flow.py`): `Try.finalbody` is a `cst.Finally` whose `.body` is an
-  `IndentedBlock`, so the recursive walk now drills one level further to
-  match every other branch.
-- `UvWorkspaceResolver` now picks up workspace members whose lockfile entry
-  uses `source = { virtual = "..." }` (uv's marker for runnable apps/services
-  that don't ship as wheels), not just `editable` ones. The workspace root
-  itself (`virtual = "."`) is still skipped.
-
-## [0.1.0] - Initial release
-
-### Added
-- Symbol-level reachability analysis built on LibCST's
-  `FullyQualifiedNameProvider` and `ScopeProvider`.
-- Resolution of relative imports, aliased imports, and re-export chains
-  through `__init__.py`.
-- `dead-cst analyze` CLI for reporting unreachable symbols, with `text` and
-  `json` output formats.
-- `dead-cst why-alive` CLI for explaining why a symbol is kept alive.
-- `dead-cst remove` CLI that rewrites files in place via a LibCST codemod.
-- Multi-package / monorepo support via the `-p base:dep1,dep2` search-path
-  spec, with topological ordering of bases.
-- Public Python API: `build_symbol_graph`, `find_reachable`, `count_nodes`,
-  `order_paths`, `remove_code`.
+- `InitSubclassPlugin` (`--plugin init_subclass`): detect classes that
+  define `__init_subclass__` and route reachability through a synthetic
+  marker node `<__init_subclass__>:<parent.fqname>` with edges
+  `parent -> marker -> subclass` for every transitive first-party
+  subclass. Registry-pattern subclasses stay alive whenever the parent
+  class does; the marker shows up in `why-alive` chains as a labeled
+  breadcrumb. Parents are pass-through, so a registry base nobody else
+  uses still surfaces as dead code.
+- `ModuleDundersPlugin`: keep module-level dunder variables (`__all__`,
+  `__version__`, `__future__` imports, etc.) alive. Always registered by
+  the CLI.
+- Path resolver architecture (`PathResolver`, `merge_paths`). Built-in
+  resolvers: `VenvResolver`, `PyprojectResolver`, `UvWorkspaceResolver`
+  (parses `uv.lock` to discover workspace members and inter-member
+  edges, including virtual workspace members that don't ship as wheels).
+  Third-party resolvers register under `dead_cst.resolvers` and load via
+  `load_resolver`.
+- `exported_roots(base)` in `dead_cst._resolvers`: inspect a base's
+  `pyproject.toml` (src-layout, hatchling/setuptools/poetry/pdm/flit
+  backends, name-match fallback) to determine which subdirs the build
+  backend would actually ship, so internal dirs like `tests/` stay scoped
+  to their owning workspace member during cross-member import resolution.
+- `--resolver` and `--plugin` flags on `analyze`, `why-alive`,
+  `unused-exports`, and `remove` for selecting path resolvers and edge
+  plugins.
+- Public Python API: `build_symbol_graph`, `find_reachable`,
+  `count_nodes`, `order_paths`, `remove_code`, plus a `position` field
+  on `SymbolNode`.
 - `py.typed` marker for downstream type-checking.
+- `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, and `ROADMAP.md` with a
+  stack-ranked plan from alpha to 1.0.
 
 [Unreleased]: https://github.com/lpetre/dead-cst/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/lpetre/dead-cst/releases/tag/v0.1.0


### PR DESCRIPTION
This PR prepares the v0.1.0 initial alpha release of `dead-cst`.

## Summary
Reorganizes the CHANGELOG to properly document the v0.1.0 release with a dated header and pre-release notice, and adds GitHub release automation to the publish workflow.

## Key Changes

### CHANGELOG.md
- Added dated `[0.1.0] - 2026-04-28` section header with pre-release notice clarifying that the public Python API, CLI flags, and output formats may change without notice until the first stable release
- Reorganized feature list to lead with core symbol-level reachability analysis capabilities, followed by CLI commands, then plugin and resolver architecture
- Consolidated related features (e.g., all framework plugins grouped together with consistent formatting)
- Improved readability through consistent line wrapping and logical grouping
- Removed duplicate/redundant entries that appeared in both the old "Initial release" and new sections

### GitHub Actions Workflow
- Added `github-release` job to `.github/workflows/publish.yml` that:
  - Triggers on version tags (`refs/tags/v*`)
  - Depends on successful PyPI publication
  - Generates release notes automatically
  - Uploads built distributions as release assets
  - Marks the release as a prerelease
  - Fails if any expected artifacts are missing

This ensures that pushing a version tag will automatically create a GitHub release with the built artifacts and auto-generated release notes.

https://claude.ai/code/session_0147UhG8yafrKbtbBBM5oBf1