### PR TITLE
tests: cover walrus, PEP 695, 701, match, and except* edge attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ A module-level `import` / `from ... import ...` is itself a declaration of type 
 - Only first-party code is analysed; third-party dependencies are treated as opaque (they appear as synthetic nodes — see `dead-cst dependencies`).
 - PEP 695 `type` statements are not tracked.
 - `__all__` is followed only when assigned a list/tuple of string literals; dynamic mutation (`__all__.append`, comprehensions, etc.) is not tracked.
+- Walrus expressions (PEP 572) at module scope — including walruses leaked from a module-level comprehension — bind a name in the module namespace at runtime but are not surfaced as top-level declarations, so cross-decl references to those names are missed.
+- PEP 750 template strings (`t"..."`, 3.14+) cannot be parsed by the pinned `libcst`, so any file containing one aborts the analysis with a `ParserSyntaxError`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ A module-level `import` / `from ... import ...` is itself a declaration of type 
 - Only first-party code is analysed; third-party dependencies are treated as opaque (they appear as synthetic nodes — see `dead-cst dependencies`).
 - PEP 695 `type` statements are not tracked.
 - `__all__` is followed only when assigned a list/tuple of string literals; dynamic mutation (`__all__.append`, comprehensions, etc.) is not tracked.
-- Walrus expressions (PEP 572) at module scope — including walruses leaked from a module-level comprehension — bind a name in the module namespace at runtime but are not surfaced as top-level declarations, so cross-decl references to those names are missed.
+- Walrus expressions (PEP 572) at module scope — including walruses leaked from a module-level comprehension — bind a name in the module namespace at runtime but are not surfaced as top-level declarations, so cross-decl references to those names are missed. The default unreachable-region detector likewise ignores walrus: `(FLAG := False)` and `if (FLAG := False):` don't enter the constant-folding table even when the RHS is a literal.
 - PEP 750 template strings (`t"..."`, 3.14+) cannot be parsed by the pinned `libcst`, so any file containing one aborts the analysis with a `ParserSyntaxError`.
 
 ## Development

--- a/tests/test_const_fold.py
+++ b/tests/test_const_fold.py
@@ -180,6 +180,22 @@ def test_tuple_unpacking_does_not_fold() -> None:
     assert out["a"] == [None]
 
 
