### PR TITLE
docs: roadmap items for call folding, suite removal, preview, and flag-audit example

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,23 +15,7 @@ for the full record.
 
 ## Tier 1 — Trust and correctness
 
-### 1. CLI integration tests
-
-`dead_cst/cli.py` is now 571 LOC and still untested. It is the largest
-untested surface in the package and the most user-visible. Cover it with
-`typer.testing.CliRunner`:
-
-- `analyze` text and JSON output (including unreachable branches and the
-  `--resolver` / `--plugin` flags)
-- `remove` with `--dry-run` and actual writes, including import pruning
-- `why-alive` predecessor tracing
-- `unused-exports` and `dependencies` output
-- Exit codes and stderr on parse errors and missing inputs
-
-Cheap to write, catches the regressions users notice first. Highest-leverage
-trust work remaining.
-
-### 2. Finish the framework-aware plugin presets
+### 1. Finish the framework-aware plugin presets
 
 `PytestPlugin`, `UnittestPlugin`, `FastAPIPlugin`, `FlaskPlugin`,
 `TyperPlugin`, `ClickPlugin`, and `InitSubclassPlugin` shipped, but the
@@ -46,44 +30,62 @@ Surface a `--preset pytest,fastapi,django` shortcut that expands to the
 existing `--plugin` wiring, and document the entry-point group so third
 parties can publish their own.
 
-### 3. `if TYPE_CHECKING:` awareness
+### 2. Function-call folding (same-file, caller-capped)
 
-Currently treated as live, which is safe but pessimistic. Tag imports inside
-`TYPE_CHECKING` blocks as type-only so removal is safe when the only
-references are themselves in type-only contexts (annotations, other
-`TYPE_CHECKING` blocks). The flow-sensitive filter (`_flow.py`) already
-distinguishes branches; this is mostly an edge-tagging change in
-`_resolve.py`. Low effort, visible win for typed codebases.
+`def is_new_auth(): return False; if is_new_auth(): X = 1` should mark `X` as
+dead, but doesn't yet — `evaluate_truthiness` doesn't fold through calls. Add
+a pre-pass in `fold_constants` that walks top-level `FunctionDef` bodies for
+trivial single-return shapes and lets the resolver recurse through them. Both
+sync `def` (folded via bare `Call`) and async `def` (folded via `Await(Call)`
+only — a bare async call returns a coroutine, always truthy). Cap by caller
+count (default 3) so that configuration helpers used in 50 places don't get
+folded into noise. Same-file only; cross-file is item 7.
 
-### 4. `--continue-on-parse-error`
+### 3. Suite-removal codemod and expanded dead-set helper
 
-A single broken file currently aborts the whole analysis, which is a
-non-starter for running in CI on large repos. Skip the file, log it, mark its
-declared symbols as live conservatively, and exit non-zero only at the end.
+`dead-cst remove` only deletes decls today; the `If` / `While` / post-
+terminator suites that `analyze` flags can't be removed automatically. Add a
+`RemoveDeadSuites` LibCST transformer covering each parent shape (`If` /
+`While` / `elif` chains / post-terminator) with empty-suite guards inserting
+`pass` where needed, and a helper that returns the union of dead decls + dead
+suite ranges + `find_kept_alive_by_dead_branches(graph)` so removal expands
+to the blast radius. Foundational for items 5 and 6 — invisible by itself,
+shipped together with whichever consumer lands first.
 
 ---
 
 ## Tier 2 — Adoption surface
 
-### 5. "New dead code only" / diff mode
+### 4. "New dead code only" / diff mode
 
 Most teams cannot fix all existing dead code in one PR. A `--since <ref>` flag
 that filters to symbols introduced or last touched after a git ref makes the
 tool drop-in for CI on existing codebases without a big-bang cleanup. This
 pattern is what drove adoption for tools like Knip in the JS ecosystem.
 
-### 6. Public reachability-explanation API
+### 5. `remove --include-dead-branches`
 
-The `why-alive` predecessor walk is locked inside CLI code. Lift it to a
-top-level `explain_reachability(graph, symbol)` that returns the path from an
-entrypoint to the symbol. Enables IDE plugins, custom dashboards, and richer
-error messages without re-implementing the BFS.
+Wire item 3's suite-removal codemod into `dead-cst remove` behind an opt-in
+flag. Default off — existing decl-only behavior keeps backward-compatibility
+while the new transformer bakes. Once warm in real-world use, flip the
+default to on and rename the opt-out to `--no-dead-branches`.
 
