### PR TITLE
visitor+cache: capture PEP 572 walrus targets, extend Cacheable to the visitor, drop __version__ from fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,22 +10,14 @@ two versions.
 ## [Unreleased]
 
 ### Changed
-- `SymbolVisitor` now satisfies the `Cacheable` protocol with class-level
-  `name: str = "default"` and an epoch `version: int`, and
-  `compute_fingerprint` includes the pair in the cache key. Bump
-  `SymbolVisitor.version` on any change to the visitor's per-file output
-  (new node kinds surfaced as decls, edge-attribution rules,
-  flow-analysis fixes, etc.) so stale `VisitorPayload` blobs invalidate
-  even between releases. Concurrent bumps on different branches merge
-  with `max()` semantics. The walrus-support change in this release
-  bumps the visitor version accordingly.
 - The package `__version__` is no longer folded into the cache
-  fingerprint. Every component whose output can shift between releases
-  (visitor, resolvers, plugins, detector) already carries its own
-  `Cacheable` `(name, version)` knob; mixing `__version__` in on top
-  let unbumped components ride for free on a release bump and masked
-  cases where the granular versions weren't being maintained. The
-  schema version and Python version still participate.
+  fingerprint. Every component whose output can shift between
+  releases (visitor, resolvers, plugins, detector) already carries
+  its own `Cacheable` `(name, version)` knob; mixing `__version__`
+  in on top let unbumped components ride for free on a release bump
+  and masked cases where the granular versions weren't being
+  maintained. The discipline now is to bump the relevant component's
+  `version`. Schema version and Python version still participate.
 
 ### Added
 - PEP 572 walrus (`:=`) bindings at module scope are now surfaced as
@@ -42,8 +34,15 @@ two versions.
   `(DEBUG := False)` and `if (DEBUG := False):` both flag dead
   branches. Walruses inside a function / class / lambda body still
   bind locally, matching Python's runtime semantics.
-
-### Added
+- `SymbolVisitor` now satisfies the `Cacheable` protocol with
+  class-level `name: str = "default"` and an epoch `version: int`,
+  and `compute_fingerprint` includes the pair in the cache key.
+  Bump `SymbolVisitor.version` on any change to the visitor's
+  per-file output (new node kinds surfaced as decls, edge-attribution
+  rules, flow-analysis fixes, etc.) so stale `VisitorPayload` blobs
+  invalidate even between releases. Concurrent bumps on different
+  branches merge with `max()` semantics. The walrus-support change
+  bumps the visitor version accordingly.
 - `UnreachableRegionDetector`: pluggable Protocol for module-level
   dead-region detection. Implementers provide
   `find_regions(wrapper) -> list[CodeRange]` and a `(name, version)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ two versions.
 
 ## [Unreleased]
 
+### Changed
+- `SymbolVisitor` now satisfies the `Cacheable` protocol with class-level
+  `name: str = "default"` and an epoch `version: int`, and
+  `compute_fingerprint` includes the pair in the cache key. Bump
+  `SymbolVisitor.version` on any change to the visitor's per-file output
+  (new node kinds surfaced as decls, edge-attribution rules,
+  flow-analysis fixes, etc.) so stale `VisitorPayload` blobs invalidate
+  even between releases. Concurrent bumps on different branches merge
+  with `max()` semantics. The walrus-support change in this release
+  bumps the visitor version accordingly.
+
 ### Added
 - PEP 572 walrus (`:=`) bindings at module scope are now surfaced as
   top-level declarations. `if (Y := src()): ...` registers `mod.Y`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ two versions.
 ## [Unreleased]
 
 ### Added
+- PEP 572 walrus (`:=`) bindings at module scope are now surfaced as
+  top-level declarations. `if (Y := src()): ...` registers `mod.Y`
+  with an outgoing edge to whatever `src` resolves to, and downstream
+  references like `def use(): return Y` get a `mod.use -> mod.Y`
+  edge. Walruses leaked from a module-level comprehension (e.g.
+  `result = [last := n for n in nums]`) are also captured: libcst's
+  `ScopeProvider` keeps the binding inside the comprehension scope,
+  so `SymbolVisitor` patches the gap by routing any unresolved Name
+  access whose `.value` matches a leaked walrus target back to the
+  matching decl. The default unreachable-region detector folds
+  walrus bindings the same way it folds `Assign` / `AnnAssign` --
+  `(DEBUG := False)` and `if (DEBUG := False):` both flag dead
+  branches. Walruses inside a function / class / lambda body still
+  bind locally, matching Python's runtime semantics.
+
+### Added
 - `UnreachableRegionDetector`: pluggable Protocol for module-level
   dead-region detection. Implementers provide
   `find_regions(wrapper) -> list[CodeRange]` and a `(name, version)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ two versions.
   even between releases. Concurrent bumps on different branches merge
   with `max()` semantics. The walrus-support change in this release
   bumps the visitor version accordingly.
