### PR TITLE
Fold resolve_import into PathResolver protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,24 @@ two versions.
   edges for every top-level decl whose binding site falls inside the
   block.
 
+### Changed
+- `PathResolver` protocol now includes a `resolve_import(name, search_paths)`
+  method, folding `name -> path` lookup into the resolver alongside
+  search-path discovery. The shipped resolvers (`PyprojectResolver`,
+  `UvWorkspaceResolver`, `VenvResolver`) all delegate to the new
+  `dead_cst._resolvers.default_resolve_import`, the `sys.path` +
+  `importlib` implementation. Custom resolvers can now override import
+  lookups for their own layout (vendored deps, `.pyi` siblings, ...)
+  without monkey-patching internals.
+- `build_symbol_graph` accepts a new `resolvers=` keyword whose entries'
+  `resolve_import` methods are tried in order. With no resolvers it
+  falls back to `default_resolve_import`, preserving today's behavior.
+- The CLI threads loaded resolvers through to the analyzer so
+  `--resolver` selections govern import lookup, not just search paths.
+- Renamed `dead_cst._resolve` to `dead_cst._edges`. The remaining
+  module is purely about edge construction in the symbol trie;
+  resolution now lives under `dead_cst._resolvers`.
+
 ## [0.1.0] - 2026-04-28
 
 Initial alpha release. `dead-cst` is pre-1.0 software: the public Python API,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,23 +21,34 @@ two versions.
   edges for every top-level decl whose binding site falls inside the
   block.
 
+### Added
+- `ManualResolver`: a `PathResolver` built from explicit
+  ``base:dep1,dep2`` specs. The CLI's ``-p`` flag now flows through
+  this resolver, so explicit specs sit in the same chain as named
+  resolvers and participate in `resolve_import` lookups too.
+
 ### Changed
 - `PathResolver` protocol now includes a `resolve_import(name, search_paths)`
   method, folding `name -> path` lookup into the resolver alongside
-  search-path discovery. The shipped resolvers (`PyprojectResolver`,
-  `UvWorkspaceResolver`, `VenvResolver`) all delegate to the new
-  `dead_cst._resolvers.default_resolve_import`, the `sys.path` +
-  `importlib` implementation. Custom resolvers can now override import
-  lookups for their own layout (vendored deps, `.pyi` siblings, ...)
-  without monkey-patching internals.
+  search-path discovery. The shipped resolvers (`ManualResolver`,
+  `PyprojectResolver`, `UvWorkspaceResolver`, `VenvResolver`) all
+  delegate to the new `dead_cst._resolvers.default_resolve_import`, the
+  `sys.path` + `importlib` implementation. Custom resolvers can now
+  override import lookups for their own layout (vendored deps, `.pyi`
+  siblings, ...) without monkey-patching internals.
 - `build_symbol_graph` accepts a new `resolvers=` keyword whose entries'
   `resolve_import` methods are tried in order. With no resolvers it
   falls back to `default_resolve_import`, preserving today's behavior.
 - The CLI threads loaded resolvers through to the analyzer so
-  `--resolver` selections govern import lookup, not just search paths.
+  `--resolver` (and ``-p``) selections govern import lookup, not just
+  search paths.
 - Renamed `dead_cst._resolve` to `dead_cst._edges`. The remaining
   module is purely about edge construction in the symbol trie;
   resolution now lives under `dead_cst._resolvers`.
+
+### Removed
+- `dead_cst.cli.parse_paths` -- callers should construct a
+  `ManualResolver` and call `.resolve(root)`.
 
 ## [0.1.0] - 2026-04-28
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,30 +15,8 @@ for the full record.
 
 ## Next release — Quality of life
 
-Two committed items for the upcoming version. Both are internal-architecture
-changes that unblock work elsewhere in the roadmap.
-
-### Resolver logic as a protocol
-
-`PathResolver` today only answers "where are the source roots?"
-(`resolve(project_root) -> PathMap`). The actual name-to-path step —
-`resolve_import` in `_resolve.py`, hard-coded to `sys.path` + `importlib` —
-sits outside the protocol, so shipped resolvers can describe a layout but
-can't influence how imports inside that layout are looked up. Fold it in:
-
-- Add a `resolve_import(name, search_paths) -> str | Path | None` method
-  to `PathResolver`. The current function in `_resolve.py` moves into the
-  `_resolvers` subpackage as the default implementation; shipped resolvers
-  (`pyproject`, `uv_workspace`, `venv`) inherit or delegate to it.
-- This lets a resolver override lookup for its own layout — e.g. a
-  vendored-deps resolver pointing at a checked-in `third_party/`, or a
-  stub-aware resolver preferring `.pyi` siblings — without monkey-patching
-  internals.
-
-`resolve_edges` is a different concern (it stitches imports to declarations
-in the already-built symbol trie) and stays in place. The file should be
-renamed though, since "resolution" now lives in `_resolvers/` and what's
-left is edge construction — `_edges.py` reads more honestly.
+One committed item for the upcoming version. The resolver-protocol
+companion piece shipped — see `CHANGELOG.md`.
 
 ### SQLite-cached graph with partial rebuilds
 
@@ -168,6 +146,11 @@ demand.
 
 Folded down from earlier tiers as they landed:
 
+- Resolver logic as a protocol: `PathResolver.resolve_import` folds
+  `name -> path` lookup into the resolver, so custom resolvers can
+  override import resolution for their own layouts. `_resolve.py`
+  renamed to `_edges.py` since resolution now lives under
+  `_resolvers/`.
 - Codemod test coverage and import pruning (Tier 1).
 - `from X import *` resolution, pessimistic by default (Tier 1).
 - `PytestPlugin`, `UnittestPlugin`, `FastAPIPlugin`, `FlaskPlugin`,