+def test_walrus_binding_does_not_fold() -> None:
+    # ``_constant_assignment_rhs`` returns ``None`` for walrus
+    # (``NamedExpr``) bindings -- they aren't ``Assign`` / ``AnnAssign``
+    # statements -- so the value never enters the fold table even when
+    # the RHS is a literal. Ideally ``x`` would resolve to ``[False]``
+    # here, matching the behaviour of a plain ``x = False`` binding.
+    out = _resolve_lookup(
+        """
+        (x := False)
+        if x:
+            pass
+        """
+    )
+    assert out["x"] == [None]
+
+
 def test_attribute_target_does_not_fold() -> None:
     out = _resolve_lookup(
         """

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -714,6 +714,421 @@ import pytest
             },
             id="comprehension-iterable-uses-enclosing-scope",
         ),
+        # ------------------------------------------------------------------
+        # PEP 572 walrus -- references inside walrus RHS are still attributed
+        # to the enclosing top-level decl. (Top-level walrus binding capture
+        # itself is documented in ``test_limitations``.)
+        # ------------------------------------------------------------------
+        pytest.param(
+            """
+            def src(): return 1
+            def f():
+                if (x := src()): return x
+                return 0
+            """,
+            {
+                "mod.f -> mod",
+                "mod.f -> mod.src",
+                "mod.src -> mod",
+            },
+            id="walrus-in-if-condition",
+        ),
+        pytest.param(
+            """
+            def src(): return None
+            def f():
+                while (x := src()) is not None:
+                    pass
+            """,
+            {
+                "mod.f -> mod",
+                "mod.f -> mod.src",
+                "mod.src -> mod",
+            },
+            id="walrus-in-while-condition",
+        ),
+        pytest.param(
+            """
+            def src(): return 1
+            def f():
+                return [n for v in [1] if (n := src())]
+            """,
+            {
+                "mod.f -> mod",
+                "mod.f -> mod.src",
+                "mod.src -> mod",
+            },
+            id="walrus-in-comprehension",
+        ),
+        pytest.param(
+            """
+            def src(): return 1
+            def f(): return f'{(x := src())}'
+            """,
+            {
+                "mod.f -> mod",
+                "mod.f -> mod.src",
+                "mod.src -> mod",
+            },
+            id="walrus-in-fstring-interpolation",
+        ),
+        # ------------------------------------------------------------------
+        # PEP 695 type-parameter syntax (3.12+) and ``type`` statements.
+        # Generic ``[T]`` clauses introduce a synthetic enclosing scope, but
+        # references in the function/class body still resolve outward to the
+        # module. ``type`` statements themselves don't surface as decls (see
+        # ``test_limitations``), but their RHS is still walked.
+        # ------------------------------------------------------------------
+        pytest.param(
+            """
+            Base = int
+            type Alias = Base
+            """,
+            # The ``type`` alias is not a top-level decl, but the RHS
+            # ``Base`` reference is attributed to the synthetic module
+            # node. ``mod -> mod.Base`` keeps ``Base`` alive whenever
+            # the module is.
+            {
+                "mod -> mod.Base",
+                "mod.Base -> mod",
+            },
+            id="pep695-type-statement-rhs-reference",
+        ),
+        pytest.param(
+            """
+            def helper(): return 1
+            def f[T](x: T) -> T:
+                return helper()
+            """,
+            {
+                "mod.f -> mod",
+                "mod.f -> mod.helper",
+                "mod.helper -> mod",
+            },
+            id="pep695-generic-function-body-reference",
+        ),
+        pytest.param(
+            """
+            def helper(): return 1
+            class C[T]:
+                def m(self): return helper()
+            """,
+            {
+                "mod.C -> mod",
+                "mod.C -> mod.helper",
+                "mod.helper -> mod",
+            },
+            id="pep695-generic-class-body-reference",
+        ),
+        pytest.param(
+            """
+            class B: pass
+            def f[T: B](x: T) -> T: return x
+            """,
+            {
+                "mod.B -> mod",
+                "mod.f -> mod",
+                "mod.f -> mod.B",
+            },
+            id="pep695-generic-typeparam-bound",
+        ),
+        pytest.param(
+            """
+            class A: pass
+            class B: pass
+            def f[T: (A, B)](x: T) -> T: return x
+            """,
+            {
+                "mod.A -> mod",
+                "mod.B -> mod",
+                "mod.f -> mod",
+                "mod.f -> mod.A",
+                "mod.f -> mod.B",
+            },
+            id="pep695-generic-typeparam-constraints",
+        ),
+        pytest.param(
+            """
+            class Default: pass
+            def f[T = Default](x): return x
+            """,
+            # PEP 696 (3.13+) typeparam default. The default expression
+            # is evaluated in the enclosing scope, so ``Default`` is
+            # referenced from ``mod.f``.
+            {
+                "mod.Default -> mod",
+                "mod.f -> mod",
+                "mod.f -> mod.Default",
+            },
+            id="pep695-generic-typeparam-default",
+        ),
+        pytest.param(
+            """
+            class Helper: pass
+            def f[*Ts](x: tuple[Helper]): return x
+            """,
+            {
+                "mod.Helper -> mod",
+                "mod.f -> mod",
+                "mod.f -> mod.Helper",
+            },
+            id="pep695-typevartuple-body-reference",
+        ),
+        pytest.param(
+            """
+            class Helper: pass
+            def f[**P](x: Helper): return x
+            """,
+            {
+                "mod.Helper -> mod",
+                "mod.f -> mod",
+                "mod.f -> mod.Helper",
+            },
+            id="pep695-paramspec-body-reference",
+        ),
+        # ------------------------------------------------------------------
+        # PEP 701 f-string syntax (3.12+) -- nested f-strings, multiline,
+        # format-spec interpolations, conversion modifiers.
+        # ------------------------------------------------------------------
+        pytest.param(
+            """
+            N = 'x'
+            def f(): return f"a {f'b {N}'} c"
+            """,
+            {
+                "mod.N -> mod",
+                "mod.f -> mod",
+                "mod.f -> mod.N",
+            },
+            id="pep701-nested-fstring-reference",
+        ),
+        pytest.param(
+            '''
+            N = "x"
+            def f(): return f"""hi
+            {N}
+            bye"""
+            ''',
+            {
+                "mod.N -> mod",
+                "mod.f -> mod",
+                "mod.f -> mod.N",
+            },
+            id="pep701-multiline-fstring-reference",
+        ),
+        pytest.param(
+            """
+            W = 5
+            N = 1
+            def f(): return f'{N:{W}d}'
+            """,
+            {
+                "mod.N -> mod",
+                "mod.W -> mod",
+                "mod.f -> mod",
+                "mod.f -> mod.N",
+                "mod.f -> mod.W",
+            },
+            id="pep701-fstring-format-spec-reference",
+        ),
+        pytest.param(
+            """
+            N = 1
+            def f(): return f'{N!r}'
+            """,
+            {
+                "mod.N -> mod",
+                "mod.f -> mod",
+                "mod.f -> mod.N",
+            },
+            id="pep701-fstring-conversion-reference",
+        ),
+        # ------------------------------------------------------------------
+        # PEP 634-636 structural pattern matching (3.10+). Names referenced
+        # from value patterns, class patterns, mapping keys, guards, and
+        # ``as`` / ``or`` pattern bodies must all attribute correctly to
+        # the enclosing top-level decl.
+        # ------------------------------------------------------------------
+        pytest.param(
+            """
+            SENT = 1
+            def f(v):
+                match v:
+                    case 1: return SENT
+                    case _: return 0
+            """,
+            {
+                "mod.SENT -> mod",
+                "mod.f -> mod",
+                "mod.f -> mod.SENT",
+            },
+            id="match-case-value-pattern-body-reference",
+        ),
+        pytest.param(
+            """
+            class Dot: pass
+            def f(v):
+                match v:
+                    case Dot(): return 1
+                    case _: return 0
+            """,
+            {
+                "mod.Dot -> mod",
+                "mod.f -> mod",
+                "mod.f -> mod.Dot",
+            },
+            id="match-case-class-pattern-reference",
+        ),
+        pytest.param(
+            """
+            class Pt:
+                __match_args__ = ('x', 'y')
+            def f(v):
+                match v:
+                    case Pt(x_val, y_val): return x_val
+                    case _: return 0
+            """,
+            {
+                "mod.Pt -> mod",
+                "mod.f -> mod",
+                "mod.f -> mod.Pt",
+            },
+            id="match-case-class-positional-pattern-reference",
+        ),
+        pytest.param(
+            """
+            class Pt:
+                x: int
+            def f(v):
+                match v:
+                    case Pt(x=val): return val
+                    case _: return 0
+            """,
+            {
+                "mod.Pt -> mod",
+                "mod.f -> mod",
+                "mod.f -> mod.Pt",
+            },
+            id="match-case-class-keyword-pattern-reference",
+        ),
+        pytest.param(
+            """
+            class K:
+                NAME = 'k'
+            def f(v):
+                match v:
+                    case {K.NAME: val}: return val
+                    case _: return 0
+            """,
+            # Mapping-pattern keys must be literal or dotted-name value
+            # patterns; ``K.NAME`` references the module-level ``K``.
+            {
+                "mod.K -> mod",
+                "mod.f -> mod",
+                "mod.f -> mod.K",
+            },
+            id="match-case-mapping-dotted-key-reference",
+        ),
+        pytest.param(
+            """
+            A = 1
+            B = 2
+            def f(v):
+                match v:
+                    case 1 | 2: return A
+                    case _: return B
+            """,
+            {
+                "mod.A -> mod",
+                "mod.B -> mod",
+                "mod.f -> mod",
+                "mod.f -> mod.A",
+                "mod.f -> mod.B",
+            },
+            id="match-case-or-pattern-body-references",
+        ),
+        pytest.param(
+            """
+            def helper(v): return v
+            def f(v):
+                match v:
+                    case [1, *rest] as found: return helper(found)
+                    case _: return 0
+            """,
+            {
+                "mod.f -> mod",
+                "mod.f -> mod.helper",
+                "mod.helper -> mod",
+            },
+            id="match-case-as-pattern-body-reference",
+        ),
+        pytest.param(
+            """
+            def pred(v): return True
+            def f(v):
+                match v:
+                    case x if pred(x): return x
+                    case _: return 0
+            """,
+            {
+                "mod.f -> mod",
+                "mod.f -> mod.pred",
+                "mod.pred -> mod",
+            },
+            id="match-case-guard-name-reference",
+        ),
+        pytest.param(
+            """
+            def helper(v): return v
+            def f(seq):
+                match seq:
+                    case [first, *rest]: return helper(first)
+                    case _: return None
+            """,
+            {
+                "mod.f -> mod",
+                "mod.f -> mod.helper",
+                "mod.helper -> mod",
+            },
+            id="match-case-sequence-pattern-body-reference",
+        ),
+        # ------------------------------------------------------------------
+        # PEP 654 ``except*`` (3.11+) exception groups. The handler body
+        # is a regular suite, so references inside it should resolve
+        # exactly like a plain ``except``.
+        # ------------------------------------------------------------------
+        pytest.param(
+            """
+            def handle(e): return e
+            def f():
+                try: pass
+                except* ValueError as eg: return handle(eg)
+            """,
+            {
+                "mod.f -> mod",
+                "mod.f -> mod.handle",
+                "mod.handle -> mod",
+            },
+            id="except-star-handler-reference",
+        ),
+        pytest.param(
+            """
+            def h1(e): return e
+            def h2(e): return e
+            def f():
+                try: pass
+                except* ValueError as eg: return h1(eg)
+                except* TypeError as eg: return h2(eg)
+            """,
+            {
+                "mod.f -> mod",
+                "mod.f -> mod.h1",
+                "mod.f -> mod.h2",
+                "mod.h1 -> mod",
+                "mod.h2 -> mod",
+            },
+            id="except-star-multiple-handler-references",
+        ),
     ],
 )
 def test_declarations(build_decl_graph, assert_edges, src, expected_edges):

--- a/tests/test_limitations.py
+++ b/tests/test_limitations.py
@@ -7,6 +7,7 @@ is the signal to promote them into ``test_declarations`` or
 ``test_imports``.
 """
 
+import libcst
 import pytest
 
 
@@ -127,3 +128,25 @@ import pytest
 def test_limitation(build_decl_graph, assert_edges, files, expected_edges):
     graph = build_decl_graph(files)
     assert_edges(graph, expected_edges)
+
+
+def test_pep750_tstring_unparseable(build_decl_graph):
+    """PEP 750 template strings (3.14) crash the analyser.
+
+    The pinned ``libcst`` cannot parse ``t"..."`` literals, so any file
+    containing one aborts ``build_symbol_graph`` with a
+    ``ParserSyntaxError`` before the symbol graph is built. Ideally the
+    visitor would either resolve interpolated names (yielding
+    ``mod.greet -> mod.NAME`` here) or at minimum skip the file. When
+    libcst gains t-string support this test will start to fail -- that
+    is the signal to add positive coverage in ``test_declarations``.
+    """
+    with pytest.raises(libcst.ParserSyntaxError):
+        build_decl_graph(
+            {
+                "mod.py": """
+                NAME = "world"
+                def greet(): return t"hello {NAME}"
+                """,
+            }
+        )

--- a/tests/test_limitations.py
+++ b/tests/test_limitations.py
@@ -23,6 +23,48 @@ import pytest
             set(),
             id="pep-695-type-statement-not-captured",
         ),