+- The package `__version__` is no longer folded into the cache
+  fingerprint. Every component whose output can shift between releases
+  (visitor, resolvers, plugins, detector) already carries its own
+  `Cacheable` `(name, version)` knob; mixing `__version__` in on top
+  let unbumped components ride for free on a release bump and masked
+  cases where the granular versions weren't being maintained. The
+  schema version and Python version still participate.
 
 ### Added
 - PEP 572 walrus (`:=`) bindings at module scope are now surfaced as

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ dead-cst remove ROOT -e ENTRYPOINT [OPTIONS]
 
 ### `dead-cst cache clear`
 
-Delete the on-disk `VisitorPayload` cache (`<root>/.dead-cst-cache/`) for a project. The cache is keyed by a fingerprint over the `PathMap`, resolver chain, and plugin set, so most layout changes invalidate it automatically; this command is for force-clearing when needed.
+Delete the on-disk `VisitorPayload` cache (`<root>/.dead-cst-cache/`) for a project. The cache is keyed by a fingerprint over the `PathMap` and every `Cacheable` component (visitor, resolvers, plugins, unreachable-region detector), so most layout or analyzer-version changes invalidate it automatically; this command is for force-clearing when needed.
 
 ```
 dead-cst cache clear [ROOT]
@@ -173,7 +173,7 @@ unreachable = graph.subgraph([n for n in graph.nodes if n not in reachable])
 remove_code(unreachable, root)
 ```
 
-All three extension points — edge plugins, path resolvers, and the unreachable-region detector — share a single `Cacheable` protocol (`name: str`, `version: int`) that feeds the per-file cache fingerprint. Bumping a component's epoch `version` invalidates stale payloads automatically, so swapping or upgrading any of them is safe by default.
+All three extension points — edge plugins, path resolvers, and the unreachable-region detector — share a single `Cacheable` protocol (`name: str`, `version: int`) that feeds the per-file cache fingerprint. The core `SymbolVisitor` carries the same pair, so visitor-level changes get an explicit knob too. Bumping a component's epoch `version` invalidates stale payloads automatically, so swapping or upgrading any of them is safe by default. The package `__version__` is intentionally *not* in the fingerprint: every component whose output can shift between releases owns a dedicated `version`, and folding in `__version__` would let unbumped components ride for free on a release bump.
 
 Entrypoint detection is fully plugin-driven. Builtins:
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,6 @@ A module-level `import` / `from ... import ...` is itself a declaration of type 
 - Only first-party code is analysed; third-party dependencies are treated as opaque (they appear as synthetic nodes — see `dead-cst dependencies`).
 - PEP 695 `type` statements are not tracked.
 - `__all__` is followed only when assigned a list/tuple of string literals; dynamic mutation (`__all__.append`, comprehensions, etc.) is not tracked.
-- Walrus expressions (PEP 572) at module scope — including walruses leaked from a module-level comprehension — bind a name in the module namespace at runtime but are not surfaced as top-level declarations, so cross-decl references to those names are missed. The default unreachable-region detector likewise ignores walrus: `(FLAG := False)` and `if (FLAG := False):` don't enter the constant-folding table even when the RHS is a literal.
 - PEP 750 template strings (`t"..."`, 3.14+) cannot be parsed by the pinned `libcst`, so any file containing one aborts the analysis with a `ParserSyntaxError`.
 
 ## Development