--- a/dead_cst/__init__.py
+++ b/dead_cst/__init__.py
@@ -54,6 +54,7 @@ from ._plugins import (
 )
 from ._resolvers import (
     BUILTIN_RESOLVERS,
+    ManualResolver,
     PathResolver,
     PyprojectResolver,
     UvWorkspaceResolver,
@@ -77,6 +78,7 @@ __all__ = [
     "GraphOp",
     "InitSubclassPlugin",
     "MainBlockPlugin",
+    "ManualResolver",
     "ModuleDundersPlugin",
     "PathResolver",
     "PluginContext",

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -2,20 +2,27 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Sequence
+from typing import Callable, Sequence
 
 import libcst as cst
 import networkx as nx
 from libcst.metadata import FullRepoManager
 
+from ._edges import resolve_edges
 from ._fqn import FixedFullyQualifiedNameProvider
 from ._plugins import (
     EdgePlugin,
     PluginContext,
     apply_ops,
 )
-from ._resolve import resolve_edges, safe_resolve_module, temp_sys_path
-from ._resolvers import PathMap, exported_roots
+from ._resolvers import (
+    PathMap,
+    PathResolver,
+    default_resolve_import,
+    exported_roots,
+    safe_resolve_module,
+    temp_sys_path,
+)
 from ._symbols import SymbolNode, SymbolTrie
 from ._visitor import SymbolVisitor
 
@@ -39,10 +46,35 @@ def order_paths(paths: PathMap) -> list[Path]:
     return list(nx.topological_sort(path_order))
 
 
+ImportResolver = Callable[[str, list[Path]], "str | Path | None"]
+
+
+def _chain_resolvers(resolvers: Sequence[PathResolver]) -> ImportResolver:
+    """Compose ``resolvers`` into one ``name -> path`` callable.
+
+    Each resolver's :meth:`PathResolver.resolve_import` is tried in
+    order; the first non-``None`` answer wins. With no resolvers,
+    falls back to :func:`default_resolve_import` so the analyzer keeps
+    working when callers don't pass any (the common public-API case).
+    """
+    if not resolvers:
+        return default_resolve_import
+
+    def _resolve(name: str, search_paths: list[Path]) -> str | Path | None:
+        for resolver in resolvers:
+            result = resolver.resolve_import(name, search_paths)
+            if result is not None:
+                return result
+        return None
+
+    return _resolve
+
+
 def build_symbol_graph(
     paths: PathMap,
     *,
     plugins: Sequence[EdgePlugin] = (),
+    resolvers: Sequence[PathResolver] = (),
     project_root: Path | None = None,
 ) -> nx.DiGraph:
     """Build a directed reachability graph of every top-level symbol under ``paths``.
@@ -79,6 +111,13 @@ def build_symbol_graph(
         Sequence of :class:`EdgePlugin` instances. Plugins emit
         :class:`AddNode`, :class:`AddEdge`, and :class:`RemoveEdge` ops;
         ``AddNode(..., entrypoint=True)`` seeds :func:`find_reachable`.
+    resolvers:
+        Sequence of :class:`PathResolver` instances whose
+        :meth:`~PathResolver.resolve_import` overrides ``name -> path``
+        lookups. Tried in order; first non-``None`` answer wins. When
+        empty, the analyzer falls back to
+        :func:`default_resolve_import` -- the same ``sys.path`` +
+        ``importlib`` lookup the shipped resolvers all delegate to.
     project_root:
         Project root used by plugins for path-relative matching. If
         omitted, inferred as the shortest path in ``paths``.
@@ -93,6 +132,7 @@ def build_symbol_graph(
     base_tries: dict[Path, SymbolTrie] = {}
     export_tries: dict[Path, SymbolTrie] = {}
     root = project_root or _infer_project_root(paths) if paths else Path.cwd()
+    import_resolver = _chain_resolvers(resolvers)
     for base in order_paths(paths):
         logger.debug("Processing base path: %s", base)
         search_paths = [base] + paths.get(base, [])
@@ -113,7 +153,7 @@ def build_symbol_graph(
                 wrapper = mgr.get_metadata_wrapper_for_path(str(file))
                 if base_modules is not None:
                     base_modules[file] = wrapper.module
-                visitor = SymbolVisitor(file, search_paths)
+                visitor = SymbolVisitor(file, search_paths, import_resolver)
                 wrapper.visit(visitor)
                 # A file's decls go into ``export_trie`` only when the file
                 # lives under one of ``base``'s exported dirs (or when the

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Callable, Sequence
+from typing import Sequence
 
 import libcst as cst
 import networkx as nx
@@ -16,13 +16,13 @@ from ._plugins import (
     apply_ops,
 )
 from ._resolvers import (
+    ImportResolver,
     PathMap,
     PathResolver,
     default_resolve_import,
     exported_roots,
-    safe_resolve_module,
-    temp_sys_path,
 )
+from ._resolvers._imports import safe_resolve_module, temp_sys_path
 from ._symbols import SymbolNode, SymbolTrie
 from ._visitor import SymbolVisitor
 
@@ -46,9 +46,6 @@ def order_paths(paths: PathMap) -> list[Path]:
     return list(nx.topological_sort(path_order))
 
 
-ImportResolver = Callable[[str, list[Path]], "str | Path | None"]
-
-
 def _chain_resolvers(resolvers: Sequence[PathResolver]) -> ImportResolver:
     """Compose ``resolvers`` into one ``name -> path`` callable.
 
@@ -56,9 +53,14 @@ def _chain_resolvers(resolvers: Sequence[PathResolver]) -> ImportResolver:
     order; the first non-``None`` answer wins. With no resolvers,
     falls back to :func:`default_resolve_import` so the analyzer keeps
     working when callers don't pass any (the common public-API case).
+    A single-resolver chain skips the closure -- the typical CLI
+    invocation passes one resolver, and the chain would just call its
+    method directly.
     """
     if not resolvers:
         return default_resolve_import
+    if len(resolvers) == 1:
+        return resolvers[0].resolve_import
 
     def _resolve(name: str, search_paths: list[Path]) -> str | Path | None:
         for resolver in resolvers:

--- a/dead_cst/_edges.py
+++ b/dead_cst/_edges.py
@@ -1,130 +1,31 @@
+"""Stitch resolved imports into ``src -> dst`` edges in the symbol graph.
+
+The visitor pass produces ``(src, Import)`` pairs where ``Import.path``
+is whatever a :class:`~dead_cst._resolvers.PathResolver` returned for
+the imported name. :func:`resolve_edges` walks those pairs against the
+already-built per-base :class:`SymbolTrie` and yields the concrete
+``(src_symbol, dst_symbol)`` edges -- following re-exports, fanning
+star imports out to every top-level decl in the target module, and
+emitting synthetic nodes for stdlib / external / unresolved targets.
+
+The ``name -> path`` half of resolution lives in
+:mod:`dead_cst._resolvers._imports`; this module is purely about edge
+construction in the trie that visitor pass populated.
+"""
+
 from __future__ import annotations
 
-import contextlib
 import logging
-import os
-import re
-import sys
-import sysconfig
-from functools import cache
-from importlib.machinery import ModuleSpec
 from pathlib import Path
 from typing import Generator
 
 from ._plugins._core import (
-    EXTERNAL_DIST_PREFIX,
-    EXTERNAL_FILE_PREFIX,
-    STDLIB_PREFIX,
     SYNTHETIC_PATH_PREFIXES,
     synthetic_node,
 )
 from ._symbols import Import, SymbolNode, SymbolTrie
 
 logger = logging.getLogger(__name__)
-
-STDLIB = Path(sysconfig.get_path("stdlib")).resolve()
-SITE_PACKAGES_MARKERS = ("site-packages", "dist-packages")
-
-
-def _canonical_dist_name(name: str) -> str:
-    """Normalize a PyPI distribution name per PEP 503.
-
-    PyPI treats ``Flask`` / ``flask`` / ``FLASK`` as the same project;
-    plugins query the analyzer by the lowercase import name (``flask``)
-    so the synthetic ``[external dist] <name>`` node has to match. PEP
-    503's canonical form is ``re.sub(r"[-_.]+", "-", name).lower()`` --
-    we apply that to the raw ``Name`` from each dist's metadata so
-    plugin lookups don't depend on whatever casing the package author
-    chose.
-
-    Note: this still uses the *distribution* name, not the import
-    (top-level) name. For most third-party packages they match after
-    canonicalization (``fastapi``, ``flask``, ``click``, ``typer``,
-    ``networkx``, ...). They differ for a handful of historic names
-    (``Pillow`` → import ``PIL``, ``PyYAML`` → import ``yaml``); plugins
-    targeting those would need an explicit dist-name override, which
-    we don't yet support.
-    """
-    return re.sub(r"[-_.]+", "-", name).lower()
-
-
-@contextlib.contextmanager
-def temp_sys_path(paths: list[Path]):
-    old = list(sys.path)
-    seen = set(old)
-    sys.path = [str(p) for p in paths if str(p) not in seen] + sys.path
-    try:
-        yield
-    finally:
-        sys.path = old
-
-
-@cache
-def safe_resolve_module(fullname: str) -> ModuleSpec | None:
-    parts = fullname.split(".")
-    search_paths = list(sys.path)
-
-    # emulate namespace __path__ resolution
-    for i, part in enumerate(parts[:-1]):
-        candidate_paths = []
-        for base in search_paths:
-            subdir = os.path.join(base, parts[i])
-            if os.path.isdir(subdir):
-                candidate_paths.append(subdir)
-        search_paths = candidate_paths
-
-    # Final part resolution
-    for finder in sys.meta_path:
-        find_spec = getattr(finder, "find_spec", None)
-        if not find_spec:
-            continue
-        try:
-            spec = find_spec(fullname, search_paths)
-            if spec:
-                return spec
-        except Exception:
-            continue
-
-    return None
-
-
-@cache
-def distribution_lookup() -> dict[Path, str]:
-    from importlib import metadata
-
-    lookup = {}
-    for dist in metadata.distributions():
-        canonical = _canonical_dist_name(dist.metadata["Name"])
-        for file in dist.files or ():
-            abs_path = Path(str(dist.locate_file(file))).resolve()
-            lookup[abs_path] = canonical
-    return lookup
-
-
-def resolve_import(name: str, search_paths: list[Path]) -> str | Path | None:
-    spec = safe_resolve_module(name)
-    if spec is None:
-        return None
-    if spec.origin is None:
-        return None
-    if spec.origin in {"built-in", "frozen"}:
-        return f"{STDLIB_PREFIX}{name}"
-    path = Path(spec.origin).resolve()
-    if path.is_relative_to(STDLIB):
-        return f"{STDLIB_PREFIX}{name}"
-
-    lookup = distribution_lookup()
-    if dist := lookup.get(path):
-        return f"{EXTERNAL_DIST_PREFIX}{dist}"
-
-    path_str = str(path)
-    if any(m in path_str for m in SITE_PACKAGES_MARKERS):
-        return f"{EXTERNAL_FILE_PREFIX}{name}"
-
-    for search in search_paths:
-        if path.is_relative_to(search):
-            return path
-    raise Exception(f"Module {name} resolved to an unexpected path: {path}")
 
 
 def resolve_edges(

--- a/dead_cst/_resolvers/__init__.py
+++ b/dead_cst/_resolvers/__init__.py
@@ -17,14 +17,9 @@ like ``tests/`` stay scoped to their owning member.
 
 from __future__ import annotations
 
-from ._core import PathMap, PathResolver, merge_paths
+from ._core import ImportResolver, PathMap, PathResolver, merge_paths
 from ._exports import exported_roots
-from ._imports import (
-    default_resolve_import,
-    distribution_lookup,
-    safe_resolve_module,
-    temp_sys_path,
-)
+from ._imports import default_resolve_import
 from .manual import ManualResolver
 from .pyproject import PyprojectResolver
 from .uv_workspace import UvWorkspaceResolver
@@ -53,6 +48,7 @@ def load_resolver(name: str) -> PathResolver:
 
 __all__ = [
     "BUILTIN_RESOLVERS",
+    "ImportResolver",
     "ManualResolver",
     "MissingVenvError",
     "PathMap",
@@ -61,10 +57,7 @@ __all__ = [
     "UvWorkspaceResolver",
     "VenvResolver",
     "default_resolve_import",
-    "distribution_lookup",
     "exported_roots",
     "load_resolver",
     "merge_paths",
-    "safe_resolve_module",
-    "temp_sys_path",
 ]

--- a/dead_cst/_resolvers/__init__.py
+++ b/dead_cst/_resolvers/__init__.py
@@ -19,6 +19,12 @@ from __future__ import annotations
 
 from ._core import PathMap, PathResolver, merge_paths
 from ._exports import exported_roots
+from ._imports import (
+    default_resolve_import,
+    distribution_lookup,
+    safe_resolve_module,
+    temp_sys_path,
+)
 from .pyproject import PyprojectResolver
 from .uv_workspace import UvWorkspaceResolver
 from .venv import MissingVenvError, VenvResolver
@@ -52,7 +58,11 @@ __all__ = [
     "PyprojectResolver",
     "UvWorkspaceResolver",
     "VenvResolver",
+    "default_resolve_import",
+    "distribution_lookup",
     "exported_roots",
     "load_resolver",
     "merge_paths",
+    "safe_resolve_module",
+    "temp_sys_path",
 ]

--- a/dead_cst/_resolvers/__init__.py
+++ b/dead_cst/_resolvers/__init__.py
@@ -25,6 +25,7 @@ from ._imports import (
     safe_resolve_module,
     temp_sys_path,
 )
+from .manual import ManualResolver
 from .pyproject import PyprojectResolver
 from .uv_workspace import UvWorkspaceResolver
 from .venv import MissingVenvError, VenvResolver
@@ -52,6 +53,7 @@ def load_resolver(name: str) -> PathResolver:
 
 __all__ = [
     "BUILTIN_RESOLVERS",
+    "ManualResolver",
     "MissingVenvError",
     "PathMap",
     "PathResolver",

--- a/dead_cst/_resolvers/_core.py
+++ b/dead_cst/_resolvers/_core.py
@@ -15,9 +15,27 @@ PathMap = dict[Path, list[Path]]
 
 @runtime_checkable
 class PathResolver(Protocol):
+    """A resolver describes a project layout in two complementary ways.
+
+    :meth:`resolve` reports the search paths the analyzer should walk
+    (``{base: [dep_paths]}``); :meth:`resolve_import` answers
+    ``name -> path`` lookups inside that layout. Splitting them lets a
+    resolver own both halves -- e.g. a vendored-deps resolver can point
+    at a checked-in ``third_party/`` and also redirect imports to it
+    without monkey-patching the analyzer.
+
+    The shipped resolvers all delegate :meth:`resolve_import` to
+    :func:`~dead_cst._resolvers._imports.default_resolve_import`, the
+    ``sys.path`` + ``importlib`` implementation. Custom resolvers
+    typically call it as a fallback after their own layout-specific
+    lookups.
+    """
+
     name: str
 
     def resolve(self, project_root: Path) -> PathMap: ...
+
+    def resolve_import(self, name: str, search_paths: list[Path]) -> str | Path | None: ...
 
 
 def load_toml(path: Path) -> dict[str, Any] | None:

--- a/dead_cst/_resolvers/_core.py
+++ b/dead_cst/_resolvers/_core.py
@@ -12,8 +12,8 @@ from typing import Any, Callable, Protocol, runtime_checkable
 
 PathMap = dict[Path, list[Path]]
 
+# ``name -> path`` lookup callable. ``None`` means "not resolvable here".
 ImportResolver = Callable[[str, list[Path]], "str | Path | None"]
-"""``name -> path`` lookup callable. ``None`` means "not resolvable here"."""
 
 
 @runtime_checkable

--- a/dead_cst/_resolvers/_core.py
+++ b/dead_cst/_resolvers/_core.py
@@ -8,9 +8,12 @@ multiple resolvers' outputs.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Callable, Protocol, runtime_checkable
 
 PathMap = dict[Path, list[Path]]
+
+ImportResolver = Callable[[str, list[Path]], "str | Path | None"]
+"""``name -> path`` lookup callable. ``None`` means "not resolvable here"."""
 
 
 @runtime_checkable

--- a/dead_cst/_resolvers/_imports.py
+++ b/dead_cst/_resolvers/_imports.py
@@ -1,0 +1,168 @@
+"""Default ``name -> path`` import resolution.
+
+Provides :func:`default_resolve_import`, the ``sys.path`` + ``importlib``
+implementation that every shipped :class:`PathResolver` delegates to.
+Custom resolvers can call it directly, replace it with their own logic
+(for vendored deps, ``.pyi`` siblings, ...), or compose both.
+
+The supporting helpers (:func:`safe_resolve_module`,
+:func:`distribution_lookup`, :func:`temp_sys_path`) are kept here so the
+analyzer and the resolvers share a single cache and one canonical
+treatment of distribution-name normalization.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import re
+import sys
+import sysconfig
+from functools import cache
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+from typing import Generator
+
+from .._plugins._core import (
+    EXTERNAL_DIST_PREFIX,
+    EXTERNAL_FILE_PREFIX,
+    STDLIB_PREFIX,
+)
+
+STDLIB = Path(sysconfig.get_path("stdlib")).resolve()
+SITE_PACKAGES_MARKERS = ("site-packages", "dist-packages")
+
+
+def _canonical_dist_name(name: str) -> str:
+    """Normalize a PyPI distribution name per PEP 503.
+
+    PyPI treats ``Flask`` / ``flask`` / ``FLASK`` as the same project;
+    plugins query the analyzer by the lowercase import name (``flask``)
+    so the synthetic ``[external dist] <name>`` node has to match. PEP
+    503's canonical form is ``re.sub(r"[-_.]+", "-", name).lower()`` --
+    we apply that to the raw ``Name`` from each dist's metadata so
+    plugin lookups don't depend on whatever casing the package author
+    chose.
+
+    Note: this still uses the *distribution* name, not the import
+    (top-level) name. For most third-party packages they match after
+    canonicalization (``fastapi``, ``flask``, ``click``, ``typer``,
+    ``networkx``, ...). They differ for a handful of historic names
+    (``Pillow`` → import ``PIL``, ``PyYAML`` → import ``yaml``); plugins
+    targeting those would need an explicit dist-name override, which
+    we don't yet support.
+    """
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+@contextlib.contextmanager
+def temp_sys_path(paths: list[Path]) -> Generator[None, None, None]:
+    """Prepend ``paths`` to ``sys.path`` for the duration of the ``with`` block.
+
+    Used by the analyzer to scope :func:`safe_resolve_module`'s lookups
+    to the current base's search paths without leaking entries between
+    bases.
+    """
+    old = list(sys.path)
+    seen = set(old)
+    sys.path = [str(p) for p in paths if str(p) not in seen] + sys.path
+    try:
+        yield
+    finally:
+        sys.path = old
+
+
+@cache
+def safe_resolve_module(fullname: str) -> ModuleSpec | None:
+    """Locate a :class:`ModuleSpec` for ``fullname`` against the current ``sys.path``.
+
+    Cached, so a base's full sweep over import edges only pays the
+    finder cost once per unique name. The analyzer clears the cache
+    between bases (search paths change) via
+    :meth:`safe_resolve_module.cache_clear`.
+    """
+    parts = fullname.split(".")
+    search_paths = list(sys.path)
+
+    # emulate namespace __path__ resolution
+    for i, part in enumerate(parts[:-1]):
+        candidate_paths = []
+        for base in search_paths:
+            subdir = os.path.join(base, parts[i])
+            if os.path.isdir(subdir):
+                candidate_paths.append(subdir)
+        search_paths = candidate_paths
+
+    # Final part resolution
+    for finder in sys.meta_path:
+        find_spec = getattr(finder, "find_spec", None)
+        if not find_spec:
+            continue
+        try:
+            spec = find_spec(fullname, search_paths)
+            if spec:
+                return spec
+        except Exception:
+            continue
+
+    return None
+
+
+@cache
+def distribution_lookup() -> dict[Path, str]:
+    """Map every installed distribution file to its canonical project name.
+
+    Used by :func:`default_resolve_import` to classify a resolved path
+    as ``[external dist] <name>`` when the file came from an installed
+    third-party distribution.
+    """
+    from importlib import metadata
+
+    lookup = {}
+    for dist in metadata.distributions():
+        canonical = _canonical_dist_name(dist.metadata["Name"])
+        for file in dist.files or ():
+            abs_path = Path(str(dist.locate_file(file))).resolve()
+            lookup[abs_path] = canonical
+    return lookup
+
+
+def default_resolve_import(name: str, search_paths: list[Path]) -> str | Path | None:
+    """Resolve a dotted module name against ``sys.path`` + the importlib finders.
+
+    Returns one of:
+
+    * a :class:`Path` when ``name`` is a first-party module under one of
+      ``search_paths`` (the analyzer ingests it as a regular graph node);
+    * a synthetic ``[stdlib] <name>`` / ``[external dist] <pkg>`` /
+      ``[external file] <name>`` string when ``name`` resolves outside
+      the project (collapsed into one synthetic node per group);
+    * ``None`` when the importlib finders can't locate ``name`` at all.
+
+    This is the implementation every shipped :class:`PathResolver`
+    delegates to. Third-party resolvers can call it as a fallback after
+    their own layout-specific lookups, or replace it entirely.
+    """
+    spec = safe_resolve_module(name)
+    if spec is None:
+        return None
+    if spec.origin is None:
+        return None
+    if spec.origin in {"built-in", "frozen"}:
+        return f"{STDLIB_PREFIX}{name}"
+    path = Path(spec.origin).resolve()
+    if path.is_relative_to(STDLIB):
+        return f"{STDLIB_PREFIX}{name}"
+
+    lookup = distribution_lookup()
+    if dist := lookup.get(path):
+        return f"{EXTERNAL_DIST_PREFIX}{dist}"
+
+    path_str = str(path)
+    if any(m in path_str for m in SITE_PACKAGES_MARKERS):
+        return f"{EXTERNAL_FILE_PREFIX}{name}"
+
+    for search in search_paths:
+        if path.is_relative_to(search):
+            return path
+    raise Exception(f"Module {name} resolved to an unexpected path: {path}")

--- a/dead_cst/_resolvers/manual.py
+++ b/dead_cst/_resolvers/manual.py
@@ -1,0 +1,49 @@
+"""Resolver built from explicit ``base:dep1,dep2`` path specs.
+
+Mirrors the CLI's ``-p`` flag as a first-class :class:`PathResolver`,
+so explicit specs flow through the same pipeline as auto-discovered
+layouts and participate in :meth:`~PathResolver.resolve_import` lookup.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ._core import PathMap
+from ._imports import default_resolve_import
+
+
+@dataclass
+class ManualResolver:
+    """Resolver built from explicit ``base:dep1,dep2`` path specs.
+
+    Each entry in ``specs`` is either ``"base"`` (no deps) or
+    ``"base:dep1,dep2,..."``. Bases and deps are joined to
+    ``project_root`` at :meth:`resolve` time; whitespace around dep
+    names is stripped and trailing empty entries are dropped, matching
+    the CLI's ``-p`` parsing.
+
+    Not registered in :data:`BUILTIN_RESOLVERS` -- :func:`load_resolver`
+    can't construct it without ``specs``. Instantiate directly when
+    composing a resolver chain programmatically.
+    """
+
+    specs: list[str] = field(default_factory=list)
+    name: str = "manual"
+
+    def resolve(self, project_root: Path) -> PathMap:
+        out: PathMap = {}
+        for spec in self.specs:
+            if ":" in spec:
+                base_str, deps_str = spec.split(":", 1)
+                base = project_root / base_str
+                deps = [project_root / d.strip() for d in deps_str.split(",") if d.strip()]
+            else:
+                base = project_root / spec
+                deps = []
+            out[base] = deps
+        return out
+
+    def resolve_import(self, name: str, search_paths: list[Path]) -> str | Path | None:
+        return default_resolve_import(name, search_paths)

--- a/dead_cst/_resolvers/pyproject.py
+++ b/dead_cst/_resolvers/pyproject.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ._core import PathMap, load_toml
+from ._imports import default_resolve_import
 
 
 @dataclass
@@ -47,3 +48,6 @@ class PyprojectResolver:
         if src.is_dir():
             return {src: []}
         return {}
+
+    def resolve_import(self, name: str, search_paths: list[Path]) -> str | Path | None:
+        return default_resolve_import(name, search_paths)

--- a/dead_cst/_resolvers/uv_workspace.py
+++ b/dead_cst/_resolvers/uv_workspace.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ._core import PathMap, load_toml
+from ._imports import default_resolve_import
 from .venv import MissingVenvError, find_venv_site_packages
 
 
@@ -94,6 +95,9 @@ class UvWorkspaceResolver:
             deps.append(site_packages)
             out[src_root] = deps
         return out
+
+    def resolve_import(self, name: str, search_paths: list[Path]) -> str | Path | None:
+        return default_resolve_import(name, search_paths)
 
 
 def _src_root_for(member_dir: Path) -> Path | None:

--- a/dead_cst/_resolvers/venv.py
+++ b/dead_cst/_resolvers/venv.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ._core import PathMap
+from ._imports import default_resolve_import
 
 
 class MissingVenvError(RuntimeError):
@@ -47,6 +48,9 @@ class VenvResolver:
         if sp is None:
             raise MissingVenvError(_missing_venv_message(project_root, self.venv_dir))
         return {project_root: [sp]}
+
+    def resolve_import(self, name: str, search_paths: list[Path]) -> str | Path | None:
+        return default_resolve_import(name, search_paths)
 
 
 def find_venv_site_packages(project_root: Path, venv_dir: str | None = None) -> Path | None:

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -4,7 +4,7 @@ import logging
 from functools import cache
 from importlib.util import resolve_name
 from pathlib import Path
-from typing import Generator, Literal, Mapping, cast
+from typing import Callable, Generator, Literal, Mapping, cast
 
 import libcst as cst
 from libcst.helpers import get_full_name_for_node
@@ -26,8 +26,10 @@ from ._branches import make_unreachable_node, unreachable_suites
 from ._flow import live_at_exit, live_referents
 from ._fqn import FixedFullyQualifiedNameProvider
 from ._plugins._core import UNRESOLVED_PREFIX
-from ._resolve import resolve_import
+from ._resolvers import default_resolve_import
 from ._symbols import Import, SymbolNode, SymbolTrie
+
+ImportResolver = Callable[[str, list[Path]], "str | Path | None"]
 
 logger = logging.getLogger(__name__)
 
@@ -88,9 +90,15 @@ class SymbolVisitor(cst.CSTVisitor):
             return list(scope.node.body.body)
         return None
 
-    def __init__(self, path: Path, search_paths: list[Path]):
+    def __init__(
+        self,
+        path: Path,
+        search_paths: list[Path],
+        import_resolver: ImportResolver = default_resolve_import,
+    ):
         self.path = path
         self.search_paths = search_paths
+        self._import_resolver = import_resolver
         self.node_to_frames: dict[cst.CSTNode, list[list[SymbolNode]]] = {}
         self.decl_stack: list[list[SymbolNode]] = []
         self.nearest_decls: dict[cst.CSTNode, list[SymbolNode]] = {}
@@ -123,7 +131,7 @@ class SymbolVisitor(cst.CSTVisitor):
 
     @cache
     def resolve_import(self, name: str) -> str | Path | None:
-        return resolve_import(name, self.search_paths)
+        return self._import_resolver(name, self.search_paths)
 
     def _push_decl(self, node: cst.CSTNode, decl: SymbolNode):
         self._push_decls(node, [decl])

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -4,7 +4,7 @@ import logging
 from functools import cache
 from importlib.util import resolve_name
 from pathlib import Path
-from typing import Callable, Generator, Literal, Mapping, cast
+from typing import Generator, Literal, Mapping, cast
 
 import libcst as cst
 from libcst.helpers import get_full_name_for_node
@@ -26,10 +26,8 @@ from ._branches import make_unreachable_node, unreachable_suites
 from ._flow import live_at_exit, live_referents
 from ._fqn import FixedFullyQualifiedNameProvider
 from ._plugins._core import UNRESOLVED_PREFIX
-from ._resolvers import default_resolve_import
+from ._resolvers import ImportResolver, default_resolve_import
 from ._symbols import Import, SymbolNode, SymbolTrie
-
-ImportResolver = Callable[[str, list[Path]], "str | Path | None"]
 
 logger = logging.getLogger(__name__)
 

--- a/dead_cst/cli.py
+++ b/dead_cst/cli.py
@@ -23,7 +23,7 @@ from ._plugins import (
 )
 from ._plugins._core import EXTERNAL_PREFIXES
 from ._plugins.module_dunders import DUNDER_PREFIX
-from ._resolvers import PathMap, load_resolver, merge_paths
+from ._resolvers import PathMap, PathResolver, load_resolver, merge_paths
 from ._symbols import SymbolNode
 
 
@@ -79,13 +79,22 @@ def build_plugins(
     return plugins
 
 
-def resolve_paths(root: Path, path_specs: list[str], resolver_names: list[str]) -> PathMap:
-    """Merge ``-p`` specs and ``--resolver`` outputs into a single path map."""
+def resolve_paths(
+    root: Path, path_specs: list[str], resolver_names: list[str]
+) -> tuple[PathMap, list[PathResolver]]:
+    """Merge ``-p`` specs and ``--resolver`` outputs into a path map and resolver list.
+
+    Returns the merged :data:`PathMap` plus the resolver instances --
+    the analyzer threads the resolvers through so each one's
+    :meth:`PathResolver.resolve_import` participates in
+    ``name -> path`` lookups, not just its :meth:`resolve` output.
+    """
+    resolvers = [load_resolver(name) for name in resolver_names]
     explicit = parse_paths(root, path_specs) if path_specs else {}
-    resolved_maps = [load_resolver(name).resolve(root) for name in resolver_names]
+    resolved_maps = [r.resolve(root) for r in resolvers]
     if not explicit and not resolved_maps:
-        return {root: []}
-    return merge_paths(explicit, *resolved_maps)
+        return {root: []}, resolvers
+    return merge_paths(explicit, *resolved_maps), resolvers
 
 
 def parse_paths(root: Path, paths_str: list[str]) -> PathMap:
@@ -161,14 +170,14 @@ def analyze(
     setup_logging(verbose)
     root = root.resolve()
 
-    paths_dict = resolve_paths(root, path or [], resolver or [])
+    paths_dict, resolvers = resolve_paths(root, path or [], resolver or [])
 
     typer.echo(f"Building symbol graph for {root}...", err=True)
     plugins = build_plugins(
         entrypoints=entrypoint or [],
         plugin_names=plugin or [],
     )
-    graph = build_symbol_graph(paths_dict, plugins=plugins, project_root=root)
+    graph = build_symbol_graph(paths_dict, plugins=plugins, resolvers=resolvers, project_root=root)
     reachable = find_reachable(graph)
 
     unreachable_graph = graph.subgraph([n for n in graph.nodes if n not in reachable])
@@ -307,14 +316,14 @@ def why_alive(
     setup_logging(verbose)
     root = root.resolve()
 
-    paths_dict = resolve_paths(root, path or [], resolver or [])
+    paths_dict, resolvers = resolve_paths(root, path or [], resolver or [])
 
     typer.echo(f"Building symbol graph for {root}...", err=True)
     plugins = build_plugins(
         entrypoints=[],
         plugin_names=plugin or [],
     )
-    graph = build_symbol_graph(paths_dict, plugins=plugins, project_root=root)
+    graph = build_symbol_graph(paths_dict, plugins=plugins, resolvers=resolvers, project_root=root)
 
     target_node: SymbolNode | None = None
     for node in graph.nodes:
@@ -372,10 +381,10 @@ def dependencies(
     setup_logging(verbose)
     root = root.resolve()
 
-    paths_dict = resolve_paths(root, path or [], resolver or [])
+    paths_dict, resolvers = resolve_paths(root, path or [], resolver or [])
 
     typer.echo(f"Building symbol graph for {root}...", err=True)
-    graph = build_symbol_graph(paths_dict, project_root=root)
+    graph = build_symbol_graph(paths_dict, resolvers=resolvers, project_root=root)
 
     deps_by_base: dict[Path, list[SymbolNode]] = {base: [] for base in order_paths(paths_dict)}
     for node in graph.nodes:
@@ -431,14 +440,14 @@ def unused_exports(
     setup_logging(verbose)
     root = root.resolve()
 
-    paths_dict = resolve_paths(root, path or [], resolver or [])
+    paths_dict, resolvers = resolve_paths(root, path or [], resolver or [])
 
     typer.echo(f"Building symbol graph for {root}...", err=True)
     plugins = build_plugins(
         entrypoints=entrypoint or [],
         plugin_names=plugin or [],
     )
-    graph = build_symbol_graph(paths_dict, plugins=plugins, project_root=root)
+    graph = build_symbol_graph(paths_dict, plugins=plugins, resolvers=resolvers, project_root=root)
     reachable = find_reachable(graph)
 
     # ModuleDundersPlugin keeps each ``__all__`` alive via a synthetic
@@ -508,14 +517,14 @@ def remove(
     setup_logging(verbose)
     root = root.resolve()
 
-    paths_dict = resolve_paths(root, path or [], resolver or [])
+    paths_dict, resolvers = resolve_paths(root, path or [], resolver or [])
 
     typer.echo(f"Building symbol graph for {root}...", err=True)
     plugins = build_plugins(
         entrypoints=entrypoint or [],
         plugin_names=plugin or [],
     )
-    graph = build_symbol_graph(paths_dict, plugins=plugins, project_root=root)
+    graph = build_symbol_graph(paths_dict, plugins=plugins, resolvers=resolvers, project_root=root)
     reachable = find_reachable(graph)
 
     unreachable_graph = graph.subgraph([n for n in graph.nodes if n not in reachable])

--- a/dead_cst/cli.py
+++ b/dead_cst/cli.py
@@ -23,7 +23,13 @@ from ._plugins import (
 )
 from ._plugins._core import EXTERNAL_PREFIXES
 from ._plugins.module_dunders import DUNDER_PREFIX
-from ._resolvers import PathMap, PathResolver, load_resolver, merge_paths
+from ._resolvers import (
+    ManualResolver,
+    PathMap,
+    PathResolver,
+    load_resolver,
+    merge_paths,
+)
 from ._symbols import SymbolNode
 
 
@@ -82,40 +88,21 @@ def build_plugins(
 def resolve_paths(
     root: Path, path_specs: list[str], resolver_names: list[str]
 ) -> tuple[PathMap, list[PathResolver]]:
-    """Merge ``-p`` specs and ``--resolver`` outputs into a path map and resolver list.
+    """Build the resolver chain from ``-p`` specs and ``--resolver`` names.
 
-    Returns the merged :data:`PathMap` plus the resolver instances --
-    the analyzer threads the resolvers through so each one's
-    :meth:`PathResolver.resolve_import` participates in
-    ``name -> path`` lookups, not just its :meth:`resolve` output.
+    ``-p`` specs become a :class:`ManualResolver` and slot into the
+    chain alongside named resolvers, so explicit specs participate in
+    :meth:`PathResolver.resolve_import` lookups too. Returns the
+    merged :data:`PathMap` and the resolver instances; the analyzer
+    threads the latter through to govern import resolution.
     """
-    resolvers = [load_resolver(name) for name in resolver_names]
-    explicit = parse_paths(root, path_specs) if path_specs else {}
-    resolved_maps = [r.resolve(root) for r in resolvers]
-    if not explicit and not resolved_maps:
-        return {root: []}, resolvers
-    return merge_paths(explicit, *resolved_maps), resolvers
-
-
-def parse_paths(root: Path, paths_str: list[str]) -> PathMap:
-    """Parse path specifications into the paths dict format.
-
-    Format: "base:dep1,dep2,dep3" or just "base" for no dependencies.
-    """
-    if not paths_str:
-        return {root: []}
-
-    result = {}
-    for spec in paths_str:
-        if ":" in spec:
-            base_str, deps_str = spec.split(":", 1)
-            base = root / base_str
-            deps = [root / d.strip() for d in deps_str.split(",") if d.strip()]
-        else:
-            base = root / spec
-            deps = []
-        result[base] = deps
-    return result
+    resolvers: list[PathResolver] = []
+    if path_specs:
+        resolvers.append(ManualResolver(specs=path_specs))
+    resolvers.extend(load_resolver(name) for name in resolver_names)
+    if not resolvers:
+        return {root: []}, []
+    return merge_paths(*[r.resolve(root) for r in resolvers]), resolvers
 
 
 def version_callback(value: bool) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -154,12 +154,16 @@ def test_parse_paths(tmp_path, specs, expected_keys, expected_deps):
 
 
 def test_resolve_paths_no_specs_no_resolvers_returns_root(tmp_path):
-    assert resolve_paths(tmp_path, [], []) == {tmp_path: []}
+    paths, resolvers = resolve_paths(tmp_path, [], [])
+    assert paths == {tmp_path: []}
+    assert resolvers == []
 
 
 def test_resolve_paths_explicit_specs_only(tmp_path):
     (tmp_path / "src").mkdir()
-    assert resolve_paths(tmp_path, ["src"], []) == {tmp_path / "src": []}
+    paths, resolvers = resolve_paths(tmp_path, ["src"], [])
+    assert paths == {tmp_path / "src": []}
+    assert resolvers == []
 
 
 def test_resolve_paths_unknown_resolver_raises(tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,7 @@ from dead_cst._plugins import (
 from dead_cst._plugins._core import EXTERNAL_DIST_PREFIX
 from dead_cst._plugins.explicit import EXPLICIT_PREFIX
 from dead_cst._symbols import SymbolNode
+from dead_cst._resolvers import ManualResolver
 from dead_cst.cli import (
     _is_dunder_all,
     _is_external_dep,
@@ -38,7 +39,6 @@ from dead_cst.cli import (
     app,
     build_plugins,
     parse_entrypoint,
-    parse_paths,
     resolve_paths,
     setup_logging,
 )
@@ -112,8 +112,8 @@ def test_parse_entrypoint_re_prefix_with_empty_pattern():
     assert result.pattern == ""
 
 
-def test_parse_paths_empty_list_returns_root_only(tmp_path):
-    assert parse_paths(tmp_path, []) == {tmp_path: []}
+def test_manual_resolver_empty_specs(tmp_path):
+    assert ManualResolver(specs=[]).resolve(tmp_path) == {}
 
 
 @pytest.mark.parametrize(
@@ -146,8 +146,8 @@ def test_parse_paths_empty_list_returns_root_only(tmp_path):
         ),
     ],
 )
-def test_parse_paths(tmp_path, specs, expected_keys, expected_deps):
-    result = parse_paths(tmp_path, specs)
+def test_manual_resolver_parses_specs(tmp_path, specs, expected_keys, expected_deps):
+    result = ManualResolver(specs=specs).resolve(tmp_path)
     assert list(result) == [tmp_path / k for k in expected_keys]
     for key, deps in expected_deps.items():
         assert result[tmp_path / key] == [tmp_path / d for d in deps]
@@ -163,7 +163,9 @@ def test_resolve_paths_explicit_specs_only(tmp_path):
     (tmp_path / "src").mkdir()
     paths, resolvers = resolve_paths(tmp_path, ["src"], [])
     assert paths == {tmp_path / "src": []}
-    assert resolvers == []
+    # ``-p`` flows through a ManualResolver so its ``resolve_import``
+    # is part of the chain alongside any named resolvers.
+    assert [r.name for r in resolvers] == ["manual"]
 
 
 def test_resolve_paths_unknown_resolver_raises(tmp_path):


### PR DESCRIPTION
Implements the "Resolver logic as a protocol" item from the roadmap.

## Summary

- `PathResolver` gains a `resolve_import(name, search_paths) -> str | Path | None` method, folding `name -> path` lookup into the resolver alongside search-path discovery. Custom resolvers can now override import resolution for their own layouts (vendored deps, `.pyi` siblings, ...) without monkey-patching internals.
- The default `sys.path` + `importlib` implementation moves from the old `_resolve.py` into `dead_cst._resolvers._imports.default_resolve_import`. Shipped resolvers (`PyprojectResolver`, `UvWorkspaceResolver`, `VenvResolver`) all delegate to it.
- New `ManualResolver` wraps the CLI's `-p base:dep1,dep2` specs in a first-class `PathResolver`, so explicit specs sit in the same chain as named resolvers and participate in `resolve_import` lookups too. `-p` and `--resolver` stay composable.
- `build_symbol_graph` accepts a new `resolvers=` keyword; entries' `resolve_import` methods are tried in order, first non-`None` wins. With no resolvers it falls back to `default_resolve_import`, preserving today's behavior.
- The CLI threads loaded resolvers through to the analyzer so `--resolver` (and `-p`) selections govern import lookup, not just search paths.
- Renamed `dead_cst._resolve` to `dead_cst._edges` — resolution now lives under `dead_cst._resolvers/`, and what's left is purely edge construction in the symbol trie. Roadmap and CHANGELOG updated.

## Test plan

- [x] `pytest` (508 passed)
- [x] `ruff check` and `ruff format --check`
- [x] `ty check`
- [x] Manual smoke: `default_resolve_import("os", [])` → `[stdlib] os`; `default_resolve_import("libcst", [])` → `[external dist] libcst`
- [x] Confirmed every shipped resolver class still satisfies `isinstance(inst, PathResolver)` after the protocol change

https://claude.ai/code/session_01S4bAEu5wKQxmYFxVcQrFFN