### PR TITLE
Refactor visitor output into a unified VisitorPayload

### DIFF
--- a/dead_cst/__init__.py
+++ b/dead_cst/__init__.py
@@ -7,8 +7,10 @@ entrypoints.
 The public API has three layers:
 
 * :func:`build_symbol_graph` parses every ``.py`` file under each base in a
-  ``{base: [dep_paths]}`` map and returns a :class:`networkx.DiGraph` of
-  :class:`SymbolNode` instances. Edges encode "keeps alive" relationships.
+  ``{base: [dep_paths]}`` map and returns a :class:`networkx.MultiDiGraph` of
+  :class:`SymbolNode` instances. Edges encode "keeps alive" relationships
+  and carry a :class:`EdgeFlags` ``flags`` attribute. References from
+  inside statically-dead suites are flagged ``DEAD_BRANCH``.
 * Edge plugins (:class:`MainBlockPlugin`, :class:`ProjectScriptsPlugin`,
   :class:`ExplicitEntrypointPlugin`, :class:`ModuleDundersPlugin`,
   :class:`PytestPlugin`, :class:`UnittestPlugin`, :class:`FastAPIPlugin`,
@@ -29,8 +31,15 @@ See the README for the CLI, the entrypoint and search-path specs, and the
 limitations of static analysis.
 """
 
-from ._analyze import build_symbol_graph, count_nodes, find_reachable, order_paths
+from ._analyze import (
+    build_symbol_graph,
+    count_nodes,
+    find_kept_alive_by_dead_branches,
+    find_reachable,
+    order_paths,
+)
 from ._codemod import remove_code
+from ._symbols import EdgeFlags, NodeFlags
 from ._plugins import (
     AddEdge,
     AddNode,
@@ -71,6 +80,7 @@ __all__ = [
     "BUILTIN_PLUGINS",
     "BUILTIN_RESOLVERS",
     "ClickPlugin",
+    "EdgeFlags",
     "EdgePlugin",
     "ExplicitEntrypointPlugin",
     "FastAPIPlugin",
@@ -80,6 +90,7 @@ __all__ = [
     "MainBlockPlugin",
     "ManualResolver",
     "ModuleDundersPlugin",
+    "NodeFlags",
     "PathResolver",
     "PluginContext",
     "ProjectScriptsPlugin",
@@ -92,6 +103,7 @@ __all__ = [
     "VenvResolver",
     "build_symbol_graph",
     "count_nodes",
+    "find_kept_alive_by_dead_branches",
     "find_reachable",
     "load_plugin",
     "load_resolver",

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -6,7 +6,7 @@ from typing import Sequence
 
 import libcst as cst
 import networkx as nx
-from libcst.metadata import FullRepoManager
+from libcst.metadata import CodeRange, FullRepoManager
 
 from ._edges import resolve_edges
 from ._fqn import FixedFullyQualifiedNameProvider
@@ -23,8 +23,8 @@ from ._resolvers import (
     exported_roots,
 )
 from ._resolvers._imports import safe_resolve_module, temp_sys_path
-from ._symbols import SymbolNode, SymbolTrie
-from ._visitor import SymbolVisitor
+from ._symbols import EdgeFlags, Import, NodeFlags, SymbolNode, SymbolTrie
+from ._visitor import SymbolVisitor, VisitorPayload
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,7 @@ def build_symbol_graph(
     plugins: Sequence[EdgePlugin] = (),
     resolvers: Sequence[PathResolver] = (),
     project_root: Path | None = None,
-) -> nx.DiGraph:
+) -> nx.MultiDiGraph:
     """Build a directed reachability graph of every top-level symbol under ``paths``.
 
     Each ``.py`` file under each base in ``paths`` is parsed with LibCST;
@@ -87,11 +87,15 @@ def build_symbol_graph(
     relationships:
 
     * a reference points at its referent,
-    * a declaration points at its containing module,
-    * a submodule points at its parent package, and
-    * synthetic ``unreachable`` nodes own edges into symbols referenced from
-      statically-dead suites (``if False:``, ``raise``-only branches, ...) so
-      those references don't keep the targets alive.
+    * a declaration points at its containing module, and
+    * a submodule points at its parent package.
+
+    References made from inside a statically-dead suite are still emitted
+    but tagged with :data:`EdgeFlags.DEAD_BRANCH`. Default
+    :func:`find_reachable` does not filter on the flag, so those refs
+    still propagate liveness through the enclosing decl. The opt-in
+    :func:`find_kept_alive_by_dead_branches` returns the set of symbols
+    that would become unreachable if every dead suite were removed.
 
     Third-party imports are surfaced as synthetic ``[external dist] <name>``
     / ``[external file] <name>`` nodes so callers can audit the
@@ -126,11 +130,16 @@ def build_symbol_graph(
 
     Returns
     -------
-    networkx.DiGraph
-        Nodes are :class:`SymbolNode` instances; entrypoint seeds carry
-        ``graph.nodes[node]["entrypoint"] = True``.
+    networkx.MultiDiGraph
+        Nodes are :class:`SymbolNode` instances. Edges carry a ``flags``
+        attribute (:class:`EdgeFlags`); ``DEAD_BRANCH``-flagged edges
+        originated inside a statically-dead suite. Entrypoint seeds
+        carry ``graph.nodes[node]["entrypoint"] = True``. Per-file
+        dead-suite positions are exposed via ``graph.graph["dead_suites"]``,
+        a ``{path: tuple[CodeRange]}`` mapping.
     """
-    symbol_graph = nx.DiGraph()
+    symbol_graph = nx.MultiDiGraph()
+    symbol_graph.graph["dead_suites"] = {}
     base_tries: dict[Path, SymbolTrie] = {}
     export_tries: dict[Path, SymbolTrie] = {}
     root = project_root or _infer_project_root(paths) if paths else Path.cwd()
@@ -143,7 +152,7 @@ def build_symbol_graph(
             base_tries[base] = current_trie = SymbolTrie()
             export_trie = SymbolTrie()
             export_roots = exported_roots(base)
-            import_edges = set()
+            import_edges: set[tuple[SymbolNode, Import, EdgeFlags]] = set()
             files = list(sorted(base.rglob("*.py")))
             mgr = FullRepoManager(
                 str(base), [str(f) for f in files], {FixedFullyQualifiedNameProvider}
@@ -157,6 +166,7 @@ def build_symbol_graph(
                     base_modules[file] = wrapper.module
                 visitor = SymbolVisitor(file, search_paths, import_resolver)
                 wrapper.visit(visitor)
+                payload = visitor.to_payload()
                 # A file's decls go into ``export_trie`` only when the file
                 # lives under one of ``base``'s exported dirs (or when the
                 # base has no export restriction). This is what hides
@@ -165,45 +175,14 @@ def build_symbol_graph(
                 # land in ``current_trie`` and the graph), but consumers'
                 # lookup tries never see them.
                 file_exported = export_roots is None or _under_any(file, export_roots)
-                curr = [visitor.trie]
-                while curr:
-                    node = curr.pop()
-                    if node.module is not None:
-                        symbol_graph.add_node(node.module)
-                        current_trie.add_declaration(node.module)
-                        if file_exported:
-                            export_trie.add_declaration(node.module)
-                    for decls in node.declarations.values():
-                        for decl in decls:
-                            symbol_graph.add_node(decl)
-                            symbol_graph.add_edge(decl, node.module)
-                            current_trie.add_declaration(decl)
-                            if file_exported:
-                                export_trie.add_declaration(decl)
-                    # Shadowed decls still belong to this module: emit them
-                    # so the graph stays well-formed (every decl has a
-                    # parent-module edge). They aren't re-added to
-                    # ``current_trie`` -- only live-at-exit decls should
-                    # win project-wide lookups.
-                    for decl in node.shadowed:
-                        symbol_graph.add_node(decl)
-                        symbol_graph.add_edge(decl, node.module)
-                    curr.extend(node.children.values())
-
-                for src, dst in visitor.internal_edges:
-                    symbol_graph.add_edge(src, dst)
-
-                # Synthetic ``unreachable`` nodes for statically-dead suites.
-                # They live in the graph as orphan sources -- nothing points
-                # at them, so reachability never visits them, but the edges
-                # they own surface which symbols are referenced from inside
-                # dead branches. Existing top-level decl edges are unchanged.
-                for unreachable in visitor.unreachable_nodes:
-                    symbol_graph.add_node(unreachable)
-                for src, dst in visitor.unreachable_internal_edges:
-                    symbol_graph.add_edge(src, dst)
-
-                import_edges |= visitor.import_edges | visitor.unreachable_import_edges
+                _apply_payload(
+                    payload,
+                    current_trie=current_trie,
+                    export_trie=export_trie,
+                    file_exported=file_exported,
+                    symbol_graph=symbol_graph,
+                    import_edges=import_edges,
+                )
 
             current_trie.add_module_hierarchy_edges(symbol_graph)
             export_tries[base] = export_trie
@@ -218,8 +197,8 @@ def build_symbol_graph(
             for dep in paths.get(base, []):
                 symbol_lookup.merge(export_tries.get(dep, base_tries[dep]))
 
-            for src, dst in resolve_edges(import_edges, symbol_lookup, base):
-                symbol_graph.add_edge(src, dst)
+            for src, dst, flags in resolve_edges(import_edges, symbol_lookup, base):
+                symbol_graph.add_edge(src, dst, flags=flags)
 
             # Plugin pass for this base, with the symbol lookup that was
             # valid at this base's resolution time and the parsed modules
@@ -248,6 +227,81 @@ def build_symbol_graph(
     return symbol_graph
 
 
+def _contains(suite: CodeRange, access: CodeRange) -> bool:
+    """``True`` iff ``access`` is fully nested inside ``suite``.
+
+    Compares ``(line, column)`` lexicographically at both ends. Suites
+    are line-aligned in practice (libcst positions an ``IndentedBlock``
+    at its first statement) so the line check usually decides; the
+    column tiebreak handles one-line ``if False: x = 1`` suites.
+    """
+    s_start = (suite.start.line, suite.start.column)
+    s_end = (suite.end.line, suite.end.column)
+    a_start = (access.start.line, access.start.column)
+    a_end = (access.end.line, access.end.column)
+    return s_start <= a_start and a_end <= s_end
+
+
+def _apply_payload(
+    payload: VisitorPayload,
+    *,
+    current_trie: SymbolTrie,
+    export_trie: SymbolTrie,
+    file_exported: bool,
+    symbol_graph: nx.MultiDiGraph,
+    import_edges: set[tuple[SymbolNode, Import, EdgeFlags]],
+) -> None:
+    """Emit ``payload`` into the in-progress per-base structures.
+
+    Drives all node routing off ``SymbolNode.flags`` and ``type``:
+
+    * ``type == "module"`` goes into the graph and the trie; no parent
+      edge (modules are themselves the parent target).
+    * Other decls go into the graph with a parent-module edge.
+      ``NodeFlags.SHADOWED`` excludes them from the trie -- the graph
+      keeps the parent edge so the decl stays well-formed, but
+      cross-module imports never resolve to it.
+
+    Edge flag derivation: each ``(src, dst, access_pos)`` entry has
+    its access position tested against ``payload.dead_suites`` for
+    containment. If matched, the resulting graph edge gets
+    :data:`EdgeFlags.DEAD_BRANCH`. Unresolved cross-file imports
+    accumulate into ``import_edges`` along with the derived flag and
+    are fed to :func:`resolve_edges` once the per-base trie is fully
+    built; resolution preserves the flag through every emission.
+
+    Per-file dead-suite positions are stashed on the graph as
+    ``graph.graph["dead_suites"][module.path]`` for downstream
+    reporting (e.g. "this file has unreachable code at line X").
+    """
+    module = next(n for n in payload.nodes if n.type == "module")
+
+    def flag_for(pos: CodeRange) -> EdgeFlags:
+        return (
+            EdgeFlags.DEAD_BRANCH
+            if any(_contains(s, pos) for s in payload.dead_suites)
+            else EdgeFlags.NONE
+        )
+
+    for n in payload.nodes:
+        symbol_graph.add_node(n)
+        if n.type != "module":
+            symbol_graph.add_edge(n, module, flags=EdgeFlags.NONE)
+        if not (n.flags & NodeFlags.SHADOWED):
+            current_trie.add_declaration(n)
+            if file_exported:
+                export_trie.add_declaration(n)
+
+    for src, dst, pos in payload.edges:
+        symbol_graph.add_edge(src, dst, flags=flag_for(pos))
+
+    for src, imp, pos in payload.imports:
+        import_edges.add((src, imp, flag_for(pos)))
+
+    if payload.dead_suites:
+        symbol_graph.graph["dead_suites"][module.path] = payload.dead_suites
+
+
 def _under_any(file: Path, roots: list[Path]) -> bool:
     """True iff ``file`` is equal to or nested under any of ``roots``."""
     f = file.resolve()
@@ -264,13 +318,18 @@ def _infer_project_root(paths: PathMap) -> Path:
     return min(bases, key=lambda p: len(p.parts))
 
 
-def find_reachable(graph: nx.DiGraph) -> set[SymbolNode]:
+def find_reachable(graph: nx.MultiDiGraph) -> set[SymbolNode]:
     """BFS forward from every node tagged as an entrypoint by a plugin.
 
     Plugins mark seeds by setting ``graph.nodes[node]["entrypoint"] = True``
     (see :func:`dead_cst._plugins.apply_ops`). There is no longer any
     built-in matching against file paths or FQNs -- that lives in
     :class:`ExplicitEntrypointPlugin`.
+
+    Edges flagged with :data:`EdgeFlags.DEAD_BRANCH` are NOT filtered
+    here -- today's behavior, where dead-code references propagate
+    liveness through the enclosing decl, is preserved. See
+    :func:`find_kept_alive_by_dead_branches` for the strict alternative.
     """
     visited: set[SymbolNode] = set()
     stack = [n for n, attrs in graph.nodes(data=True) if attrs.get("entrypoint")]
@@ -283,7 +342,40 @@ def find_reachable(graph: nx.DiGraph) -> set[SymbolNode]:
     return visited
 
 
-def count_nodes(graph: nx.DiGraph, prefix: Path | None) -> dict[str, int]:
+def _find_reachable_strict(graph: nx.MultiDiGraph) -> set[SymbolNode]:
+    """Like :func:`find_reachable` but skips ``DEAD_BRANCH``-flagged edges."""
+    visited: set[SymbolNode] = set()
+    stack = [n for n, attrs in graph.nodes(data=True) if attrs.get("entrypoint")]
+    while stack:
+        node = stack.pop()
+        if node in visited:
+            continue
+        visited.add(node)
+        for _, succ, attrs in graph.out_edges(node, data=True):
+            if attrs.get("flags", EdgeFlags.NONE) & EdgeFlags.DEAD_BRANCH:
+                continue
+            stack.append(succ)
+    return visited
+
+
+def find_kept_alive_by_dead_branches(graph: nx.MultiDiGraph) -> set[SymbolNode]:
+    """Return symbols that would become unreachable if every dead suite were removed.
+
+    Computed as ``find_reachable(graph) -`` strict-mode BFS that skips
+    every edge flagged :data:`EdgeFlags.DEAD_BRANCH`. The resulting set
+    is the "blast radius" of removing every statically-dead suite in
+    the analyzed source -- symbols currently kept alive only through a
+    chain that crosses at least one dead-branch reference.
+
+    Used by tooling that reports "if you removed your unreachable
+    code, these additional symbols would also become dead." Default
+    :func:`find_reachable` is unchanged; this is an opt-in stricter
+    pass.
+    """
+    return find_reachable(graph) - _find_reachable_strict(graph)
+
+
+def count_nodes(graph: nx.MultiDiGraph, prefix: Path | None) -> dict[str, int]:
     """Count nodes in ``graph`` by ``SymbolNode.type``, optionally restricted by path.
 
     If ``prefix`` is given, only nodes whose ``path`` is under ``prefix`` are

--- a/dead_cst/_branches.py
+++ b/dead_cst/_branches.py
@@ -2,7 +2,8 @@
 
 Determines, when possible, whether the truthiness of an expression is
 statically known. Used to identify dead branches of ``if`` / ``while``
-statements so callers can prune references that live inside them.
+statements so callers can mark references that live inside them with
+:data:`dead_cst._symbols.EdgeFlags.DEAD_BRANCH`.
 
 Only handles a small whitelist of literal forms: the ``True`` /
 ``False`` / ``None`` keywords, integer / string literals,
@@ -11,24 +12,13 @@ over those. Anything involving a name lookup (other than the three
 keywords), attribute access, function call, comparison, or other
 dynamic operation returns ``None`` (unknown). Returning ``None`` is
 always the safe default: callers must treat the branch as live.
-
-This module also owns the convention for synthetic graph nodes that
-represent dead suites. The nodes have ``type="synthetic"`` (the
-existing escape hatch in :mod:`dead_cst._symbols`) and a fqname
-prefixed with :data:`UNREACHABLE_PREFIX` (``<unreachable>:``).
-``is_unreachable_node`` is the single source of truth for that
-convention; consumers should never check the prefix string themselves.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Sequence
 
 import libcst as cst
-from libcst.metadata import CodeRange
-
-from ._symbols import SymbolNode
 
 
 _KEYWORDS: dict[str, bool] = {
@@ -36,8 +26,6 @@ _KEYWORDS: dict[str, bool] = {
     "False": False,
     "None": False,
 }
-
-UNREACHABLE_PREFIX = "<unreachable>:"
 
 
 def evaluate_truthiness(node: cst.BaseExpression) -> bool | None:
@@ -164,40 +152,3 @@ def _unreachable_in_if(node: cst.If, branch_taken: bool) -> list[cst.BaseSuite]:
         return dead
     dead.extend(_unreachable_in_if(orelse, next_taken))
     return dead
-
-
-def make_unreachable_fqname(module_fqname: str, position: CodeRange) -> str:
-    """Build the fqname for the synthetic node representing a dead suite.
-
-    The format is intentionally fixed: callers should use
-    :func:`is_unreachable_node` to identify these nodes rather than
-    string-matching on their fqnames.
-    """
-    return f"{UNREACHABLE_PREFIX}{module_fqname}:{position.start.line}:{position.start.column}"
-
-
-def make_unreachable_node(module_fqname: str, path: Path, position: CodeRange) -> SymbolNode:
-    """Build the synthetic ``SymbolNode`` for a dead suite.
-
-    Reuses ``type="synthetic"`` -- the existing escape hatch for graph
-    nodes that don't correspond to a top-level declaration -- and
-    distinguishes itself by carrying a real source ``position`` (rather
-    than the ``SYNTHETIC_POSITION`` sentinel used by entrypoint plugins)
-    plus the :data:`UNREACHABLE_PREFIX` fqname prefix.
-    """
-    return SymbolNode(
-        fqname=make_unreachable_fqname(module_fqname, position),
-        type="synthetic",
-        path=path,
-        position=position,
-    )
-
-
-def is_unreachable_node(sym: SymbolNode) -> bool:
-    """Predicate: ``True`` iff ``sym`` is a synthetic dead-suite node.
-
-    The only supported way to identify these nodes. Callers should not
-    string-match on the fqname directly; the prefix is an implementation
-    detail of this module.
-    """
-    return sym.type == "synthetic" and sym.fqname.startswith(UNREACHABLE_PREFIX)

--- a/dead_cst/_edges.py
+++ b/dead_cst/_edges.py
@@ -1,12 +1,17 @@
 """Stitch resolved imports into ``src -> dst`` edges in the symbol graph.
 
-The visitor pass produces ``(src, Import)`` pairs where ``Import.path``
-is whatever a :class:`~dead_cst._resolvers.PathResolver` returned for
-the imported name. :func:`resolve_edges` walks those pairs against the
-already-built per-base :class:`SymbolTrie` and yields the concrete
-``(src_symbol, dst_symbol)`` edges -- following re-exports, fanning
-star imports out to every top-level decl in the target module, and
-emitting synthetic nodes for stdlib / external / unresolved targets.
+The visitor pass produces ``(src, Import, flags)`` triples where
+``Import.path`` is whatever a :class:`~dead_cst._resolvers.PathResolver`
+returned for the imported name and ``flags`` is the
+:class:`~dead_cst._symbols.EdgeFlags` value the apply step derived from
+the access position. :func:`resolve_edges` walks those triples against
+the already-built per-base :class:`SymbolTrie` and yields the concrete
+``(src_symbol, dst_symbol, flags)`` triples -- following re-exports,
+fanning star imports out to every top-level decl in the target module,
+and emitting synthetic nodes for stdlib / external / unresolved
+targets. The flag is preserved through every emission so the original
+"this reference came from a dead suite" attribution survives
+resolution.
 
 The ``name -> path`` half of resolution lives in
 :mod:`dead_cst._resolvers._imports`; this module is purely about edge
@@ -23,31 +28,31 @@ from ._plugins._core import (
     SYNTHETIC_PATH_PREFIXES,
     synthetic_node,
 )
-from ._symbols import Import, SymbolNode, SymbolTrie
+from ._symbols import EdgeFlags, Import, SymbolNode, SymbolTrie
 
 logger = logging.getLogger(__name__)
 
 
 def resolve_edges(
-    import_edges: set[tuple[SymbolNode, Import]],
+    import_edges: set[tuple[SymbolNode, Import, EdgeFlags]],
     symbol_lookup: SymbolTrie,
     base: Path,
-) -> Generator[tuple[SymbolNode, SymbolNode], None, None]:
-    emitted: set[tuple[SymbolNode, SymbolNode]] = set()
+) -> Generator[tuple[SymbolNode, SymbolNode, EdgeFlags], None, None]:
+    emitted: set[tuple[SymbolNode, SymbolNode, EdgeFlags]] = set()
 
     def _emit(
-        src: SymbolNode, dst: SymbolNode
-    ) -> Generator[tuple[SymbolNode, SymbolNode], None, None]:
-        key = (src, dst)
+        src: SymbolNode, dst: SymbolNode, flags: EdgeFlags
+    ) -> Generator[tuple[SymbolNode, SymbolNode, EdgeFlags], None, None]:
+        key = (src, dst, flags)
         if key in emitted:
             return
         emitted.add(key)
         yield key
 
-    for src, dst in import_edges:
+    for src, dst, flags in import_edges:
         if not isinstance(dst.path, Path):
             if dst.path.startswith(SYNTHETIC_PATH_PREFIXES):
-                yield from _emit(src, synthetic_node(dst.path, base))
+                yield from _emit(src, synthetic_node(dst.path, base), flags)
             continue
 
         node = symbol_lookup._get(dst.module.split("."))
@@ -55,13 +60,13 @@ def resolve_edges(
             logger.warning("Failed to resolve import module: %s", dst.module)
             continue
 
-        yield from _emit(src, node.module)
+        yield from _emit(src, node.module, flags)
 
         # Star import: fan out to every top-level declaration in the target module
         if dst.star:
             for decls in node.declarations.values():
                 for decl in decls:
-                    yield from _emit(src, decl)
+                    yield from _emit(src, decl, flags)
             continue
 
         # No decl? the edge points at a module
@@ -83,7 +88,7 @@ def resolve_edges(
             decls = cur.declarations.get(part, [])
             if decls:
                 for decl in decls:
-                    yield from _emit(src, decl)
+                    yield from _emit(src, decl, flags)
 
                     # Concrete decl terminates this continuation;
                     # trailing attrs like ``.build`` are ignored.
@@ -98,7 +103,7 @@ def resolve_edges(
 
                     if not isinstance(decl.imports.path, Path):
                         if decl.imports.path.startswith(SYNTHETIC_PATH_PREFIXES):
-                            yield from _emit(src, synthetic_node(decl.imports.path, base))
+                            yield from _emit(src, synthetic_node(decl.imports.path, base), flags)
                         continue
 
                     dest = symbol_lookup._get(decl.imports.module.split("."))

--- a/dead_cst/_symbols.py
+++ b/dead_cst/_symbols.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import enum
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -9,6 +10,34 @@ import networkx as nx
 from libcst.metadata import CodeRange
 
 logger = logging.getLogger(__name__)
+
+
+class NodeFlags(enum.IntFlag):
+    """Analyzer-internal marker on :class:`SymbolNode`.
+
+    ``SHADOWED`` decls are emitted into the graph (with their parent
+    module edge) but are excluded from the lookup trie, so cross-module
+    imports never resolve to them.
+    """
+
+    NONE = 0
+    SHADOWED = enum.auto()
+
+
+class EdgeFlags(enum.IntFlag):
+    """Analyzer-internal marker on graph edges.
+
+    ``DEAD_BRANCH`` flags an edge whose reference originated inside a
+    statically-dead suite (per :func:`dead_cst._branches.unreachable_suites`).
+    Default :func:`dead_cst.find_reachable` does **not** filter by this
+    flag -- today's behavior, where dead-code references propagate
+    liveness through the enclosing decl, is preserved. The opt-in
+    :func:`dead_cst.find_kept_alive_by_dead_branches` returns the
+    "blast radius" of removing every dead suite by skipping these edges.
+    """
+
+    NONE = 0
+    DEAD_BRANCH = enum.auto()
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,6 +55,7 @@ class SymbolNode:
     path: Path
     position: CodeRange
     imports: Import | None = None
+    flags: NodeFlags = NodeFlags.NONE
 
 
 @dataclass(slots=True)
@@ -45,24 +75,19 @@ class SymbolTrie:
     # set of decls live at module exit: usually one decl, but multiple when
     # every branch of a conditional binds the same name (``if X: def f...
     # else: def f...``). All branches are legitimate runtime values and a
-    # ``from mod import name`` should reach each of them.
+    # ``from mod import name`` should reach each of them. Decls displaced
+    # before module exit are tagged with ``NodeFlags.SHADOWED`` and tracked
+    # outside the trie -- the trie only stores entries that should be
+    # reachable from cross-module imports.
     declarations: dict[str, list[SymbolNode]] = field(default_factory=dict)
-
-    # Decls strictly displaced by a later same-name decl on every path to
-    # module exit. They still belong to this module -- the symbol graph
-    # needs them so the ``decl -> module`` parent edge is emitted for
-    # shadowed decls too -- but they are not exported.
-    shadowed: list[SymbolNode] = field(default_factory=list)
 
     def add_declaration(self, decl: SymbolNode) -> None:
         """Add a declaration to the trie.
 
-        For non-module decls this just collects: the trie does not yet
-        know which decls are live at module exit. ``finalize_declarations``
-        partitions same-name decls into ``declarations`` (live exports)
-        and ``shadowed`` (strictly displaced). De-duplicates so the
-        visitor's double-push for ``Assign`` (one push for the LHS name,
-        one for the RHS value) does not register the same decl twice.
+        Decls flagged ``SHADOWED`` should never reach this method; the
+        visitor flags them and routes them around the trie. De-duplicates
+        so the visitor's double-push for ``Assign`` (one push for the LHS
+        name, one for the RHS value) does not register the same decl twice.
         """
         parts = decl.fqname.split(".")
         match decl.type:
@@ -80,24 +105,27 @@ class SymbolTrie:
                 if decl not in bucket:
                     bucket.append(decl)
 
-    def finalize_declarations(
-        self,
-        name: str,
-        live: list[SymbolNode],
-        shadowed: list[SymbolNode],
-    ) -> None:
-        """Partition collected decls for ``name`` into live vs shadowed.
+    def remove_declaration(self, decl: SymbolNode) -> None:
+        """Remove a single declaration entry by identity / equality.
 
-        ``live`` is the set of decls that bind ``name`` on at least one
-        path to module exit. ``shadowed`` is the rest. The caller is
-        expected to derive both from a flow-sensitive walk of the
-        module body (see :func:`dead_cst._flow.live_at_exit`).
+        Used by the visitor when flow analysis determines a previously
+        added decl is shadowed: the SHADOWED-flagged copy stays out of
+        the trie, and any unflagged version that reached the trie via
+        ``add_declaration`` is dropped here.
         """
-        if live:
-            self.declarations[name] = list(live)
-        else:
-            self.declarations.pop(name, None)
-        self.shadowed.extend(shadowed)
+        parts = decl.fqname.split(".")
+        node = self._get(parts[:-1])
+        if node is None:
+            return
+        bucket = node.declarations.get(parts[-1])
+        if bucket is None:
+            return
+        try:
+            bucket.remove(decl)
+        except ValueError:
+            return
+        if not bucket:
+            del node.declarations[parts[-1]]
 
     def merge(self, other: SymbolTrie) -> SymbolTrie:
         """Merge another SymbolTrie into this one.
@@ -127,7 +155,6 @@ class SymbolTrie:
             return self
         self.module = other.module
         self.declarations = {k: list(v) for k, v in other.declarations.items()}
-        self.shadowed = list(other.shadowed)
         return self
 
     def _touch(self, parts: list[str]) -> SymbolTrie:

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
+from dataclasses import dataclass
 from functools import cache
 from importlib.util import resolve_name
 from pathlib import Path
-from typing import Generator, Literal, Mapping, cast
+from typing import Generator, Literal, cast
 
 import libcst as cst
 from libcst.helpers import get_full_name_for_node
 from libcst.metadata import (
+    CodeRange,
     ParentNodeProvider,
     PositionProvider,
     ScopeProvider,
@@ -22,12 +25,12 @@ from libcst.metadata.scope_provider import (
     Scope,
 )
 
-from ._branches import make_unreachable_node, unreachable_suites
+from ._branches import unreachable_suites
 from ._flow import live_at_exit, live_referents
 from ._fqn import FixedFullyQualifiedNameProvider
 from ._plugins._core import UNRESOLVED_PREFIX
 from ._resolvers import ImportResolver, default_resolve_import
-from ._symbols import Import, SymbolNode, SymbolTrie
+from ._symbols import Import, NodeFlags, SymbolNode, SymbolTrie
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +46,38 @@ def _dotted_name_parts(
             yield nm, n
         full = f"{nm}.{node.attr.value}"
         yield full, node.attr
+
+
+@dataclass(frozen=True, slots=True)
+class VisitorPayload:
+    """Serializable per-file output of :class:`SymbolVisitor`.
+
+    Four fields cover everything the analyzer needs to reconstruct one
+    file's contribution to the symbol graph:
+
+    * ``nodes`` -- every real ``SymbolNode`` for this file (module +
+      top-level decls). Decls displaced by flow analysis are flagged
+      :data:`NodeFlags.SHADOWED`; the apply step uses that flag to keep
+      them out of the lookup trie while still emitting the parent-module
+      edge for the graph.
+    * ``edges`` -- ``(src, dst, access_pos)`` triples for resolved
+      decl-to-decl references. ``access_pos`` is the source location
+      of the reference; the apply step compares it against
+      ``dead_suites`` to decide whether the resulting graph edge gets
+      :data:`EdgeFlags.DEAD_BRANCH`.
+    * ``imports`` -- ``(src, Import, access_pos)`` triples for
+      unresolved cross-file references. The apply step feeds them into
+      ``resolve_edges`` along with the derived flag.
+    * ``dead_suites`` -- positions of every statically-dead suite in
+      the file (including ones with no outgoing references). Used both
+      for flag derivation and for surfacing "this file has unreachable
+      code at line X" reports without per-edge attribution.
+    """
+
+    nodes: tuple[SymbolNode, ...]
+    edges: tuple[tuple[SymbolNode, SymbolNode, CodeRange], ...]
+    imports: tuple[tuple[SymbolNode, Import, CodeRange], ...]
+    dead_suites: tuple[CodeRange, ...]
 
 
 def _pair_targets(
@@ -101,8 +136,13 @@ class SymbolVisitor(cst.CSTVisitor):
         self.decl_stack: list[list[SymbolNode]] = []
         self.nearest_decls: dict[cst.CSTNode, list[SymbolNode]] = {}
         self.import_lookup: dict[cst.CSTNode, Import] = {}
-        self.import_edges: set[tuple[SymbolNode, Import]] = set()
-        self.internal_edges: set[tuple[SymbolNode, SymbolNode]] = set()
+        # Edges carry the access position so the apply step can decide
+        # whether the reference originated inside a dead suite. Set
+        # semantics still dedupe identical triples; same-decl refs from
+        # different positions remain distinct (which matters when one is
+        # live and one is in a dead branch).
+        self.import_edges: set[tuple[SymbolNode, Import, CodeRange]] = set()
+        self.internal_edges: set[tuple[SymbolNode, SymbolNode, CodeRange]] = set()
         self.dunder_all_refs: list[tuple[SymbolNode, list[str]]] = []
         self.trie: SymbolTrie = SymbolTrie()
         # CST node used as the flow-analysis "binding site" for each
@@ -111,15 +151,17 @@ class SymbolVisitor(cst.CSTVisitor):
         # descendants of the containing statement, which is what
         # ``live_at_exit`` matches against.
         self.symbol_referent_nodes: dict[SymbolNode, cst.CSTNode] = {}
-        # Synthetic graph nodes for statically-unreachable branches.
-        # ``dead_suite_owner`` maps the ``id()`` of each dead suite node
-        # to the synthetic ``SymbolNode`` that "owns" any references
-        # made inside it; ``unreachable_nodes`` is the flat list the
-        # analyzer pulls into the graph.
-        self.unreachable_nodes: list[SymbolNode] = []
-        self.dead_suite_owner: dict[int, SymbolNode] = {}
-        self.unreachable_internal_edges: set[tuple[SymbolNode, SymbolNode]] = set()
-        self.unreachable_import_edges: set[tuple[SymbolNode, Import]] = set()
+        # Positions of every statically-dead suite in this file. The
+        # apply step uses this list to decide which edges land with
+        # ``EdgeFlags.DEAD_BRANCH``; the CLI surfaces them as
+        # "unreachable code at line X" reports.
+        self.dead_suites: list[CodeRange] = []
+        # Decls displaced by flow analysis. Tracked here (rather than on
+        # the trie) so the trie holds only entries cross-module imports
+        # should resolve to. Stored unflagged; ``to_payload`` produces
+        # ``NodeFlags.SHADOWED`` copies and remaps any edge endpoints
+        # that point at them, so the graph keeps consistent identity.
+        self.shadowed_decls: list[SymbolNode] = []
 
     @property
     def module_node(self) -> SymbolNode:
@@ -312,7 +354,7 @@ class SymbolVisitor(cst.CSTVisitor):
                 self.symbol_referent_nodes[sym] = alias
                 self._push_decl(alias, sym)
 
-            self.import_edges.add((self.decl_stack[-1][-1], import_info))
+            self.import_edges.add((self.decl_stack[-1][-1], import_info, self._pos(alias)))
 
     def visit_Module(self, node: cst.Module) -> None:
         assert not self.decl_stack, "Module node should be the first visited node"
@@ -342,38 +384,19 @@ class SymbolVisitor(cst.CSTVisitor):
         self._record_dead_suites(node)
 
     def _record_dead_suites(self, stmt: cst.BaseStatement) -> None:
-        """Create a synthetic ``unreachable`` graph node for each dead suite.
+        """Append the position of every statically-dead suite in ``stmt``.
 
-        Records the suite's ``id()`` so :meth:`_unreachable_owner` can
-        later attribute references made inside the suite to it. Nested
-        dead suites are handled implicitly: we visit outer ``If`` /
-        ``While`` first, then descend, so an inner dead suite registers
-        afterwards and the innermost match wins at lookup time.
+        The apply step (``_apply_payload`` in ``_analyze``) uses this
+        list to decide whether each emitted edge falls inside a dead
+        suite, in which case the edge gets ``EdgeFlags.DEAD_BRANCH``.
+        Nested dead suites are recorded as separate entries; an access
+        is "in a dead suite" if its position falls inside any of them.
         """
         for suite in unreachable_suites(stmt):
             pos = self._pos(suite)
             if pos is None:
                 continue
-            sym = make_unreachable_node(self.module_node.fqname, self.path, pos)
-            self.unreachable_nodes.append(sym)
-            self.dead_suite_owner[id(suite)] = sym
-
-    def _unreachable_owner(
-        self, node: cst.CSTNode, parent_map: Mapping[cst.CSTNode, object]
-    ) -> SymbolNode | None:
-        """Return the synthetic node owning ``node`` if it lives inside one.
-
-        Walks up via ``ParentNodeProvider`` looking for a recorded dead
-        suite. Returns the innermost match, or ``None`` if ``node`` is
-        not inside any dead suite.
-        """
-        current: object = parent_map.get(node)
-        while isinstance(current, cst.CSTNode):
-            owner = self.dead_suite_owner.get(id(current))
-            if owner is not None:
-                return owner
-            current = parent_map.get(current)
-        return None
+            self.dead_suites.append(pos)
 
     def visit_Import(self, node: cst.Import) -> None:
         self._add_import("", node)
@@ -393,7 +416,7 @@ class SymbolVisitor(cst.CSTVisitor):
             module = resolve_name(f"{prefix}{module}", current_package)
 
         if isinstance(node.names, cst.ImportStar):
-            self._add_star_import(module)
+            self._add_star_import(module, self._pos(node))
             return
 
         self._add_import(module, node)
@@ -404,9 +427,9 @@ class SymbolVisitor(cst.CSTVisitor):
         For names with more than one decl, ask :func:`live_at_exit` which
         binding sites survive on at least one path to module exit. Live
         decls stay in ``trie.declarations[name]`` (multi-valued for
-        conditional bindings); the rest move to ``trie.shadowed`` so the
-        graph keeps their parent-module edge but cross-module imports do
-        not reach them.
+        conditional bindings); the rest move to
+        ``self.shadowed_decls`` so the graph keeps their parent-module
+        edge but cross-module imports do not reach them.
         """
         trie_node = self.trie._get(self._module_fqname.split("."))
         if trie_node is None:
@@ -426,17 +449,21 @@ class SymbolVisitor(cst.CSTVisitor):
             live_ids = {id(n) for n in live_at_exit(list(module_node.body), referent_nodes)}
 
             live_decls: list[SymbolNode] = []
-            shadowed_decls: list[SymbolNode] = []
+            shadowed_here: list[SymbolNode] = []
             for d in decls:
                 ref = self.symbol_referent_nodes.get(d)
                 if ref is not None and id(ref) in live_ids:
                     live_decls.append(d)
                 else:
-                    shadowed_decls.append(d)
+                    shadowed_here.append(d)
 
-            trie_node.finalize_declarations(name, live_decls, shadowed_decls)
+            if live_decls:
+                trie_node.declarations[name] = list(live_decls)
+            else:
+                del trie_node.declarations[name]
+            self.shadowed_decls.extend(shadowed_here)
 
-    def _add_star_import(self, module: str) -> None:
+    def _add_star_import(self, module: str, access_pos: CodeRange) -> None:
         module_path = self.resolve_import(module) if module else None
         if not module_path:
             logger.warning(
@@ -444,7 +471,7 @@ class SymbolVisitor(cst.CSTVisitor):
             )
             return
         star = Import(path=module_path, module=module, star=True)
-        self.import_edges.add((self.decl_stack[-1][-1], star))
+        self.import_edges.add((self.decl_stack[-1][-1], star, access_pos))
 
     def on_leave(self, original_node: cst.CSTNode) -> None:
         self.nearest_decls[original_node] = list(self.decl_stack[-1]) if self.decl_stack else []
@@ -482,7 +509,7 @@ class SymbolVisitor(cst.CSTVisitor):
 
         for access, referent in references:
             owner_symbols = self.nearest_decls.get(access.node, [])
-            unreachable_owner = self._unreachable_owner(access.node, parent_map)
+            access_pos = self._pos(access.node)
             target_node = referent.node
             if isinstance(referent, ImportAssignment):
                 target_node = referent.as_name
@@ -510,9 +537,7 @@ class SymbolVisitor(cst.CSTVisitor):
                     )
 
                     for owner_symbol in owner_symbols:
-                        self.import_edges.add((owner_symbol, resolved_import))
-                    if unreachable_owner is not None:
-                        self.unreachable_import_edges.add((unreachable_owner, resolved_import))
+                        self.import_edges.add((owner_symbol, resolved_import, access_pos))
 
             target_symbols = [
                 s for frame in self.node_to_frames.get(target_node, ()) for s in frame
@@ -532,11 +557,12 @@ class SymbolVisitor(cst.CSTVisitor):
             for target_symbol in target_symbols:
                 for owner_symbol in owner_symbols:
                     if target_symbol != owner_symbol and target_symbol and owner_symbol:
-                        self.internal_edges.add((owner_symbol, target_symbol))
-                if unreachable_owner is not None and target_symbol is not None:
-                    self.unreachable_internal_edges.add((unreachable_owner, target_symbol))
+                        self.internal_edges.add((owner_symbol, target_symbol, access_pos))
 
-        # Resolve __all__ string references to declarations in the current module
+        # Resolve __all__ string references to declarations in the current module.
+        # The owner's own position stands in as the access position -- the
+        # ``__all__`` literal is a single source location, not a per-name
+        # one, so the per-string subexpression isn't worth tracking.
         if self.dunder_all_refs:
             module_sym = self.node_to_frames[original_node][0][0]
             module_trie = self.trie._get(module_sym.fqname.split("."))
@@ -545,4 +571,45 @@ class SymbolVisitor(cst.CSTVisitor):
                     for name in names:
                         for target in module_trie.declarations.get(name, []):
                             if target != owner:
-                                self.internal_edges.add((owner, target))
+                                self.internal_edges.add((owner, target, owner.position))
+
+    def to_payload(self) -> VisitorPayload:
+        """Materialize visitor state into a serializable :class:`VisitorPayload`.
+
+        Decls in :attr:`shadowed_decls` are emitted as
+        :data:`NodeFlags.SHADOWED` flagged copies and any edge endpoint
+        pointing at them is remapped to the same flagged identity, so
+        the resulting graph nodes and edges line up. The per-edge
+        :class:`CodeRange` (the access position) is preserved as-is;
+        the apply step in :mod:`dead_cst._analyze` derives the
+        :data:`EdgeFlags.DEAD_BRANCH` flag from it by checking
+        containment against :attr:`dead_suites`.
+        """
+        flag_map: dict[SymbolNode, SymbolNode] = {
+            d: dataclasses.replace(d, flags=d.flags | NodeFlags.SHADOWED)
+            for d in self.shadowed_decls
+        }
+
+        def remap(sym: SymbolNode) -> SymbolNode:
+            return flag_map.get(sym, sym)
+
+        nodes: list[SymbolNode] = []
+        stack: list[SymbolTrie] = [self.trie]
+        while stack:
+            tnode = stack.pop()
+            if tnode.module is not None:
+                nodes.append(tnode.module)
+            for decls in tnode.declarations.values():
+                nodes.extend(decls)
+            stack.extend(tnode.children.values())
+        nodes.extend(remap(d) for d in self.shadowed_decls)
+
+        edges = tuple((remap(src), remap(dst), pos) for src, dst, pos in self.internal_edges)
+        imports = tuple((remap(src), dst, pos) for src, dst, pos in self.import_edges)
+
+        return VisitorPayload(
+            nodes=tuple(nodes),
+            edges=edges,
+            imports=imports,
+            dead_suites=tuple(self.dead_suites),
+        )

--- a/dead_cst/cli.py
+++ b/dead_cst/cli.py
@@ -12,9 +12,9 @@ from typing import Annotated
 
 import networkx as nx
 import typer
+from libcst.metadata import CodeRange
 
 from . import build_symbol_graph, count_nodes, find_reachable, order_paths, remove_code
-from ._branches import is_unreachable_node
 from ._plugins import (
     EdgePlugin,
     ExplicitEntrypointPlugin,
@@ -179,8 +179,8 @@ def analyze(
 
 
 def _output_text(
-    graph: nx.DiGraph,
-    unreachable: nx.DiGraph,
+    graph: nx.MultiDiGraph,
+    unreachable: nx.MultiDiGraph,
     root: Path,
     paths_dict: PathMap,
 ) -> None:
@@ -189,10 +189,10 @@ def _output_text(
         total_counts = count_nodes(graph, base)
         unreachable_counts = count_nodes(unreachable, base)
         for kind in sorted(total_counts):
-            # Synthetic nodes (entrypoint sentinels, dead-suite markers)
-            # don't represent user-visible declarations; reporting them
-            # as "dead" alongside functions/classes would be misleading.
-            # Dead-suite nodes get their own section below.
+            # Synthetic nodes (entrypoint sentinels, external-dist markers,
+            # dunder-all stand-ins) don't represent user-visible
+            # declarations; reporting them alongside functions/classes
+            # would be misleading.
             if kind == "synthetic":
                 continue
             total = total_counts[kind]
@@ -202,39 +202,56 @@ def _output_text(
             else:
                 typer.echo(f"  {kind}: {total} total")
 
-    dead_real, branches = _partition_unreachable(unreachable)
+    dead_real = _dead_real(unreachable)
     if dead_real:
         typer.echo(f"\nDead symbols ({len(dead_real)}):")
         for node in sorted(dead_real, key=lambda n: (str(n.path), n.fqname)):
             typer.echo(f"  {node.fqname} ({node.type}) at {_rel_path(node.path, root)}")
 
+    branches = _dead_suite_locations(graph, paths_dict)
     if branches:
         typer.echo(f"\nUnreachable branches ({len(branches)}):")
-        for node in sorted(branches, key=lambda n: (str(n.path), n.position.start)):
-            rel = _rel_path(node.path, root)
-            start = node.position.start
-            end = node.position.end
+        for path, pos in branches:
+            rel = _rel_path(path, root)
+            start = pos.start
+            end = pos.end
             typer.echo(f"  {rel}:{start.line}:{start.column}-{end.line}:{end.column}")
 
 
-def _partition_unreachable(
-    unreachable: nx.DiGraph,
-) -> tuple[list[SymbolNode], list[SymbolNode]]:
-    """Split ``unreachable.nodes`` into ``(dead_real, branches)`` in one pass.
+def _dead_real(unreachable: nx.MultiDiGraph) -> list[SymbolNode]:
+    """Return real (non-synthetic) dead nodes from ``unreachable``.
 
-    Synthetic dead-suite nodes are orphan sources -- never visited by
-    reachability -- so they always land in ``unreachable``.
+    Synthetic nodes -- entrypoint sentinels, external-dist markers,
+    dunder-all stand-ins -- are excluded; they don't represent
+    user-visible declarations and would confuse the dead-code report.
     """
-    dead_real: list[SymbolNode] = []
-    branches: list[SymbolNode] = []
-    for n in unreachable.nodes:
-        (branches if is_unreachable_node(n) else dead_real).append(n)
-    return dead_real, branches
+    return [n for n in unreachable.nodes if n.type != "synthetic"]
+
+
+def _dead_suite_locations(
+    graph: nx.MultiDiGraph, paths_dict: PathMap
+) -> list[tuple[Path, CodeRange]]:
+    """Flatten ``graph.graph["dead_suites"]`` into a sorted ``(path, pos)`` list.
+
+    Restricted to files under one of the analyzed bases so the report
+    doesn't surface dead suites in workspace dependencies that the
+    user isn't asking about.
+    """
+    bases = list(paths_dict)
+    raw: dict = graph.graph.get("dead_suites", {})
+    out: list[tuple[Path, CodeRange]] = []
+    for path, suites in raw.items():
+        if not any(path.is_relative_to(b) for b in bases):
+            continue
+        for pos in suites:
+            out.append((path, pos))
+    out.sort(key=lambda entry: (str(entry[0]), entry[1].start.line, entry[1].start.column))
+    return out
 
 
 def _output_json(
-    graph: nx.DiGraph,
-    unreachable: nx.DiGraph,
+    graph: nx.MultiDiGraph,
+    unreachable: nx.MultiDiGraph,
     root: Path,
     paths_dict: PathMap,
 ) -> None:
@@ -257,8 +274,7 @@ def _output_json(
             if kind != "synthetic"
         }
 
-    dead_real, branches = _partition_unreachable(unreachable)
-    for node in sorted(dead_real, key=lambda n: (str(n.path), n.fqname)):
+    for node in sorted(_dead_real(unreachable), key=lambda n: (str(n.path), n.fqname)):
         result["dead_symbols"].append(
             {
                 "fqname": node.fqname,
@@ -267,12 +283,12 @@ def _output_json(
             }
         )
 
-    for node in sorted(branches, key=lambda n: (str(n.path), n.position.start)):
+    for path, pos in _dead_suite_locations(graph, paths_dict):
         result["unreachable_branches"].append(
             {
-                "path": str(_rel_path(node.path, root)),
-                "start": {"line": node.position.start.line, "column": node.position.start.column},
-                "end": {"line": node.position.end.line, "column": node.position.end.column},
+                "path": str(_rel_path(path, root)),
+                "start": {"line": pos.start.line, "column": pos.start.column},
+                "end": {"line": pos.end.line, "column": pos.end.column},
             }
         )
 
@@ -444,8 +460,8 @@ def unused_exports(
     pruned = graph.copy()
     pruned.remove_edges_from(
         [
-            (s, d)
-            for s, d in graph.edges
+            (s, d, k)
+            for s, d, k in graph.edges(keys=True)
             if _is_dunder_all(d) and s.type == "synthetic" and s.fqname.startswith(DUNDER_PREFIX)
         ]
     )
@@ -516,11 +532,11 @@ def remove(
 
     unreachable_graph = graph.subgraph([n for n in graph.nodes if n not in reachable])
 
-    # Synthetic ``unreachable`` nodes are reported by ``analyze`` but
-    # not yet removable by ``remove`` -- the codemod doesn't know how to
-    # delete an arbitrary suite. Filter them out of the listing so we
-    # don't promise something we don't deliver.
-    removable = [n for n in unreachable_graph.nodes if not is_unreachable_node(n)]
+    # Synthetic nodes (entrypoint sentinels, external-dist markers,
+    # dunder-all stand-ins) aren't user-visible declarations. The
+    # codemod can't delete them, so they're filtered out of the
+    # remove listing.
+    removable = [n for n in unreachable_graph.nodes if n.type != "synthetic"]
 
     if not removable:
         typer.echo("No dead code found.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,7 @@ import textwrap
 import networkx as nx
 import pytest
 
-from dead_cst import build_symbol_graph
-from dead_cst._branches import is_unreachable_node
+from dead_cst import EdgeFlags, build_symbol_graph
 
 
 @pytest.fixture
@@ -26,7 +25,7 @@ def write_files(tmp_path):
 
 @pytest.fixture
 def build_decl_graph(tmp_path):
-    def _make_graph(files: dict[str, str]) -> nx.DiGraph:
+    def _make_graph(files: dict[str, str]) -> nx.MultiDiGraph:
         for filename, content in files.items():
             full_path = tmp_path / filename
             full_path.parent.mkdir(parents=True, exist_ok=True)
@@ -36,26 +35,24 @@ def build_decl_graph(tmp_path):
     return _make_graph
 
 
-def _has_unreachable_endpoint(edge) -> bool:
-    src, dst = edge
-    return is_unreachable_node(src) or is_unreachable_node(dst)
+def _is_dead_branch(attrs) -> bool:
+    return bool(attrs.get("flags", EdgeFlags.NONE) & EdgeFlags.DEAD_BRANCH)
 
 
 @pytest.fixture
 def assert_edges():
-    def _check(graph: nx.DiGraph, expected_edges: set[str]):
-        """Compare visitor.internal_edges to expected 'a -> b' strings.
+    def _check(graph: nx.MultiDiGraph, expected_edges: set[str]):
+        """Compare graph edges to expected 'a -> b' strings.
 
-        Edges touching synthetic ``unreachable`` nodes are excluded so
-        these "real symbol graph" assertions don't churn whenever a new
-        ``if False:`` / ``if True:`` test case is added. Tests covering
-        unreachable behavior should use ``assert_unreachable_edges``.
+        Iterates the full edge set, including ``DEAD_BRANCH``-flagged
+        edges. The flag is metadata-only -- default ``find_reachable``
+        traverses these edges, and the live-graph view should reflect
+        them. Tests that want only the dead-code references use
+        :func:`assert_dead_branch_edges`. Parallel edges (same
+        ``(u, v)`` pair, different attrs) collapse to one assertion
+        entry; ``set`` deduping handles that automatically.
         """
-        actual_edges = {
-            f"{src.fqname} -> {dst.fqname}"
-            for src, dst in graph.edges
-            if not _has_unreachable_endpoint((src, dst))
-        }
+        actual_edges = {f"{src.fqname} -> {dst.fqname}" for src, dst in graph.edges(keys=False)}
         assert actual_edges == expected_edges
 
     return _check
@@ -69,8 +66,7 @@ def assert_positional_edges():
     (module nodes keep their bare fqname). Use this for tests where
     multiple top-level decls share a fqname -- e.g. redeclarations and
     shadowing -- so the per-textual-decl identity is visible in the
-    assertion. Synthetic ``unreachable`` nodes are filtered out for the
-    same reason as :func:`assert_edges`.
+    assertion.
     """
 
     def _fmt(sym):
@@ -81,34 +77,29 @@ def assert_positional_edges():
         start = sym.position.start
         return f"{sym.fqname}@{start.line}:{start.column}"
 
-    def _check(graph: nx.DiGraph, expected_edges: set[str]):
-        actual_edges = {
-            f"{_fmt(src)} -> {_fmt(dst)}"
-            for src, dst in graph.edges
-            if not _has_unreachable_endpoint((src, dst))
-        }
+    def _check(graph: nx.MultiDiGraph, expected_edges: set[str]):
+        actual_edges = {f"{_fmt(src)} -> {_fmt(dst)}" for src, dst in graph.edges(keys=False)}
         assert actual_edges == expected_edges
 
     return _check
 
 
 @pytest.fixture
-def assert_unreachable_edges():
-    """Assert on edges originating from synthetic ``unreachable`` nodes.
+def assert_dead_branch_edges():
+    """Assert on edges flagged ``EdgeFlags.DEAD_BRANCH``.
 
-    Format: ``"<line:col> -> target.fqname"``. Per-suite location is the
-    only useful identifier for the source side; the target is rendered
-    by fqname. Edges that don't originate from an unreachable node are
-    ignored.
+    Format: ``"src.fqname -> dst.fqname"``. The previous synthetic-node
+    model carried per-suite line/column on the edge source; that
+    fidelity is intentionally dropped (see plan -- per-suite
+    attribution is a payload-level concern, not a per-edge one).
     """
 
-    def _check(graph: nx.DiGraph, expected_edges: set[str]):
-        actual = set()
-        for src, dst in graph.edges:
-            if not is_unreachable_node(src):
-                continue
-            start = src.position.start
-            actual.add(f"<{start.line}:{start.column}> -> {dst.fqname}")
+    def _check(graph: nx.MultiDiGraph, expected_edges: set[str]):
+        actual = {
+            f"{src.fqname} -> {dst.fqname}"
+            for src, dst, attrs in graph.edges(data=True)
+            if _is_dead_branch(attrs)
+        }
         assert actual == expected_edges
 
     return _check

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,6 @@ import pytest
 from libcst.metadata import CodePosition, CodeRange
 from typer.testing import CliRunner
 
-from dead_cst._branches import UNREACHABLE_PREFIX
 from dead_cst._plugins import (
     ExplicitEntrypointPlugin,
     MainBlockPlugin,
@@ -32,9 +31,9 @@ from dead_cst._plugins.explicit import EXPLICIT_PREFIX
 from dead_cst._symbols import SymbolNode
 from dead_cst._resolvers import ManualResolver
 from dead_cst.cli import (
+    _dead_real,
     _is_dunder_all,
     _is_external_dep,
-    _partition_unreachable,
     _rel_path,
     app,
     build_plugins,
@@ -259,26 +258,26 @@ def test_rel_path_equal_to_root_yields_empty(tmp_path):
     assert _rel_path(tmp_path, tmp_path) == Path(".")
 
 
-def test_partition_unreachable_splits_synthetic_branches_from_real():
+def test_dead_real_filters_synthetic_nodes():
+    """Synthetic nodes (entrypoint sentinels, external markers) are
+    excluded from the dead-symbol report so we don't surface them
+    alongside user-visible declarations."""
     import networkx as nx
 
     real = SymbolNode("pkg.f", "function", Path("/a.py"), _pos())
-    branch = SymbolNode(f"{UNREACHABLE_PREFIX}pkg.a:5:0", "synthetic", Path("/a.py"), _pos())
     entrypoint_synth = SymbolNode(f"{EXPLICIT_PREFIX}pkg.f", "synthetic", Path("/a.py"), _pos())
 
-    g = nx.DiGraph()
-    for n in (real, branch, entrypoint_synth):
+    g = nx.MultiDiGraph()
+    for n in (real, entrypoint_synth):
         g.add_node(n)
 
-    dead_real, branches = _partition_unreachable(g)
-    assert dead_real == [real, entrypoint_synth]
-    assert branches == [branch]
+    assert _dead_real(g) == [real]
 
 
-def test_partition_unreachable_empty_graph_returns_empty_lists():
+def test_dead_real_empty_graph_returns_empty_list():
     import networkx as nx
 
-    assert _partition_unreachable(nx.DiGraph()) == ([], [])
+    assert _dead_real(nx.MultiDiGraph()) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -325,5 +325,5 @@ def test_third_party_import_creates_synthetic_node(build_decl_graph):
         f"{[n.fqname for n in graph.nodes if n.type == 'synthetic']}"
     )
 
-    edge_srcs = {src.fqname for src, dst in graph.edges if dst in nx_nodes}
+    edge_srcs = {src.fqname for src, dst in graph.edges(keys=False) if dst in nx_nodes}
     assert {"p.uses_nx.nx", "p.uses_nx.build"} <= edge_srcs

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1,0 +1,290 @@
+"""Tests for the per-file ``VisitorPayload`` shape and its apply step.
+
+The visitor's per-file output is collapsed into :class:`VisitorPayload`
+with four fields: ``nodes``, ``edges``, ``imports``, ``dead_suites``.
+``_analyze._apply_payload`` reads them, derives
+:data:`EdgeFlags.DEAD_BRANCH` per edge by checking each access
+position against the file's dead-suite list, and emits the per-file
+contribution to the symbol graph.
+
+These tests cover the new layer directly:
+
+* the flag plumbing on :class:`SymbolNode` and the new
+  :class:`EdgeFlags` IntFlag,
+* the per-file ``VisitorPayload`` shape and pickle round-trip (the
+  cache pre-flight),
+* edge-flag derivation: refs inside dead suites land with
+  ``DEAD_BRANCH``, refs outside don't.
+
+End-to-end behavior of the analyzer is already covered by
+``test_declarations`` / ``test_unreachable_branches`` /
+``test_imports``; this file focuses on the payload contract itself.
+"""
+
+from __future__ import annotations
+
+import pickle
+import textwrap
+from pathlib import Path
+
+from libcst.metadata import CodePosition, CodeRange, FullRepoManager
+
+from dead_cst import EdgeFlags, NodeFlags, build_symbol_graph
+from dead_cst._fqn import FixedFullyQualifiedNameProvider
+from dead_cst._symbols import SymbolNode
+from dead_cst._visitor import SymbolVisitor, VisitorPayload
+
+
+def _pos(line: int = 1, column: int = 0) -> CodeRange:
+    return CodeRange(start=CodePosition(line, column), end=CodePosition(line, column + 1))
+
+
+# ---------------------------------------------------------------------------
+# Flag enums
+# ---------------------------------------------------------------------------
+
+
+def test_node_flags_default_is_none():
+    """Bare ``SymbolNode`` construction leaves ``flags`` cleared.
+
+    The default needs to stay ``NONE`` so existing call sites that
+    construct ``SymbolNode`` without flags (plugins, tests) keep
+    producing live, unshadowed nodes.
+    """
+    n = SymbolNode("pkg.f", "function", Path("/a.py"), _pos())
+    assert n.flags is NodeFlags.NONE
+    assert not (n.flags & NodeFlags.SHADOWED)
+
+
+def test_node_flags_compose_via_or():
+    """An :class:`IntFlag` lets callers OR multiple markers together."""
+    combined = NodeFlags.SHADOWED | NodeFlags.SHADOWED
+    assert combined & NodeFlags.SHADOWED
+
+
+def test_edge_flags_dead_branch_distinct_from_none():
+    """``DEAD_BRANCH`` is a distinct bit from ``NONE``."""
+    assert EdgeFlags.DEAD_BRANCH & EdgeFlags.DEAD_BRANCH
+    assert not (EdgeFlags.NONE & EdgeFlags.DEAD_BRANCH)
+
+
+# ---------------------------------------------------------------------------
+# VisitorPayload shape
+# ---------------------------------------------------------------------------
+
+
+def _payload_from_source(tmp_path: Path, src: str) -> tuple[VisitorPayload, Path]:
+    """Run ``SymbolVisitor`` over ``src`` and return its payload.
+
+    Bypasses ``build_symbol_graph`` so we can inspect the visitor's own
+    output -- i.e. what would be cached -- without the per-base
+    apply-and-resolve work on top.
+    """
+    file = tmp_path / "pkg.py"
+    file.write_text(textwrap.dedent(src).strip() + "\n")
+    mgr = FullRepoManager(str(tmp_path), [str(file)], {FixedFullyQualifiedNameProvider})
+    wrapper = mgr.get_metadata_wrapper_for_path(str(file))
+    visitor = SymbolVisitor(file, [tmp_path])
+    wrapper.visit(visitor)
+    return visitor.to_payload(), file
+
+
+def test_payload_module_node_present(tmp_path):
+    """Every payload lists exactly one ``type='module'`` node for the file."""
+    payload, _ = _payload_from_source(
+        tmp_path,
+        """
+        def f(): pass
+        """,
+    )
+    modules = [n for n in payload.nodes if n.type == "module"]
+    assert len(modules) == 1
+    assert modules[0].fqname == "pkg"
+
+
+def test_payload_shadowed_decl_carries_flag(tmp_path):
+    """Decls displaced by flow analysis are emitted with ``SHADOWED``.
+
+    The visitor's ``_finalize_module_declarations`` partitions same-name
+    decls into live vs. displaced via :func:`live_at_exit`; the
+    displaced copies pick up :data:`NodeFlags.SHADOWED` only at
+    payload-construction time. Live decls never gain the flag.
+    """
+    payload, _ = _payload_from_source(
+        tmp_path,
+        """
+        def f():
+            return 1
+
+        def f():
+            return 2
+        """,
+    )
+    fs = sorted(
+        (n for n in payload.nodes if n.fqname == "pkg.f"),
+        key=lambda n: n.position.start.line,
+    )
+    assert len(fs) == 2
+    assert fs[0].flags & NodeFlags.SHADOWED
+    assert not (fs[1].flags & NodeFlags.SHADOWED)
+
+
+def test_payload_records_dead_suites(tmp_path):
+    """Statically-dead suites land in ``payload.dead_suites``.
+
+    The list is the source of truth for "where in the file are
+    statically-unreachable regions" -- the apply step uses it for
+    edge-flag derivation, and the CLI surfaces it for the
+    "Unreachable branches" report.
+    """
+    payload, _ = _payload_from_source(
+        tmp_path,
+        """
+        def used(): pass
+
+        if False:
+            used()
+
+        if False:
+            pass
+        """,
+    )
+    assert len(payload.dead_suites) == 2
+
+
+def test_payload_edge_carries_access_pos(tmp_path):
+    """Each edge entry has an access-position third field.
+
+    The position is what the apply step compares against
+    ``dead_suites`` to decide whether the resulting graph edge gets
+    ``EdgeFlags.DEAD_BRANCH``. Type-checked here as ``CodeRange``.
+    """
+    payload, _ = _payload_from_source(
+        tmp_path,
+        """
+        def used(): pass
+
+        used()
+        """,
+    )
+    assert payload.edges
+    for src, dst, pos in payload.edges:
+        assert isinstance(src, SymbolNode)
+        assert isinstance(dst, SymbolNode)
+        assert isinstance(pos, CodeRange)
+
+
+def test_apply_flags_dead_branch_edges(tmp_path, write_files):
+    """End-to-end: refs inside dead suites land with ``DEAD_BRANCH``."""
+    write_files(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": """
+                def helper(): pass
+
+                helper()      # live ref
+                if False:
+                    helper()  # dead ref
+            """,
+        }
+    )
+    graph = build_symbol_graph({tmp_path: []})
+    helper = next(n for n in graph.nodes if n.fqname == "pkg.a.helper")
+    module = next(n for n in graph.nodes if n.fqname == "pkg.a")
+
+    # MultiDiGraph: parallel edges between the same pair are kept
+    # separate. Both live and dead-branch refs to ``helper`` produce
+    # edges from the module; the flag distinguishes them.
+    edges = list(graph.edges(module, data=True))
+    flags_seen = {attrs.get("flags", EdgeFlags.NONE) for _, dst, attrs in edges if dst == helper}
+    assert EdgeFlags.NONE in flags_seen
+    assert EdgeFlags.DEAD_BRANCH in flags_seen
+
+
+def test_payload_pickle_round_trip(tmp_path):
+    """Payload survives pickle / unpickle.
+
+    This is the sanity check for the upcoming SQLite cache work --
+    payloads will be pickled into the ``file_cache`` table. If the
+    nested ``CodeRange`` / ``Path`` / ``Import`` types ever stop being
+    picklable, this test catches it before the cache PR lands.
+    """
+    payload, _ = _payload_from_source(
+        tmp_path,
+        """
+        from typing import List
+
+        def used(): pass
+
+        def f():
+            return used()
+
+        def f():
+            return 2
+
+        if False:
+            used()
+        """,
+    )
+    restored = pickle.loads(pickle.dumps(payload))
+    assert restored == payload
+
+
+# ---------------------------------------------------------------------------
+# Graph-level integration
+# ---------------------------------------------------------------------------
+
+
+def test_shadowed_decl_in_graph_keeps_consistent_identity(tmp_path, write_files):
+    """Shadowed decl + edges referencing it share one graph node.
+
+    The risk of mishandled remapping is two graph nodes for one
+    logical decl: an unflagged copy implicitly created by ``add_edge``
+    plus the flagged copy added by ``add_node``. Confirm by walking
+    the assembled graph and asserting every edge endpoint that
+    matches a shadowed decl IS that flagged instance, not a parallel
+    unflagged twin.
+    """
+    write_files(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": """
+                def f():
+                    return 1
+
+                g = f
+
+                def f():
+                    return 2
+            """,
+        }
+    )
+    g = build_symbol_graph({tmp_path: []})
+    shadowed = [n for n in g.nodes if n.flags & NodeFlags.SHADOWED]
+    assert len(shadowed) == 1
+    s = shadowed[0]
+    # Every graph node with this fqname must be either ``s`` itself or
+    # the live (unflagged) sibling -- never an unflagged copy of the
+    # shadowed binding.
+    matches = [n for n in g.nodes if n.fqname == s.fqname]
+    assert len(matches) == 2
+    flagged_matches = [n for n in matches if n.flags & NodeFlags.SHADOWED]
+    assert flagged_matches == [s]
+
+
+def test_dead_suites_exposed_on_graph(tmp_path, write_files):
+    """``graph.graph['dead_suites']`` lists positions per analyzed file."""
+    write_files(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": """
+                if False:
+                    pass
+            """,
+        }
+    )
+    g = build_symbol_graph({tmp_path: []})
+    suites = g.graph["dead_suites"]
+    file = tmp_path / "pkg" / "a.py"
+    assert file in suites
+    assert len(suites[file]) == 1

--- a/tests/test_unreachable_branches.py
+++ b/tests/test_unreachable_branches.py
@@ -1,35 +1,33 @@
-"""End-to-end tests for synthetic ``unreachable`` graph nodes.
+"""End-to-end tests for ``EdgeFlags.DEAD_BRANCH`` on graph edges.
 
 When the visitor sees a statically-dead ``if`` / ``while`` suite (per
-:mod:`dead_cst._branches`) it creates a synthetic ``SymbolNode`` with
-``type="synthetic"`` and a fqname prefixed with ``<unreachable>:``.
-Every reference made from inside that suite gets a parallel edge
-``synthetic -> referent`` -- the original ``enclosing-decl -> referent``
-edge is left in place. The synthetic node is an orphan (no incoming
-edges) so reachability never visits it; the parallel edges are purely
-for surfacing.
+:mod:`dead_cst._branches`) it records the suite's position. The
+analyzer's apply step then flags every reference whose access position
+falls inside any recorded dead suite with
+:data:`dead_cst.EdgeFlags.DEAD_BRANCH` -- a single tagged edge per
+reference, no parallel synthetic source node.
 
-These tests exercise the integration end-to-end through
-``build_symbol_graph``: visitor creation of nodes, attribution of
-references inside dead suites, and behavior across nested suites and
-import references.
+By default :func:`find_reachable` does not filter on this flag, so
+dead-code references still propagate liveness through the enclosing
+decl. :func:`find_kept_alive_by_dead_branches` returns the strict
+diff: symbols that would become unreachable if every dead suite were
+severed.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import networkx as nx
 
-from dead_cst._branches import is_unreachable_node
+from dead_cst import find_kept_alive_by_dead_branches, find_reachable
 
 
-def _unreachable_nodes(graph: nx.DiGraph) -> list:
-    return sorted(
-        (n for n in graph.nodes if is_unreachable_node(n)),
-        key=lambda n: (str(n.path), n.position.start.line, n.position.start.column),
-    )
+def _dead_suite_positions(graph: nx.MultiDiGraph, file: Path) -> tuple:
+    return graph.graph.get("dead_suites", {}).get(file, ())
 
 
-def test_if_false_creates_synthetic_node(build_decl_graph):
+def test_if_false_records_dead_suite(build_decl_graph, tmp_path):
     graph = build_decl_graph(
         {
             "mod.py": """
@@ -39,20 +37,17 @@ def test_if_false_creates_synthetic_node(build_decl_graph):
             """
         }
     )
-    branches = _unreachable_nodes(graph)
-    assert len(branches) == 1
-    suite = branches[0]
-    assert suite.type == "synthetic"
-    # Fqname is opaque; identification goes through is_unreachable_node.
-    assert is_unreachable_node(suite)
+    suites = _dead_suite_positions(graph, tmp_path / "mod.py")
+    assert len(suites) == 1
+    pos = suites[0]
     # libcst positions an ``IndentedBlock`` at its first statement, not
     # at the ``if`` keyword. Pin both line and column to lock down the
     # convention surfacing relies on.
-    assert suite.position.start.line == 3
-    assert suite.position.start.column == 4
+    assert pos.start.line == 3
+    assert pos.start.column == 4
 
 
-def test_if_true_marks_else_as_unreachable(build_decl_graph):
+def test_if_true_marks_else_as_unreachable(build_decl_graph, tmp_path):
     graph = build_decl_graph(
         {
             "mod.py": """
@@ -64,10 +59,10 @@ def test_if_true_marks_else_as_unreachable(build_decl_graph):
             """
         }
     )
-    assert len(_unreachable_nodes(graph)) == 1
+    assert len(_dead_suite_positions(graph, tmp_path / "mod.py")) == 1
 
 
-def test_unknown_condition_creates_no_synthetic_node(build_decl_graph):
+def test_unknown_condition_records_no_dead_suite(build_decl_graph, tmp_path):
     graph = build_decl_graph(
         {
             "mod.py": """
@@ -79,10 +74,10 @@ def test_unknown_condition_creates_no_synthetic_node(build_decl_graph):
             """
         }
     )
-    assert _unreachable_nodes(graph) == []
+    assert _dead_suite_positions(graph, tmp_path / "mod.py") == ()
 
 
-def test_unreachable_node_has_edge_to_internal_referent(build_decl_graph, assert_unreachable_edges):
+def test_dead_branch_internal_ref_is_flagged(build_decl_graph, assert_dead_branch_edges):
     graph = build_decl_graph(
         {
             "mod.py": """
@@ -92,14 +87,14 @@ def test_unreachable_node_has_edge_to_internal_referent(build_decl_graph, assert
             """
         }
     )
-    # Position is the body's first statement.
-    assert_unreachable_edges(graph, {"<3:4> -> mod.helper"})
+    assert_dead_branch_edges(graph, {"mod -> mod.helper"})
 
 
-def test_unreachable_node_has_edge_to_import_referent(build_decl_graph, assert_unreachable_edges):
+def test_dead_branch_import_ref_is_flagged(build_decl_graph, assert_dead_branch_edges):
     # Reference to an imported name from inside a dead suite produces
     # the same edge fan-out as a reference from a live decl: the local
-    # import decl, the upstream module, and the resolved target.
+    # import decl, the upstream module, and the resolved target. All
+    # of them get the ``DEAD_BRANCH`` flag.
     graph = build_decl_graph(
         {
             "pkg/__init__.py": "",
@@ -111,20 +106,24 @@ def test_unreachable_node_has_edge_to_import_referent(build_decl_graph, assert_u
             """,
         }
     )
-    assert_unreachable_edges(
+    assert_dead_branch_edges(
         graph,
         {
-            "<3:4> -> pkg.b.helper",
-            "<3:4> -> pkg.a",
-            "<3:4> -> pkg.a.helper",
+            "pkg.b -> pkg.b.helper",
+            "pkg.b -> pkg.a",
+            "pkg.b -> pkg.a.helper",
         },
     )
 
 
-def test_original_edges_are_preserved_when_branch_is_dead(build_decl_graph, assert_edges):
-    # The "real symbol graph" still contains the enclosing-module ->
-    # helper edge. The unreachable-edge filtering in ``assert_edges``
-    # ensures this assertion is unaffected by the synthetic node.
+def test_default_find_reachable_traverses_dead_branch_edges(build_decl_graph):
+    """Default reachability still keeps ``helper`` alive via the dead-branch ref.
+
+    Today's behavior preservation: even when the only reference to
+    ``helper`` is ``if False: helper()``, ``find_reachable`` from the
+    module-as-entrypoint still reaches it. The edge is flagged but
+    not skipped.
+    """
     graph = build_decl_graph(
         {
             "mod.py": """
@@ -134,16 +133,33 @@ def test_original_edges_are_preserved_when_branch_is_dead(build_decl_graph, asse
             """
         }
     )
-    assert_edges(
-        graph,
+    # Mark the module as an entrypoint manually; the build_decl_graph
+    # fixture doesn't run plugins.
+    module = next(n for n in graph.nodes if n.fqname == "mod")
+    graph.nodes[module]["entrypoint"] = True
+    helper = next(n for n in graph.nodes if n.fqname == "mod.helper")
+    assert helper in find_reachable(graph)
+
+
+def test_find_kept_alive_by_dead_branches_returns_strict_diff(build_decl_graph):
+    """Strict pruning surfaces ``helper`` as kept-alive-only-by-dead-code."""
+    graph = build_decl_graph(
         {
-            "mod.helper -> mod",
-            "mod -> mod.helper",
-        },
+            "mod.py": """
+            def helper(): pass
+            if False:
+                helper()
+            """
+        }
     )
+    module = next(n for n in graph.nodes if n.fqname == "mod")
+    graph.nodes[module]["entrypoint"] = True
+    helper = next(n for n in graph.nodes if n.fqname == "mod.helper")
+    blast = find_kept_alive_by_dead_branches(graph)
+    assert helper in blast
 
 
-def test_nested_dead_suites_create_separate_synthetic_nodes(build_decl_graph):
+def test_nested_dead_suites_record_separate_positions(build_decl_graph, tmp_path):
     graph = build_decl_graph(
         {
             "mod.py": """
@@ -156,13 +172,13 @@ def test_nested_dead_suites_create_separate_synthetic_nodes(build_decl_graph):
             """
         }
     )
-    branches = _unreachable_nodes(graph)
-    assert len(branches) == 2
+    assert len(_dead_suite_positions(graph, tmp_path / "mod.py")) == 2
 
 
-def test_nested_dead_suite_attributes_to_innermost(build_decl_graph, assert_unreachable_edges):
-    # ``a()`` is inside the outer dead suite only; ``b()`` is inside
-    # both, but the innermost suite owns it.
+def test_nested_dead_suites_flag_both_refs(build_decl_graph, assert_dead_branch_edges):
+    # Both refs are inside at least one dead suite; both are flagged.
+    # The previous synthetic-node model attributed each ref to the
+    # innermost suite -- that fidelity intentionally goes away here.
     graph = build_decl_graph(
         {
             "mod.py": """
@@ -175,16 +191,10 @@ def test_nested_dead_suite_attributes_to_innermost(build_decl_graph, assert_unre
             """
         }
     )
-    assert_unreachable_edges(
-        graph,
-        {
-            "<4:4> -> mod.a",
-            "<6:8> -> mod.b",
-        },
-    )
+    assert_dead_branch_edges(graph, {"mod -> mod.a", "mod -> mod.b"})
 
 
-def test_while_false_creates_synthetic_node(build_decl_graph, assert_unreachable_edges):
+def test_while_false_flags_internal_ref(build_decl_graph, assert_dead_branch_edges):
     graph = build_decl_graph(
         {
             "mod.py": """
@@ -194,10 +204,10 @@ def test_while_false_creates_synthetic_node(build_decl_graph, assert_unreachable
             """
         }
     )
-    assert_unreachable_edges(graph, {"<3:4> -> mod.helper"})
+    assert_dead_branch_edges(graph, {"mod -> mod.helper"})
 
 
-def test_while_true_else_is_unreachable(build_decl_graph, assert_unreachable_edges):
+def test_while_true_else_flags_internal_ref(build_decl_graph, assert_dead_branch_edges):
     graph = build_decl_graph(
         {
             "mod.py": """
@@ -209,29 +219,14 @@ def test_while_true_else_is_unreachable(build_decl_graph, assert_unreachable_edg
             """
         }
     )
-    assert_unreachable_edges(graph, {"<5:4> -> mod.helper"})
-
-
-def test_synthetic_nodes_are_unreachable_from_entrypoints(build_decl_graph):
-    # No incoming edges, so reachability skips them. Critical so the
-    # parallel edges do not accidentally keep symbols alive.
-    graph = build_decl_graph(
-        {
-            "mod.py": """
-            def helper(): pass
-            if False:
-                helper()
-            """
-        }
-    )
-    suite = _unreachable_nodes(graph)[0]
-    assert graph.in_degree(suite) == 0
+    assert_dead_branch_edges(graph, {"mod -> mod.helper"})
 
 
 def test_decls_inside_dead_branch_remain_in_graph(build_decl_graph, assert_edges):
     # Per the design decision: top-level decls defined inside a dead
-    # branch keep their normal node + edges. The synthetic node coexists
-    # with them; pruning is a follow-up.
+    # branch keep their normal node + edges. The flagged-edge model
+    # only marks references made from dead code; the decl itself is
+    # not flagged.
     graph = build_decl_graph(
         {
             "mod.py": """
@@ -240,7 +235,7 @@ def test_decls_inside_dead_branch_remain_in_graph(build_decl_graph, assert_edges
             """
         }
     )
-    fqnames = {n.fqname for n in graph.nodes if not is_unreachable_node(n)}
+    fqnames = {n.fqname for n in graph.nodes}
     assert "mod.foo" in fqnames
     assert_edges(
         graph,
@@ -250,9 +245,7 @@ def test_decls_inside_dead_branch_remain_in_graph(build_decl_graph, assert_edges
     )
 
 
-def test_elif_false_in_chain_creates_synthetic_for_only_dead_branch(
-    build_decl_graph, assert_unreachable_edges
-):
+def test_elif_false_in_chain_flags_only_dead_branch(build_decl_graph, assert_dead_branch_edges):
     graph = build_decl_graph(
         {
             "mod.py": """
@@ -268,5 +261,5 @@ def test_elif_false_in_chain_creates_synthetic_for_only_dead_branch(
             """
         }
     )
-    # Only the ``elif False:`` body is unreachable.
-    assert_unreachable_edges(graph, {"<7:4> -> mod.b"})
+    # Only the ``elif False:`` body is dead, so only ``b`` is flagged.
+    assert_dead_branch_edges(graph, {"mod -> mod.b"})


### PR DESCRIPTION
## Why

The SQLite cache item in `ROADMAP.md:21–39` needs a clean per-file
shape to pickle into the `file_cache` table. The visitor today exposes
seven attributes that `_analyze.py` walks in lockstep, plus a
synthetic-tombstone abstraction that exists mainly to dodge
`DiGraph`'s "one edge per `(u, v)` pair" limitation. This PR is the
data-shape groundwork; the actual SQLite plumbing follows in a second
PR.

## What changed

**`SymbolNode.flags: NodeFlags`** keeps the `SHADOWED` marker:
shadowed decls go to the graph (parent edge intact) but skip the
lookup trie so cross-module imports never resolve to them.

**New `EdgeFlags(IntFlag)` with `DEAD_BRANCH`**: marks edges whose
reference originated inside a statically-dead suite. The flag is
**audit metadata by default** — `find_reachable` does NOT filter by
it, so today's behavior (dead-code references propagate liveness
through the enclosing decl) is preserved.

**New `find_kept_alive_by_dead_branches(graph)`**: the opt-in strict
variant. Returns the set of symbols that would become unreachable if
every dead suite were severed — the "blast radius" of removing every
unreachable region in the source. Future tooling (a CLI command, a
`remove --include-dead-branches` flag) will wire this up; this PR
just lands the primitive.

**New `VisitorPayload`** (4 fields, fully static):

```python
@dataclass(frozen=True, slots=True)
class VisitorPayload:
    nodes:       tuple[SymbolNode, ...]
    edges:       tuple[tuple[SymbolNode, SymbolNode, CodeRange], ...]
    imports:     tuple[tuple[SymbolNode, Import,    CodeRange], ...]
    dead_suites: tuple[CodeRange, ...]
```

- `edges` and `imports` are split by `dst` type — no more
  `SymbolNode | Import` union or runtime `isinstance` dispatch at apply.
- Every ref entry carries the access position. `_apply_payload`
  derives the `EdgeFlags` per edge by checking position-vs-suite
  containment.
- `dead_suites` enumerates every dead suite in the file (including
  ones with no outgoing refs). The CLI surfaces these as
  "Unreachable branches at line X" via a new graph-level attribute
  (`graph.graph["dead_suites"]`).

**Graph type: `nx.DiGraph` → `nx.MultiDiGraph`.** The same
`(src, dst)` pair can now carry both a live edge and a `DEAD_BRANCH`
edge as parallel entries with independent `flags`. `find_reachable`
still works (`successors` de-duplicates).

**Synthetic tombstone removal.** `_branches.py` loses
`make_unreachable_node`, `make_unreachable_fqname`,
`is_unreachable_node`, and `UNREACHABLE_PREFIX`. The static-truthiness
logic (`evaluate_truthiness`, `unreachable_suites`,
`unreachable_bodies`) stays. CLI's `_partition_unreachable` collapses
to `_dead_real` (excludes all `type=="synthetic"` nodes uniformly)
plus `_dead_suite_locations` reading from the new graph attribute.

**Trade-off acknowledged**: per-edge "which dead suite owned this
ref?" attribution is dropped (deliberate fidelity loss). The per-file
`dead_suites` list still drives the "this file has unreachable code
at line X" report; what's gone is linking specific edges to specific
suites within a file.

## Behavior

No change to default analyze output. 510 existing tests pass plus 11
new payload-contract tests (521 total).

The `assert_unreachable_edges` test fixture is renamed to
`assert_dead_branch_edges` and now filters by `EdgeFlags.DEAD_BRANCH`
rather than synthetic-node identity. Test assertion strings change
format (`<line:col> -> target.fqname` → `src.fqname -> dst.fqname`)
to reflect the dropped per-suite attribution.

## Test plan

- [x] `uv run pytest` — 521 passed.
- [x] `uv run ruff check . && uv run ruff format --check .` — clean.
- [x] New `tests/test_payload.py` covers:
  - `NodeFlags` and `EdgeFlags` membership / composition
  - `VisitorPayload` field shape: nodes, edges with access pos,
    imports, dead_suites
  - `to_payload()` emits `SHADOWED` flagged copies for displaced decls
  - Edge endpoints pointing at shadowed decls are remapped to the
    flagged identity (no parallel unflagged twin in the graph)
  - End-to-end: live + dead-branch refs to the same target produce
    parallel edges with distinct `flags` (the MultiDiGraph win)
  - `graph.graph["dead_suites"]` enumeration
  - `VisitorPayload` survives `pickle` round-trip (PR 2 pre-flight)
- [x] `tests/test_unreachable_branches.py` rewrites every assertion
  for the new model (dead-suite enumeration via graph attr,
  `assert_dead_branch_edges` for flag-filtered edges, direct tests
  for `find_reachable` vs `find_kept_alive_by_dead_branches`).

## Follow-up

- **PR 2**: SQLite cache built on `VisitorPayload`. `GraphCache(path)`
  keyed by per-file content hash, fingerprint check for
  resolver/plugin/workspace changes, `--no-cache` flag,
  `dead-cst cache clear` subcommand.
- **PR 3**: CLI surface for blast-radius reporting -- a
  `dead-cst dead-branch-dependents` command and a
  `dead-cst remove --include-dead-branches` flag, both wired through
  the `find_kept_alive_by_dead_branches` primitive landed here.

https://claude.ai/code/session_01T81m2KgwrQbDoTYiC1CR1i