-### 7. Coverage tracking in CI
+### 6. `dead-cst preview` (graph-clustered patches)
 
-Add codecov (or coveralls) to `.github/workflows/ci.yml` to establish a
-baseline and prevent silent regressions. Small, but the value compounds once
-Tier 1 lands and we want to defend the new test coverage.
+Peer subcommand to `analyze` / `remove` that renders item 3's codemod as
+per-cluster unified diffs instead of editing files. Clusters are weakly-
+connected components of the unreachable subgraph: each WCC is the maximal
+unit that can be applied atomically without leaving dangling references.
+Cluster headers carry blast-radius metadata (symbols, LOC, files affected).
+Composes with `git apply` (whole cluster) and `git add -p` (per-line review)
+without needing a custom TUI; see item 10 for the deferred TUI shape.
+
+### 7. Cross-file trivial-return folding
+
+Item 2 only folds within a single file. Cross-module folding
+(`from flags import is_new_auth; if is_new_auth():` resolving via the import)
+requires plumbing fold state through `resolve_edges` and bumping the cache
+contract. Defer until item 2 ships and demand is real.
 
 ---
 
@@ -97,16 +99,32 @@ undiscovered. A short Sphinx site with one tutorial each ("write a custom
 that's already built. The docstring pass already in place gives the API
 reference for free.
 
-### 9. `del` modeling
+### 9. `examples/flag_audit/` recipe
 
-Documented limitation in `tests/test_limitations.py`. Low real-world impact;
-tackle once Tier 1–2 has shipped and the protocol surface is stable.
+A working example, not a CLI command. Ships a `flags.toml` mapping flag-name
+→ fixed truthiness, a `FlagAuditDetector(DefaultUnreachableRegionDetector)`
+whose `resolve()` answers `check_flag("foo")` calls per the toml config, and
+a `main()` that builds the graph, calls `find_kept_alive_by_dead_branches`,
+and prints "removing flag X would delete N symbols / M LOC". Item 2 makes
+this much cleaner: a one-line wrapper `def is_new_auth(): return
+check_flag("new-auth")` folds without the detector having to recognize the
+wrapper directly.
+
+### 10. Interactive TUI (`dead-cst review`)
+
+Speculative; only promote if `git add -p` over item 6's output proves
+insufficient. Design direction when promoted: walk the cluster condensation
+in topological order, asking accept/reject for each cluster, stopping on the
+first rejection (or letting the user mark "skip" to keep going). Equivalent
+to a DAG-walk where rejecting a parent means we don't bother asking about
+its successors. Pairs directly with item 6's WCC clustering — the data
+shape carries over.
 
 ---
 
 ## Tier 4 — Speculative, wait for signal
 
-### 10. Multiple reachability frontiers
+### 11. Multiple reachability frontiers
 
 Splitting "reachable from tests" vs. "reachable from production entrypoints"
 is interesting and would enable rules like "no production code reachable only
@@ -125,6 +143,33 @@ Folded down from earlier tiers as they landed:
   removing a dead alias releases its references; users that reference
   the alias get an edge into it. The codemod's `RemoveDeadSymbols`
   pass deletes unreachable aliases.
+- PEP 572 walrus (`:=`) bindings at module scope are surfaced as top-level
+  decls and folded by the unreachable-region detector the same way
+  `Assign` / `AnnAssign` are. Walruses leaked from module-level
+  comprehensions are captured by patching `ScopeProvider`'s comprehension-
+  scoped binding.
+- `UnreachableRegionDetector` Protocol with a shipped
+  `DefaultUnreachableRegionDetector` running three passes per file: the
+  literal-only `unreachable_suites` walk, a `fold_constants` fixpoint pre-
+  pass (chained `Name = literal` propagation), and a post-terminator scan
+  over every statement-bearing suite. Subclasses override
+  `resolve(self, expr) -> bool | None` to fold domain-specific expressions;
+  folded values flow through the same fixpoint loop.
+- `Cacheable` Protocol unifying `(name, version)` across visitor, resolvers,
+  plugins, and detectors. Package `__version__` removed from the cache
+  fingerprint — each component carries its own knob, and concurrent bumps
+  on different branches merge with `max()` semantics.
+- `DecoratedDeclPlugin` and `LiteralListPlugin` abstract bases for the two
+  most common plugin idioms (decorator-driven decls and string-literal-list
+  registries). `ClickPlugin` migrated to the former.
+- E2E test suite at `tests/e2e/` (`-m e2e`, deselected by default) clones
+  real repos at pinned SHAs and exercises analyze + why-alive + project-
+  specific plugins.
+- CLI integration tests at `tests/test_cli.py` covering analyze, remove,
+  why-alive, unused-exports, and dependencies via `typer.testing.CliRunner`
+  (Tier 1).
+- Coverage tracking in CI: Codecov upload from the 3.13 matrix entry with
+  per-component thresholds in `codecov.yml` (Tier 2).
 - SQLite-cached graph with partial rebuilds: `GraphCache` stores
   pickled `VisitorPayload` blobs keyed by per-file content hash under
   `<root>/.dead-cst-cache/cache.db`. Cache hits skip the per-file
@@ -142,7 +187,7 @@ Folded down from earlier tiers as they landed:
 - `from X import *` resolution, pessimistic by default (Tier 1).
 - `PytestPlugin`, `UnittestPlugin`, `FastAPIPlugin`, `FlaskPlugin`,
   `TyperPlugin`, `ClickPlugin`, and `InitSubclassPlugin` (Tier 1,
-  partial — see item 2).
+  partial — see item 1).
 - `unused-exports` and `dependencies` CLI commands.
 - Unreachable-branch detection surfaced as synthetic graph nodes.
 - Workspace-aware cross-member import scoping via `exported_roots`.