+        pytest.param(
+            {
+                "mod.py": """
+                def src(): return 1
+                if (Y := src()): pass
+                def use(): return Y
+                """,
+            },
+            # PEP 572 walrus expressions at module scope bind a name
+            # in the enclosing (module) scope, but the visitor does not
+            # record that name as a top-level declaration. ``use``
+            # therefore gets no ``use -> mod.Y`` edge -- ideally the
+            # graph would contain ``mod.Y -> mod`` and
+            # ``mod.use -> mod.Y``.
+            {
+                "mod -> mod.src",
+                "mod.src -> mod",
+                "mod.use -> mod",
+            },
+            id="walrus-toplevel-binding-not-captured",
+        ),
+        pytest.param(
+            {
+                "mod.py": """
+                nums = [1, 2, 3]
+                result = [last := n for n in nums]
+                def use(): return last
+                """,
+            },
+            # A walrus inside a comprehension leaks its binding to the
+            # enclosing scope (here, the module). The visitor doesn't
+            # capture that leak either, so ``use`` references a name
+            # the graph never models. Ideally ``mod.last`` would exist
+            # with ``mod.use -> mod.last``.
+            {
+                "mod.nums -> mod",
+                "mod.result -> mod",
+                "mod.result -> mod.nums",
+                "mod.use -> mod",
+            },
+            id="walrus-comprehension-toplevel-leak-not-captured",
+        ),
         # ------------------------------------------------------------------
         # Dynamic / runtime features
         # ------------------------------------------------------------------