--- a/dead_cst/_branches.py
+++ b/dead_cst/_branches.py
@@ -112,6 +112,11 @@ def evaluate_truthiness(
                 return None
         return len(node.elements) > 0
 
+    if isinstance(node, cst.NamedExpr):
+        # ``(x := V)`` evaluates to ``V``; the assignment side-effect
+        # doesn't change the expression's runtime value.
+        return evaluate_truthiness(node.value, resolve_expr)
+
     if isinstance(node, cst.UnaryOperation) and isinstance(node.operator, cst.Not):
         inner = evaluate_truthiness(node.expression, resolve_expr)
         return None if inner is None else not inner
@@ -253,7 +258,7 @@ class DefaultUnreachableRegionDetector:
     """
 
     name: str = "default"
-    version: int = 1777795837
+    version: int = 1777800597
 
     def resolve(self, expr: cst.BaseExpression) -> bool | None:
         """Hook for domain-specific constant folding. Default: defer.

--- a/dead_cst/_cache.py
+++ b/dead_cst/_cache.py
@@ -48,7 +48,7 @@ from ._branches import (
 )
 from ._plugins._core import EdgePlugin
 from ._resolvers import PathMap, PathResolver
-from ._visitor import VisitorPayload
+from ._visitor import SymbolVisitor, VisitorPayload
 from ._version import __version__
 
 logger = logging.getLogger(__name__)
@@ -79,17 +79,22 @@ def compute_fingerprint(
 ) -> str:
     """SHA-256 of every input that affects payload semantics for one analysis run.
 
-    Includes the dead-cst version (any code change can shift visitor
-    output), Python version (pickle protocol stability), the
-    ``PathMap`` (the search-path layout governs ``Import.path``
-    resolution), and the resolver / plugin / detector chain.
-    Resolvers, plugins, and the detector all satisfy
-    :class:`~dead_cst._cacheable.Cacheable` and are fingerprinted by
-    their ``(name, version)`` pair: bumping ``version`` invalidates
-    the file_cache so new output replaces the old. ``version`` is a
-    Unix epoch int by convention, so concurrent bumps on different
-    branches merge with ``max()``-wins semantics rather than
-    colliding on a re-used integer label.
+    Includes the dead-cst version (covers tagged releases), Python
+    version (pickle protocol stability), the ``PathMap`` (the
+    search-path layout governs ``Import.path`` resolution), and the
+    visitor / resolver / plugin / detector chain. Each component
+    satisfies :class:`~dead_cst._cacheable.Cacheable` and is
+    fingerprinted by its ``(name, version)`` pair: bumping
+    ``version`` invalidates the file_cache so new output replaces
+    the old. ``version`` is a Unix epoch int by convention, so
+    concurrent bumps on different branches merge with ``max()``-wins
+    semantics rather than colliding on a re-used integer label.
+
+    The visitor's own ``(name, version)`` is included so a
+    behaviour-affecting change to ``SymbolVisitor`` invalidates
+    cached payloads even between releases (``__version__`` only
+    moves on tag bumps, so a dev-loop edit at the same version
+    would otherwise be served from stale blobs).
 
     Each value is normalized to a stable string before hashing so
     equivalent inputs produce equal keys.
@@ -98,6 +103,7 @@ def compute_fingerprint(
     h.update(f"schema={SCHEMA_VERSION}\n".encode())
     h.update(f"version={__version__}\n".encode())
     h.update(f"python={sys.version_info.major}.{sys.version_info.minor}\n".encode())
+    h.update(f"visitor={SymbolVisitor.name}@{SymbolVisitor.version}\n".encode())
 
     h.update(b"paths=\n")
     for base in sorted(paths, key=lambda p: str(p)):

--- a/dead_cst/_cache.py
+++ b/dead_cst/_cache.py
@@ -12,10 +12,11 @@ Two tables make up the database:
 
 ``meta`` holds a single ``fingerprint`` row covering everything that
 could change a payload's *interpretation* without touching file
-contents -- the dead-cst version, Python version, search paths, and
-the chain of resolver names. A fingerprint mismatch on open wipes
-``file_cache`` and writes the new fingerprint, so the very next
-analysis fully rebuilds the graph.
+contents -- Python version, search paths, and the visitor / resolver
+/ plugin / detector chain (each contributing its own
+``Cacheable`` ``(name, version)`` pair). A fingerprint mismatch on
+open wipes ``file_cache`` and writes the new fingerprint, so the
+very next analysis fully rebuilds the graph.
 
 ``file_cache`` is one row per analyzed file, keyed by absolute path,
 with the file's SHA-256 content hash and the pickled payload. A hash
@@ -49,7 +50,6 @@ from ._branches import (
 from ._plugins._core import EdgePlugin
 from ._resolvers import PathMap, PathResolver
 from ._visitor import SymbolVisitor, VisitorPayload
-from ._version import __version__
 
 logger = logging.getLogger(__name__)
 
@@ -79,29 +79,29 @@ def compute_fingerprint(
 ) -> str:
     """SHA-256 of every input that affects payload semantics for one analysis run.
 
-    Includes the dead-cst version (covers tagged releases), Python
-    version (pickle protocol stability), the ``PathMap`` (the
-    search-path layout governs ``Import.path`` resolution), and the
-    visitor / resolver / plugin / detector chain. Each component
-    satisfies :class:`~dead_cst._cacheable.Cacheable` and is
-    fingerprinted by its ``(name, version)`` pair: bumping
-    ``version`` invalidates the file_cache so new output replaces
-    the old. ``version`` is a Unix epoch int by convention, so
-    concurrent bumps on different branches merge with ``max()``-wins
-    semantics rather than colliding on a re-used integer label.
+    Includes Python version (pickle protocol stability), the
+    ``PathMap`` (the search-path layout governs ``Import.path``
+    resolution), and the visitor / resolver / plugin / detector
+    chain. Each component satisfies
+    :class:`~dead_cst._cacheable.Cacheable` and is fingerprinted by
+    its ``(name, version)`` pair: bumping ``version`` invalidates
+    the file_cache so new output replaces the old. ``version`` is a
+    Unix epoch int by convention, so concurrent bumps on different
+    branches merge with ``max()``-wins semantics rather than
+    colliding on a re-used integer label.
 
-    The visitor's own ``(name, version)`` is included so a
-    behaviour-affecting change to ``SymbolVisitor`` invalidates
-    cached payloads even between releases (``__version__`` only
-    moves on tag bumps, so a dev-loop edit at the same version
-    would otherwise be served from stale blobs).
+    The dead-cst package ``__version__`` is *not* in the fingerprint:
+    every component whose output could shift between releases carries
+    its own ``Cacheable`` knob, and folding ``__version__`` in on top
+    would let lazily-unbumped components ride for free on a release
+    bump. Bumping the relevant component's ``version`` is the
+    discipline; ``__version__`` is not a substitute.
 
     Each value is normalized to a stable string before hashing so
     equivalent inputs produce equal keys.
     """
     h = hashlib.sha256()
     h.update(f"schema={SCHEMA_VERSION}\n".encode())
-    h.update(f"version={__version__}\n".encode())
     h.update(f"python={sys.version_info.major}.{sys.version_info.minor}\n".encode())
     h.update(f"visitor={SymbolVisitor.name}@{SymbolVisitor.version}\n".encode())
 

--- a/dead_cst/_const_fold.py
+++ b/dead_cst/_const_fold.py
@@ -23,9 +23,11 @@ flag:`` resolves correctly because the RHS evaluation consults the
 external resolver before falling back to the table.
 
 Only single-target ``Name`` LHS shapes participate. Tuple unpacking,
-attribute / subscript targets, walrus, augmented assign, parameter
-defaults, and import bindings all return ``None`` from the RHS lookup
-helper, which the caller treats as "unknown" -- the safe default.
+attribute / subscript targets, augmented assign, parameter defaults,
+and import bindings all return ``None`` from the RHS lookup helper,
+which the caller treats as "unknown" -- the safe default. Walrus
+(``name := expr``) does fold: the binding is unambiguous and the
+fixpoint loop happily propagates a literal RHS through it.
 Bindings whose live values disagree (e.g. ``if cond: x = True else:
 x = False``) likewise stay unknown. Cycles (``a = b; b = a``) never
 escape the unknown bucket because neither ever resolves.
@@ -183,10 +185,12 @@ def _constant_assignment_rhs(
     """RHS of a simple ``name = expr`` (or ``name: T = expr``) binding.
 
     Returns ``None`` for any shape we don't fold: tuple/list unpacking,
-    attribute or subscript targets, walrus, augmented assign,
-    parameter defaults, import bindings, etc. Multi-target chained
-    assignment (``a = b = expr``) is supported because all targets
-    share one RHS.
+    attribute or subscript targets, augmented assign, parameter
+    defaults, import bindings, etc. Multi-target chained assignment
+    (``a = b = expr``) is supported because all targets share one RHS.
+    Walrus (``name := expr``) is also supported -- the surrounding
+    expression context doesn't matter for fold purposes since the
+    binding's value is unambiguously ``expr``.
     """
     parent = parent_map.get(binding_node)
     if isinstance(parent, cst.AssignTarget):
@@ -199,6 +203,12 @@ def _constant_assignment_rhs(
             return None
         return grandparent.value
     if isinstance(parent, cst.AnnAssign):
+        if not isinstance(parent.target, cst.Name):
+            return None
+        if parent.target is not binding_node:
+            return None
+        return parent.value
+    if isinstance(parent, cst.NamedExpr):
         if not isinstance(parent.target, cst.Name):
             return None
         if parent.target is not binding_node:

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -170,6 +170,16 @@ class SymbolVisitor(cst.CSTVisitor):
         # ``NodeFlags.SHADOWED`` copies and remaps any edge endpoints
         # that point at them, so the graph keeps consistent identity.
         self.shadowed_decls: list[SymbolNode] = []
+        # Module-scope walrus targets keyed by name. PEP 572 says a
+        # walrus inside a comprehension binds in the comprehension's
+        # enclosing scope, but ``ScopeProvider`` doesn't propagate the
+        # binding out -- the access ``return last`` in
+        # ``def use(): return last`` lands with empty referents when
+        # ``last`` was bound by a walrus inside a module-level
+        # comprehension. We patch that gap in ``on_leave`` by routing
+        # any unresolved Name access whose ``.value`` matches a leaked
+        # walrus target back to the corresponding decl.
+        self.walrus_leak_targets: dict[str, list[SymbolNode]] = {}
 
     @property
     def module_node(self) -> SymbolNode:
@@ -391,6 +401,73 @@ class SymbolVisitor(cst.CSTVisitor):
     def visit_AnnAssign(self, node: cst.AnnAssign) -> None:
         self._add_variable(node)
 
+    def visit_NamedExpr(self, node: cst.NamedExpr) -> None:
+        self._add_walrus(node)
+
+    def _walrus_module_scope(self, node: cst.NamedExpr) -> tuple[bool, bool]:
+        """``(at_module, in_comprehension)`` for the walrus's binding scope.
+
+        Per PEP 572, a walrus inside a comprehension binds in the
+        comprehension's enclosing scope, so we ignore comprehension
+        scopes when deciding "at module". The first ``FunctionDef`` /
+        ``Lambda`` / ``ClassDef`` ancestor terminates the walk;
+        reaching ``Module`` without hitting one of those means the
+        binding leaks to the module namespace. The second flag is
+        ``True`` iff the walk passed through any comprehension on the
+        way -- callers use it to decide whether pushing a value frame
+        would steal attribution from the comprehension target's
+        fallback (``Comprehension targets share their enclosing decl's
+        frame, so a walrus's value frame would create spurious
+        last -> result edges in ``[last := n for n in nums]``).
+        """
+        parent_map = cast("dict[cst.CSTNode, cst.CSTNode]", self.metadata[ParentNodeProvider])
+        parent = parent_map.get(node)
+        in_comp = False
+        while parent is not None:
+            if isinstance(parent, (cst.FunctionDef, cst.Lambda, cst.ClassDef)):
+                return False, in_comp
+            if isinstance(parent, (cst.ListComp, cst.SetComp, cst.DictComp, cst.GeneratorExp)):
+                in_comp = True
+            parent = parent_map.get(parent)
+        return True, in_comp
+
+    def _add_walrus(self, node: cst.NamedExpr) -> None:
+        """Surface a module-scope walrus target as a top-level decl.
+
+        Pushes a frame on the target ``Name`` so accesses elsewhere
+        that resolve to the binding via ``ScopeProvider`` find the
+        correct symbol. For walruses outside any comprehension a
+        frame is also pushed on the value subtree so RHS accesses
+        attribute to the walrus decl (mirroring ``_add_variable``).
+        Comprehension-leaked walruses skip the value frame: their
+        for-loop targets fall back to the enclosing decl's frame, and
+        layering the walrus's frame on top would route those fallback
+        edges through the walrus decl instead.
+        """
+        at_module, in_comp = self._walrus_module_scope(node)
+        if not at_module:
+            return
+        if not isinstance(node.target, cst.Name):
+            return
+
+        # Walrus targets in comprehensions don't get a module-scoped
+        # FQN from the provider -- it returns ``mod.<comprehension>.x``
+        # there. Build the module-scoped FQN directly to keep the
+        # decl's identity consistent with what other top-level decls
+        # use.
+        fqname = f"{self.module_node.fqname}.{node.target.value}"
+        pos = self._pos(node.target)
+        sym = SymbolNode(fqname, "variable", self.path, pos)
+        self.symbol_referent_nodes[sym] = node.target
+        self.walrus_leak_targets.setdefault(node.target.value, []).append(sym)
+
+        # Push frames in reverse CST-visit order: the target ``Name`` is
+        # visited before the value, so the value frame goes on first
+        # (popped last). Mirrors the ordering in ``_add_variable``.
+        if not in_comp:
+            self._push_decls(node.value, [sym])
+        self._push_decls(node.target, [sym])
+
     def visit_Import(self, node: cst.Import) -> None:
         self._add_import("", node)
 
@@ -499,6 +576,29 @@ class SymbolVisitor(cst.CSTVisitor):
                         referents = [r for r in referents if id(r.node) in live_ids]
                 for referent in referents:
                     references.add((access, referent))
+
+        # Walrus bindings that leaked from a comprehension don't appear
+        # in the enclosing scope's assignment list (libcst's
+        # ``ScopeProvider`` keeps them in the ``ComprehensionScope``),
+        # so any access to the leaked name lands here with empty
+        # referents. Route those accesses to the matching top-level
+        # walrus decl so the graph mirrors the runtime semantics.
+        if self.walrus_leak_targets:
+            for scope in scopes:
+                for access in scope.accesses:
+                    if not isinstance(access.node, cst.Name):
+                        continue
+                    if any(isinstance(r, Assignment) for r in access.referents):
+                        continue
+                    targets = self.walrus_leak_targets.get(access.node.value)
+                    if not targets:
+                        continue
+                    owner_symbols = self.nearest_decls.get(access.node, [])
+                    access_pos = self._pos(access.node)
+                    for target_symbol in targets:
+                        for owner_symbol in owner_symbols:
+                            if target_symbol != owner_symbol and target_symbol and owner_symbol:
+                                self.internal_edges.add((owner_symbol, target_symbol, access_pos))
 
         for access, referent in references:
             owner_symbols = self.nearest_decls.get(access.node, [])

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -111,6 +111,18 @@ class SymbolVisitor(cst.CSTVisitor):
         PositionProvider,
     )
 
+    # ``Cacheable`` (name, version) fingerprint contributed to the
+    # per-run cache key. ``__version__`` already covers tagged releases,
+    # but it doesn't move between commits, so a behaviour-affecting
+    # visitor change between two installs at the same dev version
+    # would be served from stale ``VisitorPayload`` blobs. Bump
+    # ``version`` (to the current Unix epoch) on any change to the
+    # visitor's per-file output -- new node kinds surfaced as decls,
+    # edge-attribution rules, flow-analysis fixes, etc. Concurrent
+    # bumps on different branches merge with ``max()`` semantics.
+    name: str = "default"
+    version: int = 1777800597
+
     def _pos(self, node: cst.CSTNode):
         return self.get_metadata(PositionProvider, node, default=None)
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -155,11 +155,13 @@ def test_fingerprint_changes_when_unreachable_detector_version_bumped(tmp_path):
 def test_fingerprint_changes_when_visitor_version_bumped(tmp_path, monkeypatch):
     """Bumping ``SymbolVisitor.version`` invalidates the cache key.
 
-    The visitor's ``__version__`` only ticks on tagged releases, so a
-    behaviour-affecting visitor change between two installs at the
-    same dev version would otherwise be served from stale cached
-    payloads. ``SymbolVisitor`` carries its own ``Cacheable``
-    ``(name, version)`` pair to give that change a knob.
+    The package ``__version__`` is intentionally not in the
+    fingerprint: every component whose output could shift between
+    releases carries its own ``Cacheable`` knob, so the discipline is
+    to bump the relevant component rather than relying on a release
+    bump to invalidate everything at once. ``SymbolVisitor`` carries
+    a ``(name, version)`` pair so visitor-level changes get an
+    explicit knob.
     """
     from dead_cst._visitor import SymbolVisitor
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -152,6 +152,23 @@ def test_fingerprint_changes_when_unreachable_detector_version_bumped(tmp_path):
     assert fp_v1 != fp_v2
 
 
+def test_fingerprint_changes_when_visitor_version_bumped(tmp_path, monkeypatch):
+    """Bumping ``SymbolVisitor.version`` invalidates the cache key.
+
+    The visitor's ``__version__`` only ticks on tagged releases, so a
+    behaviour-affecting visitor change between two installs at the
+    same dev version would otherwise be served from stale cached
+    payloads. ``SymbolVisitor`` carries its own ``Cacheable``
+    ``(name, version)`` pair to give that change a knob.
+    """
+    from dead_cst._visitor import SymbolVisitor
+
+    fp_v1 = compute_fingerprint(paths={tmp_path: []}, resolvers=[])
+    monkeypatch.setattr(SymbolVisitor, "version", SymbolVisitor.version + 1)
+    fp_v2 = compute_fingerprint(paths={tmp_path: []}, resolvers=[])
+    assert fp_v1 != fp_v2
+
+
 def test_fingerprint_changes_when_plugin_version_bumped(tmp_path):
     """Bumping a plugin's epoch ``version`` invalidates the cache key.
 

--- a/tests/test_const_fold.py
+++ b/tests/test_const_fold.py
@@ -180,12 +180,10 @@ def test_tuple_unpacking_does_not_fold() -> None:
     assert out["a"] == [None]
 
 
-def test_walrus_binding_does_not_fold() -> None:
-    # ``_constant_assignment_rhs`` returns ``None`` for walrus
-    # (``NamedExpr``) bindings -- they aren't ``Assign`` / ``AnnAssign``
-    # statements -- so the value never enters the fold table even when
-    # the RHS is a literal. Ideally ``x`` would resolve to ``[False]``
-    # here, matching the behaviour of a plain ``x = False`` binding.
+def test_walrus_binding_folds() -> None:
+    # ``_constant_assignment_rhs`` recognises ``NamedExpr`` bindings the
+    # same way it recognises ``Assign`` / ``AnnAssign`` -- the walrus
+    # target's value is unambiguously the RHS, so a literal RHS folds.
     out = _resolve_lookup(
         """
         (x := False)
@@ -193,7 +191,25 @@ def test_walrus_binding_does_not_fold() -> None:
             pass
         """
     )
-    assert out["x"] == [None]
+    assert out["x"] == [False]
+
+
+def test_walrus_in_if_test_folds() -> None:
+    # ``evaluate_truthiness`` unwraps ``NamedExpr`` to its value, so the
+    # if-test's truthiness is statically known even when the test is a
+    # bare walrus expression.
+    out = _resolve_lookup(
+        """
+        if (x := False):
+            pass
+        """
+    )
+    # Two ``x`` accesses: the walrus target binding (folded via the
+    # NamedExpr handler in ``_constant_assignment_rhs``) and... actually
+    # only one access -- the walrus target Name is a binding, not an
+    # access. The ``if`` test's NamedExpr is an expression, not a Name
+    # access, so no entry shows up in ``out`` at all.
+    assert "x" not in out
 
 
 def test_attribute_target_does_not_fold() -> None:

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -520,10 +520,17 @@ import pytest
             def f(): return 1
             x = (y := f())
             """,
+            # The walrus surfaces ``y`` as its own top-level decl, so
+            # the RHS reference to ``f`` attributes to ``y`` rather
+            # than to ``x``. Reachability is preserved -- ``f`` is
+            # still kept alive transitively when ``x`` is reachable
+            # because the parser registers ``mod.y -> mod`` so the
+            # parent-module edge keeps ``y`` (and thus ``f``) live.
             {
                 "mod.f -> mod",
                 "mod.x -> mod",
-                "mod.x -> mod.f",
+                "mod.y -> mod",
+                "mod.y -> mod.f",
             },
             id="walrus-in-assignment-rhs",
         ),
@@ -715,10 +722,48 @@ import pytest
             id="comprehension-iterable-uses-enclosing-scope",
         ),
         # ------------------------------------------------------------------
-        # PEP 572 walrus -- references inside walrus RHS are still attributed
-        # to the enclosing top-level decl. (Top-level walrus binding capture
-        # itself is documented in ``test_limitations``.)
+        # PEP 572 walrus -- module-scope walruses surface as top-level
+        # decls, references inside the RHS attribute to that decl, and
+        # cross-decl uses get edges to it. Walruses inside a function /
+        # class / lambda body stay local; their RHS references attribute
+        # to the enclosing top-level decl as before.
         # ------------------------------------------------------------------
+        pytest.param(
+            """
+            def src(): return 1
+            if (Y := src()): pass
+            def use(): return Y
+            """,
+            {
+                "mod.src -> mod",
+                "mod.Y -> mod",
+                "mod.Y -> mod.src",
+                "mod.use -> mod",
+                "mod.use -> mod.Y",
+            },
+            id="walrus-toplevel-binding-captured",
+        ),
+        pytest.param(
+            """
+            nums = [1, 2, 3]
+            result = [last := n for n in nums]
+            def use(): return last
+            """,
+            # A walrus inside a comprehension leaks its binding to the
+            # enclosing (module) scope per PEP 572. ``mod.last`` is
+            # surfaced as a top-level decl and ``use``'s reference is
+            # routed to it via the unresolved-access fixup in
+            # ``SymbolVisitor.on_leave``.
+            {
+                "mod.nums -> mod",
+                "mod.result -> mod",
+                "mod.result -> mod.nums",
+                "mod.last -> mod",
+                "mod.use -> mod",
+                "mod.use -> mod.last",
+            },
+            id="walrus-comprehension-toplevel-leak-captured",
+        ),
         pytest.param(
             """
             def src(): return 1

--- a/tests/test_limitations.py
+++ b/tests/test_limitations.py
@@ -24,48 +24,6 @@ import pytest
             set(),
             id="pep-695-type-statement-not-captured",
         ),