@@ -158,6 +203,13 @@ Folded down from earlier tiers as they landed:
 - Stub file (`.pyi`) ingestion
 - Cross-language analysis
 - Language Server Protocol implementation
+- `if TYPE_CHECKING:` rewriting (treating type-only imports as removable)
+- Continuing analysis past parse errors (would silently miss usages from
+  the unparseable file, leading to false-positive dead reports)
+- `del` statement modeling (no real-world bug filed; revisit if a limitation
+  test is added that demonstrates a problem)
+- `explain_reachability` public API (the `why-alive` CLI is sufficient until
+  external tooling actually asks for it)
 
 These may be worth revisiting after a stable 1.0, but each adds significant
 surface area without addressing current adoption blockers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,7 +39,7 @@ trivial single-return shapes and lets the resolver recurse through them. Both
 sync `def` (folded via bare `Call`) and async `def` (folded via `Await(Call)`
 only — a bare async call returns a coroutine, always truthy). Cap by caller
 count (default 3) so that configuration helpers used in 50 places don't get
-folded into noise. Same-file only; cross-file is item 7.
+folded into noise. Same-file only; cross-file is item 8.
 
 ### 3. Suite-removal codemod and expanded dead-set helper
 
@@ -49,7 +49,7 @@ terminator suites that `analyze` flags can't be removed automatically. Add a
 `While` / `elif` chains / post-terminator) with empty-suite guards inserting
 `pass` where needed, and a helper that returns the union of dead decls + dead
 suite ranges + `find_kept_alive_by_dead_branches(graph)` so removal expands
-to the blast radius. Foundational for items 5 and 6 — invisible by itself,
+to the blast radius. Foundational for items 5 and 7 — invisible by itself,
 shipped together with whichever consumer lands first.
 
 ---
@@ -70,7 +70,18 @@ flag. Default off — existing decl-only behavior keeps backward-compatibility
 while the new transformer bakes. Once warm in real-world use, flip the
 default to on and rename the opt-out to `--no-dead-branches`.
 
-### 6. `dead-cst preview` (graph-clustered patches)
+### 6. `remove --inline-folds`
+
+Wire item 2's function-call folding into `dead-cst remove` behind an opt-in
+flag, mirroring item 5's shape for suites. For every trivial-return function
+the fold pass classifies as a constant, rewrite each call site with that
+constant and (when the function has no surviving consumers) delete the
+function itself. Default off; flip to default-on once warm in real-world
+use. Composes with item 5: once a fold is inlined, `if is_new_auth():`
+becomes `if False:`, which the suite-removal pass then collapses in the
+same run.
+
+### 7. `dead-cst preview` (graph-clustered patches)
 
 Peer subcommand to `analyze` / `remove` that renders item 3's codemod as
 per-cluster unified diffs instead of editing files. Clusters are weakly-