--- a/tests/test_unreachable_branches.py
+++ b/tests/test_unreachable_branches.py
@@ -419,6 +419,51 @@ def test_default_detector_folds_annotated_constant(build_decl_graph, assert_dead
     assert_dead_branch_edges(graph, {"mod -> mod.helper"})
 
 
+def test_default_detector_does_not_fold_walrus_binding(build_decl_graph, assert_dead_branch_edges):
+    """Limitation: walrus bindings are invisible to the fold table.
+
+    The const-folder's ``_constant_assignment_rhs`` only recognises
+    ``Assign`` and ``AnnAssign`` shapes, so a walrus binding -- even
+    one whose RHS is a plain literal -- never enters the table. The
+    if-test therefore stays unknown and the body isn't flagged dead.
+    Ideally ``mod -> mod.helper`` would be flagged here, matching the
+    behaviour of an equivalent ``DEBUG = False`` binding.
+    """
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            (DEBUG := False)
+            def helper(): pass
+            if DEBUG:
+                helper()
+            """
+        }
+    )
+    assert_dead_branch_edges(graph, set())
+
+
+def test_default_detector_does_not_fold_walrus_in_if_test(
+    build_decl_graph, assert_dead_branch_edges
+):
+    """Limitation: walrus *expression* truthiness isn't recognised either.
+
+    ``evaluate_truthiness`` doesn't unwrap ``NamedExpr``, so even when
+    the walrus's RHS is a literal -- meaning the whole expression's
+    runtime value is statically known -- the if-body isn't flagged.
+    Ideally ``mod -> mod.helper`` would be flagged.
+    """
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            def helper(): pass
+            if (DEBUG := False):
+                helper()
+            """
+        }
+    )
+    assert_dead_branch_edges(graph, set())
+
+
 def test_default_detector_folds_constant_in_function(build_decl_graph, assert_dead_branch_edges):
     graph = build_decl_graph(
         {


### PR DESCRIPTION
Adds positive test cases for reference attribution through Python
3.10-3.13 syntax forms that were previously untested or only lightly
covered:

- walrus (PEP 572) inside if/while/comprehension/f-string conditions
- PEP 695 generics: function/class type-parameter bodies, bounds,
  constraints, PEP 696 defaults, TypeVarTuple, ParamSpec; ``type``
  statement RHS reference
- PEP 701 f-strings: nested, multiline, format-spec, conversion
- structural pattern matching: value/class/positional/keyword/mapping/
  or/as/guard/sequence patterns
- ``except*`` exception-group handlers (PEP 654)

Also documents two known walrus gaps in ``test_limitations``:
top-level ``if (Y := f()):`` and walrus inside a module-level
comprehension both leak a binding to module scope that the visitor
does not surface as a top-level declaration, so cross-decl references
to those names are missed.

t-strings (PEP 750) are intentionally skipped: libcst 1.8.2 cannot
parse ``t"..."`` yet.