-        pytest.param(
-            {
-                "mod.py": """
-                def src(): return 1
-                if (Y := src()): pass
-                def use(): return Y
-                """,
-            },
-            # PEP 572 walrus expressions at module scope bind a name
-            # in the enclosing (module) scope, but the visitor does not
-            # record that name as a top-level declaration. ``use``
-            # therefore gets no ``use -> mod.Y`` edge -- ideally the
-            # graph would contain ``mod.Y -> mod`` and
-            # ``mod.use -> mod.Y``.
-            {
-                "mod -> mod.src",
-                "mod.src -> mod",
-                "mod.use -> mod",
-            },
-            id="walrus-toplevel-binding-not-captured",
-        ),
-        pytest.param(
-            {
-                "mod.py": """
-                nums = [1, 2, 3]
-                result = [last := n for n in nums]
-                def use(): return last
-                """,
-            },
-            # A walrus inside a comprehension leaks its binding to the
-            # enclosing scope (here, the module). The visitor doesn't
-            # capture that leak either, so ``use`` references a name
-            # the graph never models. Ideally ``mod.last`` would exist
-            # with ``mod.use -> mod.last``.
-            {
-                "mod.nums -> mod",
-                "mod.result -> mod",
-                "mod.result -> mod.nums",
-                "mod.use -> mod",
-            },
-            id="walrus-comprehension-toplevel-leak-not-captured",
-        ),
         # ------------------------------------------------------------------
         # Dynamic / runtime features
         # ------------------------------------------------------------------

