### PR TITLE
Fix MainBlockPlugin missing edges for decls bound inside `__main__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ two versions.
 
 ## [Unreleased]
 
+### Fixed
+- `MainBlockPlugin` now keeps decls bound inside the
+  `if __name__ == "__main__":` block alive, not just the containing
+  module. Previously a top-level decl introduced by an assignment in
+  the block (e.g. `app = Foo(fn=main).cli()`) had no incoming edge --
+  the visitor's value-frame produced `app -> Foo` / `app -> main`, but
+  nothing pointed at `app` itself -- so the chain was unreachable and
+  `Foo` / `main` were reported dead. The plugin now resolves the
+  block's `CodeRange` via `PositionProvider` and emits `synth -> decl`
+  edges for every top-level decl whose binding site falls inside the
+  block.
+
 ## [0.1.0] - 2026-04-28
 
 Initial alpha release. `dead-cst` is pre-1.0 software: the public Python API,

--- a/dead_cst/_plugins/main_block.py
+++ b/dead_cst/_plugins/main_block.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Iterable
 
 import libcst as cst
+from libcst.metadata import CodePosition, CodeRange, PositionProvider
 
 from ._core import GraphOp, PluginContext, is_name, mark_entrypoints
 
@@ -16,14 +17,23 @@ MAIN_BLOCK_PREFIX = "<__main__>:"
 class MainBlockPlugin:
     """Treat ``if __name__ == "__main__":`` blocks as entrypoints.
 
-    For each module that contains a top-level ``if __name__ == "__main__":``
-    block, emit a synthetic entrypoint node with an edge to the containing
-    module. The module's existing internal edges (collected by the regular
-    visitor) then keep every symbol referenced in the block reachable.
+    For each module containing a top-level ``if __name__ == "__main__":``
+    block, emit a synthetic entrypoint with edges to (a) the containing
+    module and (b) every top-level decl whose binding site falls inside
+    the block's source range.
 
-    There's no useful import-based prefilter here, but the parsed modules
-    are already in the per-base cache, so iterating every module is
-    effectively free.
+    Why both: the visitor records ``module -> referent`` edges for bare
+    references inside the block (so ``main()`` keeps ``main`` alive via
+    the module edge alone). But assignments like
+    ``app = Foo(fn=main).cli()`` register ``app`` as a top-level decl
+    whose value frame produces ``app -> Foo`` / ``app -> main`` -- and
+    ``app`` itself has no incoming reference. Without a direct
+    ``synth -> app`` edge that chain stays unreachable and ``Foo`` /
+    ``main`` look dead.
+
+    There's no useful import-based prefilter here, but the parsed
+    modules are already in the per-base cache, so iterating every
+    module is effectively free.
     """
 
     name: str = "main_block"
@@ -31,20 +41,41 @@ class MainBlockPlugin:
     def contribute(self, ctx: PluginContext) -> Iterable[GraphOp]:
         for path, module_node in ctx.base_modules():
             module = ctx.parse(path)
-            if module is None or not _has_main_block(module):
+            if module is None:
                 continue
+            main_block = _find_main_block(module)
+            if main_block is None:
+                continue
+            block_range = cst.MetadataWrapper(module, unsafe_skip_copy=True).resolve(
+                PositionProvider
+            )[main_block]
+            block_decls = [
+                node
+                for node in ctx.base_nodes()
+                if node.path == path
+                and node.type in ("class", "function", "variable", "import")
+                and _range_contains(block_range, node.position)
+            ]
             yield from mark_entrypoints(
-                f"{MAIN_BLOCK_PREFIX}{module_node.fqname}", path, [module_node]
+                f"{MAIN_BLOCK_PREFIX}{module_node.fqname}",
+                path,
+                [module_node, *block_decls],
             )
 
 
-def _has_main_block(module: cst.Module) -> bool:
+def _find_main_block(module: cst.Module) -> cst.If | None:
     for stmt in module.body:
-        if not isinstance(stmt, cst.If):
-            continue
-        if _is_name_eq_main(stmt.test):
-            return True
-    return False
+        if isinstance(stmt, cst.If) and _is_name_eq_main(stmt.test):
+            return stmt
+    return None
+
+
+def _range_contains(outer: CodeRange, inner: CodeRange) -> bool:
+    return _le(outer.start, inner.start) and _le(inner.end, outer.end)
+
+
+def _le(a: CodePosition, b: CodePosition) -> bool:
+    return (a.line, a.column) <= (b.line, b.column)
 
 
 def _is_name_eq_main(expr: cst.BaseExpression) -> bool:

--- a/tests/test_plugins/test_main_block.py
+++ b/tests/test_plugins/test_main_block.py
@@ -32,6 +32,66 @@ def test_main_block_plugin_marks_module_entrypoint(tmp_path, write_files, reacha
     assert "pkg.other" not in reached
 
 
+def test_main_block_keeps_block_decls_alive(tmp_path, write_files, reachable_fqnames):
+    # ``app`` is bound inside the block but never read elsewhere in the
+    # module, so the only edges pointing in are the visitor's
+    # ``app -> Foo`` / ``app -> main`` from the assignment frame. Without
+    # a direct ``synth -> app`` edge from the plugin, the chain is
+    # unreachable and ``Foo`` / ``main`` look dead.
+    write_files(
+        {
+            "pkg/__init__.py": "",
+            "pkg/script.py": """
+            def main(): ...
+
+            class Foo:
+                def __init__(self, fn): self.fn = fn
+                def cli(self): return self
+
+            class Unused: ...
+
+            if __name__ == "__main__":
+                app = Foo(fn=main).cli()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    assert {"pkg.script", "pkg.script.app", "pkg.script.Foo", "pkg.script.main"} <= reached
+    assert "pkg.script.Unused" not in reached
+
+
+def test_main_block_keeps_nested_block_decls_alive(tmp_path, write_files, reachable_fqnames):
+    # Nested compound statements inside the main block still hold
+    # top-level decls (the visitor doesn't push a frame for if/for/with),
+    # so position-based filtering catches them too.
+    write_files(
+        {
+            "pkg/__init__.py": "",
+            "pkg/script.py": """
+            class Foo: ...
+            class Unused: ...
+
+            if __name__ == "__main__":
+                if True:
+                    app = Foo()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    assert {"pkg.script.app", "pkg.script.Foo"} <= reached
+    assert "pkg.script.Unused" not in reached
+
+
 def test_main_block_reversed_comparison(tmp_path, write_files, reachable_fqnames):
     write_files(
         {


### PR DESCRIPTION
## Summary

`MainBlockPlugin` previously emitted only `synth → module` and relied on
the visitor's internal edges to propagate liveness into the
`if __name__ == "__main__":` block. That covers bare references
(`main()` is owned by the module via `nearest_decls`, so `module → main`
already exists), but it misses the case where the block introduces a
new top-level decl that nothing else reads:

```python
def main(): ...

