### PR TITLE
analyze: parallelize per-file visitor passes with --workers/-j

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,25 @@ two versions.
 ### Added
 - `build_symbol_graph(workers=N)` (and matching `--workers` / `-j` CLI
   flag) dispatches per-file visitor + observe passes to a
-  `ProcessPoolExecutor` when at least two cache-miss files exist in a
-  base. Workers return `VisitorPayload` blobs to the main process,
-  which still owns SQLite cache writes, trie stitching, and edge
-  resolution; serial behaviour and graph output are unchanged. A
-  fresh pool spins up per base so each worker's `sys.path` and
-  `FullRepoManager` match the base being processed, and cache-warm
-  bases never start one. `workers=None` (default) and `workers=1`
-  keep the existing serial path.
+  `ProcessPoolExecutor` when at least two cache-miss files exist
+  across all bases. Workers return `VisitorPayload` blobs to the
+  main process, which still owns SQLite cache writes, trie
+  stitching, and edge resolution; serial behaviour and graph output
+  are unchanged. A single persistent pool spans the whole run with
+  tasks sorted by `search_paths`, so any one worker tends to see
+  contiguous miss runs from the same base; on each transition the
+  worker rebinds `sys.path` and clears `safe_resolve_module` plus
+  `distribution_lookup` so cross-venv uv-workspace members don't
+  inherit a sibling base's resolution state. `workers=None`
+  (default) and `workers=1` keep the existing serial path.
+
+### Changed
+- `build_symbol_graph` is now structured as three phases: collect
+  per-base specs (cache hits + miss files), compute every miss
+  payload (serial or parallel), then per-base apply + edge stitch +
+  plugin finalize. The graph and cache contents are unchanged; the
+  rearrangement makes the parallel path tractable and removes
+  `temp_sys_path` from the main process loop in parallel mode.
 
 ## [0.4.0] - 2026-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,16 +21,27 @@ two versions.
   contiguous miss runs from the same base; on each transition the
   worker rebinds `sys.path` and clears `safe_resolve_module` plus
   `distribution_lookup` so cross-venv uv-workspace members don't
-  inherit a sibling base's resolution state. `workers=None`
-  (default) and `workers=1` keep the existing serial path.
+  inherit a sibling base's resolution state. The FQN provider's
+  per-base cache is now built once in the parent over miss files
+  only and shipped per-task to workers, so workers no longer rebuild
+  a `FullRepoManager` and the analyzer skips FQN computation for
+  cache-hit files entirely. `workers=None` (default) and
+  `workers=1` keep the in-process path.
 
 ### Changed
-- `build_symbol_graph` is now structured as three phases: collect
-  per-base specs (cache hits + miss files), compute every miss
-  payload (serial or parallel), then per-base apply + edge stitch +
-  plugin finalize. The graph and cache contents are unchanged; the
-  rearrangement makes the parallel path tractable and removes
-  `temp_sys_path` from the main process loop in parallel mode.
+- `build_symbol_graph` runs as three phases: collect per-base specs
+  (cache hits + miss files + per-base FQN cache), compute every miss
+  payload (in-process or via the pool), then per-base apply + edge
+  stitch + plugin finalize. The graph and cache contents are
+  unchanged. The in-process and worker paths share a single
+  `_process_task` body — the only difference is whether the runner
+  state lives on the main process or in worker globals.
+
+### Removed
+- The internal `temp_sys_path` context manager
+  (`dead_cst._resolvers._imports`). The runner now manages
+  `sys.path` directly, restoring it from a baseline snapshot when
+  the in-process path finishes. Not part of the public API.
 
 ## [0.4.0] - 2026-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ two versions.
 
 ## [Unreleased]
 
+### Added
+- `build_symbol_graph(workers=N)` (and matching `--workers` / `-j` CLI
+  flag) dispatches per-file visitor + observe passes to a
+  `ProcessPoolExecutor` when at least two cache-miss files exist in a
+  base. Workers return `VisitorPayload` blobs to the main process,
+  which still owns SQLite cache writes, trie stitching, and edge
+  resolution; serial behaviour and graph output are unchanged. A
+  fresh pool spins up per base so each worker's `sys.path` and
+  `FullRepoManager` match the base being processed, and cache-warm
+  bases never start one. `workers=None` (default) and `workers=1`
+  keep the existing serial path.
+
 ## [0.4.0] - 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ dead-cst analyze ROOT -e ENTRYPOINT [OPTIONS]
 | `--format` | Output format: `text` or `json` |
 | `-v, --verbose` | Enable verbose logging |
 | `--no-cache` | Bypass the per-file `VisitorPayload` cache |
+| `-j, --workers` | Run cache-miss visitor passes in this many worker processes (`>=2` enables it) |
 
 Exit code 1 if dead code is found, 0 otherwise.
 
@@ -79,6 +80,7 @@ dead-cst why-alive ROOT FQNAME [OPTIONS]
 | `--plugin` | Edge plugin to run, e.g. `main_block`, `project_scripts` (repeatable) |
 | `-v, --verbose` | Enable verbose logging |
 | `--no-cache` | Bypass the per-file `VisitorPayload` cache |
+| `-j, --workers` | Run cache-miss visitor passes in this many worker processes (`>=2` enables it) |
 
 ### `dead-cst unused-exports`
 
@@ -96,6 +98,7 @@ dead-cst unused-exports ROOT -e ENTRYPOINT [OPTIONS]
 | `--plugin` | Edge plugin to run, e.g. `main_block`, `project_scripts` (repeatable) |
 | `-v, --verbose` | Enable verbose logging |
 | `--no-cache` | Bypass the per-file `VisitorPayload` cache |
+| `-j, --workers` | Run cache-miss visitor passes in this many worker processes (`>=2` enables it) |
 
 ### `dead-cst dependencies`
 
@@ -115,6 +118,7 @@ dead-cst dependencies ROOT [OPTIONS]
 | `--format` | Output format: `text` or `json` |
 | `-v, --verbose` | Enable verbose logging |
 | `--no-cache` | Bypass the per-file `VisitorPayload` cache |
+| `-j, --workers` | Run cache-miss visitor passes in this many worker processes (`>=2` enables it) |
 
 ### `dead-cst remove`
 
@@ -133,6 +137,7 @@ dead-cst remove ROOT -e ENTRYPOINT [OPTIONS]
 | `-v, --verbose` | Enable verbose logging |
 | `--dry-run` | Show what would be removed without making changes |
 | `--no-cache` | Bypass the per-file `VisitorPayload` cache |
+| `-j, --workers` | Run cache-miss visitor passes in this many worker processes (`>=2` enables it) |
 
 ### `dead-cst cache clear`
 

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import logging
+import sys
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Sequence
 