--- a/tests/test_unreachable_branches.py
+++ b/tests/test_unreachable_branches.py
@@ -419,15 +419,13 @@ def test_default_detector_folds_annotated_constant(build_decl_graph, assert_dead
     assert_dead_branch_edges(graph, {"mod -> mod.helper"})
 
 
-def test_default_detector_does_not_fold_walrus_binding(build_decl_graph, assert_dead_branch_edges):
-    """Limitation: walrus bindings are invisible to the fold table.
+def test_default_detector_folds_walrus_binding(build_decl_graph, assert_dead_branch_edges):
+    """Walrus bindings fold the same as ``Assign`` / ``AnnAssign``.
 
-    The const-folder's ``_constant_assignment_rhs`` only recognises
-    ``Assign`` and ``AnnAssign`` shapes, so a walrus binding -- even
-    one whose RHS is a plain literal -- never enters the table. The
-    if-test therefore stays unknown and the body isn't flagged dead.
-    Ideally ``mod -> mod.helper`` would be flagged here, matching the
-    behaviour of an equivalent ``DEBUG = False`` binding.
+    ``_constant_assignment_rhs`` recognises ``NamedExpr`` parents, so a
+    walrus whose RHS is a plain literal enters the fold table just
+    like ``DEBUG = False`` would. The if-test reads the bound name and
+    the body is flagged dead.
     """
     graph = build_decl_graph(
         {
@@ -439,18 +437,15 @@ def test_default_detector_does_not_fold_walrus_binding(build_decl_graph, assert_
             """
         }
     )
