### PR TITLE
feat: pluggable UnreachableRegionDetector + shared Cacheable protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ two versions.
 ## [Unreleased]
 
 ### Added
+- `UnreachableRegionDetector`: pluggable Protocol for module-level
+  dead-region detection. Implementers provide
+  `find_regions(wrapper) -> list[CodeRange]` and a `(name, version)`
+  pair; consumers pass an instance via the new
+  `build_symbol_graph(unreachable_detector=...)` keyword. Lets a
+  company fold domain knowledge (e.g. "`settings.IS_PROD` is always
+  `True` in production") into the analysis without forking the
+  package. The shipped `DefaultUnreachableRegionDetector` preserves
+  existing behavior — literal-only truthiness on `if` / `while`
+  tests. The detector runs from inside `SymbolVisitor.visit_Module`
+  reusing the analyzer's already-resolved `PositionProvider`, so the
+  abstraction is free for the default path.
+- `Cacheable` Protocol (`name: str`, `version: int`): the shared
+  cache-fingerprint contract that `EdgePlugin`, `PathResolver`, and
+  `UnreachableRegionDetector` now all inherit from. Bumping a
+  component's epoch `version` invalidates the per-file cache the same
+  way it does for plugins. `compute_fingerprint` reads the attributes
+  directly instead of falling back to `getattr` defaults.
 - `DecoratedDeclPlugin`: abstract `EdgePlugin` base for the "find decls
   decorated by `@<module>.<name>(...)` or assigned via
   `X = <module>.<ctor>(...)` in files matching a search path" idiom.
@@ -55,6 +73,13 @@ two versions.
   marker for idempotent reuse.
 
 ### Changed
+- `PathResolver` is now a `Cacheable` Protocol: shipped resolvers
+  (`ManualResolver`, `PyprojectResolver`, `UvWorkspaceResolver`,
+  `VenvResolver`) all carry an epoch `version: int` matching the
+  plugin convention, and the per-file cache fingerprint includes
+  each resolver's `(name, version)` pair. Bump a resolver's
+  `version` when its layout-discovery or `resolve_import` logic
+  changes; stale `VisitorPayload` blobs rebuild automatically.
 - `EdgePlugin.version` is now `int` (Unix epoch by convention) rather
   than `str`. Bump `version` to the current epoch on any change to a
   plugin's `observe` shape that should not be served from older

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,10 @@ flask_routes = "myproj.plugins:FlaskRoutesPlugin"
 
 A resolver implements `PathResolver`: a `name: str` attribute and a `resolve(project_root)` method returning a `{base: [dep_paths]}` dict. Built-in resolvers live in `_resolvers.py`; third-party resolvers register under `dead_cst.resolvers`.
 
+## Adding an unreachable-region detector
+
+A detector implements `UnreachableRegionDetector`: `find_regions(wrapper) -> list[CodeRange]` plus the standard `Cacheable` `(name, version)` pair. The built-in `DefaultUnreachableRegionDetector` runs literal-only truthiness on `if` / `while` tests; subclass it (or write a fresh one) to fold in domain knowledge — e.g. "`settings.IS_PROD` is always `True` in production." Pass an instance via `build_symbol_graph(unreachable_detector=...)`. The detector's `(name, version)` participates in the per-file cache fingerprint, so bumping `version` after a logic change invalidates stale `VisitorPayload` blobs automatically.
+
 ## Adding a test
 
 Tests use the `build_decl_graph` fixture (in `tests/conftest.py`), which writes a dict of `{filename: source}` to a tmpdir, runs `build_symbol_graph` on it, and returns the resulting graph. The `assert_edges` fixture compares edges as `"src.fqname -> dst.fqname"` strings.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,9 @@ unreachable = graph.subgraph([n for n in graph.nodes if n not in reachable])
 remove_code(unreachable, root)
 ```
 
-Entrypoint detection is now fully plugin-driven. Builtins:
+All three extension points — edge plugins, path resolvers, and the unreachable-region detector — share a single `Cacheable` protocol (`name: str`, `version: int`) that feeds the per-file cache fingerprint. Bumping a component's epoch `version` invalidates stale payloads automatically, so swapping or upgrading any of them is safe by default.
+
+Entrypoint detection is fully plugin-driven. Builtins:
 
 | Plugin | Purpose |
 |---|---|
@@ -249,8 +251,6 @@ class IsProdDetector:
 
 graph = build_symbol_graph({root: []}, unreachable_detector=IsProdDetector())
 ```
-
-Plugins, resolvers, and detectors all share a single `Cacheable` protocol — `name: str` plus an epoch-int `version: int` — that feeds the per-file cache fingerprint, so any swap or version bump invalidates stale payloads automatically.
 
 ## Graph model
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,40 @@ Write your own from scratch by implementing the `EdgePlugin` protocol (`name`, `
 
 Path resolution is similarly pluggable. `PathResolver` implementations return a `{base: [dep_paths]}` map to feed `build_symbol_graph`. Builtins: `VenvResolver`, `PyprojectResolver`, `UvWorkspaceResolver` (parses `uv.lock` to discover workspace members and their inter-member dep edges). Third-party resolvers register under `dead_cst.resolvers`.
 
+Unreachable-code detection is a single swappable callable. `build_symbol_graph` accepts an `unreachable_detector: Callable[[cst.MetadataWrapper], list[CodeRange]]`; the default, `default_unreachable_regions`, runs the literal-only truthiness evaluator on every `if` / `while` test. Override it to fold in domain knowledge — e.g. config flags whose values are fixed in production:
+
+```python
+import libcst as cst
+from libcst.metadata import CodeRange, MetadataWrapper, PositionProvider
+from dead_cst import build_symbol_graph
+
+def my_detector(wrapper: MetadataWrapper) -> list[CodeRange]:
+    positions = wrapper.resolve(PositionProvider)
+    out: list[CodeRange] = []
+
+    class V(cst.CSTVisitor):
+        def visit_If(self, node):
+            # "settings.IS_PROD is always True" -- mark the else-branch dead.
+            if isinstance(node.test, cst.Name) and node.test.value == "IS_PROD":
+                if isinstance(node.orelse, cst.Else):
+                    pos = positions.get(node.orelse.body)
+                    if pos is not None:
+                        out.append(pos)
+
+    wrapper.module.visit(V())
+    return out
+
+# Optional name/version feed the per-file cache fingerprint -- bump
+# version when the detector's logic changes so stale payloads are
+# rebuilt automatically.
+my_detector.name = "my_detector"
+my_detector.version = 1700000000
+
+graph = build_symbol_graph({root: []}, unreachable_detector=my_detector)
+```
+
+The default detector ships with a stable `name` / `version`; bare callables fall back to `__name__` and `0` for fingerprinting.
+
 ## Graph model
 
 The graph has one node per top-level declaration plus a synthetic module node per file. Edges run from a declaration to each symbol it references, and from every submodule to its parent package so `__init__.py` stays alive as long as anything in the package does. Entrypoints seed the reachability walk; every node not reached is reported as dead.

--- a/README.md
+++ b/README.md
@@ -214,39 +214,43 @@ Write your own from scratch by implementing the `EdgePlugin` protocol (`name`, `
 
 Path resolution is similarly pluggable. `PathResolver` implementations return a `{base: [dep_paths]}` map to feed `build_symbol_graph`. Builtins: `VenvResolver`, `PyprojectResolver`, `UvWorkspaceResolver` (parses `uv.lock` to discover workspace members and their inter-member dep edges). Third-party resolvers register under `dead_cst.resolvers`.
 
-Unreachable-code detection is a single swappable callable. `build_symbol_graph` accepts an `unreachable_detector: Callable[[cst.MetadataWrapper], list[CodeRange]]`; the default, `default_unreachable_regions`, runs the literal-only truthiness evaluator on every `if` / `while` test. Override it to fold in domain knowledge — e.g. config flags whose values are fixed in production:
+Unreachable-code detection is pluggable through the `UnreachableRegionDetector` protocol. `build_symbol_graph` accepts an `unreachable_detector` whose `find_regions(wrapper) -> list[CodeRange]` is invoked once per file; the built-in `DefaultUnreachableRegionDetector` runs the literal-only truthiness evaluator on every `if` / `while` test. Override it to fold in domain knowledge — e.g. config flags whose values are fixed in production:
 
 ```python
+from dataclasses import dataclass
+
 import libcst as cst
 from libcst.metadata import CodeRange, MetadataWrapper, PositionProvider
 from dead_cst import build_symbol_graph
 
-def my_detector(wrapper: MetadataWrapper) -> list[CodeRange]:
-    positions = wrapper.resolve(PositionProvider)
-    out: list[CodeRange] = []
+@dataclass(frozen=True)
+class IsProdDetector:
+    # name/version satisfy the Cacheable contract -- bump version when
+    # the detector's logic changes so stale per-file payloads rebuild
+    # automatically.
+    name: str = "is_prod"
+    version: int = 1700000000
 
-    class V(cst.CSTVisitor):
-        def visit_If(self, node):
-            # "settings.IS_PROD is always True" -- mark the else-branch dead.
-            if isinstance(node.test, cst.Name) and node.test.value == "IS_PROD":
-                if isinstance(node.orelse, cst.Else):
-                    pos = positions.get(node.orelse.body)
-                    if pos is not None:
-                        out.append(pos)
+    def find_regions(self, wrapper: MetadataWrapper) -> list[CodeRange]:
+        positions = wrapper.resolve(PositionProvider)
+        out: list[CodeRange] = []
 
-    wrapper.module.visit(V())
-    return out
+        class V(cst.CSTVisitor):
+            def visit_If(self, node):
+                # "settings.IS_PROD is always True" -- mark the else-branch dead.
+                if isinstance(node.test, cst.Name) and node.test.value == "IS_PROD":
+                    if isinstance(node.orelse, cst.Else):
+                        pos = positions.get(node.orelse.body)
+                        if pos is not None:
+                            out.append(pos)
 
-# Optional name/version feed the per-file cache fingerprint -- bump
-# version when the detector's logic changes so stale payloads are
-# rebuilt automatically.
-my_detector.name = "my_detector"
-my_detector.version = 1700000000
+        wrapper.module.visit(V())
+        return out
 
-graph = build_symbol_graph({root: []}, unreachable_detector=my_detector)
+graph = build_symbol_graph({root: []}, unreachable_detector=IsProdDetector())
 ```
 
-The default detector ships with a stable `name` / `version`; bare callables fall back to `__name__` and `0` for fingerprinting.
+Plugins, resolvers, and detectors all share a single `Cacheable` protocol — `name: str` plus an epoch-int `version: int` — that feeds the per-file cache fingerprint, so any swap or version bump invalidates stale payloads automatically.
 
 ## Graph model
 

--- a/dead_cst/__init__.py
+++ b/dead_cst/__init__.py
@@ -38,6 +38,10 @@ from ._analyze import (
     find_reachable,
     order_paths,
 )
+from ._branches import (
+    UnreachableRegionDetector,
+    default_unreachable_regions,
+)
 from ._codemod import remove_code
 from ._symbols import EdgeFlags, NodeFlags
 from ._plugins import (
@@ -108,10 +112,12 @@ __all__ = [
     "RemoveEdge",
     "TyperPlugin",
     "UnittestPlugin",
+    "UnreachableRegionDetector",
     "UvWorkspaceResolver",
     "VenvResolver",
     "build_symbol_graph",
     "count_nodes",
+    "default_unreachable_regions",
     "entrypoint_payload",
     "find_kept_alive_by_dead_branches",
     "find_reachable",

--- a/dead_cst/__init__.py
+++ b/dead_cst/__init__.py
@@ -39,9 +39,10 @@ from ._analyze import (
     order_paths,
 )
 from ._branches import (
+    DefaultUnreachableRegionDetector,
     UnreachableRegionDetector,
-    default_unreachable_regions,
 )
+from ._cacheable import Cacheable
 from ._codemod import remove_code
 from ._symbols import EdgeFlags, NodeFlags
 from ._plugins import (
@@ -89,8 +90,10 @@ __all__ = [
     "AddNode",
     "BUILTIN_PLUGINS",
     "BUILTIN_RESOLVERS",
+    "Cacheable",
     "ClickPlugin",
     "DecoratedDeclPlugin",
+    "DefaultUnreachableRegionDetector",
     "EdgeFlags",
     "EdgePlugin",
     "ExplicitEntrypointPlugin",
@@ -117,7 +120,6 @@ __all__ = [
     "VenvResolver",
     "build_symbol_graph",
     "count_nodes",
-    "default_unreachable_regions",
     "entrypoint_payload",
     "find_kept_alive_by_dead_branches",
     "find_reachable",

--- a/dead_cst/__init__.py
+++ b/dead_cst/__init__.py
@@ -4,7 +4,10 @@
 reports (or removes) anything not reachable from a configurable set of
 entrypoints.
 
-The public API has three layers:
+The public API has three extension points, all of which inherit from a
+single :class:`Cacheable` protocol (``name: str``, ``version: int``) so
+the per-file cache invalidates cleanly when any of them is swapped or
+bumped:
 
 * :func:`build_symbol_graph` parses every ``.py`` file under each base in a
   ``{base: [dep_paths]}`` map and returns a :class:`networkx.MultiDiGraph` of
@@ -21,6 +24,12 @@ The public API has three layers:
 * Path resolvers (:class:`VenvResolver`, :class:`PyprojectResolver`,
   :class:`UvWorkspaceResolver`) discover the ``{base: [dep_paths]}`` map
   itself from a project root, so callers don't have to hand-build it.
+* The unreachable-region detector (:class:`UnreachableRegionDetector`)
+  decides which source ranges count as statically dead. The built-in
+  :class:`DefaultUnreachableRegionDetector` runs literal-only truthiness
+  on ``if`` / ``while`` tests; supply a custom one via
+  ``build_symbol_graph(unreachable_detector=...)`` to fold in domain
+  knowledge (e.g. config flags whose values are fixed in production).
 
 After plugins run, :func:`find_reachable` walks successors from every node
 tagged with ``entrypoint=True`` and returns the live set;

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -8,6 +8,10 @@ import libcst as cst
 import networkx as nx
 from libcst.metadata import CodeRange, FullRepoManager
 
+from ._branches import (
+    UnreachableRegionDetector,
+    default_unreachable_regions,
+)
 from ._cache import GraphCache
 from ._edges import resolve_edges
 from ._fqn import FixedFullyQualifiedNameProvider
@@ -82,6 +86,7 @@ def build_symbol_graph(
     resolvers: Sequence[PathResolver] = (),
     project_root: Path | None = None,
     cache: GraphCache | None = None,
+    unreachable_detector: UnreachableRegionDetector | None = None,
 ) -> nx.MultiDiGraph:
     """Build a directed reachability graph of every top-level symbol under ``paths``.
 
@@ -139,6 +144,16 @@ def build_symbol_graph(
         unconditionally on every invocation -- the cache only
         short-circuits the per-file visit. Pass ``None`` (the default)
         to bypass caching entirely.
+    unreachable_detector:
+        Optional :data:`~dead_cst._branches.UnreachableRegionDetector`
+        invoked once per file to compute the set of statically-dead
+        suite positions. Defaults to
+        :func:`~dead_cst._branches.default_unreachable_regions`, which
+        evaluates only literal-truthiness of ``if`` / ``while`` tests.
+        Override to fold in domain knowledge (e.g. config flags whose
+        value is fixed in production). The returned :class:`CodeRange`
+        list feeds :data:`EdgeFlags.DEAD_BRANCH` derivation and the
+        per-file ``graph.graph["dead_suites"]`` reporting map.
 
     Returns
     -------
@@ -156,6 +171,7 @@ def build_symbol_graph(
     export_tries: dict[Path, SymbolTrie] = {}
     root = project_root or _infer_project_root(paths) if paths else Path.cwd()
     import_resolver = _chain_resolvers(resolvers)
+    detector = unreachable_detector or default_unreachable_regions
     for base in order_paths(paths):
         logger.debug("Processing base path: %s", base)
         search_paths = [base] + paths.get(base, [])
@@ -182,7 +198,8 @@ def build_symbol_graph(
                     wrapper = mgr.get_metadata_wrapper_for_path(str(file))
                     visitor = SymbolVisitor(file, search_paths, import_resolver)
                     wrapper.visit(visitor)
-                    base_payload = visitor.to_payload()
+                    dead_suites = tuple(detector(wrapper))
+                    base_payload = visitor.to_payload(dead_suites=dead_suites)
                     plugin_payload = _run_observe(
                         plugins, file, wrapper.module, base_payload, base, root
                     )

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -9,8 +9,8 @@ import networkx as nx
 from libcst.metadata import CodeRange, FullRepoManager
 
 from ._branches import (
+    DefaultUnreachableRegionDetector,
     UnreachableRegionDetector,
-    default_unreachable_regions,
 )
 from ._cache import GraphCache
 from ._edges import resolve_edges
@@ -145,15 +145,16 @@ def build_symbol_graph(
         short-circuits the per-file visit. Pass ``None`` (the default)
         to bypass caching entirely.
     unreachable_detector:
-        Optional :data:`~dead_cst._branches.UnreachableRegionDetector`
-        invoked once per file to compute the set of statically-dead
-        suite positions. Defaults to
-        :func:`~dead_cst._branches.default_unreachable_regions`, which
-        evaluates only literal-truthiness of ``if`` / ``while`` tests.
-        Override to fold in domain knowledge (e.g. config flags whose
-        value is fixed in production). The returned :class:`CodeRange`
-        list feeds :data:`EdgeFlags.DEAD_BRANCH` derivation and the
-        per-file ``graph.graph["dead_suites"]`` reporting map.
+        Optional :class:`~dead_cst._branches.UnreachableRegionDetector`
+        whose :meth:`find_regions` is invoked once per file to compute
+        the set of statically-dead suite positions. Defaults to
+        :class:`~dead_cst._branches.DefaultUnreachableRegionDetector`,
+        which evaluates only literal-truthiness of ``if`` / ``while``
+        tests. Override to fold in domain knowledge (e.g. config flags
+        whose value is fixed in production). The returned
+        :class:`CodeRange` list feeds :data:`EdgeFlags.DEAD_BRANCH`
+        derivation and the per-file ``graph.graph["dead_suites"]``
+        reporting map.
 
     Returns
     -------
@@ -171,7 +172,13 @@ def build_symbol_graph(
     export_tries: dict[Path, SymbolTrie] = {}
     root = project_root or _infer_project_root(paths) if paths else Path.cwd()
     import_resolver = _chain_resolvers(resolvers)
-    detector = unreachable_detector or default_unreachable_regions
+    # Materialize once and share across files so all visitors see the
+    # same fingerprint-contributing instance.
+    detector = (
+        unreachable_detector
+        if unreachable_detector is not None
+        else DefaultUnreachableRegionDetector()
+    )
     for base in order_paths(paths):
         logger.debug("Processing base path: %s", base)
         search_paths = [base] + paths.get(base, [])
@@ -196,10 +203,15 @@ def build_symbol_graph(
                             {FixedFullyQualifiedNameProvider},
                         )
                     wrapper = mgr.get_metadata_wrapper_for_path(str(file))
-                    visitor = SymbolVisitor(file, search_paths, import_resolver)
+                    visitor = SymbolVisitor(
+                        file,
+                        search_paths,
+                        import_resolver,
+                        unreachable_detector=detector,
+                        wrapper=wrapper,
+                    )
                     wrapper.visit(visitor)
-                    dead_suites = tuple(detector(wrapper))
-                    base_payload = visitor.to_payload(dead_suites=dead_suites)
+                    base_payload = visitor.to_payload()
                     plugin_payload = _run_observe(
                         plugins, file, wrapper.module, base_payload, base, root
                     )

--- a/dead_cst/_branches.py
+++ b/dead_cst/_branches.py
@@ -12,13 +12,22 @@ over those. Anything involving a name lookup (other than the three
 keywords), attribute access, function call, comparison, or other
 dynamic operation returns ``None`` (unknown). Returning ``None`` is
 always the safe default: callers must treat the branch as live.
+
+Module-level unreachable-region detection is exposed as a swappable
+callable (:data:`UnreachableRegionDetector`) so downstream consumers
+can fold in domain knowledge -- e.g. config flags whose values are
+fixed in production -- without forking the analyzer. The default
+detector, :func:`default_unreachable_regions`, walks every ``if`` and
+``while`` in the module and runs the literal-only evaluator above on
+the test expression.
 """
 
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Callable, Sequence
 
 import libcst as cst
+from libcst.metadata import CodeRange, MetadataWrapper, PositionProvider
 
 
 _KEYWORDS: dict[str, bool] = {
@@ -127,6 +136,62 @@ def unreachable_bodies(stmt: cst.BaseStatement) -> list[Sequence[cst.CSTNode]]:
     ``if False: x = 1``).
     """
     return [suite.body for suite in unreachable_suites(stmt)]
+
+
+# Type alias for the unreachable-region detector callable. The
+# analyzer invokes one detector per module after the visitor has
+# walked it; the returned list of :class:`CodeRange` determines which
+# declarations and references are flagged with
+# :data:`dead_cst._symbols.EdgeFlags.DEAD_BRANCH` and which positions
+# are surfaced as "unreachable code at line X" reports.
+#
+# Pass a custom detector to :func:`dead_cst.build_symbol_graph` to
+# layer on company-specific constant folding (e.g. "``settings.IS_PROD``
+# is always ``True``"). The default,
+# :func:`default_unreachable_regions`, runs literal-only truthiness on
+# every ``if`` / ``while`` test.
+#
+# Optional ``name`` and ``version`` attributes on the callable feed
+# the per-file cache fingerprint, so swapping detectors invalidates
+# stale ``VisitorPayload`` blobs automatically. Bare functions fall
+# back to ``__name__`` and ``0``; set / bump these explicitly when
+# the detector's logic changes.
+UnreachableRegionDetector = Callable[[MetadataWrapper], list[CodeRange]]
+
+
+def default_unreachable_regions(wrapper: MetadataWrapper) -> list[CodeRange]:
+    """Default detector: literal-truthiness analysis on ``if`` / ``while``.
+
+    Walks every ``cst.If`` and ``cst.While`` in the module, runs
+    :func:`unreachable_suites` on each, and returns the
+    :class:`CodeRange` of every dead suite. The order of the result
+    follows the document order of the suites.
+    """
+    positions = wrapper.resolve(PositionProvider)
+    found: list[CodeRange] = []
+
+    class _Collector(cst.CSTVisitor):
+        def visit_If(self, node: cst.If) -> None:
+            self._collect(node)
+
+        def visit_While(self, node: cst.While) -> None:
+            self._collect(node)
+
+        def _collect(self, stmt: cst.BaseStatement) -> None:
+            for suite in unreachable_suites(stmt):
+                pos = positions.get(suite)
+                if pos is not None:
+                    found.append(pos)
+
+    wrapper.module.visit(_Collector())
+    return found
+
+
+# Cache-fingerprint metadata for the default detector. Custom detectors
+# that want stable cache reuse should set their own ``name`` / ``version``
+# (a Unix-epoch int by convention, matching the ``EdgePlugin`` story).
+default_unreachable_regions.name = "default"  # type: ignore[attr-defined]
+default_unreachable_regions.version = 1  # type: ignore[attr-defined]
 
 
 def _unreachable_in_if(node: cst.If, branch_taken: bool) -> list[cst.BaseSuite]:

--- a/dead_cst/_branches.py
+++ b/dead_cst/_branches.py
@@ -13,21 +13,23 @@ keywords), attribute access, function call, comparison, or other
 dynamic operation returns ``None`` (unknown). Returning ``None`` is
 always the safe default: callers must treat the branch as live.
 
-Module-level unreachable-region detection is exposed as a swappable
-callable (:data:`UnreachableRegionDetector`) so downstream consumers
+Module-level unreachable-region detection is exposed as the
+:class:`UnreachableRegionDetector` protocol so downstream consumers
 can fold in domain knowledge -- e.g. config flags whose values are
-fixed in production -- without forking the analyzer. The default
-detector, :func:`default_unreachable_regions`, walks every ``if`` and
-``while`` in the module and runs the literal-only evaluator above on
-the test expression.
+fixed in production -- without forking the analyzer.
+:class:`DefaultUnreachableRegionDetector` ships the literal-only
+behavior above and is used when callers don't supply their own.
 """
 
 from __future__ import annotations
 
-from typing import Callable, Sequence
+from dataclasses import dataclass
+from typing import Protocol, Sequence, runtime_checkable
 
 import libcst as cst
 from libcst.metadata import CodeRange, MetadataWrapper, PositionProvider
+
+from ._cacheable import Cacheable
 
 
 _KEYWORDS: dict[str, bool] = {
@@ -138,60 +140,61 @@ def unreachable_bodies(stmt: cst.BaseStatement) -> list[Sequence[cst.CSTNode]]:
     return [suite.body for suite in unreachable_suites(stmt)]
 
 
-# Type alias for the unreachable-region detector callable. The
-# analyzer invokes one detector per module after the visitor has
-# walked it; the returned list of :class:`CodeRange` determines which
-# declarations and references are flagged with
-# :data:`dead_cst._symbols.EdgeFlags.DEAD_BRANCH` and which positions
-# are surfaced as "unreachable code at line X" reports.
-#
-# Pass a custom detector to :func:`dead_cst.build_symbol_graph` to
-# layer on company-specific constant folding (e.g. "``settings.IS_PROD``
-# is always ``True``"). The default,
-# :func:`default_unreachable_regions`, runs literal-only truthiness on
-# every ``if`` / ``while`` test.
-#
-# Optional ``name`` and ``version`` attributes on the callable feed
-# the per-file cache fingerprint, so swapping detectors invalidates
-# stale ``VisitorPayload`` blobs automatically. Bare functions fall
-# back to ``__name__`` and ``0``; set / bump these explicitly when
-# the detector's logic changes.
-UnreachableRegionDetector = Callable[[MetadataWrapper], list[CodeRange]]
+@runtime_checkable
+class UnreachableRegionDetector(Cacheable, Protocol):
+    """Finds statically-unreachable source regions in a parsed module.
 
+    Detectors run once per file after the visitor walk; the returned
+    list of :class:`CodeRange` determines which references land
+    flagged with :data:`dead_cst._symbols.EdgeFlags.DEAD_BRANCH` and
+    which positions are surfaced as "unreachable code at line X"
+    reports.
 
-def default_unreachable_regions(wrapper: MetadataWrapper) -> list[CodeRange]:
-    """Default detector: literal-truthiness analysis on ``if`` / ``while``.
+    Pass a custom detector to :func:`dead_cst.build_symbol_graph` to
+    layer on company-specific constant folding (e.g.
+    ``settings.IS_PROD`` is always ``True``). The default,
+    :class:`DefaultUnreachableRegionDetector`, runs literal-only
+    truthiness on every ``if`` / ``while`` test.
 
-    Walks every ``cst.If`` and ``cst.While`` in the module, runs
-    :func:`unreachable_suites` on each, and returns the
-    :class:`CodeRange` of every dead suite. The order of the result
-    follows the document order of the suites.
+    Inherits the ``(name, version)`` contract from :class:`Cacheable`
+    so swapping detectors invalidates stale ``VisitorPayload`` blobs
+    automatically.
     """
-    positions = wrapper.resolve(PositionProvider)
-    found: list[CodeRange] = []
 
-    class _Collector(cst.CSTVisitor):
-        def visit_If(self, node: cst.If) -> None:
-            self._collect(node)
-
-        def visit_While(self, node: cst.While) -> None:
-            self._collect(node)
-
-        def _collect(self, stmt: cst.BaseStatement) -> None:
-            for suite in unreachable_suites(stmt):
-                pos = positions.get(suite)
-                if pos is not None:
-                    found.append(pos)
-
-    wrapper.module.visit(_Collector())
-    return found
+    def find_regions(self, wrapper: MetadataWrapper) -> list[CodeRange]: ...
 
 
-# Cache-fingerprint metadata for the default detector. Custom detectors
-# that want stable cache reuse should set their own ``name`` / ``version``
-# (a Unix-epoch int by convention, matching the ``EdgePlugin`` story).
-default_unreachable_regions.name = "default"  # type: ignore[attr-defined]
-default_unreachable_regions.version = 1  # type: ignore[attr-defined]
+@dataclass(frozen=True)
+class DefaultUnreachableRegionDetector:
+    """Built-in :class:`UnreachableRegionDetector`.
+
+    Walks every ``cst.If`` and ``cst.While`` in the module and runs
+    :func:`unreachable_suites` on each, returning the
+    :class:`CodeRange` of every dead suite in document order.
+    """
+
+    name: str = "default"
+    version: int = 1
+
+    def find_regions(self, wrapper: MetadataWrapper) -> list[CodeRange]:
+        positions = wrapper.resolve(PositionProvider)
+        found: list[CodeRange] = []
+
+        class _Collector(cst.CSTVisitor):
+            def visit_If(self, node: cst.If) -> None:
+                self._collect(node)
+
+            def visit_While(self, node: cst.While) -> None:
+                self._collect(node)
+
+            def _collect(self, stmt: cst.BaseStatement) -> None:
+                for suite in unreachable_suites(stmt):
+                    pos = positions.get(suite)
+                    if pos is not None:
+                        found.append(pos)
+
+        wrapper.module.visit(_Collector())
+        return found
 
 
 def _unreachable_in_if(node: cst.If, branch_taken: bool) -> list[cst.BaseSuite]:

--- a/dead_cst/_cache.py
+++ b/dead_cst/_cache.py
@@ -42,6 +42,10 @@ import sys
 from pathlib import Path
 from typing import Sequence
 
+from ._branches import (
+    UnreachableRegionDetector,
+    default_unreachable_regions,
+)
 from ._plugins._core import EdgePlugin
 from ._resolvers import PathMap, PathResolver
 from ._visitor import VisitorPayload
@@ -71,6 +75,7 @@ def compute_fingerprint(
     paths: PathMap,
     resolvers: Sequence[PathResolver],
     plugins: Sequence[EdgePlugin] = (),
+    unreachable_detector: UnreachableRegionDetector | None = None,
 ) -> str:
     """SHA-256 of every input that affects payload semantics for one analysis run.
 
@@ -78,14 +83,14 @@ def compute_fingerprint(
     output), Python version (pickle protocol stability), the
     ``PathMap`` (the search-path layout governs ``Import.path``
     resolution), the resolver chain (resolvers override
-    ``name -> path`` lookups), and the plugin set. Plugins are
-    fingerprinted by ``(name, version)`` because their ``observe``
-    contributions are folded into each cached payload; bumping a
-    plugin's ``version`` invalidates the file_cache so the new
-    observe output replaces the old. ``version`` is a Unix epoch
-    int by convention, so concurrent bumps on different branches
-    merge with ``max()``-wins semantics rather than colliding on a
-    re-used integer label.
+    ``name -> path`` lookups), the plugin set, and the
+    unreachable-region detector. Plugins and the detector are
+    fingerprinted by ``(name, version)`` because their output is
+    folded into each cached payload; bumping ``version`` invalidates
+    the file_cache so new output replaces the old. ``version`` is a
+    Unix epoch int by convention, so concurrent bumps on different
+    branches merge with ``max()``-wins semantics rather than colliding
+    on a re-used integer label.
 
     Each value is normalized to a stable string before hashing so
     equivalent inputs produce equal keys.
@@ -114,6 +119,13 @@ def compute_fingerprint(
     )
     for name, version in plugin_entries:
         h.update(f"  {name}@{version}\n".encode())
+
+    detector = unreachable_detector or default_unreachable_regions
+    detector_name = getattr(
+        detector, "name", getattr(detector, "__name__", type(detector).__name__)
+    )
+    detector_version = int(getattr(detector, "version", 0))
+    h.update(f"unreachable_detector={detector_name}@{detector_version}\n".encode())
 
     return h.hexdigest()
 

--- a/dead_cst/_cache.py
+++ b/dead_cst/_cache.py
@@ -43,8 +43,8 @@ from pathlib import Path
 from typing import Sequence
 
 from ._branches import (
+    DefaultUnreachableRegionDetector,
     UnreachableRegionDetector,
-    default_unreachable_regions,
 )
 from ._plugins._core import EdgePlugin
 from ._resolvers import PathMap, PathResolver
@@ -82,15 +82,14 @@ def compute_fingerprint(
     Includes the dead-cst version (any code change can shift visitor
     output), Python version (pickle protocol stability), the
     ``PathMap`` (the search-path layout governs ``Import.path``
-    resolution), the resolver chain (resolvers override
-    ``name -> path`` lookups), the plugin set, and the
-    unreachable-region detector. Plugins and the detector are
-    fingerprinted by ``(name, version)`` because their output is
-    folded into each cached payload; bumping ``version`` invalidates
+    resolution), and the resolver / plugin / detector chain.
+    Resolvers, plugins, and the detector all satisfy
+    :class:`~dead_cst._cacheable.Cacheable` and are fingerprinted by
+    their ``(name, version)`` pair: bumping ``version`` invalidates
     the file_cache so new output replaces the old. ``version`` is a
     Unix epoch int by convention, so concurrent bumps on different
-    branches merge with ``max()``-wins semantics rather than colliding
-    on a re-used integer label.
+    branches merge with ``max()``-wins semantics rather than
+    colliding on a re-used integer label.
 
     Each value is normalized to a stable string before hashing so
     equivalent inputs produce equal keys.
@@ -106,26 +105,19 @@ def compute_fingerprint(
         h.update(f"  {base}:{','.join(deps)}\n".encode())
 
     h.update(b"resolvers=\n")
-    for name in sorted(getattr(r, "name", type(r).__name__) for r in resolvers):
-        h.update(f"  {name}\n".encode())
+    for r_name, r_version in sorted((r.name, r.version) for r in resolvers):
+        h.update(f"  {r_name}@{r_version}\n".encode())
 
     h.update(b"plugins=\n")
-    plugin_entries = sorted(
-        (
-            getattr(p, "name", type(p).__name__),
-            int(getattr(p, "version", 0)),
-        )
-        for p in plugins
-    )
-    for name, version in plugin_entries:
-        h.update(f"  {name}@{version}\n".encode())
+    for p_name, p_version in sorted((p.name, p.version) for p in plugins):
+        h.update(f"  {p_name}@{p_version}\n".encode())
 
-    detector = unreachable_detector or default_unreachable_regions
-    detector_name = getattr(
-        detector, "name", getattr(detector, "__name__", type(detector).__name__)
+    detector = (
+        unreachable_detector
+        if unreachable_detector is not None
+        else DefaultUnreachableRegionDetector()
     )
-    detector_version = int(getattr(detector, "version", 0))
-    h.update(f"unreachable_detector={detector_name}@{detector_version}\n".encode())
+    h.update(f"unreachable_detector={detector.name}@{detector.version}\n".encode())
 
     return h.hexdigest()
 

--- a/dead_cst/_cacheable.py
+++ b/dead_cst/_cacheable.py
@@ -1,0 +1,30 @@
+"""Shared :class:`Cacheable` protocol for fingerprintable analyzer inputs.
+
+Plugins and the unreachable-region detector both fold their per-file
+output into the cached :class:`~dead_cst._visitor.VisitorPayload`, so
+swapping or reconfiguring either must invalidate stale entries. Both
+contribute a stable ``(name, version)`` pair to the cache fingerprint;
+:class:`Cacheable` is the structural type that captures that contract
+in one place. :func:`~dead_cst._cache.compute_fingerprint` accepts any
+``Cacheable`` directly so it can read ``.name`` / ``.version`` without
+``getattr`` defaults.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Cacheable(Protocol):
+    """Stable ``(name, version)`` identity used by the cache fingerprint.
+
+    ``version`` is a Unix epoch int by convention. Bump it (to the
+    current epoch) on any change that shouldn't be served from older
+    caches. Epoch ints merge with ``max()`` semantics, so two
+    branches bumping the same component never collide on a re-used
+    label.
+    """
+
+    name: str
+    version: int

--- a/dead_cst/_plugins/_core.py
+++ b/dead_cst/_plugins/_core.py
@@ -29,6 +29,7 @@ import libcst as cst
 import networkx as nx
 from libcst.metadata import CodePosition, CodeRange
 
+from .._cacheable import Cacheable
 from .._symbols import NodeFlags, SymbolNode, SymbolTrie
 
 if TYPE_CHECKING:
@@ -319,7 +320,7 @@ class ObserveContext:
 
 
 @runtime_checkable
-class EdgePlugin(Protocol):
+class EdgePlugin(Cacheable, Protocol):
     """A plugin that contributes nodes/edges per file plus an optional
     per-base graph-finalize pass.
 
@@ -339,16 +340,10 @@ class EdgePlugin(Protocol):
       that needs the full graph (factory walks, transitive subclass
       closure, ``[project.scripts]`` lookups).
 
-    ``version`` is a Unix epoch int by convention. Bump it (to the
-    current epoch) on any change to the plugin's per-file ``observe``
-    output that shouldn't be served from older caches. Epoch ints
-    merge with ``max()`` semantics: when two branches both bump the
-    same plugin, whichever commit is later wins instead of producing
-    a string-collision conflict like ``"2"`` vs ``"2"``.
+    Inherits the ``(name, version)`` contract from :class:`Cacheable`
+    so the analyzer's per-file cache invalidates when a plugin's
+    ``observe`` output changes (bump the epoch ``version``).
     """
-
-    name: str
-    version: int
 
     def observe(self, ctx: ObserveContext) -> "VisitorPayload | None": ...
 

--- a/dead_cst/_resolvers/_core.py
+++ b/dead_cst/_resolvers/_core.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable, Protocol, runtime_checkable
 
+from .._cacheable import Cacheable
+
 PathMap = dict[Path, list[Path]]
 
 # ``name -> path`` lookup callable. ``None`` means "not resolvable here".
@@ -17,7 +19,7 @@ ImportResolver = Callable[[str, list[Path]], "str | Path | None"]
 
 
 @runtime_checkable
-class PathResolver(Protocol):
+class PathResolver(Cacheable, Protocol):
     """A resolver describes a project layout in two complementary ways.
 
     :meth:`resolve` reports the search paths the analyzer should walk
@@ -32,9 +34,11 @@ class PathResolver(Protocol):
     ``sys.path`` + ``importlib`` implementation. Custom resolvers
     typically call it as a fallback after their own layout-specific
     lookups.
-    """
 
-    name: str
+    Inherits the ``(name, version)`` contract from :class:`Cacheable`
+    so the per-file cache invalidates when a resolver's layout-discovery
+    or import-resolution logic changes (bump the epoch ``version``).
+    """
 
     def resolve(self, project_root: Path) -> PathMap: ...
 

--- a/dead_cst/_resolvers/manual.py
+++ b/dead_cst/_resolvers/manual.py
@@ -31,6 +31,7 @@ class ManualResolver:
 
     specs: list[str] = field(default_factory=list)
     name: str = "manual"
+    version: int = 1777760307
 
     def resolve(self, project_root: Path) -> PathMap:
         out: PathMap = {}

--- a/dead_cst/_resolvers/pyproject.py
+++ b/dead_cst/_resolvers/pyproject.py
@@ -27,6 +27,7 @@ class PyprojectResolver:
     """
 
     name: str = "pyproject"
+    version: int = 1777760307
 
     def resolve(self, project_root: Path) -> PathMap:
         project_root = project_root.resolve()

--- a/dead_cst/_resolvers/uv_workspace.py
+++ b/dead_cst/_resolvers/uv_workspace.py
@@ -48,6 +48,7 @@ class UvWorkspaceResolver:
 
     lock_path: Path | None = None
     name: str = "uv_workspace"
+    version: int = 1777760307
 
     def resolve(self, project_root: Path) -> PathMap:
         project_root = project_root.resolve()

--- a/dead_cst/_resolvers/venv.py
+++ b/dead_cst/_resolvers/venv.py
@@ -41,6 +41,7 @@ class VenvResolver:
 
     venv_dir: str | None = None
     name: str = "venv"
+    version: int = 1777760307
 
     def resolve(self, project_root: Path) -> PathMap:
         project_root = project_root.resolve()

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -25,6 +25,7 @@ from libcst.metadata.scope_provider import (
     Scope,
 )
 
+from ._branches import DefaultUnreachableRegionDetector, UnreachableRegionDetector
 from ._flow import live_at_exit, live_referents
 from ._fqn import FixedFullyQualifiedNameProvider
 from ._plugins._core import UNRESOLVED_PREFIX
@@ -127,10 +128,22 @@ class SymbolVisitor(cst.CSTVisitor):
         path: Path,
         search_paths: list[Path],
         import_resolver: ImportResolver = default_resolve_import,
+        unreachable_detector: UnreachableRegionDetector | None = None,
+        wrapper: cst.MetadataWrapper | None = None,
     ):
         self.path = path
         self.search_paths = search_paths
         self._import_resolver = import_resolver
+        self._unreachable_detector = (
+            unreachable_detector
+            if unreachable_detector is not None
+            else DefaultUnreachableRegionDetector()
+        )
+        # Stash the wrapper that's about to drive ``visit`` so the
+        # unreachable-region detector can reuse the same resolved
+        # metadata cache (notably ``PositionProvider``) instead of
+        # paying O(file) to re-resolve on a sibling wrapper.
+        self._wrapper = wrapper
         self.node_to_frames: dict[cst.CSTNode, list[list[SymbolNode]]] = {}
         self.decl_stack: list[list[SymbolNode]] = []
         self.nearest_decls: dict[cst.CSTNode, list[SymbolNode]] = {}
@@ -150,6 +163,7 @@ class SymbolVisitor(cst.CSTVisitor):
         # descendants of the containing statement, which is what
         # ``live_at_exit`` matches against.
         self.symbol_referent_nodes: dict[SymbolNode, cst.CSTNode] = {}
+        self.dead_suites: list[CodeRange] = []
         # Decls displaced by flow analysis. Tracked here (rather than on
         # the trie) so the trie holds only entries cross-module imports
         # should resolve to. Stored unflagged; ``to_payload`` produces
@@ -358,6 +372,12 @@ class SymbolVisitor(cst.CSTVisitor):
         # node after ``on_leave`` has popped the module frame.
         self._module_fqname = sym.fqname
         self._push_decl(node, sym)
+        # Reuse the wrapper that's driving this visit when one was
+        # provided -- it already has ``PositionProvider`` resolved, so
+        # the detector hits the cache. ``unsafe_skip_copy`` is fine for
+        # the fallback path because the detector reads metadata only.
+        wrapper = self._wrapper or cst.MetadataWrapper(node, unsafe_skip_copy=True)
+        self.dead_suites = list(self._unreachable_detector.find_regions(wrapper))
 
     def visit_FunctionDef(self, node: cst.FunctionDef) -> None:
         self._add_decl(node, "function")
@@ -546,7 +566,7 @@ class SymbolVisitor(cst.CSTVisitor):
                             if target != owner:
                                 self.internal_edges.add((owner, target, owner.position))
 
-    def to_payload(self, *, dead_suites: tuple[CodeRange, ...] = ()) -> VisitorPayload:
+    def to_payload(self) -> VisitorPayload:
         """Materialize visitor state into a serializable :class:`VisitorPayload`.
 
         Decls in :attr:`shadowed_decls` are emitted as
@@ -556,12 +576,9 @@ class SymbolVisitor(cst.CSTVisitor):
         :class:`CodeRange` (the access position) is preserved as-is;
         the apply step in :mod:`dead_cst._analyze` derives the
         :data:`EdgeFlags.DEAD_BRANCH` flag from it by checking
-        containment against ``dead_suites``.
-
-        ``dead_suites`` is supplied by the caller -- the analyzer runs
-        a swappable :data:`~dead_cst._branches.UnreachableRegionDetector`
-        on the file's :class:`cst.MetadataWrapper` and passes the
-        result here.
+        containment against :attr:`dead_suites` (populated by the
+        configured :class:`~dead_cst._branches.UnreachableRegionDetector`
+        in :meth:`visit_Module`).
         """
         flag_map: dict[SymbolNode, SymbolNode] = {
             d: dataclasses.replace(d, flags=d.flags | NodeFlags.SHADOWED)
@@ -589,5 +606,5 @@ class SymbolVisitor(cst.CSTVisitor):
             nodes=tuple(nodes),
             edges=edges,
             imports=imports,
-            dead_suites=dead_suites,
+            dead_suites=tuple(self.dead_suites),
         )

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -25,7 +25,6 @@ from libcst.metadata.scope_provider import (
     Scope,
 )
 
-from ._branches import unreachable_suites
 from ._flow import live_at_exit, live_referents
 from ._fqn import FixedFullyQualifiedNameProvider
 from ._plugins._core import UNRESOLVED_PREFIX
@@ -151,11 +150,6 @@ class SymbolVisitor(cst.CSTVisitor):
         # descendants of the containing statement, which is what
         # ``live_at_exit`` matches against.
         self.symbol_referent_nodes: dict[SymbolNode, cst.CSTNode] = {}
-        # Positions of every statically-dead suite in this file. The
-        # apply step uses this list to decide which edges land with
-        # ``EdgeFlags.DEAD_BRANCH``; the CLI surfaces them as
-        # "unreachable code at line X" reports.
-        self.dead_suites: list[CodeRange] = []
         # Decls displaced by flow analysis. Tracked here (rather than on
         # the trie) so the trie holds only entries cross-module imports
         # should resolve to. Stored unflagged; ``to_payload`` produces
@@ -377,27 +371,6 @@ class SymbolVisitor(cst.CSTVisitor):
     def visit_AnnAssign(self, node: cst.AnnAssign) -> None:
         self._add_variable(node)
 
-    def visit_If(self, node: cst.If) -> None:
-        self._record_dead_suites(node)
-
-    def visit_While(self, node: cst.While) -> None:
-        self._record_dead_suites(node)
-
-    def _record_dead_suites(self, stmt: cst.BaseStatement) -> None:
-        """Append the position of every statically-dead suite in ``stmt``.
-
-        The apply step (``_apply_payload`` in ``_analyze``) uses this
-        list to decide whether each emitted edge falls inside a dead
-        suite, in which case the edge gets ``EdgeFlags.DEAD_BRANCH``.
-        Nested dead suites are recorded as separate entries; an access
-        is "in a dead suite" if its position falls inside any of them.
-        """
-        for suite in unreachable_suites(stmt):
-            pos = self._pos(suite)
-            if pos is None:
-                continue
-            self.dead_suites.append(pos)
-
     def visit_Import(self, node: cst.Import) -> None:
         self._add_import("", node)
 
@@ -573,7 +546,7 @@ class SymbolVisitor(cst.CSTVisitor):
                             if target != owner:
                                 self.internal_edges.add((owner, target, owner.position))
 
-    def to_payload(self) -> VisitorPayload:
+    def to_payload(self, *, dead_suites: tuple[CodeRange, ...] = ()) -> VisitorPayload:
         """Materialize visitor state into a serializable :class:`VisitorPayload`.
 
         Decls in :attr:`shadowed_decls` are emitted as
@@ -583,7 +556,12 @@ class SymbolVisitor(cst.CSTVisitor):
         :class:`CodeRange` (the access position) is preserved as-is;
         the apply step in :mod:`dead_cst._analyze` derives the
         :data:`EdgeFlags.DEAD_BRANCH` flag from it by checking
-        containment against :attr:`dead_suites`.
+        containment against ``dead_suites``.
+
+        ``dead_suites`` is supplied by the caller -- the analyzer runs
+        a swappable :data:`~dead_cst._branches.UnreachableRegionDetector`
+        on the file's :class:`cst.MetadataWrapper` and passes the
+        result here.
         """
         flag_map: dict[SymbolNode, SymbolNode] = {
             d: dataclasses.replace(d, flags=d.flags | NodeFlags.SHADOWED)
@@ -611,5 +589,5 @@ class SymbolVisitor(cst.CSTVisitor):
             nodes=tuple(nodes),
             edges=edges,
             imports=imports,
-            dead_suites=tuple(self.dead_suites),
+            dead_suites=dead_suites,
         )

--- a/dead_cst/cli.py
+++ b/dead_cst/cli.py
@@ -103,10 +103,11 @@ def _maybe_cache(
     """Yield a per-run :class:`GraphCache`, or ``None`` when ``--no-cache`` is set.
 
     The fingerprint covers the resolved ``PathMap``, resolver chain,
-    and plugin set so a layout, import-resolution, or plugin change
-    wipes the on-disk ``file_cache`` automatically (see
-    :func:`compute_fingerprint`). The context manager closes the
-    SQLite connection on exit, even when the analysis raises.
+    plugin set, and the default unreachable-region detector so a
+    layout, import-resolution, or plugin change wipes the on-disk
+    ``file_cache`` automatically (see :func:`compute_fingerprint`).
+    The context manager closes the SQLite connection on exit, even
+    when the analysis raises.
     """
     if no_cache:
         yield None

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -24,7 +24,7 @@ import pytest
 from libcst.metadata import MetadataWrapper
 
 from dead_cst._branches import (
-    default_unreachable_regions,
+    DefaultUnreachableRegionDetector,
     evaluate_truthiness,
     unreachable_bodies,
 )
@@ -334,7 +334,7 @@ def test_unsupported_statement_returns_empty() -> None:
 
 
 # ----------------------------------------------------------------------
-# default_unreachable_regions: module-level CodeRange detector.
+# DefaultUnreachableRegionDetector: module-level CodeRange detector.
 # ----------------------------------------------------------------------
 
 
@@ -343,7 +343,7 @@ def _wrapper(src: str) -> MetadataWrapper:
 
 
 def test_default_detector_returns_empty_for_no_dead_code() -> None:
-    regions = default_unreachable_regions(
+    regions = DefaultUnreachableRegionDetector().find_regions(
         _wrapper(
             """
             def f(): pass
@@ -354,7 +354,7 @@ def test_default_detector_returns_empty_for_no_dead_code() -> None:
 
 
 def test_default_detector_finds_if_false_body() -> None:
-    regions = default_unreachable_regions(
+    regions = DefaultUnreachableRegionDetector().find_regions(
         _wrapper(
             """
             if False:
@@ -367,7 +367,7 @@ def test_default_detector_finds_if_false_body() -> None:
 
 
 def test_default_detector_finds_multiple_dead_suites() -> None:
-    regions = default_unreachable_regions(
+    regions = DefaultUnreachableRegionDetector().find_regions(
         _wrapper(
             """
             if False:
@@ -386,7 +386,7 @@ def test_default_detector_finds_multiple_dead_suites() -> None:
 
 
 def test_default_detector_handles_while() -> None:
-    regions = default_unreachable_regions(
+    regions = DefaultUnreachableRegionDetector().find_regions(
         _wrapper(
             """
             while False:
@@ -398,6 +398,7 @@ def test_default_detector_handles_while() -> None:
 
 
 def test_default_detector_carries_fingerprint_metadata() -> None:
-    """``name`` / ``version`` attributes feed the cache fingerprint."""
-    assert default_unreachable_regions.name == "default"
-    assert isinstance(default_unreachable_regions.version, int)
+    """``name`` / ``version`` feed the cache fingerprint via ``Cacheable``."""
+    detector = DefaultUnreachableRegionDetector()
+    assert detector.name == "default"
+    assert isinstance(detector.version, int)

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -21,7 +21,13 @@ from typing import Sequence
 import libcst as cst
 import pytest
 
-from dead_cst._branches import evaluate_truthiness, unreachable_bodies
+from libcst.metadata import MetadataWrapper
+
+from dead_cst._branches import (
+    default_unreachable_regions,
+    evaluate_truthiness,
+    unreachable_bodies,
+)
 
 
 def _expr(src: str) -> cst.BaseExpression:
@@ -325,3 +331,73 @@ def test_while_unknown_returns_no_dead_bodies() -> None:
 def test_unsupported_statement_returns_empty() -> None:
     stmt = _stmt("x = 1")
     assert unreachable_bodies(stmt) == []
+
+
+# ----------------------------------------------------------------------
+# default_unreachable_regions: module-level CodeRange detector.
+# ----------------------------------------------------------------------
+
+
+def _wrapper(src: str) -> MetadataWrapper:
+    return MetadataWrapper(cst.parse_module(textwrap.dedent(src).strip() + "\n"))
+
+
+def test_default_detector_returns_empty_for_no_dead_code() -> None:
+    regions = default_unreachable_regions(
+        _wrapper(
+            """
+            def f(): pass
+            """
+        )
+    )
+    assert regions == []
+
+
+def test_default_detector_finds_if_false_body() -> None:
+    regions = default_unreachable_regions(
+        _wrapper(
+            """
+            if False:
+                x = 1
+            """
+        )
+    )
+    assert len(regions) == 1
+    assert regions[0].start.line == 2
+
+
+def test_default_detector_finds_multiple_dead_suites() -> None:
+    regions = default_unreachable_regions(
+        _wrapper(
+            """
+            if False:
+                a = 1
+
+            if True:
+                b = 2
+            else:
+                c = 3
+            """
+        )
+    )
+    # First the ``if False`` body, then the ``else`` of ``if True``.
+    starts = sorted(r.start.line for r in regions)
+    assert starts == [2, 7]
+
+
+def test_default_detector_handles_while() -> None:
+    regions = default_unreachable_regions(
+        _wrapper(
+            """
+            while False:
+                x = 1
+            """
+        )
+    )
+    assert len(regions) == 1
+
+
+def test_default_detector_carries_fingerprint_metadata() -> None:
+    """``name`` / ``version`` attributes feed the cache fingerprint."""
+    assert default_unreachable_regions.name == "default"
+    assert isinstance(default_unreachable_regions.version, int)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -108,38 +108,47 @@ def test_fingerprint_changes_when_unreachable_detector_changes(tmp_path):
     """Swapping the unreachable-region detector flips the fingerprint.
 
     Detectors are folded into each cached payload's ``dead_suites``
-    list, so a detector swap must invalidate the file_cache. The
-    default detector ships with a stable ``name`` / ``version``;
-    custom detectors are fingerprinted by their callable's name (or
-    explicit ``name`` attribute) and ``version``.
+    list, so a detector swap must invalidate the file_cache. Both the
+    default and custom detectors satisfy ``Cacheable`` via their
+    ``(name, version)`` pair.
     """
+    from dataclasses import dataclass
+
     from libcst.metadata import CodeRange, MetadataWrapper
 
-    def custom(wrapper: MetadataWrapper) -> list[CodeRange]:
-        return []
+    @dataclass(frozen=True)
+    class Custom:
+        name: str = "custom"
+        version: int = 1
 
-    custom.name = "custom"  # type: ignore[attr-defined]
-    custom.version = 1  # type: ignore[attr-defined]
+        def find_regions(self, wrapper: MetadataWrapper) -> list[CodeRange]:
+            return []
 
     fp_default = compute_fingerprint(paths={tmp_path: []}, resolvers=[])
-    fp_custom = compute_fingerprint(paths={tmp_path: []}, resolvers=[], unreachable_detector=custom)
+    fp_custom = compute_fingerprint(
+        paths={tmp_path: []}, resolvers=[], unreachable_detector=Custom()
+    )
     assert fp_default != fp_custom
 
 
 def test_fingerprint_changes_when_unreachable_detector_version_bumped(tmp_path):
     """Bumping a detector's ``version`` invalidates the cache key."""
+    from dataclasses import dataclass
+
     from libcst.metadata import CodeRange, MetadataWrapper
 
-    def custom(wrapper: MetadataWrapper) -> list[CodeRange]:
-        return []
+    @dataclass(frozen=True)
+    class Custom:
+        name: str = "custom"
+        version: int = 1
 
-    custom.name = "custom"  # type: ignore[attr-defined]
-    custom.version = 1  # type: ignore[attr-defined]
+        def find_regions(self, wrapper: MetadataWrapper) -> list[CodeRange]:
+            return []
 
-    fp_v1 = compute_fingerprint(paths={tmp_path: []}, resolvers=[], unreachable_detector=custom)
-
-    custom.version = 2  # type: ignore[attr-defined]
-    fp_v2 = compute_fingerprint(paths={tmp_path: []}, resolvers=[], unreachable_detector=custom)
+    fp_v1 = compute_fingerprint(paths={tmp_path: []}, resolvers=[], unreachable_detector=Custom())
+    fp_v2 = compute_fingerprint(
+        paths={tmp_path: []}, resolvers=[], unreachable_detector=Custom(version=2)
+    )
     assert fp_v1 != fp_v2
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -104,6 +104,45 @@ def test_fingerprint_subclasses_with_distinct_names_distinct(tmp_path):
     assert fp_a != fp_b
 
 
+def test_fingerprint_changes_when_unreachable_detector_changes(tmp_path):
+    """Swapping the unreachable-region detector flips the fingerprint.
+
+    Detectors are folded into each cached payload's ``dead_suites``
+    list, so a detector swap must invalidate the file_cache. The
+    default detector ships with a stable ``name`` / ``version``;
+    custom detectors are fingerprinted by their callable's name (or
+    explicit ``name`` attribute) and ``version``.
+    """
+    from libcst.metadata import CodeRange, MetadataWrapper
+
+    def custom(wrapper: MetadataWrapper) -> list[CodeRange]:
+        return []
+
+    custom.name = "custom"  # type: ignore[attr-defined]
+    custom.version = 1  # type: ignore[attr-defined]
+
+    fp_default = compute_fingerprint(paths={tmp_path: []}, resolvers=[])
+    fp_custom = compute_fingerprint(paths={tmp_path: []}, resolvers=[], unreachable_detector=custom)
+    assert fp_default != fp_custom
+
+
+def test_fingerprint_changes_when_unreachable_detector_version_bumped(tmp_path):
+    """Bumping a detector's ``version`` invalidates the cache key."""
+    from libcst.metadata import CodeRange, MetadataWrapper
+
+    def custom(wrapper: MetadataWrapper) -> list[CodeRange]:
+        return []
+
+    custom.name = "custom"  # type: ignore[attr-defined]
+    custom.version = 1  # type: ignore[attr-defined]
+
+    fp_v1 = compute_fingerprint(paths={tmp_path: []}, resolvers=[], unreachable_detector=custom)
+
+    custom.version = 2  # type: ignore[attr-defined]
+    fp_v2 = compute_fingerprint(paths={tmp_path: []}, resolvers=[], unreachable_detector=custom)
+    assert fp_v1 != fp_v2
+
+
 def test_fingerprint_changes_when_plugin_version_bumped(tmp_path):
     """Bumping a plugin's epoch ``version`` invalidates the cache key.
 

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -78,15 +78,20 @@ def _payload_from_source(tmp_path: Path, src: str) -> tuple[VisitorPayload, Path
 
     Bypasses ``build_symbol_graph`` so we can inspect the visitor's own
     output -- i.e. what would be cached -- without the per-base
-    apply-and-resolve work on top.
+    apply-and-resolve work on top. Mirrors the analyzer's call into
+    :func:`default_unreachable_regions` so the resulting payload's
+    ``dead_suites`` field matches an end-to-end run.
     """
+    from dead_cst._branches import default_unreachable_regions
+
     file = tmp_path / "pkg.py"
     file.write_text(textwrap.dedent(src).strip() + "\n")
     mgr = FullRepoManager(str(tmp_path), [str(file)], {FixedFullyQualifiedNameProvider})
     wrapper = mgr.get_metadata_wrapper_for_path(str(file))
     visitor = SymbolVisitor(file, [tmp_path])
     wrapper.visit(visitor)
-    return visitor.to_payload(), file
+    dead_suites = tuple(default_unreachable_regions(wrapper))
+    return visitor.to_payload(dead_suites=dead_suites), file
 
 
 def test_payload_module_node_present(tmp_path):

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -78,20 +78,15 @@ def _payload_from_source(tmp_path: Path, src: str) -> tuple[VisitorPayload, Path
 
     Bypasses ``build_symbol_graph`` so we can inspect the visitor's own
     output -- i.e. what would be cached -- without the per-base
-    apply-and-resolve work on top. Mirrors the analyzer's call into
-    :func:`default_unreachable_regions` so the resulting payload's
-    ``dead_suites`` field matches an end-to-end run.
+    apply-and-resolve work on top.
     """
-    from dead_cst._branches import default_unreachable_regions
-
     file = tmp_path / "pkg.py"
     file.write_text(textwrap.dedent(src).strip() + "\n")
     mgr = FullRepoManager(str(tmp_path), [str(file)], {FixedFullyQualifiedNameProvider})
     wrapper = mgr.get_metadata_wrapper_for_path(str(file))
-    visitor = SymbolVisitor(file, [tmp_path])
+    visitor = SymbolVisitor(file, [tmp_path], wrapper=wrapper)
     wrapper.visit(visitor)
-    dead_suites = tuple(default_unreachable_regions(wrapper))
-    return visitor.to_payload(dead_suites=dead_suites), file
+    return visitor.to_payload(), file
 
 
 def test_payload_module_node_present(tmp_path):

--- a/tests/test_unreachable_branches.py
+++ b/tests/test_unreachable_branches.py
@@ -255,6 +255,8 @@ def test_custom_detector_folds_constants(tmp_path, write_files, assert_dead_bran
     path as the literal-only default, so internal references inside
     the dead branch land tagged with ``EdgeFlags.DEAD_BRANCH``.
     """
+    from dataclasses import dataclass
+
     import libcst as cst
     from libcst.metadata import MetadataWrapper, PositionProvider
 
@@ -275,25 +277,30 @@ def test_custom_detector_folds_constants(tmp_path, write_files, assert_dead_bran
         }
     )
 
-    def detector(wrapper: MetadataWrapper):
-        positions = wrapper.resolve(PositionProvider)
-        out = []
+    @dataclass(frozen=True)
+    class IsProdDetector:
+        name: str = "is_prod"
+        version: int = 1
 
-        class _V(cst.CSTVisitor):
-            def visit_If(self, node: cst.If) -> None:
-                test = node.test
-                # Hard-coded "settings.IS_PROD is always True" -- the
-                # default literal detector returns ``None`` here.
-                if isinstance(test, cst.Name) and test.value == "IS_PROD":
-                    if node.orelse is not None and isinstance(node.orelse, cst.Else):
-                        pos = positions.get(node.orelse.body)
-                        if pos is not None:
-                            out.append(pos)
+        def find_regions(self, wrapper: MetadataWrapper):
+            positions = wrapper.resolve(PositionProvider)
+            out = []
 
-        wrapper.module.visit(_V())
-        return out
+            class _V(cst.CSTVisitor):
+                def visit_If(self, node: cst.If) -> None:
+                    test = node.test
+                    # Hard-coded "settings.IS_PROD is always True" --
+                    # the default literal detector returns ``None`` here.
+                    if isinstance(test, cst.Name) and test.value == "IS_PROD":
+                        if isinstance(node.orelse, cst.Else):
+                            pos = positions.get(node.orelse.body)
+                            if pos is not None:
+                                out.append(pos)
 
-    graph = build_symbol_graph({tmp_path: []}, unreachable_detector=detector)
+            wrapper.module.visit(_V())
+            return out
+
+    graph = build_symbol_graph({tmp_path: []}, unreachable_detector=IsProdDetector())
     assert_dead_branch_edges(graph, {"mod -> mod.dev_only"})
 
 

--- a/tests/test_unreachable_branches.py
+++ b/tests/test_unreachable_branches.py
@@ -245,6 +245,84 @@ def test_decls_inside_dead_branch_remain_in_graph(build_decl_graph, assert_edges
     )
 
 
+def test_custom_detector_folds_constants(tmp_path, write_files, assert_dead_branch_edges):
+    """End-to-end: a custom detector can mark non-literal branches dead.
+
+    Demonstrates the user-facing extension story: a company-specific
+    detector that knows ``settings.IS_PROD`` is always ``True`` walks
+    the file and returns the dead else-branch's :class:`CodeRange`.
+    The analyzer feeds those positions through the same flag-derivation
+    path as the literal-only default, so internal references inside
+    the dead branch land tagged with ``EdgeFlags.DEAD_BRANCH``.
+    """
+    import libcst as cst
+    from libcst.metadata import MetadataWrapper, PositionProvider
+
+    from dead_cst import build_symbol_graph
+
+    write_files(
+        {
+            "mod.py": """
+            from settings import IS_PROD
+            def prod_only(): pass
+            def dev_only(): pass
+            if IS_PROD:
+                prod_only()
+            else:
+                dev_only()
+            """,
+            "settings.py": "IS_PROD = True\n",
+        }
+    )
+
+    def detector(wrapper: MetadataWrapper):
+        positions = wrapper.resolve(PositionProvider)
+        out = []
+
+        class _V(cst.CSTVisitor):
+            def visit_If(self, node: cst.If) -> None:
+                test = node.test
+                # Hard-coded "settings.IS_PROD is always True" -- the
+                # default literal detector returns ``None`` here.
+                if isinstance(test, cst.Name) and test.value == "IS_PROD":
+                    if node.orelse is not None and isinstance(node.orelse, cst.Else):
+                        pos = positions.get(node.orelse.body)
+                        if pos is not None:
+                            out.append(pos)
+
+        wrapper.module.visit(_V())
+        return out
+
+    graph = build_symbol_graph({tmp_path: []}, unreachable_detector=detector)
+    assert_dead_branch_edges(graph, {"mod -> mod.dev_only"})
+
+
+def test_default_detector_does_not_flag_named_condition(tmp_path, write_files):
+    """Sanity check: the default detector leaves ``if NAME`` branches alone.
+
+    Counterpart to :func:`test_custom_detector_folds_constants` --
+    without a custom detector, ``if IS_PROD:`` is unknown and no
+    suite is recorded as dead.
+    """
+    from dead_cst import build_symbol_graph
+
+    write_files(
+        {
+            "mod.py": """
+            from settings import IS_PROD
+            def f(): pass
+            if IS_PROD:
+                f()
+            else:
+                f()
+            """,
+            "settings.py": "IS_PROD = True\n",
+        }
+    )
+    graph = build_symbol_graph({tmp_path: []})
+    assert _dead_suite_positions(graph, tmp_path / "mod.py") == ()
+
+
 def test_elif_false_in_chain_flags_only_dead_branch(build_decl_graph, assert_dead_branch_edges):
     graph = build_decl_graph(
         {


### PR DESCRIPTION
## Summary

Make unreachable-code detection a third pluggable extension point alongside `EdgePlugin` and `PathResolver`, and unify the cache-fingerprint contract across all three.

- **`UnreachableRegionDetector` Protocol**: `find_regions(wrapper) -> list[CodeRange]` plus a `Cacheable` `(name, version)` pair. Pass an instance via `build_symbol_graph(unreachable_detector=...)` to fold company-specific constant folding (e.g. "`settings.IS_PROD` is always `True` in production") into the analysis without forking the package. The shipped `DefaultUnreachableRegionDetector` preserves existing behavior — literal-only truthiness on `if` / `while` tests.
- **`Cacheable` Protocol** (`name: str`, `version: int`): the single source of truth for the cache-fingerprint contract. `EdgePlugin`, `PathResolver`, and `UnreachableRegionDetector` all inherit from it. `compute_fingerprint` now reads attributes directly instead of falling back to `getattr` defaults.
- **`PathResolver` gains `version`**: the four shipped resolvers (`ManualResolver`, `PyprojectResolver`, `UvWorkspaceResolver`, `VenvResolver`) declare `version: int = 1777760307`, matching the plugin convention. Resolver bumps now invalidate stale `VisitorPayload` blobs the same way plugin bumps do.
- **Detector runs inside `SymbolVisitor.visit_Module`** and reuses the analyzer's already-resolved `MetadataWrapper` (threaded through the visitor's constructor), so the abstraction is free for the default path — no duplicate CST walk and no re-resolved `PositionProvider`.

## Documentation

- README: new "Cacheable across all three extension points" intro paragraph + a worked custom-detector example.
- `dead_cst/__init__.py` package docstring: extension-point list grows from three bullets to four.
- CHANGELOG `[Unreleased]`: new `UnreachableRegionDetector` and `Cacheable` entries plus the `PathResolver` versioning change.
- CONTRIBUTING: new "Adding an unreachable-region detector" section.

## Test plan

- [x] `uv run pytest` — 557 passed (added detector unit tests, an end-to-end constant-folding test that proves `EdgeFlags.DEAD_BRANCH` flows through, and two cache-fingerprint tests covering swap and version-bump invalidation).
- [x] `uv run prek run --all-files` — ruff, ruff-format, ty type-check, docstring/format hooks all clean.

https://claude.ai/code/session_01267kSyEiMTXCLtwqyKy2eg