class Foo:
    def __init__(self, fn): self.fn = fn
    def cli(self): return self

if __name__ == "__main__":
    app = Foo(fn=main).cli()
```

The visitor records `app` as a top-level variable (the `if` doesn't push
a decl frame, so `_add_variable` runs at depth 1) and pushes `[app]`
over the RHS, producing `app → Foo` and `app → main`. But `app` itself
is never read — so nothing points at it, the chain stays unreachable,
and `Foo` / `main` get reported as dead. Same shape applies to anything
bound inside the block whose name isn't read elsewhere in the module
(imports, function/class defs, etc.).

## Fix

Resolve the block's `CodeRange` once via `PositionProvider`, then emit
`synth → decl` for every node in `ctx.base_nodes()` whose `path`
matches the module and whose stored `position` falls inside that range
(types `class` / `function` / `variable` / `import`). The synth seed
already exists for the module edge; we just extend its target list.

After the fix, the buggy snippet's reachable set is
`{pkg, pkg.script, pkg.script.app, pkg.script.Foo, pkg.script.main}`
and an `Unused` class in the same file stays dead.

## Test plan

- [x] New `test_main_block_keeps_block_decls_alive` — covers the
      `app = Foo(fn=main).cli()` shape.
- [x] New `test_main_block_keeps_nested_block_decls_alive` — covers
      decls bound inside a nested compound statement (`if True:`)
      within the `__main__` block.
- [x] Existing `test_main_block_plugin_marks_module_entrypoint` and
      `test_main_block_reversed_comparison` still pass.
- [x] Full suite green (510 passed), `ruff` and `ty` clean.
- [x] CHANGELOG entry under `[Unreleased] / Fixed`.

https://claude.ai/code/session_01XeStY4VCE6Pi66pzTUesHC