-    assert_dead_branch_edges(graph, set())
+    assert_dead_branch_edges(graph, {"mod -> mod.helper"})
 
 
-def test_default_detector_does_not_fold_walrus_in_if_test(
-    build_decl_graph, assert_dead_branch_edges
-):
-    """Limitation: walrus *expression* truthiness isn't recognised either.
+def test_default_detector_folds_walrus_in_if_test(build_decl_graph, assert_dead_branch_edges):
+    """Walrus *expression* truthiness folds through ``NamedExpr``.
 
-    ``evaluate_truthiness`` doesn't unwrap ``NamedExpr``, so even when
-    the walrus's RHS is a literal -- meaning the whole expression's
-    runtime value is statically known -- the if-body isn't flagged.
-    Ideally ``mod -> mod.helper`` would be flagged.
+    ``evaluate_truthiness`` unwraps ``NamedExpr`` to its value, so when
+    the walrus's RHS is a literal the whole expression's truthiness is
+    statically known and the if-body is flagged dead.
     """
     graph = build_decl_graph(
         {
@@ -461,7 +456,7 @@ def test_default_detector_does_not_fold_walrus_in_if_test(
             """
         }
     )
-    assert_dead_branch_edges(graph, set())
+    assert_dead_branch_edges(graph, {"mod -> mod.helper"})
 
 
 def test_default_detector_folds_constant_in_function(build_decl_graph, assert_dead_branch_edges):