@@ -87,6 +90,7 @@ def build_symbol_graph(
     project_root: Path | None = None,
     cache: GraphCache | None = None,
     unreachable_detector: UnreachableRegionDetector | None = None,
+    workers: int | None = None,
 ) -> nx.MultiDiGraph:
     """Build a directed reachability graph of every top-level symbol under ``paths``.
 
@@ -155,6 +159,16 @@ def build_symbol_graph(
         :class:`CodeRange` list feeds :data:`EdgeFlags.DEAD_BRANCH`
         derivation and the per-file ``graph.graph["dead_suites"]``
         reporting map.
+    workers:
+        When set to an integer ``>= 2``, the per-file visitor + observe
+        passes for cache-miss files are dispatched to a
+        :class:`~concurrent.futures.ProcessPoolExecutor`. Workers
+        return :class:`VisitorPayload` objects to the main process,
+        which still owns the SQLite cache write and the trie-stitching
+        / edge-resolution stages. ``None`` (default) and ``1`` keep
+        the serial path. A fresh pool is built per base so each
+        worker's ``sys.path`` and ``FullRepoManager`` match the base
+        being processed; cache-warm bases never spin one up.
 
     Returns
     -------
@@ -189,35 +203,33 @@ def build_symbol_graph(
             export_roots = exported_roots(base)
             import_edges: set[tuple[SymbolNode, Import, EdgeFlags]] = set()
             files = list(sorted(base.rglob("*.py")))
-            # Lazily constructed on the first cache miss; an all-cached
-            # base never builds the manager, since FQN metadata is only
-            # needed when running the visitor.
-            mgr: FullRepoManager | None = None
+            hits: dict[Path, VisitorPayload] = {}
+            miss_files: list[Path] = []
             for file in files:
                 payload = cache.get(file) if cache is not None else None
                 if payload is None:
-                    if mgr is None:
-                        mgr = FullRepoManager(
-                            str(base),
-                            [str(f) for f in files],
-                            {FixedFullyQualifiedNameProvider},
-                        )
-                    wrapper = mgr.get_metadata_wrapper_for_path(str(file))
-                    visitor = SymbolVisitor(
-                        file,
-                        search_paths,
-                        import_resolver,
-                        unreachable_detector=detector,
-                        wrapper=wrapper,
-                    )
-                    wrapper.visit(visitor)
-                    base_payload = visitor.to_payload()
-                    plugin_payload = _run_observe(
-                        plugins, file, wrapper.module, base_payload, base, root
-                    )
-                    payload = _merge_payloads(base_payload, plugin_payload)
-                    if cache is not None:
-                        cache.put(file, payload)
+                    miss_files.append(file)
+                else:
+                    hits[file] = payload
+
+            miss_payloads = _compute_miss_payloads(
+                miss_files=miss_files,
+                files=files,
+                base=base,
+                search_paths=search_paths,
+                project_root=root,
+                import_resolver=import_resolver,
+                detector=detector,
+                plugins=plugins,
+                resolvers=resolvers,
+                cache=cache,
+                workers=workers,
+            )
+
+            for file in files:
+                payload = hits.get(file)
+                if payload is None:
+                    payload = miss_payloads[file]
                 # A file's decls go into ``export_trie`` only when the file
                 # lives under one of ``base``'s exported dirs (or when the
                 # base has no export restriction). This is what hides
@@ -307,6 +319,217 @@ def _run_observe(
         if contribution is not None:
             payloads.append(contribution)
     return _merge_payloads(*payloads) if payloads else make_payload()
+
+
+def _process_one_file(
+    file: Path,
+    *,
+    mgr: FullRepoManager,
+    search_paths: list[Path],
+    import_resolver: ImportResolver,
+    detector: UnreachableRegionDetector,
+    plugins: Sequence[EdgePlugin],
+    base: Path,
+    project_root: Path,
+) -> VisitorPayload:
+    """Run the visitor + observe pass for a single file and return its payload.
+
+    Shared by the serial path inside :func:`build_symbol_graph` and the
+    worker entry point used when ``workers >= 2``. The caller owns the
+    :class:`FullRepoManager` so it can be reused across files in the
+    same base (the FQN cache is precomputed per base) and so workers
+    don't rebuild it on every task.
+    """
+    wrapper = mgr.get_metadata_wrapper_for_path(str(file))
+    visitor = SymbolVisitor(
+        file,
+        search_paths,
+        import_resolver,
+        unreachable_detector=detector,
+        wrapper=wrapper,
+    )
+    wrapper.visit(visitor)
+    base_payload = visitor.to_payload()
+    plugin_payload = _run_observe(plugins, file, wrapper.module, base_payload, base, project_root)
+    return _merge_payloads(base_payload, plugin_payload)
+
+
+@dataclass(frozen=True)
+class _WorkerInit:
+    """Per-base bundle of state shipped to each :class:`ProcessPoolExecutor` worker.
+
+    Captures everything a worker needs to reproduce the parent's
+    visitor environment: the base + search paths (for ``sys.path`` and
+    ``FullRepoManager`` construction), the full file list (FQN gen
+    cache spans every file in the base), the resolver chain (rebuilt
+    via :func:`_chain_resolvers` inside the worker since the resolver
+    closure isn't picklable), the detector, the plugin list, and the
+    project root used by ``_run_observe``. Frozen so misuse from a
+    worker can't leak state back into queued tasks.
+    """
+
+    base: Path
+    search_paths: tuple[Path, ...]
+    files: tuple[Path, ...]
+    detector: UnreachableRegionDetector
+    plugins: tuple[EdgePlugin, ...]
+    resolvers: tuple[PathResolver, ...]
+    project_root: Path
+
+
+@dataclass
+class _WorkerCtx:
+    """Per-worker mutable state populated by :func:`_init_worker`.
+
+    ``mgr`` is built lazily on the first task so workers that never
+    receive one don't pay the construction cost; the first task in a
+    worker pays it once and subsequent tasks reuse the same FQN cache.
+    """
+
+    init: _WorkerInit
+    import_resolver: ImportResolver
+    mgr: FullRepoManager | None = field(default=None)
+
+
+_worker_ctx: _WorkerCtx | None = None
+
+
+def _init_worker(init: _WorkerInit) -> None:
+    """Pool initializer: prime ``sys.path``, the resolver chain, and worker globals.
+
+    Adds ``init.search_paths`` to ``sys.path`` so
+    :func:`default_resolve_import` finds first-party modules under the
+    current base. Clears :func:`safe_resolve_module`'s LRU cache for
+    the same hygiene the parent does between bases. Rebuilds the
+    resolver chain locally because :func:`_chain_resolvers` returns a
+    closure (not picklable across processes); the ``PathResolver``
+    instances themselves are picklable dataclasses and travel via
+    ``init``.
+    """
+    global _worker_ctx
+    seen = set(sys.path)
+    for p in init.search_paths:
+        s = str(p)
+        if s not in seen:
+            sys.path.insert(0, s)
+    safe_resolve_module.cache_clear()
+    _worker_ctx = _WorkerCtx(
+        init=init,
+        import_resolver=_chain_resolvers(init.resolvers),
+    )
+
+
+def _worker_process_file(file: Path) -> tuple[Path, VisitorPayload]:
+    """Pool task: run :func:`_process_one_file` for ``file`` against worker state.
+
+    Returns ``(file, payload)`` so :meth:`Executor.map` results can be
+    matched back to inputs without relying on submission order.
+    Constructs the per-worker :class:`FullRepoManager` lazily on first
+    use; subsequent tasks in the same worker reuse it.
+    """
+    ctx = _worker_ctx
+    assert ctx is not None, "_init_worker must run before _worker_process_file"
+    if ctx.mgr is None:
+        ctx.mgr = FullRepoManager(
+            str(ctx.init.base),
+            [str(f) for f in ctx.init.files],
+            {FixedFullyQualifiedNameProvider},
+        )
+    payload = _process_one_file(
+        file,
+        mgr=ctx.mgr,
+        search_paths=list(ctx.init.search_paths),
+        import_resolver=ctx.import_resolver,
+        detector=ctx.init.detector,
+        plugins=ctx.init.plugins,
+        base=ctx.init.base,
+        project_root=ctx.init.project_root,
+    )
+    return file, payload
+
+
+def _compute_miss_payloads(
+    *,
+    miss_files: list[Path],
+    files: list[Path],
+    base: Path,
+    search_paths: list[Path],
+    project_root: Path,
+    import_resolver: ImportResolver,
+    detector: UnreachableRegionDetector,
+    plugins: Sequence[EdgePlugin],
+    resolvers: Sequence[PathResolver],
+    cache: GraphCache | None,
+    workers: int | None,
+) -> dict[Path, VisitorPayload]:
+    """Run visitor + observe for every cache-miss file in a base.
+
+    Splits on the ``workers`` knob:
+
+    * ``None`` / ``1`` / ``len(miss_files) < 2`` -- serial path. Builds
+      one :class:`FullRepoManager` for the base and reuses it across
+      every miss.
+    * ``>= 2`` with at least two misses -- spawns a
+      :class:`ProcessPoolExecutor` keyed to this base.
+      :func:`_init_worker` ships the resolver chain + detector +
+      plugins to each worker, which build their own
+      ``FullRepoManager`` on first task. The pool is capped at
+      ``min(workers, len(miss_files))`` so a small batch doesn't
+      over-provision processes.
+
+    Cache writes happen on the main process as each payload arrives,
+    so a partial run still warms the cache for files that completed.
+    Iteration order matches ``miss_files`` (sorted) for determinism.
+    """
+    if not miss_files:
+        return {}
+
+    use_pool = workers is not None and workers >= 2 and len(miss_files) >= 2
+    miss_payloads: dict[Path, VisitorPayload] = {}
+
+    if not use_pool:
+        mgr = FullRepoManager(
+            str(base),
+            [str(f) for f in files],
+            {FixedFullyQualifiedNameProvider},
+        )
+        for file in miss_files:
+            payload = _process_one_file(
+                file,
+                mgr=mgr,
+                search_paths=search_paths,
+                import_resolver=import_resolver,
+                detector=detector,
+                plugins=plugins,
+                base=base,
+                project_root=project_root,
+            )
+            miss_payloads[file] = payload
+            if cache is not None:
+                cache.put(file, payload)
+        return miss_payloads
+
+    init = _WorkerInit(
+        base=base,
+        search_paths=tuple(search_paths),
+        files=tuple(files),
+        detector=detector,
+        plugins=tuple(plugins),
+        resolvers=tuple(resolvers),
+        project_root=project_root,
+    )
+    assert workers is not None
+    max_workers = min(workers, len(miss_files))
+    with ProcessPoolExecutor(
+        max_workers=max_workers,
+        initializer=_init_worker,
+        initargs=(init,),
+    ) as pool:
+        for file, payload in pool.map(_worker_process_file, miss_files):
+            miss_payloads[file] = payload
+            if cache is not None:
+                cache.put(file, payload)
+    return miss_payloads
 
 
 def _merge_payloads(*payloads: VisitorPayload) -> VisitorPayload:

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -348,7 +348,11 @@ def _process_one_file(
     builds, just without re-walking the file list every time.
     """
     module = cst.parse_module(file.read_text())
-    wrapper = MetadataWrapper(module, True, {FixedFullyQualifiedNameProvider: fqn_entry})
+    wrapper = MetadataWrapper(
+        module,
+        unsafe_skip_copy=True,
+        cache={FixedFullyQualifiedNameProvider: fqn_entry},
+    )
     visitor = SymbolVisitor(
         file,
         search_paths,
@@ -546,28 +550,22 @@ def _build_sorted_tasks(base_specs: dict[Path, _BaseSpec], project_root: Path) -
 
     Sorting puts same-base tasks adjacent so a runner sees at most one
     ``sys.path`` transition per base it touches, regardless of total
-    file count. The sort key is computed once per task rather than
-    per-comparator-call.
+    file count. Sorting on ``Path`` tuples directly is fine -- it's
+    just attribute access per comparison.
     """
-    keyed: list[tuple[tuple[str, ...], str, _Task]] = []
-    for base, spec in base_specs.items():
-        sp_key = tuple(str(p) for p in spec.search_paths)
-        for file in spec.miss_files:
-            keyed.append(
-                (
-                    sp_key,
-                    str(file),
-                    _Task(
-                        file=file,
-                        base=base,
-                        search_paths=spec.search_paths,
-                        fqn_entry=spec.fqn_cache[str(file)],
-                        project_root=project_root,
-                    ),
-                )
-            )
-    keyed.sort(key=lambda kt: (kt[0], kt[1]))
-    return [kt[2] for kt in keyed]
+    tasks: list[_Task] = [
+        _Task(
+            file=file,
+            base=base,
+            search_paths=spec.search_paths,
+            fqn_entry=spec.fqn_cache[str(file)],
+            project_root=project_root,
+        )
+        for base, spec in base_specs.items()
+        for file in spec.miss_files
+    ]
+    tasks.sort(key=lambda t: (t.search_paths, t.file))
+    return tasks
 
 
 def _compute_all_miss_payloads(

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -32,7 +32,7 @@ from ._resolvers import (
     default_resolve_import,
     exported_roots,
 )
-from ._resolvers._imports import safe_resolve_module, temp_sys_path
+from ._resolvers._imports import distribution_lookup, safe_resolve_module, temp_sys_path
 from ._symbols import EdgeFlags, Import, NodeFlags, SymbolNode, SymbolTrie
 from ._visitor import SymbolVisitor, VisitorPayload
 
@@ -193,95 +193,101 @@ def build_symbol_graph(
         if unreachable_detector is not None
         else DefaultUnreachableRegionDetector()
     )
-    for base in order_paths(paths):
-        logger.debug("Processing base path: %s", base)
-        search_paths = [base] + paths.get(base, [])
-        safe_resolve_module.cache_clear()
-        with temp_sys_path(search_paths):
-            base_tries[base] = current_trie = SymbolTrie()
-            export_trie = SymbolTrie()
-            export_roots = exported_roots(base)
-            import_edges: set[tuple[SymbolNode, Import, EdgeFlags]] = set()
-            files = list(sorted(base.rglob("*.py")))
-            hits: dict[Path, VisitorPayload] = {}
-            miss_files: list[Path] = []
-            for file in files:
-                payload = cache.get(file) if cache is not None else None
-                if payload is None:
-                    miss_files.append(file)
-                else:
-                    hits[file] = payload
+    # Phase 1: enumerate every base's files and partition into
+    # cache hits (deserialized inline) and miss files (need a visitor
+    # pass). Done up front so the parallel path can build a single
+    # task list across every base.
+    base_specs = _collect_base_specs(paths, cache)
 
-            miss_payloads = _compute_miss_payloads(
-                miss_files=miss_files,
-                files=files,
-                base=base,
-                search_paths=search_paths,
-                project_root=root,
-                import_resolver=import_resolver,
-                detector=detector,
-                plugins=plugins,
-                resolvers=resolvers,
-                cache=cache,
-                workers=workers,
+    # Phase 2: run the visitor + observe pass for every miss file.
+    # Serial dispatch enters ``temp_sys_path`` per base (parent
+    # process is doing the work). Parallel dispatch builds one
+    # persistent ``ProcessPoolExecutor`` for the whole run, sorts
+    # tasks by ``search_paths`` so a worker tends to see contiguous
+    # runs from the same base, and rebinds ``sys.path`` +
+    # invalidates the resolver caches only when the search-path
+    # tuple changes. Cache writes happen on the main process either
+    # way so failure semantics match the serial path.
+    miss_payloads = _compute_all_miss_payloads(
+        base_specs=base_specs,
+        project_root=root,
+        detector=detector,
+        plugins=plugins,
+        resolvers=resolvers,
+        import_resolver=import_resolver,
+        cache=cache,
+        workers=workers,
+    )
+
+    # Phase 3: per-base apply + edge stitching + plugin finalize.
+    # ``order_paths`` puts dependencies before dependents so each
+    # base's lookup trie sees its deps' exports. No ``sys.path``
+    # state required here -- ``resolve_edges`` works off the trie
+    # and plugins' ``finalize`` is graph-only.
+    for base in order_paths(paths):
+        logger.debug("Stitching base path: %s", base)
+        spec = base_specs[base]
+        base_tries[base] = current_trie = SymbolTrie()
+        export_trie = SymbolTrie()
+        export_roots = exported_roots(base)
+        import_edges: set[tuple[SymbolNode, Import, EdgeFlags]] = set()
+
+        for file in spec.files:
+            payload = spec.hits.get(file)
+            if payload is None:
+                payload = miss_payloads[base][file]
+            # A file's decls go into ``export_trie`` only when the file
+            # lives under one of ``base``'s exported dirs (or when the
+            # base has no export restriction). This is what hides
+            # ``tests/`` from dependents in the typical workspace
+            # layout: the member analyzes its own ``tests/`` (decls
+            # land in ``current_trie`` and the graph), but consumers'
+            # lookup tries never see them.
+            file_exported = export_roots is None or _under_any(file, export_roots)
+            _apply_payload(
+                payload,
+                current_trie=current_trie,
+                export_trie=export_trie,
+                file_exported=file_exported,
+                symbol_graph=symbol_graph,
+                import_edges=import_edges,
             )
 
-            for file in files:
-                payload = hits.get(file)
-                if payload is None:
-                    payload = miss_payloads[file]
-                # A file's decls go into ``export_trie`` only when the file
-                # lives under one of ``base``'s exported dirs (or when the
-                # base has no export restriction). This is what hides
-                # ``tests/`` from dependents in the typical workspace
-                # layout: the member analyzes its own ``tests/`` (decls
-                # land in ``current_trie`` and the graph), but consumers'
-                # lookup tries never see them.
-                file_exported = export_roots is None or _under_any(file, export_roots)
-                _apply_payload(
-                    payload,
-                    current_trie=current_trie,
-                    export_trie=export_trie,
-                    file_exported=file_exported,
-                    symbol_graph=symbol_graph,
-                    import_edges=import_edges,
-                )
+        current_trie.add_module_hierarchy_edges(symbol_graph)
+        export_tries[base] = export_trie
 
-            current_trie.add_module_hierarchy_edges(symbol_graph)
-            export_tries[base] = export_trie
+        # Per-consumer lookup trie: this base's full trie (everything
+        # in scope when resolving its own imports) plus each dep's
+        # *exported* trie (what the dep ships to consumers). Deps are
+        # processed earlier by topological order, so their export
+        # tries already exist.
+        symbol_lookup = SymbolTrie()
+        symbol_lookup.merge(current_trie)
+        for dep in paths.get(base, []):
+            symbol_lookup.merge(export_tries.get(dep, base_tries[dep]))
 
-            # Per-consumer lookup trie: this base's full trie (everything
-            # in scope when resolving its own imports) plus each dep's
-            # *exported* trie (what the dep ships to consumers). Deps are
-            # processed earlier by topological order, so their export
-            # tries already exist.
-            symbol_lookup = SymbolTrie()
-            symbol_lookup.merge(current_trie)
-            for dep in paths.get(base, []):
-                symbol_lookup.merge(export_tries.get(dep, base_tries[dep]))
+        for src, dst, flags in resolve_edges(import_edges, symbol_lookup, base):
+            symbol_graph.add_edge(src, dst, flags=flags)
 
-            for src, dst, flags in resolve_edges(import_edges, symbol_lookup, base):
-                symbol_graph.add_edge(src, dst, flags=flags)
-
-            # Per-base finalize pass: plugins do graph-only work here
-            # (factory walks, transitive subclass closure, pyproject
-            # script lookups). No CST access -- per-file CST work
-            # already happened in the observe step.
-            if plugins:
-                ctx = PluginContext(
-                    graph=symbol_graph,
-                    symbol_lookup=symbol_lookup,
-                    base=base,
-                    project_root=root,
-                )
-                for plugin in plugins:
-                    if not isinstance(plugin, EdgePlugin):
-                        raise TypeError(f"Plugin {plugin!r} does not satisfy EdgePlugin protocol")
-                    # Materialize before applying so plugins can iterate
-                    # ctx.graph.nodes without tripping "dictionary changed
-                    # size during iteration".
-                    ops = list(plugin.finalize(ctx))
-                    apply_ops(symbol_graph, ops)
+        # Per-base finalize pass: plugins do graph-only work here
+        # (factory walks, transitive subclass closure, pyproject
+        # script lookups). No CST access -- per-file CST work
+        # already happened in the observe step.
+        if plugins:
+            ctx = PluginContext(
+                graph=symbol_graph,
+                symbol_lookup=symbol_lookup,
+                base=base,
+                project_root=root,
+            )
+            for plugin in plugins:
+                if not isinstance(plugin, EdgePlugin):
+                    raise TypeError(f"Plugin {plugin!r} does not satisfy EdgePlugin protocol")
+                # Materialize before applying so plugins can iterate
+                # ctx.graph.nodes without tripping "dictionary changed
+                # size during iteration".
+                ops = list(plugin.finalize(ctx))
+                apply_ops(symbol_graph, ops)
 
     return symbol_graph
 
@@ -355,181 +361,310 @@ def _process_one_file(
 
 
 @dataclass(frozen=True)
-class _WorkerInit:
-    """Per-base bundle of state shipped to each :class:`ProcessPoolExecutor` worker.
+class _BaseSpec:
+    """Per-base file list partitioned into cache hits and miss files.
 
-    Captures everything a worker needs to reproduce the parent's
-    visitor environment: the base + search paths (for ``sys.path`` and
-    ``FullRepoManager`` construction), the full file list (FQN gen
-    cache spans every file in the base), the resolver chain (rebuilt
-    via :func:`_chain_resolvers` inside the worker since the resolver
-    closure isn't picklable), the detector, the plugin list, and the
-    project root used by ``_run_observe``. Frozen so misuse from a
-    worker can't leak state back into queued tasks.
+    Built once up front in :func:`_collect_base_specs` so the parallel
+    path can flatten every base's miss files into a single sorted task
+    list and the apply phase can iterate every base in deterministic
+    order without re-reading the cache.
     """
 
     base: Path
     search_paths: tuple[Path, ...]
     files: tuple[Path, ...]
+    hits: dict[Path, VisitorPayload]
+    miss_files: tuple[Path, ...]
+
+
+def _collect_base_specs(paths: PathMap, cache: GraphCache | None) -> dict[Path, _BaseSpec]:
+    """Walk every base, hash every file, partition hits from misses.
+
+    Cache reads happen on the main process; each hit is materialized
+    once and stashed on the spec, so the apply phase doesn't pay a
+    second lookup. Iteration order is ``order_paths(paths)`` so the
+    apply phase sees deps before dependents.
+    """
+    specs: dict[Path, _BaseSpec] = {}
+    for base in order_paths(paths):
+        search_paths = (base,) + tuple(paths.get(base, []))
+        files = tuple(sorted(base.rglob("*.py")))
+        hits: dict[Path, VisitorPayload] = {}
+        miss_files: list[Path] = []
+        for file in files:
+            payload = cache.get(file) if cache is not None else None
+            if payload is None:
+                miss_files.append(file)
+            else:
+                hits[file] = payload
+        specs[base] = _BaseSpec(
+            base=base,
+            search_paths=search_paths,
+            files=files,
+            hits=hits,
+            miss_files=tuple(miss_files),
+        )
+    return specs
+
+
+@dataclass(frozen=True)
+class _WorkerInit:
+    """Run-wide state shipped to every :class:`ProcessPoolExecutor` worker.
+
+    Captures everything a worker needs that doesn't change between
+    bases: the detector, the plugin set, and the resolver list. The
+    resolver chain is rebuilt locally via :func:`_chain_resolvers` --
+    its closure form isn't picklable across processes, but the
+    ``PathResolver`` instances themselves are dataclass-picklable.
+    Per-base context (search paths, file list, base path) travels on
+    each :class:`_WorkerTask`.
+    """
+
     detector: UnreachableRegionDetector
     plugins: tuple[EdgePlugin, ...]
     resolvers: tuple[PathResolver, ...]
+
+
+@dataclass(frozen=True)
+class _WorkerTask:
+    """Per-file unit of work dispatched to a worker.
+
+    Carries the base context inline so workers don't need to be
+    re-initialized when the active base changes -- they detect a new
+    ``search_paths`` value and rebind ``sys.path`` + invalidate the
+    resolver caches in place. ``project_root`` is constant for the
+    run but travels here so the worker doesn't need a separate global.
+    """
+
+    file: Path
+    base: Path
+    search_paths: tuple[Path, ...]
+    files_in_base: tuple[Path, ...]
     project_root: Path
 
 
 @dataclass
-class _WorkerCtx:
+class _WorkerState:
     """Per-worker mutable state populated by :func:`_init_worker`.
 
-    ``mgr`` is built lazily on the first task so workers that never
-    receive one don't pay the construction cost; the first task in a
-    worker pays it once and subsequent tasks reuse the same FQN cache.
+    ``sys_path_baseline`` snapshots the worker's pristine ``sys.path``
+    at startup (i.e. inherited from the parent before any per-base
+    prefix). Each transition rebuilds ``sys.path`` from
+    ``search_paths + baseline``. ``last_search_paths`` is the
+    transition key: when it changes we drop ``mgr`` (different base
+    means a different file list, so the FQN gen cache must be
+    rebuilt) and clear the LRU caches.
     """
 
     init: _WorkerInit
     import_resolver: ImportResolver
+    sys_path_baseline: list[str]
+    last_search_paths: tuple[Path, ...] | None = field(default=None)
     mgr: FullRepoManager | None = field(default=None)
 
 
-_worker_ctx: _WorkerCtx | None = None
+_worker_state: _WorkerState | None = None
 
 
 def _init_worker(init: _WorkerInit) -> None:
-    """Pool initializer: prime ``sys.path``, the resolver chain, and worker globals.
+    """Pool initializer: snapshot ``sys.path`` and build worker globals.
 
-    Adds ``init.search_paths`` to ``sys.path`` so
-    :func:`default_resolve_import` finds first-party modules under the
-    current base. Clears :func:`safe_resolve_module`'s LRU cache for
-    the same hygiene the parent does between bases. Rebuilds the
-    resolver chain locally because :func:`_chain_resolvers` returns a
-    closure (not picklable across processes); the ``PathResolver``
-    instances themselves are picklable dataclasses and travel via
-    ``init``.
+    No per-base setup happens here -- :func:`_worker_process_task`
+    detects the first base on its first task and rebinds ``sys.path``
+    against the snapshot. This keeps the pool persistent across every
+    base in the run; the parent never re-creates it.
     """
-    global _worker_ctx
-    seen = set(sys.path)
-    for p in init.search_paths:
-        s = str(p)
-        if s not in seen:
-            sys.path.insert(0, s)
-    safe_resolve_module.cache_clear()
-    _worker_ctx = _WorkerCtx(
+    global _worker_state
+    _worker_state = _WorkerState(
         init=init,
         import_resolver=_chain_resolvers(init.resolvers),
+        sys_path_baseline=list(sys.path),
     )
 
 
-def _worker_process_file(file: Path) -> tuple[Path, VisitorPayload]:
-    """Pool task: run :func:`_process_one_file` for ``file`` against worker state.
+def _rebind_sys_path(search_paths: tuple[Path, ...], baseline: list[str]) -> None:
+    """Set ``sys.path`` to ``search_paths + baseline``, deduplicated.
 
-    Returns ``(file, payload)`` so :meth:`Executor.map` results can be
-    matched back to inputs without relying on submission order.
-    Constructs the per-worker :class:`FullRepoManager` lazily on first
-    use; subsequent tasks in the same worker reuse it.
+    ``temp_sys_path`` does effectively the same thing in the parent
+    when run serially. Workers can't use a contextmanager (the
+    transition is event-driven, not block-scoped), so the rebinding
+    happens explicitly. Order matters: search_paths first so
+    first-party imports beat any same-named modules on the original
+    ``sys.path``.
     """
-    ctx = _worker_ctx
-    assert ctx is not None, "_init_worker must run before _worker_process_file"
-    if ctx.mgr is None:
-        ctx.mgr = FullRepoManager(
-            str(ctx.init.base),
-            [str(f) for f in ctx.init.files],
+    new_path: list[str] = []
+    seen: set[str] = set()
+    for p in search_paths:
+        s = str(p)
+        if s not in seen:
+            new_path.append(s)
+            seen.add(s)
+    for s in baseline:
+        if s not in seen:
+            new_path.append(s)
+            seen.add(s)
+    sys.path[:] = new_path
+
+
+def _on_search_paths_change(state: _WorkerState, search_paths: tuple[Path, ...]) -> None:
+    """Rebind ``sys.path`` and invalidate every resolver cache.
+
+    Must be called whenever the active ``search_paths`` tuple
+    changes. Clears :func:`safe_resolve_module` (its LRU keys on
+    fullname only, so cross-base reuse would silently leak earlier
+    bases' resolutions) and :func:`distribution_lookup` (caches the
+    venv's installed dist map, which differs across uv-workspace
+    members that ship their own ``.venv``). ``mgr`` goes too --
+    different base means a different file list, so the
+    ``FullRepoManager``'s FQN gen cache must be rebuilt.
+    """
+    _rebind_sys_path(search_paths, state.sys_path_baseline)
+    safe_resolve_module.cache_clear()
+    distribution_lookup.cache_clear()
+    state.mgr = None
+    state.last_search_paths = search_paths
+
+
+def _worker_process_task(task: _WorkerTask) -> tuple[Path, Path, VisitorPayload]:
+    """Pool task: rebind ``sys.path`` if needed, then visit + observe ``task.file``.
+
+    Returns ``(base, file, payload)`` so the parent can route the
+    payload back into the right per-base bucket. Sorting tasks by
+    ``search_paths`` in the parent keeps any one worker's transitions
+    bounded -- in steady state each worker sees one transition per
+    base it touches, regardless of total file count.
+    """
+    state = _worker_state
+    assert state is not None, "_init_worker must run before _worker_process_task"
+    if state.last_search_paths != task.search_paths:
+        _on_search_paths_change(state, task.search_paths)
+    if state.mgr is None:
+        state.mgr = FullRepoManager(
+            str(task.base),
+            [str(f) for f in task.files_in_base],
             {FixedFullyQualifiedNameProvider},
         )
     payload = _process_one_file(
-        file,
-        mgr=ctx.mgr,
-        search_paths=list(ctx.init.search_paths),
-        import_resolver=ctx.import_resolver,
-        detector=ctx.init.detector,
-        plugins=ctx.init.plugins,
-        base=ctx.init.base,
-        project_root=ctx.init.project_root,
+        task.file,
+        mgr=state.mgr,
+        search_paths=list(task.search_paths),
+        import_resolver=state.import_resolver,
+        detector=state.init.detector,
+        plugins=state.init.plugins,
+        base=task.base,
+        project_root=task.project_root,
     )
-    return file, payload
+    return task.base, task.file, payload
 
 
-def _compute_miss_payloads(
+def _compute_all_miss_payloads(
     *,
-    miss_files: list[Path],
-    files: list[Path],
-    base: Path,
-    search_paths: list[Path],
+    base_specs: dict[Path, _BaseSpec],
     project_root: Path,
-    import_resolver: ImportResolver,
     detector: UnreachableRegionDetector,
     plugins: Sequence[EdgePlugin],
     resolvers: Sequence[PathResolver],
+    import_resolver: ImportResolver,
     cache: GraphCache | None,
     workers: int | None,
-) -> dict[Path, VisitorPayload]:
-    """Run visitor + observe for every cache-miss file in a base.
+) -> dict[Path, dict[Path, VisitorPayload]]:
+    """Run visitor + observe for every cache-miss file across every base.
 
-    Splits on the ``workers`` knob:
+    Two paths:
 
-    * ``None`` / ``1`` / ``len(miss_files) < 2`` -- serial path. Builds
-      one :class:`FullRepoManager` for the base and reuses it across
-      every miss.
-    * ``>= 2`` with at least two misses -- spawns a
-      :class:`ProcessPoolExecutor` keyed to this base.
-      :func:`_init_worker` ships the resolver chain + detector +
-      plugins to each worker, which build their own
-      ``FullRepoManager`` on first task. The pool is capped at
-      ``min(workers, len(miss_files))`` so a small batch doesn't
-      over-provision processes.
+    * Serial (``workers`` ``None`` / ``1`` / total misses < 2) --
+      iterate bases in order, enter ``temp_sys_path`` per base,
+      clear the resolver caches, build one ``FullRepoManager`` per
+      base, run :func:`_process_one_file` for each miss in turn.
+    * Parallel -- one persistent :class:`ProcessPoolExecutor` for the
+      whole run. Tasks are sorted by ``search_paths`` so a worker
+      tends to see contiguous miss runs from the same base; on each
+      transition the worker rebinds ``sys.path`` + invalidates the
+      resolver caches via :func:`_on_search_paths_change`. Cap the
+      pool at ``min(workers, total_misses)`` so a small batch doesn't
+      over-provision.
 
     Cache writes happen on the main process as each payload arrives,
     so a partial run still warms the cache for files that completed.
-    Iteration order matches ``miss_files`` (sorted) for determinism.
+    Returns ``{base: {file: payload}}`` even for bases with no
+    misses, so the caller can index without an existence check.
     """
-    if not miss_files:
-        return {}
+    out: dict[Path, dict[Path, VisitorPayload]] = {b: {} for b in base_specs}
+    total_misses = sum(len(s.miss_files) for s in base_specs.values())
+    if total_misses == 0:
+        return out
 
-    use_pool = workers is not None and workers >= 2 and len(miss_files) >= 2
-    miss_payloads: dict[Path, VisitorPayload] = {}
+    use_pool = workers is not None and workers >= 2 and total_misses >= 2
 
     if not use_pool:
-        mgr = FullRepoManager(
-            str(base),
-            [str(f) for f in files],
-            {FixedFullyQualifiedNameProvider},
-        )
-        for file in miss_files:
-            payload = _process_one_file(
-                file,
-                mgr=mgr,
-                search_paths=search_paths,
-                import_resolver=import_resolver,
-                detector=detector,
-                plugins=plugins,
-                base=base,
-                project_root=project_root,
+        # Serial path: ``safe_resolve_module``'s LRU keys on fullname only
+        # so we clear it at every base boundary; ``distribution_lookup``
+        # only depends on the venv's ``site-packages`` (stable in a
+        # single-process run, the first-party prefix that moves doesn't
+        # carry dist-info dirs), so paying its rebuild cost per base
+        # would punish the common single-venv case for no correctness
+        # win. Worker transitions clear it (cross-venv possible there).
+        for base, spec in base_specs.items():
+            if not spec.miss_files:
+                continue
+            search_paths = list(spec.search_paths)
+            safe_resolve_module.cache_clear()
+            with temp_sys_path(search_paths):
+                mgr = FullRepoManager(
+                    str(base),
+                    [str(f) for f in spec.files],
+                    {FixedFullyQualifiedNameProvider},
+                )
+                for file in spec.miss_files:
+                    payload = _process_one_file(
+                        file,
+                        mgr=mgr,
+                        search_paths=search_paths,
+                        import_resolver=import_resolver,
+                        detector=detector,
+                        plugins=plugins,
+                        base=base,
+                        project_root=project_root,
+                    )
+                    out[base][file] = payload
+                    if cache is not None:
+                        cache.put(file, payload)
+        return out
+
+    tasks: list[_WorkerTask] = []
+    for base, spec in base_specs.items():
+        for file in spec.miss_files:
+            tasks.append(
+                _WorkerTask(
+                    file=file,
+                    base=base,
+                    search_paths=spec.search_paths,
+                    files_in_base=spec.files,
+                    project_root=project_root,
+                )
             )
-            miss_payloads[file] = payload
-            if cache is not None:
-                cache.put(file, payload)
-        return miss_payloads
+    # Sort by search_paths so workers see contiguous runs from the
+    # same base; transition cost is small but bounded transitions
+    # also keep the FQN gen cache hot for longer.
+    tasks.sort(key=lambda t: (tuple(str(p) for p in t.search_paths), str(t.file)))
 
     init = _WorkerInit(
-        base=base,
-        search_paths=tuple(search_paths),
-        files=tuple(files),
         detector=detector,
         plugins=tuple(plugins),
         resolvers=tuple(resolvers),
-        project_root=project_root,
     )
     assert workers is not None
-    max_workers = min(workers, len(miss_files))
+    max_workers = min(workers, len(tasks))
     with ProcessPoolExecutor(
         max_workers=max_workers,
         initializer=_init_worker,
         initargs=(init,),
     ) as pool:
-        for file, payload in pool.map(_worker_process_file, miss_files):
-            miss_payloads[file] = payload
+        for base, file, payload in pool.map(_worker_process_task, tasks):
+            out[base][file] = payload
             if cache is not None:
                 cache.put(file, payload)
-    return miss_payloads
+    return out
 
 
 def _merge_payloads(*payloads: VisitorPayload) -> VisitorPayload:

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -33,7 +33,7 @@ from ._resolvers import (
     default_resolve_import,
     exported_roots,
 )
-from ._resolvers._imports import distribution_lookup, safe_resolve_module, temp_sys_path
+from ._resolvers._imports import distribution_lookup, safe_resolve_module
 from ._symbols import EdgeFlags, Import, NodeFlags, SymbolNode, SymbolTrie
 from ._visitor import SymbolVisitor, VisitorPayload
 
@@ -203,14 +203,11 @@ def build_symbol_graph(
     base_specs = _collect_base_specs(paths, cache)
 
     # Phase 2: run the visitor + observe pass for every miss file.
-    # Serial dispatch enters ``temp_sys_path`` per base (parent
-    # process is doing the work). Parallel dispatch builds one
-    # persistent ``ProcessPoolExecutor`` for the whole run, sorts
-    # tasks by ``search_paths`` so a worker tends to see contiguous
-    # runs from the same base, and rebinds ``sys.path`` +
-    # invalidates the resolver caches only when the search-path
-    # tuple changes. Cache writes happen on the main process either
-    # way so failure semantics match the serial path.
+    # Tasks are sorted by ``search_paths`` so the runner sees one
+    # transition per base regardless of file count. Workers and the
+    # in-process serial path share the same ``_process_task`` body;
+    # only the executor differs. Cache writes happen on the main
+    # process so failure semantics match either way.
     miss_payloads = _compute_all_miss_payloads(
         base_specs=base_specs,
         project_root=root,
@@ -425,29 +422,11 @@ def _collect_base_specs(paths: PathMap, cache: GraphCache | None) -> dict[Path, 
 
 
 @dataclass(frozen=True)
-class _WorkerInit:
-    """Run-wide state shipped to every :class:`ProcessPoolExecutor` worker.
-
-    Captures everything a worker needs that doesn't change between
-    bases: the detector, the plugin set, and the resolver list. The
-    resolver chain is rebuilt locally via :func:`_chain_resolvers` --
-    its closure form isn't picklable across processes, but the
-    ``PathResolver`` instances themselves are dataclass-picklable.
-    Per-base context (search paths, file list, base path) travels on
-    each :class:`_WorkerTask`.
-    """
-
-    detector: UnreachableRegionDetector
-    plugins: tuple[EdgePlugin, ...]
-    resolvers: tuple[PathResolver, ...]
-
-
-@dataclass(frozen=True)
-class _WorkerTask:
-    """Per-file unit of work dispatched to a worker.
+class _Task:
+    """Per-file unit of work for the visitor + observe pass.
 
     ``fqn_entry`` is this file's slice of the per-base FQN cache built
-    once in the parent (see :func:`_collect_base_specs`); the worker
+    once in the parent (see :func:`_collect_base_specs`); the runner
     injects it into a :class:`MetadataWrapper` rather than rebuilding
     a :class:`FullRepoManager`. ``search_paths`` doubles as the
     transition key for ``sys.path`` rebinding + resolver-cache
@@ -462,50 +441,25 @@ class _WorkerTask:
 
 
 @dataclass
-class _WorkerState:
-    """Per-worker mutable state populated by :func:`_init_worker`.
+class _RunnerState:
+    """Mutable state for the per-task runner, shared by serial and worker paths.
 
-    ``sys_path_baseline`` snapshots the worker's pristine ``sys.path``
-    at startup. Each transition rebuilds ``sys.path`` from
-    ``search_paths + baseline`` and clears the resolver LRUs.
-    ``last_search_paths`` is the transition key.
+    ``sys_path_baseline`` is the original ``sys.path`` captured at
+    runner startup; transitions rebuild ``sys.path`` from
+    ``search_paths + baseline`` and clear the resolver LRUs. The
+    serial caller restores ``sys.path`` from the baseline when the run
+    finishes; workers don't bother since the process is about to exit.
     """
 
-    init: _WorkerInit
+    detector: UnreachableRegionDetector
+    plugins: tuple[EdgePlugin, ...]
     import_resolver: ImportResolver
     sys_path_baseline: list[str]
     last_search_paths: tuple[Path, ...] | None = field(default=None)
 
 
-_worker_state: _WorkerState | None = None
-
-
-def _init_worker(init: _WorkerInit) -> None:
-    """Pool initializer: snapshot ``sys.path`` and build worker globals.
-
-    No per-base setup happens here -- :func:`_worker_process_task`
-    detects the first base on its first task and rebinds ``sys.path``
-    against the snapshot. This keeps the pool persistent across every
-    base in the run; the parent never re-creates it.
-    """
-    global _worker_state
-    _worker_state = _WorkerState(
-        init=init,
-        import_resolver=_chain_resolvers(init.resolvers),
-        sys_path_baseline=list(sys.path),
-    )
-
-
 def _rebind_sys_path(search_paths: tuple[Path, ...], baseline: list[str]) -> None:
-    """Set ``sys.path`` to ``search_paths + baseline``, deduplicated.
-
-    ``temp_sys_path`` does effectively the same thing in the parent
-    when run serially. Workers can't use a contextmanager (the
-    transition is event-driven, not block-scoped), so the rebinding
-    happens explicitly. Order matters: search_paths first so
-    first-party imports beat any same-named modules on the original
-    ``sys.path``.
-    """
+    """Set ``sys.path`` to ``search_paths + baseline``, deduplicated."""
     new_path: list[str] = []
     seen: set[str] = set()
     for p in search_paths:
@@ -523,48 +477,97 @@ def _rebind_sys_path(search_paths: tuple[Path, ...], baseline: list[str]) -> Non
 def _clear_resolver_caches() -> None:
     """Drop the two ``sys.path``-derived resolver caches.
 
-    Both :func:`safe_resolve_module` (keyed on fullname) and
-    :func:`distribution_lookup` (keyed on ``()``) read live
-    ``sys.path`` and would otherwise return stale results when the
-    base changes -- the first because the same name resolves to a
-    different base's first-party path, the second because uv-workspace
-    members can ship their own ``.venv``.
+    :func:`safe_resolve_module` keys on fullname and
+    :func:`distribution_lookup` keys on ``()`` -- both read live
+    ``sys.path`` and would otherwise return stale results across
+    bases (different first-party prefix; uv-workspace members shipping
+    their own ``.venv``).
     """
     safe_resolve_module.cache_clear()
     distribution_lookup.cache_clear()
 
 
-def _on_search_paths_change(state: _WorkerState, search_paths: tuple[Path, ...]) -> None:
-    """Worker transition: rebind ``sys.path``, clear resolver caches."""
-    _rebind_sys_path(search_paths, state.sys_path_baseline)
-    _clear_resolver_caches()
-    state.last_search_paths = search_paths
+def _process_task(state: _RunnerState, task: _Task) -> tuple[Path, Path, VisitorPayload]:
+    """Run one task, transitioning ``sys.path`` + caches if the base changed.
 
-
-def _worker_process_task(task: _WorkerTask) -> tuple[Path, Path, VisitorPayload]:
-    """Pool task: rebind ``sys.path`` if needed, then visit + observe ``task.file``.
-
-    Returns ``(base, file, payload)`` so the parent can route the
-    payload back into the right per-base bucket. Sorting tasks by
-    ``search_paths`` in the parent keeps any one worker's transitions
-    bounded -- in steady state each worker sees one transition per
-    base it touches, regardless of total file count.
+    Used by both the in-process serial loop and the
+    :class:`ProcessPoolExecutor` workers; the only difference between
+    the two is who owns ``state`` (a local in serial, a per-process
+    global in workers).
     """
-    state = _worker_state
-    assert state is not None, "_init_worker must run before _worker_process_task"
     if state.last_search_paths != task.search_paths:
-        _on_search_paths_change(state, task.search_paths)
+        _rebind_sys_path(task.search_paths, state.sys_path_baseline)
+        _clear_resolver_caches()
+        state.last_search_paths = task.search_paths
     payload = _process_one_file(
         task.file,
         fqn_entry=task.fqn_entry,
         search_paths=list(task.search_paths),
         import_resolver=state.import_resolver,
-        detector=state.init.detector,
-        plugins=state.init.plugins,
+        detector=state.detector,
+        plugins=state.plugins,
         base=task.base,
         project_root=task.project_root,
     )
     return task.base, task.file, payload
+
+
+_worker_state: _RunnerState | None = None
+
+
+def _init_worker(
+    detector: UnreachableRegionDetector,
+    plugins: tuple[EdgePlugin, ...],
+    resolvers: tuple[PathResolver, ...],
+) -> None:
+    """Pool initializer: build the worker's :class:`_RunnerState`.
+
+    Resolver chain is rebuilt locally because :func:`_chain_resolvers`
+    can return a closure (not picklable); the resolver instances
+    themselves travel as picklable dataclasses.
+    """
+    global _worker_state
+    _worker_state = _RunnerState(
+        detector=detector,
+        plugins=plugins,
+        import_resolver=_chain_resolvers(resolvers),
+        sys_path_baseline=list(sys.path),
+    )
+
+
+def _worker_process_task(task: _Task) -> tuple[Path, Path, VisitorPayload]:
+    """Pool task: delegate to :func:`_process_task` against the worker's state."""
+    assert _worker_state is not None, "_init_worker must run before _worker_process_task"
+    return _process_task(_worker_state, task)
+
+
+def _build_sorted_tasks(base_specs: dict[Path, _BaseSpec], project_root: Path) -> list[_Task]:
+    """Flatten every base's miss files into one task list, sorted by search_paths.
+
+    Sorting puts same-base tasks adjacent so a runner sees at most one
+    ``sys.path`` transition per base it touches, regardless of total
+    file count. The sort key is computed once per task rather than
+    per-comparator-call.
+    """
+    keyed: list[tuple[tuple[str, ...], str, _Task]] = []
+    for base, spec in base_specs.items():
+        sp_key = tuple(str(p) for p in spec.search_paths)
+        for file in spec.miss_files:
+            keyed.append(
+                (
+                    sp_key,
+                    str(file),
+                    _Task(
+                        file=file,
+                        base=base,
+                        search_paths=spec.search_paths,
+                        fqn_entry=spec.fqn_cache[str(file)],
+                        project_root=project_root,
+                    ),
+                )
+            )
+    keyed.sort(key=lambda kt: (kt[0], kt[1]))
+    return [kt[2] for kt in keyed]
 
 
 def _compute_all_miss_payloads(
@@ -580,95 +583,57 @@ def _compute_all_miss_payloads(
 ) -> dict[Path, dict[Path, VisitorPayload]]:
     """Run visitor + observe for every cache-miss file across every base.
 
-    Two paths:
-
-    * Serial (``workers`` ``None`` / ``1`` / total misses < 2) --
-      iterate bases in order, enter ``temp_sys_path`` per base,
-      clear the resolver caches, run :func:`_process_one_file` for
-      each miss in turn using the precomputed FQN entry from
-      ``spec.fqn_cache``.
-    * Parallel -- one persistent :class:`ProcessPoolExecutor` for the
-      whole run. Tasks are sorted by ``search_paths`` so a worker
-      tends to see contiguous miss runs from the same base; on each
-      transition the worker rebinds ``sys.path`` + invalidates the
-      resolver caches via :func:`_on_search_paths_change`. Cap the
-      pool at ``min(workers, total_misses)`` so a small batch doesn't
-      over-provision.
+    Both branches use :func:`_process_task` for the per-task work; they
+    differ only in whether the runner state lives on the main process
+    or in :class:`ProcessPoolExecutor` workers. The pool is opt-in
+    (``workers >= 2`` and at least two miss files); below that, the
+    in-process path avoids pool startup cost.
 
     Cache writes happen on the main process as each payload arrives,
     so a partial run still warms the cache for files that completed.
-    Returns ``{base: {file: payload}}`` even for bases with no
-    misses, so the caller can index without an existence check.
+    Returns ``{base: {file: payload}}`` even for bases with no misses,
+    so the caller can index without an existence check.
     """
     out: dict[Path, dict[Path, VisitorPayload]] = {b: {} for b in base_specs}
     total_misses = sum(len(s.miss_files) for s in base_specs.values())
     if total_misses == 0:
         return out
 
+    tasks = _build_sorted_tasks(base_specs, project_root)
     use_pool = workers is not None and workers >= 2 and total_misses >= 2
 
-    if not use_pool:
-        for base, spec in base_specs.items():
-            if not spec.miss_files:
-                continue
-            search_paths = list(spec.search_paths)
-            _clear_resolver_caches()
-            with temp_sys_path(search_paths):
-                for file in spec.miss_files:
-                    payload = _process_one_file(
-                        file,
-                        fqn_entry=spec.fqn_cache[str(file)],
-                        search_paths=search_paths,
-                        import_resolver=import_resolver,
-                        detector=detector,
-                        plugins=plugins,
-                        base=base,
-                        project_root=project_root,
-                    )
-                    out[base][file] = payload
-                    if cache is not None:
-                        cache.put(file, payload)
+    def _record(base: Path, file: Path, payload: VisitorPayload) -> None:
+        out[base][file] = payload
+        if cache is not None:
+            cache.put(file, payload)
+
+    if use_pool:
+        assert workers is not None
+        with ProcessPoolExecutor(
+            max_workers=min(workers, len(tasks)),
+            initializer=_init_worker,
+            initargs=(detector, tuple(plugins), tuple(resolvers)),
+        ) as pool:
+            for base, file, payload in pool.map(_worker_process_task, tasks):
+                _record(base, file, payload)
         return out
 
-    # Sort tasks so each worker sees contiguous runs from the same
-    # base; bounded transitions keep the resolver caches hot. The sort
-    # key is computed once per task rather than per comparator call.
-    keyed_tasks: list[tuple[tuple[str, ...], str, _WorkerTask]] = []
-    for base, spec in base_specs.items():
-        sp_key = tuple(str(p) for p in spec.search_paths)
-        for file in spec.miss_files:
-            keyed_tasks.append(
-                (
-                    sp_key,
-                    str(file),
-                    _WorkerTask(
-                        file=file,
-                        base=base,
-                        search_paths=spec.search_paths,
-                        fqn_entry=spec.fqn_cache[str(file)],
-                        project_root=project_root,
-                    ),
-                )
-            )
-    keyed_tasks.sort(key=lambda kt: (kt[0], kt[1]))
-    tasks = [kt[2] for kt in keyed_tasks]
-
-    init = _WorkerInit(
+    # Serial: run every task in-process. Restore ``sys.path`` on the
+    # way out so callers (tests, library users) don't see lingering
+    # mutations from the runner's per-base rebinds.
+    baseline = list(sys.path)
+    state = _RunnerState(
         detector=detector,
         plugins=tuple(plugins),
-        resolvers=tuple(resolvers),
+        import_resolver=import_resolver,
+        sys_path_baseline=baseline,
     )
-    assert workers is not None
-    max_workers = min(workers, len(tasks))
-    with ProcessPoolExecutor(
-        max_workers=max_workers,
-        initializer=_init_worker,
-        initargs=(init,),
-    ) as pool:
-        for base, file, payload in pool.map(_worker_process_task, tasks):
-            out[base][file] = payload
-            if cache is not None:
-                cache.put(file, payload)
+    try:
+        for task in tasks:
+            base, file, payload = _process_task(state, task)
+            _record(base, file, payload)
+    finally:
+        sys.path[:] = baseline
     return out
 
 

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -5,11 +5,12 @@ import sys
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Sequence
+from typing import Mapping, Sequence
 
 import libcst as cst
 import networkx as nx
-from libcst.metadata import CodeRange, FullRepoManager
+from libcst.helpers.module import ModuleNameAndPackage
+from libcst.metadata import CodeRange, MetadataWrapper
 
 from ._branches import (
     DefaultUnreachableRegionDetector,
@@ -166,9 +167,11 @@ def build_symbol_graph(
         return :class:`VisitorPayload` objects to the main process,
         which still owns the SQLite cache write and the trie-stitching
         / edge-resolution stages. ``None`` (default) and ``1`` keep
-        the serial path. A fresh pool is built per base so each
-        worker's ``sys.path`` and ``FullRepoManager`` match the base
-        being processed; cache-warm bases never spin one up.
+        the serial path. The pool is persistent across bases; tasks
+        are sorted by ``search_paths`` so each worker tends to see
+        contiguous runs from one base, and the FQN cache is built
+        once in the parent and shipped per-task rather than rebuilt
+        in each worker.
 
     Returns
     -------
@@ -330,7 +333,7 @@ def _run_observe(
 def _process_one_file(
     file: Path,
     *,
-    mgr: FullRepoManager,
+    fqn_entry: ModuleNameAndPackage,
     search_paths: list[Path],
     import_resolver: ImportResolver,
     detector: UnreachableRegionDetector,
@@ -340,13 +343,15 @@ def _process_one_file(
 ) -> VisitorPayload:
     """Run the visitor + observe pass for a single file and return its payload.
 
-    Shared by the serial path inside :func:`build_symbol_graph` and the
-    worker entry point used when ``workers >= 2``. The caller owns the
-    :class:`FullRepoManager` so it can be reused across files in the
-    same base (the FQN cache is precomputed per base) and so workers
-    don't rebuild it on every task.
+    The caller owns the precomputed FQN entry (built once per base by
+    :func:`_collect_base_specs`) so we can construct
+    :class:`MetadataWrapper` directly with ``cache=`` injected,
+    skipping :class:`FullRepoManager`'s per-instance ``gen_cache``
+    rebuild. Same shape ``FullRepoManager.get_metadata_wrapper_for_path``
+    builds, just without re-walking the file list every time.
     """
-    wrapper = mgr.get_metadata_wrapper_for_path(str(file))
+    module = cst.parse_module(file.read_text())
+    wrapper = MetadataWrapper(module, True, {FixedFullyQualifiedNameProvider: fqn_entry})
     visitor = SymbolVisitor(
         file,
         search_paths,
@@ -367,7 +372,9 @@ class _BaseSpec:
     Built once up front in :func:`_collect_base_specs` so the parallel
     path can flatten every base's miss files into a single sorted task
     list and the apply phase can iterate every base in deterministic
-    order without re-reading the cache.
+    order without re-reading the cache. ``fqn_cache`` covers only the
+    miss files -- hit files never go through the visitor, so they
+    don't need an FQN entry.
     """
 
     base: Path
@@ -375,6 +382,7 @@ class _BaseSpec:
     files: tuple[Path, ...]
     hits: dict[Path, VisitorPayload]
     miss_files: tuple[Path, ...]
+    fqn_cache: Mapping[str, ModuleNameAndPackage]
 
 
 def _collect_base_specs(paths: PathMap, cache: GraphCache | None) -> dict[Path, _BaseSpec]:
@@ -382,7 +390,10 @@ def _collect_base_specs(paths: PathMap, cache: GraphCache | None) -> dict[Path, 
 
     Cache reads happen on the main process; each hit is materialized
     once and stashed on the spec, so the apply phase doesn't pay a
-    second lookup. Iteration order is ``order_paths(paths)`` so the
+    second lookup. The FQN cache is built once per base over the
+    miss files only -- workers don't rebuild it, and we skip the
+    ``calculate_module_and_package`` call for files we'll serve
+    from the cache. Iteration order is ``order_paths(paths)`` so the
     apply phase sees deps before dependents.
     """
     specs: dict[Path, _BaseSpec] = {}
@@ -397,12 +408,18 @@ def _collect_base_specs(paths: PathMap, cache: GraphCache | None) -> dict[Path, 
                 miss_files.append(file)
             else:
                 hits[file] = payload
+        fqn_cache: Mapping[str, ModuleNameAndPackage] = (
+            FixedFullyQualifiedNameProvider.gen_cache(base, [str(f) for f in miss_files], timeout=5)
+            if miss_files
+            else {}
+        )
         specs[base] = _BaseSpec(
             base=base,
             search_paths=search_paths,
             files=files,
             hits=hits,
             miss_files=tuple(miss_files),
+            fqn_cache=fqn_cache,
         )
     return specs
 
@@ -429,17 +446,18 @@ class _WorkerInit:
 class _WorkerTask:
     """Per-file unit of work dispatched to a worker.
 
-    Carries the base context inline so workers don't need to be
-    re-initialized when the active base changes -- they detect a new
-    ``search_paths`` value and rebind ``sys.path`` + invalidate the
-    resolver caches in place. ``project_root`` is constant for the
-    run but travels here so the worker doesn't need a separate global.
+    ``fqn_entry`` is this file's slice of the per-base FQN cache built
+    once in the parent (see :func:`_collect_base_specs`); the worker
+    injects it into a :class:`MetadataWrapper` rather than rebuilding
+    a :class:`FullRepoManager`. ``search_paths`` doubles as the
+    transition key for ``sys.path`` rebinding + resolver-cache
+    invalidation.
     """
 
     file: Path
     base: Path
     search_paths: tuple[Path, ...]
-    files_in_base: tuple[Path, ...]
+    fqn_entry: ModuleNameAndPackage
     project_root: Path
 
 
@@ -448,19 +466,15 @@ class _WorkerState:
     """Per-worker mutable state populated by :func:`_init_worker`.
 
     ``sys_path_baseline`` snapshots the worker's pristine ``sys.path``
-    at startup (i.e. inherited from the parent before any per-base
-    prefix). Each transition rebuilds ``sys.path`` from
-    ``search_paths + baseline``. ``last_search_paths`` is the
-    transition key: when it changes we drop ``mgr`` (different base
-    means a different file list, so the FQN gen cache must be
-    rebuilt) and clear the LRU caches.
+    at startup. Each transition rebuilds ``sys.path`` from
+    ``search_paths + baseline`` and clears the resolver LRUs.
+    ``last_search_paths`` is the transition key.
     """
 
     init: _WorkerInit
     import_resolver: ImportResolver
     sys_path_baseline: list[str]
     last_search_paths: tuple[Path, ...] | None = field(default=None)
-    mgr: FullRepoManager | None = field(default=None)
 
 
 _worker_state: _WorkerState | None = None
@@ -521,10 +535,9 @@ def _clear_resolver_caches() -> None:
 
 
 def _on_search_paths_change(state: _WorkerState, search_paths: tuple[Path, ...]) -> None:
-    """Worker transition: rebind ``sys.path``, clear caches, drop the FQN mgr."""
+    """Worker transition: rebind ``sys.path``, clear resolver caches."""
     _rebind_sys_path(search_paths, state.sys_path_baseline)
     _clear_resolver_caches()
-    state.mgr = None
     state.last_search_paths = search_paths
 
 
@@ -541,15 +554,9 @@ def _worker_process_task(task: _WorkerTask) -> tuple[Path, Path, VisitorPayload]
     assert state is not None, "_init_worker must run before _worker_process_task"
     if state.last_search_paths != task.search_paths:
         _on_search_paths_change(state, task.search_paths)
-    if state.mgr is None:
-        state.mgr = FullRepoManager(
-            str(task.base),
-            [str(f) for f in task.files_in_base],
-            {FixedFullyQualifiedNameProvider},
-        )
     payload = _process_one_file(
         task.file,
-        mgr=state.mgr,
+        fqn_entry=task.fqn_entry,
         search_paths=list(task.search_paths),
         import_resolver=state.import_resolver,
         detector=state.init.detector,
@@ -577,8 +584,9 @@ def _compute_all_miss_payloads(
 
     * Serial (``workers`` ``None`` / ``1`` / total misses < 2) --
       iterate bases in order, enter ``temp_sys_path`` per base,
-      clear the resolver caches, build one ``FullRepoManager`` per
-      base, run :func:`_process_one_file` for each miss in turn.
+      clear the resolver caches, run :func:`_process_one_file` for
+      each miss in turn using the precomputed FQN entry from
+      ``spec.fqn_cache``.
     * Parallel -- one persistent :class:`ProcessPoolExecutor` for the
       whole run. Tasks are sorted by ``search_paths`` so a worker
       tends to see contiguous miss runs from the same base; on each
@@ -606,15 +614,10 @@ def _compute_all_miss_payloads(
             search_paths = list(spec.search_paths)
             _clear_resolver_caches()
             with temp_sys_path(search_paths):
-                mgr = FullRepoManager(
-                    str(base),
-                    [str(f) for f in spec.files],
-                    {FixedFullyQualifiedNameProvider},
-                )
                 for file in spec.miss_files:
                     payload = _process_one_file(
                         file,
-                        mgr=mgr,
+                        fqn_entry=spec.fqn_cache[str(file)],
                         search_paths=search_paths,
                         import_resolver=import_resolver,
                         detector=detector,
@@ -628,7 +631,7 @@ def _compute_all_miss_payloads(
         return out
 
     # Sort tasks so each worker sees contiguous runs from the same
-    # base; bounded transitions keep the FQN gen cache hot. The sort
+    # base; bounded transitions keep the resolver caches hot. The sort
     # key is computed once per task rather than per comparator call.
     keyed_tasks: list[tuple[tuple[str, ...], str, _WorkerTask]] = []
     for base, spec in base_specs.items():
@@ -642,7 +645,7 @@ def _compute_all_miss_payloads(
                         file=file,
                         base=base,
                         search_paths=spec.search_paths,
-                        files_in_base=spec.files,
+                        fqn_entry=spec.fqn_cache[str(file)],
                         project_root=project_root,
                     ),
                 )

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -506,21 +506,24 @@ def _rebind_sys_path(search_paths: tuple[Path, ...], baseline: list[str]) -> Non
     sys.path[:] = new_path
 
 
-def _on_search_paths_change(state: _WorkerState, search_paths: tuple[Path, ...]) -> None:
-    """Rebind ``sys.path`` and invalidate every resolver cache.
+def _clear_resolver_caches() -> None:
+    """Drop the two ``sys.path``-derived resolver caches.
 
-    Must be called whenever the active ``search_paths`` tuple
-    changes. Clears :func:`safe_resolve_module` (its LRU keys on
-    fullname only, so cross-base reuse would silently leak earlier
-    bases' resolutions) and :func:`distribution_lookup` (caches the
-    venv's installed dist map, which differs across uv-workspace
-    members that ship their own ``.venv``). ``mgr`` goes too --
-    different base means a different file list, so the
-    ``FullRepoManager``'s FQN gen cache must be rebuilt.
+    Both :func:`safe_resolve_module` (keyed on fullname) and
+    :func:`distribution_lookup` (keyed on ``()``) read live
+    ``sys.path`` and would otherwise return stale results when the
+    base changes -- the first because the same name resolves to a
+    different base's first-party path, the second because uv-workspace
+    members can ship their own ``.venv``.
     """
-    _rebind_sys_path(search_paths, state.sys_path_baseline)
     safe_resolve_module.cache_clear()
     distribution_lookup.cache_clear()
+
+
+def _on_search_paths_change(state: _WorkerState, search_paths: tuple[Path, ...]) -> None:
+    """Worker transition: rebind ``sys.path``, clear caches, drop the FQN mgr."""
+    _rebind_sys_path(search_paths, state.sys_path_baseline)
+    _clear_resolver_caches()
     state.mgr = None
     state.last_search_paths = search_paths
 
@@ -597,18 +600,11 @@ def _compute_all_miss_payloads(
     use_pool = workers is not None and workers >= 2 and total_misses >= 2
 
     if not use_pool:
-        # Serial path: ``safe_resolve_module``'s LRU keys on fullname only
-        # so we clear it at every base boundary; ``distribution_lookup``
-        # only depends on the venv's ``site-packages`` (stable in a
-        # single-process run, the first-party prefix that moves doesn't
-        # carry dist-info dirs), so paying its rebuild cost per base
-        # would punish the common single-venv case for no correctness
-        # win. Worker transitions clear it (cross-venv possible there).
         for base, spec in base_specs.items():
             if not spec.miss_files:
                 continue
             search_paths = list(spec.search_paths)
-            safe_resolve_module.cache_clear()
+            _clear_resolver_caches()
             with temp_sys_path(search_paths):
                 mgr = FullRepoManager(
                     str(base),
@@ -631,22 +627,28 @@ def _compute_all_miss_payloads(
                         cache.put(file, payload)
         return out
 
-    tasks: list[_WorkerTask] = []
+    # Sort tasks so each worker sees contiguous runs from the same
+    # base; bounded transitions keep the FQN gen cache hot. The sort
+    # key is computed once per task rather than per comparator call.
+    keyed_tasks: list[tuple[tuple[str, ...], str, _WorkerTask]] = []
     for base, spec in base_specs.items():
+        sp_key = tuple(str(p) for p in spec.search_paths)
         for file in spec.miss_files:
-            tasks.append(
-                _WorkerTask(
-                    file=file,
-                    base=base,
-                    search_paths=spec.search_paths,
-                    files_in_base=spec.files,
-                    project_root=project_root,
+            keyed_tasks.append(
+                (
+                    sp_key,
+                    str(file),
+                    _WorkerTask(
+                        file=file,
+                        base=base,
+                        search_paths=spec.search_paths,
+                        files_in_base=spec.files,
+                        project_root=project_root,
+                    ),
                 )
             )
-    # Sort by search_paths so workers see contiguous runs from the
-    # same base; transition cost is small but bounded transitions
-    # also keep the FQN gen cache hot for longer.
-    tasks.sort(key=lambda t: (tuple(str(p) for p in t.search_paths), str(t.file)))
+    keyed_tasks.sort(key=lambda kt: (kt[0], kt[1]))
+    tasks = [kt[2] for kt in keyed_tasks]
 
     init = _WorkerInit(
         detector=detector,

--- a/dead_cst/_resolvers/_imports.py
+++ b/dead_cst/_resolvers/_imports.py
@@ -5,15 +5,14 @@ implementation that every shipped :class:`PathResolver` delegates to.
 Custom resolvers can call it directly, replace it with their own logic
 (for vendored deps, ``.pyi`` siblings, ...), or compose both.
 
-The supporting helpers (:func:`safe_resolve_module`,
-:func:`distribution_lookup`, :func:`temp_sys_path`) are kept here so the
-analyzer and the resolvers share a single cache and one canonical
-treatment of distribution-name normalization.
+The supporting helpers (:func:`safe_resolve_module` and
+:func:`distribution_lookup`) live here so the analyzer and the
+resolvers share a single cache and one canonical treatment of
+distribution-name normalization.
 """
 
 from __future__ import annotations
 
-import contextlib
 import os
 import re
 import sys
@@ -21,7 +20,6 @@ import sysconfig
 from functools import cache
 from importlib.machinery import ModuleSpec
 from pathlib import Path
-from typing import Generator
 
 from .._plugins._core import (
     EXTERNAL_DIST_PREFIX,
@@ -53,23 +51,6 @@ def _canonical_dist_name(name: str) -> str:
     we don't yet support.
     """
     return re.sub(r"[-_.]+", "-", name).lower()
-
-
-@contextlib.contextmanager
-def temp_sys_path(paths: list[Path]) -> Generator[None, None, None]:
-    """Prepend ``paths`` to ``sys.path`` for the duration of the ``with`` block.
-
-    Used by the analyzer to scope :func:`safe_resolve_module`'s lookups
-    to the current base's search paths without leaking entries between
-    bases.
-    """
-    old = list(sys.path)
-    seen = set(old)
-    sys.path = [str(p) for p in paths if str(p) not in seen] + sys.path
-    try:
-        yield
-    finally:
-        sys.path = old
 
 
 @cache

--- a/dead_cst/_resolvers/_imports.py
+++ b/dead_cst/_resolvers/_imports.py
@@ -115,6 +115,14 @@ def distribution_lookup() -> dict[Path, str]:
     Used by :func:`default_resolve_import` to classify a resolved path
     as ``[external dist] <name>`` when the file came from an installed
     third-party distribution.
+
+    Cached process-wide. The analyzer clears it in worker transitions
+    (see :func:`dead_cst._analyze._on_search_paths_change`) so a worker
+    that crosses a venv boundary -- e.g. between two uv-workspace
+    members each with their own ``.venv`` -- doesn't keep the prior
+    venv's dist map. Serial single-process runs already have a stable
+    ``sys.path`` at the venv level (only the first-party prefix moves
+    between bases), so the cache survives across bases there.
     """
     from importlib import metadata
 

--- a/dead_cst/cli.py
+++ b/dead_cst/cli.py
@@ -43,6 +43,16 @@ from ._symbols import SymbolNode
 app = typer.Typer(help="Dead code analysis for Python using libcst.")
 
 
+WorkersOption = Annotated[
+    int | None,
+    typer.Option(
+        "--workers",
+        "-j",
+        help="Run cache-miss visitor passes in this many worker processes (>=2 enables it).",
+    ),
+]
+
+
 class OutputFormat(str, Enum):
     text = "text"
     json = "json"
@@ -187,14 +197,7 @@ def analyze(
     no_cache: Annotated[
         bool, typer.Option("--no-cache", help="Bypass the per-file VisitorPayload cache.")
     ] = False,
-    workers: Annotated[
-        int | None,
-        typer.Option(
-            "--workers",
-            "-j",
-            help="Run cache-miss visitor passes in this many worker processes (>=2 enables it).",
-        ),
-    ] = None,
+    workers: WorkersOption = None,
 ) -> None:
     """Analyze a Python codebase for dead code."""
     setup_logging(verbose)
@@ -368,14 +371,7 @@ def why_alive(
     no_cache: Annotated[
         bool, typer.Option("--no-cache", help="Bypass the per-file VisitorPayload cache.")
     ] = False,
-    workers: Annotated[
-        int | None,
-        typer.Option(
-            "--workers",
-            "-j",
-            help="Run cache-miss visitor passes in this many worker processes (>=2 enables it).",
-        ),
-    ] = None,
+    workers: WorkersOption = None,
 ) -> None:
     """Show why a symbol is considered alive (reachable)."""
     setup_logging(verbose)
@@ -452,14 +448,7 @@ def dependencies(
     no_cache: Annotated[
         bool, typer.Option("--no-cache", help="Bypass the per-file VisitorPayload cache.")
     ] = False,
-    workers: Annotated[
-        int | None,
-        typer.Option(
-            "--workers",
-            "-j",
-            help="Run cache-miss visitor passes in this many worker processes (>=2 enables it).",
-        ),
-    ] = None,
+    workers: WorkersOption = None,
 ) -> None:
     """List third-party dependencies imported by the codebase."""
     setup_logging(verbose)
@@ -529,14 +518,7 @@ def unused_exports(
     no_cache: Annotated[
         bool, typer.Option("--no-cache", help="Bypass the per-file VisitorPayload cache.")
     ] = False,
-    workers: Annotated[
-        int | None,
-        typer.Option(
-            "--workers",
-            "-j",
-            help="Run cache-miss visitor passes in this many worker processes (>=2 enables it).",
-        ),
-    ] = None,
+    workers: WorkersOption = None,
 ) -> None:
     """Report __all__ entries whose targets are only alive because of __all__."""
     setup_logging(verbose)
@@ -625,14 +607,7 @@ def remove(
     no_cache: Annotated[
         bool, typer.Option("--no-cache", help="Bypass the per-file VisitorPayload cache.")
     ] = False,
-    workers: Annotated[
-        int | None,
-        typer.Option(
-            "--workers",
-            "-j",
-            help="Run cache-miss visitor passes in this many worker processes (>=2 enables it).",
-        ),
-    ] = None,
+    workers: WorkersOption = None,
 ) -> None:
     """Remove dead code from a Python codebase."""
     setup_logging(verbose)

--- a/dead_cst/cli.py
+++ b/dead_cst/cli.py
@@ -187,6 +187,14 @@ def analyze(
     no_cache: Annotated[
         bool, typer.Option("--no-cache", help="Bypass the per-file VisitorPayload cache.")
     ] = False,
+    workers: Annotated[
+        int | None,
+        typer.Option(
+            "--workers",
+            "-j",
+            help="Run cache-miss visitor passes in this many worker processes (>=2 enables it).",
+        ),
+    ] = None,
 ) -> None:
     """Analyze a Python codebase for dead code."""
     setup_logging(verbose)
@@ -206,6 +214,7 @@ def analyze(
             resolvers=resolvers,
             project_root=root,
             cache=cache,
+            workers=workers,
         )
     reachable = find_reachable(graph)
 
@@ -359,6 +368,14 @@ def why_alive(
     no_cache: Annotated[
         bool, typer.Option("--no-cache", help="Bypass the per-file VisitorPayload cache.")
     ] = False,
+    workers: Annotated[
+        int | None,
+        typer.Option(
+            "--workers",
+            "-j",
+            help="Run cache-miss visitor passes in this many worker processes (>=2 enables it).",
+        ),
+    ] = None,
 ) -> None:
     """Show why a symbol is considered alive (reachable)."""
     setup_logging(verbose)
@@ -378,6 +395,7 @@ def why_alive(
             resolvers=resolvers,
             project_root=root,
             cache=cache,
+            workers=workers,
         )
 
     target_node: SymbolNode | None = None
@@ -434,6 +452,14 @@ def dependencies(
     no_cache: Annotated[
         bool, typer.Option("--no-cache", help="Bypass the per-file VisitorPayload cache.")
     ] = False,
+    workers: Annotated[
+        int | None,
+        typer.Option(
+            "--workers",
+            "-j",
+            help="Run cache-miss visitor passes in this many worker processes (>=2 enables it).",
+        ),
+    ] = None,
 ) -> None:
     """List third-party dependencies imported by the codebase."""
     setup_logging(verbose)
@@ -448,6 +474,7 @@ def dependencies(
             resolvers=resolvers,
             project_root=root,
             cache=cache,
+            workers=workers,
         )
 
     deps_by_base: dict[Path, list[SymbolNode]] = {base: [] for base in order_paths(paths_dict)}
@@ -502,6 +529,14 @@ def unused_exports(
     no_cache: Annotated[
         bool, typer.Option("--no-cache", help="Bypass the per-file VisitorPayload cache.")
     ] = False,
+    workers: Annotated[
+        int | None,
+        typer.Option(
+            "--workers",
+            "-j",
+            help="Run cache-miss visitor passes in this many worker processes (>=2 enables it).",
+        ),
+    ] = None,
 ) -> None:
     """Report __all__ entries whose targets are only alive because of __all__."""
     setup_logging(verbose)
@@ -521,6 +556,7 @@ def unused_exports(
             resolvers=resolvers,
             project_root=root,
             cache=cache,
+            workers=workers,
         )
     reachable = find_reachable(graph)
 
@@ -589,6 +625,14 @@ def remove(
     no_cache: Annotated[
         bool, typer.Option("--no-cache", help="Bypass the per-file VisitorPayload cache.")
     ] = False,
+    workers: Annotated[
+        int | None,
+        typer.Option(
+            "--workers",
+            "-j",
+            help="Run cache-miss visitor passes in this many worker processes (>=2 enables it).",
+        ),
+    ] = None,
 ) -> None:
     """Remove dead code from a Python codebase."""
     setup_logging(verbose)
@@ -608,6 +652,7 @@ def remove(
             resolvers=resolvers,
             project_root=root,
             cache=cache,
+            workers=workers,
         )
     reachable = find_reachable(graph)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,13 @@ markers = [
 branch = true
 source = ["dead_cst"]
 omit = ["dead_cst/_version.py"]
+# ProcessPoolExecutor workers (used by ``build_symbol_graph(workers=...)``)
+# must run with the multiprocessing tracer or coverage's import-time
+# instrumentation drifts the class identity of ``_CallItem`` and causes
+# pickle round-trips to fail under ``pytest --cov``.
+concurrency = ["thread", "multiprocessing"]
+parallel = true
+sigterm = true
 
 [tool.coverage.report]
 exclude_lines = [

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -395,8 +395,9 @@ def test_warm_run_with_plugins_parses_zero_files(tmp_path, monkeypatch):
     analyzer skips both the visitor and the per-plugin observe. The
     per-base ``finalize`` step is graph-only (no CST access). This
     test pins that contract: even with every builtin plugin enabled,
-    a warm run never instantiates ``FullRepoManager`` and never calls
-    ``cst.parse_module`` from inside the analyzer.
+    a warm run never instantiates :class:`SymbolVisitor` or
+    :class:`MetadataWrapper`, never calls ``cst.parse_module``, and
+    never builds the per-base FQN cache.
     """
     import libcst as cst
 
@@ -451,34 +452,44 @@ def test_warm_run_with_plugins_parses_zero_files(tmp_path, monkeypatch):
         build_symbol_graph({tmp_path: []}, plugins=plugins, cache=cache)
 
     visitor_calls: list[object] = []
-    mgr_calls: list[object] = []
+    wrapper_calls: list[object] = []
     parse_calls: list[object] = []
+    fqn_calls: list[object] = []
     real_visitor = _analyze.SymbolVisitor
-    real_mgr = _analyze.FullRepoManager
+    real_wrapper = _analyze.MetadataWrapper
     real_parse = cst.parse_module
+    real_gen_cache = _analyze.FixedFullyQualifiedNameProvider.gen_cache
 
     def _visitor_spy(*args, **kwargs):
         visitor_calls.append(args)
         return real_visitor(*args, **kwargs)
 
-    def _mgr_spy(*args, **kwargs):
-        mgr_calls.append(args)
-        return real_mgr(*args, **kwargs)
+    def _wrapper_spy(*args, **kwargs):
+        wrapper_calls.append(args)
+        return real_wrapper(*args, **kwargs)
 
     def _parse_spy(*args, **kwargs):
         parse_calls.append(args)
         return real_parse(*args, **kwargs)
 
+    def _fqn_spy(*args, **kwargs):
+        fqn_calls.append(args)
+        return real_gen_cache(*args, **kwargs)
+
     monkeypatch.setattr(_analyze, "SymbolVisitor", _visitor_spy)
-    monkeypatch.setattr(_analyze, "FullRepoManager", _mgr_spy)
+    monkeypatch.setattr(_analyze, "MetadataWrapper", _wrapper_spy)
     monkeypatch.setattr(cst, "parse_module", _parse_spy)
+    monkeypatch.setattr(
+        _analyze.FixedFullyQualifiedNameProvider, "gen_cache", classmethod(_fqn_spy)
+    )
 
     with GraphCache(db, fingerprint=fp) as cache:
         build_symbol_graph({tmp_path: []}, plugins=plugins, cache=cache)
 
     assert visitor_calls == []
-    assert mgr_calls == []
+    assert wrapper_calls == []
     assert parse_calls == []
+    assert fqn_calls == []
 
 
 def test_edited_file_re_runs_visitor(tmp_path, monkeypatch):

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -126,8 +126,8 @@ def test_parallel_falls_back_to_serial_for_single_miss(tmp_path, monkeypatch):
     assert calls == [], "single-miss run should not spawn a pool"
 
 
-def test_parallel_pool_capped_at_miss_count(tmp_path, monkeypatch):
-    """The pool caps ``max_workers`` at ``len(miss_files)``."""
+def test_parallel_pool_capped_at_total_task_count(tmp_path, monkeypatch):
+    """The pool caps ``max_workers`` at the total number of cache-miss tasks."""
     _write(tmp_path, _multi_file_layout())
 
     from dead_cst import _analyze
@@ -142,7 +142,7 @@ def test_parallel_pool_capped_at_miss_count(tmp_path, monkeypatch):
     monkeypatch.setattr(_analyze, "ProcessPoolExecutor", _spy)
     build_symbol_graph({tmp_path: []}, workers=64)
     # Five files in _multi_file_layout(); pool should be capped at 5.
-    assert seen and all(w <= 5 for w in seen)
+    assert seen == [5]
 
 
 @pytest.mark.parametrize("workers", [None, 1])
@@ -161,3 +161,109 @@ def test_workers_none_or_one_keeps_serial_path(tmp_path, monkeypatch, workers):
     monkeypatch.setattr(_analyze, "ProcessPoolExecutor", _spy)
     build_symbol_graph({tmp_path: []}, workers=workers)
     assert calls == []
+
+
+def test_multi_base_uses_one_pool(tmp_path, monkeypatch):
+    """Two bases share a single persistent pool, not one per base."""
+    base_a = tmp_path / "a"
+    base_b = tmp_path / "b"
+    _write(
+        base_a,
+        {
+            "pkg/__init__.py": "",
+            "pkg/x.py": "def x(): pass\n",
+            "pkg/y.py": "from .x import x\ndef y(): return x()\n",
+        },
+    )
+    _write(
+        base_b,
+        {
+            "pkg/__init__.py": "",
+            "pkg/p.py": "def p(): pass\n",
+            "pkg/q.py": "from .p import p\ndef q(): return p()\n",
+        },
+    )
+
+    from dead_cst import _analyze
+
+    pool_calls = []
+    real = _analyze.ProcessPoolExecutor
+
+    def _spy(*args, **kwargs):
+        pool_calls.append(kwargs.get("max_workers"))
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(_analyze, "ProcessPoolExecutor", _spy)
+    build_symbol_graph({base_a: [], base_b: []}, workers=2)
+    assert len(pool_calls) == 1, f"expected exactly one pool across both bases, got {pool_calls!r}"
+
+
+def test_multi_base_parallel_matches_serial(tmp_path):
+    """Multi-base parallel runs produce the same graph as the serial path."""
+    base_a = tmp_path / "a"
+    base_b = tmp_path / "b"
+    _write(
+        base_a,
+        {
+            "pkg/__init__.py": "",
+            "pkg/x.py": "def x(): pass\n",
+            "pkg/y.py": "from .x import x\ndef y(): return x()\n",
+        },
+    )
+    _write(
+        base_b,
+        {
+            "pkg/__init__.py": "",
+            "pkg/p.py": "def p(): pass\n",
+            "pkg/q.py": "from .p import p\ndef q(): return p()\n",
+        },
+    )
+    paths = {base_a: [], base_b: []}
+    serial = build_symbol_graph(paths)
+    parallel = build_symbol_graph(paths, workers=2)
+    assert _node_set(parallel) == _node_set(serial)
+    assert _edge_set(parallel) == _edge_set(serial)
+
+
+def test_tasks_sorted_by_search_paths(tmp_path, monkeypatch):
+    """Worker tasks are sorted by ``search_paths`` so each worker sees contiguous bases."""
+    base_a = tmp_path / "a"
+    base_b = tmp_path / "b"
+    _write(
+        base_a,
+        {
+            "pkg/__init__.py": "",
+            "pkg/x.py": "def x(): pass\n",
+            "pkg/y.py": "def y(): pass\n",
+        },
+    )
+    _write(
+        base_b,
+        {
+            "pkg/__init__.py": "",
+            "pkg/p.py": "def p(): pass\n",
+            "pkg/q.py": "def q(): pass\n",
+        },
+    )
+
+    from dead_cst import _analyze
+
+    captured: list = []
+    real_map = _analyze.ProcessPoolExecutor.map  # bound on the class
+
+    def _spy_map(self, fn, iterable, *args, **kwargs):
+        materialized = list(iterable)
+        captured.append([t.search_paths for t in materialized])
+        return real_map(self, fn, materialized, *args, **kwargs)
+
+    monkeypatch.setattr(_analyze.ProcessPoolExecutor, "map", _spy_map)
+    build_symbol_graph({base_a: [], base_b: []}, workers=2)
+
+    assert len(captured) == 1
+    sps = captured[0]
+    # Same-base tasks land contiguously after the sort.
+    runs = [sps[0]]
+    for sp in sps[1:]:
+        if sp != runs[-1]:
+            runs.append(sp)
+    assert len(runs) == len(set(runs)), f"expected each base's tasks contiguous, got order {sps!r}"

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,0 +1,163 @@
+"""Tests for the ``workers`` parameter on :func:`build_symbol_graph`.
+
+The serial and parallel paths must produce identical graphs and warm
+the cache identically. Workers communicate by pickling
+:class:`VisitorPayload` blobs back to the main process; the SQLite
+cache write still happens on the main process so failure semantics
+match the serial path.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from dead_cst import build_symbol_graph
+from dead_cst._cache import (
+    CACHE_DIR_NAME,
+    GraphCache,
+    compute_fingerprint,
+)
+
+
+def _write(root: Path, files: dict[str, str]) -> None:
+    for rel, src in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(textwrap.dedent(src).strip() + "\n")
+
+
+def _node_set(graph) -> set[tuple[str, str]]:
+    return {(n.fqname, n.type) for n in graph.nodes}
+
+
+def _edge_set(graph) -> set[tuple[str, str]]:
+    return {(s.fqname, d.fqname) for s, d in graph.edges()}
+
+
+def _multi_file_layout() -> dict[str, str]:
+    return {
+        "pkg/__init__.py": "",
+        "pkg/a.py": """
+            def f():
+                pass
+
+            def g():
+                return f()
+        """,
+        "pkg/b.py": """
+            from .a import g
+
+            def h():
+                return g()
+        """,
+        "pkg/c.py": """
+            from .b import h
+
+            def main():
+                return h()
+        """,
+        "pkg/d.py": """
+            VALUE = 42
+
+            def lookup():
+                return VALUE
+        """,
+    }
+
+
+def test_parallel_matches_serial(tmp_path):
+    """``workers=2`` and the default serial path return the same graph."""
+    _write(tmp_path, _multi_file_layout())
+    serial = build_symbol_graph({tmp_path: []})
+    parallel = build_symbol_graph({tmp_path: []}, workers=2)
+    assert _node_set(parallel) == _node_set(serial)
+    assert _edge_set(parallel) == _edge_set(serial)
+
+
+def test_parallel_warms_cache(tmp_path):
+    """Parallel runs write payloads to the cache so a follow-up run skips workers."""
+    _write(tmp_path, _multi_file_layout())
+    db = tmp_path / CACHE_DIR_NAME / "cache.db"
+    fp = compute_fingerprint(paths={tmp_path: []}, resolvers=[])
+
+    with GraphCache(db, fingerprint=fp) as cache:
+        cold = build_symbol_graph({tmp_path: []}, cache=cache, workers=2)
+
+    # Every .py file under tmp_path should now be cached.
+    files = sorted(tmp_path.rglob("*.py"))
+    with GraphCache(db, fingerprint=fp) as cache:
+        for f in files:
+            assert cache.get(f) is not None, f"{f} missing from cache after parallel run"
+
+    # And a follow-up serial run sees the same graph.
+    with GraphCache(db, fingerprint=fp) as cache:
+        warm = build_symbol_graph({tmp_path: []}, cache=cache)
+    assert _node_set(warm) == _node_set(cold)
+    assert _edge_set(warm) == _edge_set(cold)
+
+
+def test_parallel_falls_back_to_serial_for_single_miss(tmp_path, monkeypatch):
+    """``workers=2`` with a single cache-miss skips the pool (overhead floor)."""
+    _write(tmp_path, _multi_file_layout())
+    db = tmp_path / CACHE_DIR_NAME / "cache.db"
+    fp = compute_fingerprint(paths={tmp_path: []}, resolvers=[])
+
+    with GraphCache(db, fingerprint=fp) as cache:
+        build_symbol_graph({tmp_path: []}, cache=cache)
+
+    # Edit one file so exactly one miss survives.
+    (tmp_path / "pkg" / "a.py").write_text("def f():\n    return 1\n")
+
+    from dead_cst import _analyze
+
+    calls = []
+    real = _analyze.ProcessPoolExecutor
+
+    def _spy(*args, **kwargs):
+        calls.append(kwargs.get("max_workers"))
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(_analyze, "ProcessPoolExecutor", _spy)
+    with GraphCache(db, fingerprint=fp) as cache:
+        build_symbol_graph({tmp_path: []}, cache=cache, workers=4)
+    assert calls == [], "single-miss run should not spawn a pool"
+
+
+def test_parallel_pool_capped_at_miss_count(tmp_path, monkeypatch):
+    """The pool caps ``max_workers`` at ``len(miss_files)``."""
+    _write(tmp_path, _multi_file_layout())
+
+    from dead_cst import _analyze
+
+    seen = []
+    real = _analyze.ProcessPoolExecutor
+
+    def _spy(*args, **kwargs):
+        seen.append(kwargs.get("max_workers"))
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(_analyze, "ProcessPoolExecutor", _spy)
+    build_symbol_graph({tmp_path: []}, workers=64)
+    # Five files in _multi_file_layout(); pool should be capped at 5.
+    assert seen and all(w <= 5 for w in seen)
+
+
+@pytest.mark.parametrize("workers", [None, 1])
+def test_workers_none_or_one_keeps_serial_path(tmp_path, monkeypatch, workers):
+    """``workers=None`` and ``workers=1`` never spawn a pool."""
+    _write(tmp_path, _multi_file_layout())
+    from dead_cst import _analyze
+
+    calls = []
+    real = _analyze.ProcessPoolExecutor
+
+    def _spy(*args, **kwargs):
+        calls.append(kwargs)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(_analyze, "ProcessPoolExecutor", _spy)
+    build_symbol_graph({tmp_path: []}, workers=workers)
+    assert calls == []


### PR DESCRIPTION
## Summary

Per-file visitor + observe is the cold-run bottleneck (LibCST scope/FQN walks, GIL-bound). This PR adds an opt-in `workers=N` knob to `build_symbol_graph` (CLI: `--workers` / `-j`) that dispatches cache-miss files to a single persistent `ProcessPoolExecutor` for the whole run. Workers return `VisitorPayload` blobs to the main process, which keeps SQLite cache writes, trie stitching, and edge resolution serial — so the parallel path produces a byte-for-byte equivalent graph and warms the cache the same way.

## Design

- **Three-phase pipeline.** `build_symbol_graph` is staged as: (1) collect per-base specs (cache hits + miss files + per-base FQN cache); (2) run visitor + observe for every miss payload (in-process or via the pool); (3) per-base apply + edge stitch + plugin finalize. The graph and cache contents are unchanged.
- **Single persistent pool, sorted task stream.** One `ProcessPoolExecutor` covers the whole run with tasks sorted by `search_paths`, so each worker tends to see contiguous miss runs from the same base. On each transition the worker rebinds `sys.path` and clears `safe_resolve_module` + `distribution_lookup` so cross-venv uv-workspace members don't inherit a sibling base's resolution state.
- **Shared FQN cache.** `FixedFullyQualifiedNameProvider.gen_cache` is called once per base in the parent over miss files only. Workers receive their file's `ModuleNameAndPackage` per task and inject it into `MetadataWrapper(module, unsafe_skip_copy=True, cache=...)` directly, skipping `FullRepoManager` entirely. Cache-hit files don't pay any FQN computation.
- **Unified runner.** In-process and worker paths share a single `_process_task(state, task)` body; the only difference is whether the runner state lives on the main process or in worker process globals. The in-process path captures a `sys.path` baseline at start and restores it on exit.
- **Cache writes stay on main.** Workers must send the payload back regardless (the main process needs it for trie + import_edges), so writing in the worker would only add a SQLite commit on top of the IPC round-trip. Keeping writes serial avoids WAL-lock contention and makes failure semantics simple.
- **Defaults unchanged.** `workers=None` (default) and `workers=1` keep the in-process path. Public API and graph output are unchanged.

## Coverage tooling

`pytest --cov` instruments worker subprocesses; without `concurrency = ["multiprocessing"]` in `[tool.coverage.run]`, the tracer drifts the class identity of `concurrent.futures.process._CallItem` and pickle round-trips fail. Adding the multiprocessing tracer (plus `parallel = true` and `sigterm = true`) makes coverage subprocess-safe.

## Performance

Cold runs on the flux0 fixture (server + cli, ~84 .py files, 4 CPUs):

| | wall | user CPU |
|---|---|---|
| serial | 6.6s | 6.5s |
| `--workers 4` | 3.6s | 6.5s |
| warm (any) | 0.85s | 0.80s |

~1.8× speedup on a 4-core box; sublinear because pickling and worker startup eat into the 4× ceiling. Speedup scales with file count — bigger codebases get closer to linear.

## What's new

- `dead_cst/_analyze.py`: `build_symbol_graph(workers=...)`, `_BaseSpec`, `_Task`, `_RunnerState`, `_process_task`, `_init_worker`, `_worker_process_task`, `_compute_all_miss_payloads`, `_collect_base_specs`, `_build_sorted_tasks`, `_clear_resolver_caches`, `_rebind_sys_path`, `_process_one_file`.
- `dead_cst/cli.py`: shared `WorkersOption` alias used by `analyze`, `why-alive`, `unused-exports`, `dependencies`, `remove`.
- `dead_cst/_resolvers/_imports.py`: `temp_sys_path` removed (the runner manages `sys.path` directly now).
- `tests/test_parallel.py`: 9 tests covering serial-vs-parallel graph equivalence (single + multi base), cache warming, single-pool guarantee across bases, contiguous-task ordering, single-miss fallback, pool-size capping, `workers=None`/`1` no-pool path.
- `tests/test_cache.py`: warm-run zero-parse test rewritten for the new gates (`MetadataWrapper`, `gen_cache` instead of `FullRepoManager`).
- `pyproject.toml`: coverage config tweak for subprocess tracing.
- `README.md`, `CHANGELOG.md`: documented.

## Test plan

- [x] `uv run pytest` (655 tests pass, no regressions)
- [x] `uv run pytest --cov=dead_cst --cov-branch --cov-report=xml` (parallel tests work under coverage)
- [x] `uv run pytest -m e2e` (10/10 pass)
- [x] `uv run prek run --all-files` (ruff + ty pass)
- [x] CLI smoke test: `dead-cst analyze` produces identical output for `--workers 4` and the default in-process run on a multi-file fixture

https://claude.ai/code/session_011GtWAT2G2aQDAgjZ2fnvXz