@@ -78,9 +89,9 @@ connected components of the unreachable subgraph: each WCC is the maximal
 unit that can be applied atomically without leaving dangling references.
 Cluster headers carry blast-radius metadata (symbols, LOC, files affected).
 Composes with `git apply` (whole cluster) and `git add -p` (per-line review)
-without needing a custom TUI; see item 10 for the deferred TUI shape.
+without needing a custom TUI; see item 11 for the deferred TUI shape.
 
-### 7. Cross-file trivial-return folding
+### 8. Cross-file trivial-return folding
 
 Item 2 only folds within a single file. Cross-module folding
 (`from flags import is_new_auth; if is_new_auth():` resolving via the import)
@@ -91,7 +102,7 @@ contract. Defer until item 2 ships and demand is real.
 
 ## Tier 3 — Polish and ecosystem
 
-### 8. Read the Docs site with plugin/resolver tutorials
+### 9. Read the Docs site with plugin/resolver tutorials
 
 The `EdgePlugin` and `PathResolver` protocols are well-designed but
 undiscovered. A short Sphinx site with one tutorial each ("write a custom
@@ -99,7 +110,7 @@ undiscovered. A short Sphinx site with one tutorial each ("write a custom
 that's already built. The docstring pass already in place gives the API
 reference for free.
 
-### 9. `examples/flag_audit/` recipe
+### 10. `examples/flag_audit/` recipe
 
 A working example, not a CLI command. Ships a `flags.toml` mapping flag-name
 → fixed truthiness, a `FlagAuditDetector(DefaultUnreachableRegionDetector)`
@@ -110,21 +121,21 @@ this much cleaner: a one-line wrapper `def is_new_auth(): return
 check_flag("new-auth")` folds without the detector having to recognize the
 wrapper directly.
 
-### 10. Interactive TUI (`dead-cst review`)
+### 11. Interactive TUI (`dead-cst review`)
 
-Speculative; only promote if `git add -p` over item 6's output proves
+Speculative; only promote if `git add -p` over item 7's output proves
 insufficient. Design direction when promoted: walk the cluster condensation
 in topological order, asking accept/reject for each cluster, stopping on the
 first rejection (or letting the user mark "skip" to keep going). Equivalent
 to a DAG-walk where rejecting a parent means we don't bother asking about
-its successors. Pairs directly with item 6's WCC clustering — the data
+its successors. Pairs directly with item 7's WCC clustering — the data
 shape carries over.
 
 ---
 
 ## Tier 4 — Speculative, wait for signal
 
-### 11. Multiple reachability frontiers
+### 12. Multiple reachability frontiers
 
 Splitting "reachable from tests" vs. "reachable from production entrypoints"
 is interesting and would enable rules like "no production code reachable only
@@ -194,22 +205,3 @@ Folded down from earlier tiers as they landed:
 - Position-aware shadowing in the codemod.
 - `ModuleDundersPlugin` replacing `--preserve-dunder-all`.
 - Public-API docstring pass across the package.
-
----
-
-## Out of scope (for now)
-
-- Per-symbol weighting / decay heuristics
-- Stub file (`.pyi`) ingestion
-- Cross-language analysis
-- Language Server Protocol implementation
-- `if TYPE_CHECKING:` rewriting (treating type-only imports as removable)
-- Continuing analysis past parse errors (would silently miss usages from
-  the unparseable file, leading to false-positive dead reports)
-- `del` statement modeling (no real-world bug filed; revisit if a limitation
-  test is added that demonstrates a problem)
-- `explain_reachability` public API (the `why-alive` CLI is sufficient until
-  external tooling actually asks for it)
-
-These may be worth revisiting after a stable 1.0, but each adds significant
-surface area without addressing current adoption blockers.


### PR DESCRIPTION
Adds Tier 1 items for same-file trivial-return folding (sync + async
via await, caller-capped) and the foundational suite-removal codemod
plus expanded blast-radius dead-set helper. Adds Tier 2 items for the
two consumers — `remove --include-dead-branches` (opt-in flag, default
off) and a peer `dead-cst preview` subcommand that emits per-cluster
unified diffs over WCCs of the unreachable subgraph. Adds Tier 3 items
for the `examples/flag_audit/` recipe and the deferred interactive TUI
(documenting the topological-DAG-walk acceptance shape).

https://claude.ai/code/session_01NWu3kmxStNnRzH51Dmr7sM