### PR DESCRIPTION
## Summary

Three related changes that started with the documented walrus limitations and ended up tightening the cache-fingerprint discipline.

### 1. Capture PEP 572 walrus targets at module scope
- **Top-level walruses** (`if (Y := src()): ...`) now register `mod.Y` as a top-level decl. The walrus's RHS-frame attribution mirrors `_add_variable`, so references inside the value subtree (like `src` in `(Y := src())`) get edges from `mod.Y`. Downstream uses such as `def use(): return Y` resolve via `ScopeProvider` and produce the expected `mod.use -> mod.Y` edge.
- **Comprehension-leaked walruses** (`result = [last := n for n in nums]`) are also captured. `libcst`'s `ScopeProvider` keeps the binding inside the `ComprehensionScope`, so `SymbolVisitor.on_leave` runs an unresolved-access fixup: any Name access whose `.value` matches a leaked walrus target is routed back to the matching decl. The walrus's value frame is intentionally skipped inside comprehensions to avoid hijacking comp-target attribution (`mod.last -> mod.result` would otherwise leak).
- Walruses inside a function / class / lambda body still bind locally, matching Python's runtime semantics — the lexical-scope check stops at the first `FunctionDef` / `Lambda` / `ClassDef` ancestor.
- The default unreachable-region detector now folds walrus bindings the same way it folds `Assign` / `AnnAssign`. `_constant_assignment_rhs` recognises `NamedExpr` parents, and `evaluate_truthiness` unwraps `NamedExpr` to its value, so `(DEBUG := False); if DEBUG:` and `if (DEBUG := False):` both flag dead branches. Detector `version` bumped accordingly.
- Limitation tests promoted to positive coverage in `test_declarations`, `test_const_fold`, and `test_unreachable_branches`. README and `_const_fold` doc updated.

### 2. Extend `Cacheable` to `SymbolVisitor`
`SymbolVisitor` now satisfies the same `Cacheable` protocol as the detector / plugins / resolvers via class-level `name: str = "default"` and an epoch `version: int`. `compute_fingerprint` includes the pair, so a behaviour-affecting change to the visitor (exactly the kind of change in this PR) invalidates stale `VisitorPayload` blobs. Concurrent bumps merge with `max()` semantics. Visitor `version` bumped for the walrus support.

### 3. Drop package `__version__` from the cache fingerprint
Every component whose per-file output can shift between releases (visitor, resolvers, plugins, detector) already carries its own `Cacheable` `(name, version)` knob. Folding `__version__` in on top let unbumped components ride for free on a release bump and masked cases where the granular versions weren't being maintained. The discipline now is to bump the relevant component. Schema version and Python version still participate.

## Test plan
- [x] `uv run pytest` — 642 passed
- [x] `uv run prek run --all-files` — all hooks pass (ruff, ruff-format, ty, uv-lock)
- [x] New `test_fingerprint_changes_when_visitor_version_bumped` covers the visitor-Cacheable wiring
- [x] Walrus limitation tests are now positive coverage; `test_limitations.py` no longer documents walrus gaps

https://claude.ai/code/session_01V7VqfKboHsHyC1G8KQVkVZ