### PR TITLE
resolvers: fix path classification for system-Python and editable installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,28 @@ two versions.
   `sys.path` directly, restoring it from a baseline snapshot when
   the in-process path finishes. Not part of the public API.
 
+### Fixed
+- Path classification in `default_resolve_import` no longer
+  misclassifies third-party packages as stdlib when running against
+  a Python install whose `site-packages` is nested *inside* the
+  stdlib root (the typical layout for a system Python with no venv,
+  e.g. `/usr/local/lib/python3.13/site-packages` under
+  `/usr/local/lib/python3.13`). The stdlib check now excludes paths
+  under `purelib` / `platlib` and any directory named
+  `site-packages` / `dist-packages`.
+- Editably-installed third-party packages (`pip install -e`,
+  `uv pip install -e`) are now resolved to `[external dist] <name>`
+  instead of raising `Module ... resolved to an unexpected path`.
+  Distribution metadata is consulted via PEP 610
+  `direct_url.json` and any `.pth` shims in the dist's
+  `RECORD`, so editable source dirs that live outside the project's
+  search paths still get attributed to their owning distribution.
+  The new cache (`editable_distribution_roots`) is cleared alongside
+  `distribution_lookup` on worker venv transitions. All four
+  shipping resolvers (`venv`, `pyproject`, `uv_workspace`,
+  `manual`) bump their `version` so cached `VisitorPayload` blobs
+  rebuild against the corrected classification.
+
 ## [0.4.0] - 2026-05-03
 
 ### Added

--- a/dead_cst/_analyze.py
+++ b/dead_cst/_analyze.py
@@ -33,7 +33,11 @@ from ._resolvers import (
     default_resolve_import,
     exported_roots,
 )
-from ._resolvers._imports import distribution_lookup, safe_resolve_module
+from ._resolvers._imports import (
+    distribution_lookup,
+    editable_distribution_roots,
+    safe_resolve_module,
+)
 from ._symbols import EdgeFlags, Import, NodeFlags, SymbolNode, SymbolTrie
 from ._visitor import SymbolVisitor, VisitorPayload
 
@@ -479,16 +483,18 @@ def _rebind_sys_path(search_paths: tuple[Path, ...], baseline: list[str]) -> Non
 
 
 def _clear_resolver_caches() -> None:
-    """Drop the two ``sys.path``-derived resolver caches.
+    """Drop the ``sys.path``-derived resolver caches.
 
     :func:`safe_resolve_module` keys on fullname and
-    :func:`distribution_lookup` keys on ``()`` -- both read live
-    ``sys.path`` and would otherwise return stale results across
-    bases (different first-party prefix; uv-workspace members shipping
-    their own ``.venv``).
+    :func:`distribution_lookup` / :func:`editable_distribution_roots`
+    key on ``()`` -- all three read live ``sys.path`` (or
+    :mod:`importlib.metadata` against it) and would otherwise return
+    stale results across bases (different first-party prefix;
+    uv-workspace members shipping their own ``.venv``).
     """
     safe_resolve_module.cache_clear()
     distribution_lookup.cache_clear()
+    editable_distribution_roots.cache_clear()
 
 
 def _process_task(state: _RunnerState, task: _Task) -> tuple[Path, Path, VisitorPayload]:

--- a/dead_cst/_resolvers/_imports.py
+++ b/dead_cst/_resolvers/_imports.py
@@ -13,6 +13,7 @@ distribution-name normalization.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import sys
@@ -27,7 +28,25 @@ from .._plugins._core import (
     STDLIB_PREFIX,
 )
 
+
+def _resolved_sysconfig_path(name: str) -> Path | None:
+    raw = sysconfig.get_path(name)
+    if not raw:
+        return None
+    try:
+        return Path(raw).resolve()
+    except OSError:
+        return None
+
+
+# A system Python install (no venv) typically nests purelib/platlib *inside*
+# the stdlib root (e.g. ``/usr/local/lib/python3.13/site-packages`` under
+# ``/usr/local/lib/python3.13``). Capturing both lets us classify a resolved
+# path as stdlib only when it isn't actually a third-party package living
+# under that same root.
 STDLIB = Path(sysconfig.get_path("stdlib")).resolve()
+PURELIB = _resolved_sysconfig_path("purelib")
+PLATLIB = _resolved_sysconfig_path("platlib")
 SITE_PACKAGES_MARKERS = ("site-packages", "dist-packages")
 
 
@@ -116,6 +135,120 @@ def distribution_lookup() -> dict[Path, str]:
     return lookup
 
 
+@cache
+def editable_distribution_roots() -> tuple[tuple[Path, str], ...]:
+    """Source-directory roots for editably-installed distributions.
+
+    A modern ``pip install -e`` / ``uv pip install -e`` only records
+    metadata files plus a ``.pth`` (or PEP 660 finder proxy) in the
+    dist's ``RECORD``. The actual ``.py`` source lives in the user's
+    project directory and never appears in :func:`distribution_lookup`.
+    We surface it here by reading each dist's ``direct_url.json``
+    (PEP 610) and any ``.pth`` shims it ships, so an importer of, say,
+    an editable ``dead-cst`` resolves to ``[external dist] dead-cst``
+    instead of raising on an "unexpected path" or being silently
+    misclassified.
+
+    Returns ``(root, canonical_name)`` tuples sorted longest-path first
+    so prefix-matching against nested editable layouts picks the most
+    specific dist. Cached alongside :func:`distribution_lookup` and
+    cleared together when the analyzer transitions across venvs.
+    """
+    from importlib import metadata
+
+    roots: list[tuple[Path, str]] = []
+    for dist in metadata.distributions():
+        canonical = _canonical_dist_name(dist.metadata["Name"])
+        for root in _editable_source_roots(dist):
+            roots.append((root, canonical))
+    roots.sort(key=lambda pair: len(pair[0].parts), reverse=True)
+    return tuple(roots)
+
+
+def _editable_source_roots(dist) -> list[Path]:
+    """Discover editable source directories advertised by ``dist``.
+
+    Honors PEP 610 (``direct_url.json`` with ``dir_info.editable=true``)
+    and the ``.pth`` shim style used by uv / setuptools-legacy
+    editables. Both are best-effort: malformed metadata or missing
+    files just yield no roots for this dist.
+    """
+    roots: list[Path] = []
+
+    direct_url = _safe_read_dist_text(dist, "direct_url.json")
+    if direct_url:
+        try:
+            data = json.loads(direct_url)
+        except json.JSONDecodeError:
+            data = {}
+        if isinstance(data, dict) and data.get("dir_info", {}).get("editable"):
+            url = data.get("url")
+            if isinstance(url, str) and url.startswith("file://"):
+                # ``file:///abs/path`` -> ``/abs/path``; ``file://host/path`` is
+                # not portable on POSIX but we let Path normalize whatever's
+                # left of the scheme prefix.
+                candidate = Path(url[len("file://") :])
+                if candidate.is_absolute() and candidate.is_dir():
+                    roots.append(candidate.resolve())
+
+    for file in dist.files or ():
+        if not str(file).endswith(".pth"):
+            continue
+        try:
+            text = Path(str(dist.locate_file(file))).read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or line.startswith(("import ", "import\t")):
+                continue
+            candidate = Path(line)
+            if candidate.is_absolute() and candidate.is_dir():
+                roots.append(candidate.resolve())
+
+    # Deduplicate while preserving order.
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for root in roots:
+        if root not in seen:
+            seen.add(root)
+            unique.append(root)
+    return unique
+
+
+def _safe_read_dist_text(dist, name: str) -> str | None:
+    try:
+        return dist.read_text(name)
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _is_site_packages_path(path: Path) -> bool:
+    """True when ``path`` lives inside an interpreter's third-party install dir.
+
+    We check ``purelib`` / ``platlib`` first since they're the
+    interpreter-blessed locations, then fall back to the conventional
+    directory names for layouts where sysconfig disagrees with reality
+    (Debian ``dist-packages`` siblings, vendored bundles, ...).
+    """
+    if PURELIB is not None and path.is_relative_to(PURELIB):
+        return True
+    if PLATLIB is not None and path.is_relative_to(PLATLIB):
+        return True
+    return any(part in SITE_PACKAGES_MARKERS for part in path.parts)
+
+
+def _is_stdlib_path(path: Path) -> bool:
+    """True when ``path`` is part of the standard library.
+
+    Excludes nested site-packages because a system Python install lays
+    them out *inside* ``STDLIB`` (e.g. ``.../python3.13/site-packages``
+    under ``.../python3.13``); a naive ``is_relative_to(STDLIB)`` would
+    otherwise misclassify every third-party package as stdlib.
+    """
+    return path.is_relative_to(STDLIB) and not _is_site_packages_path(path)
+
+
 def default_resolve_import(name: str, search_paths: list[Path]) -> str | Path | None:
     """Resolve a dotted module name against ``sys.path`` + the importlib finders.
 
@@ -140,15 +273,21 @@ def default_resolve_import(name: str, search_paths: list[Path]) -> str | Path | 
     if spec.origin in {"built-in", "frozen"}:
         return f"{STDLIB_PREFIX}{name}"
     path = Path(spec.origin).resolve()
-    if path.is_relative_to(STDLIB):
+
+    # Distribution lookup runs before the stdlib check so that, on a
+    # system Python where site-packages is nested inside the stdlib
+    # root, third-party packages are still correctly attributed to
+    # their distribution rather than swallowed into ``[stdlib]``.
+    if dist := distribution_lookup().get(path):
+        return f"{EXTERNAL_DIST_PREFIX}{dist}"
+    for root, dist in editable_distribution_roots():
+        if path.is_relative_to(root):
+            return f"{EXTERNAL_DIST_PREFIX}{dist}"
+
+    if _is_stdlib_path(path):
         return f"{STDLIB_PREFIX}{name}"
 
-    lookup = distribution_lookup()
-    if dist := lookup.get(path):
-        return f"{EXTERNAL_DIST_PREFIX}{dist}"
-
-    path_str = str(path)
-    if any(m in path_str for m in SITE_PACKAGES_MARKERS):
+    if _is_site_packages_path(path):
         return f"{EXTERNAL_FILE_PREFIX}{name}"
 
     for search in search_paths:

--- a/dead_cst/_resolvers/manual.py
+++ b/dead_cst/_resolvers/manual.py
@@ -31,7 +31,7 @@ class ManualResolver:
 
     specs: list[str] = field(default_factory=list)
     name: str = "manual"
-    version: int = 1777760307
+    version: int = 1777973896
 
     def resolve(self, project_root: Path) -> PathMap:
         out: PathMap = {}

--- a/dead_cst/_resolvers/pyproject.py
+++ b/dead_cst/_resolvers/pyproject.py
@@ -27,7 +27,7 @@ class PyprojectResolver:
     """
 
     name: str = "pyproject"
-    version: int = 1777760307
+    version: int = 1777973896
 
     def resolve(self, project_root: Path) -> PathMap:
         project_root = project_root.resolve()

--- a/dead_cst/_resolvers/uv_workspace.py
+++ b/dead_cst/_resolvers/uv_workspace.py
@@ -48,7 +48,7 @@ class UvWorkspaceResolver:
 
     lock_path: Path | None = None
     name: str = "uv_workspace"
-    version: int = 1777760307
+    version: int = 1777973896
 
     def resolve(self, project_root: Path) -> PathMap:
         project_root = project_root.resolve()

--- a/dead_cst/_resolvers/venv.py
+++ b/dead_cst/_resolvers/venv.py
@@ -41,7 +41,7 @@ class VenvResolver:
 
     venv_dir: str | None = None
     name: str = "venv"
-    version: int = 1777760307
+    version: int = 1777973896
 
     def resolve(self, project_root: Path) -> PathMap:
         project_root = project_root.resolve()

--- a/tests/test_resolvers/test_imports.py
+++ b/tests/test_resolvers/test_imports.py
@@ -1,0 +1,348 @@
+"""Tests for :mod:`dead_cst._resolvers._imports` path classification.
+
+The bugs these guard against:
+
+1. A system Python install (no venv) nests ``site-packages`` inside the
+   stdlib root, so a naive ``path.is_relative_to(STDLIB)`` swallows every
+   third-party package into ``[stdlib] <name>``.
+2. ``pip install -e`` / ``uv pip install -e`` records only a ``.pth`` shim
+   plus dist-info in ``RECORD``; the actual source files never appear in
+   :func:`distribution_lookup`. Without help, an importer of an editable
+   third-party package raised ``Module ... resolved to an unexpected path``.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from dead_cst._resolvers import _imports
+from dead_cst._resolvers._imports import (
+    _editable_source_roots,
+    _is_site_packages_path,
+    _is_stdlib_path,
+    default_resolve_import,
+)
+
+
+def test_is_stdlib_path_excludes_nested_site_packages(tmp_path: Path):
+    stdlib = tmp_path / "lib" / "python3.13"
+    site_packages = stdlib / "site-packages"
+    site_packages.mkdir(parents=True)
+
+    with patch.object(_imports, "STDLIB", stdlib.resolve()):
+        with patch.object(_imports, "PURELIB", site_packages.resolve()):
+            with patch.object(_imports, "PLATLIB", site_packages.resolve()):
+                # Genuine stdlib module
+                assert _is_stdlib_path(stdlib / "json" / "__init__.py")
+                # Third-party package nested under stdlib root
+                assert not _is_stdlib_path(site_packages / "requests" / "__init__.py")
+
+
+def test_is_stdlib_path_with_dist_packages_sibling(tmp_path: Path):
+    """Debian-style layout: dist-packages lives alongside stdlib, not under it."""
+    stdlib = tmp_path / "lib" / "python3.13"
+    dist_packages = tmp_path / "lib" / "python3" / "dist-packages"
+    stdlib.mkdir(parents=True)
+    dist_packages.mkdir(parents=True)
+
+    with patch.object(_imports, "STDLIB", stdlib.resolve()):
+        with patch.object(_imports, "PURELIB", None):
+            with patch.object(_imports, "PLATLIB", None):
+                assert _is_stdlib_path(stdlib / "json" / "__init__.py")
+                # dist-packages isn't under STDLIB so the check returns False;
+                # the markers fallback also catches the directory name.
+                assert not _is_stdlib_path(dist_packages / "yaml" / "__init__.py")
+
+
+def test_is_site_packages_path_uses_purelib(tmp_path: Path):
+    purelib = tmp_path / "venv" / "lib" / "python3.13" / "site-packages"
+    purelib.mkdir(parents=True)
+
+    with patch.object(_imports, "PURELIB", purelib.resolve()):
+        with patch.object(_imports, "PLATLIB", None):
+            assert _is_site_packages_path(purelib / "click" / "__init__.py")
+            assert not _is_site_packages_path(tmp_path / "src" / "myproj" / "__init__.py")
+
+
+def test_is_site_packages_path_falls_back_to_markers(tmp_path: Path):
+    """When sysconfig disagrees with the actual layout, the dir-name fallback
+    still catches site-packages / dist-packages."""
+    weird_sp = tmp_path / "weirdpython" / "lib" / "site-packages"
+    weird_sp.mkdir(parents=True)
+
+    with patch.object(_imports, "PURELIB", None):
+        with patch.object(_imports, "PLATLIB", None):
+            assert _is_site_packages_path(weird_sp / "pkg" / "__init__.py")
+
+
+def _fake_dist(
+    files: list[str] | None = None,
+    direct_url: dict | None = None,
+    pth_contents: dict[str, str] | None = None,
+    base: Path | None = None,
+) -> types.SimpleNamespace:
+    """Build a duck-typed ``importlib.metadata.Distribution`` stand-in.
+
+    Only the surface :func:`_editable_source_roots` actually touches:
+    ``files`` (relative paths), ``locate_file`` (resolves against ``base``)
+    and ``read_text`` (returns ``direct_url.json`` content).
+    """
+    base = base or Path("/nonexistent")
+    pth_contents = pth_contents or {}
+
+    class _PathLike(str):
+        pass
+
+    file_objs = [_PathLike(f) for f in (files or ())]
+
+    def locate_file(rel: str) -> Path:
+        # ``.pth`` shims live in site-packages, but for unit tests we
+        # write them somewhere accessible (``pth_contents`` keys map to
+        # absolute on-disk locations).
+        s = str(rel)
+        if s in pth_contents:
+            return Path(pth_contents[s])
+        return base / s
+
+    def read_text(name: str) -> str | None:
+        if name == "direct_url.json" and direct_url is not None:
+            return json.dumps(direct_url)
+        return None
+
+    return types.SimpleNamespace(
+        files=file_objs,
+        locate_file=locate_file,
+        read_text=read_text,
+    )
+
+
+def test_editable_source_roots_from_direct_url(tmp_path: Path):
+    src = tmp_path / "src-project"
+    src.mkdir()
+
+    dist = _fake_dist(
+        direct_url={"url": f"file://{src}", "dir_info": {"editable": True}},
+    )
+    roots = _editable_source_roots(dist)
+    assert roots == [src.resolve()]
+
+
+def test_editable_source_roots_ignores_non_editable_direct_url(tmp_path: Path):
+    src = tmp_path / "src-project"
+    src.mkdir()
+
+    dist = _fake_dist(
+        direct_url={"url": f"file://{src}", "dir_info": {"editable": False}},
+    )
+    assert _editable_source_roots(dist) == []
+
+
+def test_editable_source_roots_from_pth_shim(tmp_path: Path):
+    src = tmp_path / "my-editable"
+    src.mkdir()
+    pth = tmp_path / "site" / "_editable_impl_my_editable.pth"
+    pth.parent.mkdir()
+    pth.write_text(str(src))
+
+    dist = _fake_dist(
+        files=["_editable_impl_my_editable.pth"],
+        pth_contents={"_editable_impl_my_editable.pth": str(pth)},
+    )
+    assert _editable_source_roots(dist) == [src.resolve()]
+
+
+def test_editable_source_roots_skips_pth_import_lines(tmp_path: Path):
+    """``.pth`` files can also contain ``import foo`` activation hooks; those
+    aren't directories and must not be treated as editable roots."""
+    pth = tmp_path / "site" / "activate.pth"
+    pth.parent.mkdir()
+    pth.write_text("import sitecustomize\n# a comment\n")
+
+    dist = _fake_dist(
+        files=["activate.pth"],
+        pth_contents={"activate.pth": str(pth)},
+    )
+    assert _editable_source_roots(dist) == []
+
+
+def test_editable_source_roots_handles_malformed_direct_url(tmp_path: Path):
+    dist = types.SimpleNamespace(
+        files=[],
+        locate_file=lambda rel: tmp_path / rel,
+        read_text=lambda name: "{not valid json" if name == "direct_url.json" else None,
+    )
+    assert _editable_source_roots(dist) == []
+
+
+def _make_spec(name: str, origin: str) -> ModuleSpec:
+    return ModuleSpec(name, loader=None, origin=origin)
+
+
+def test_default_resolve_import_third_party_under_stdlib_root(tmp_path: Path):
+    """Reproduces the real bug: stdlib at ``<prefix>/lib/python3.13`` with
+    site-packages nested at ``<prefix>/lib/python3.13/site-packages``.
+
+    Before the fix, ``requests`` resolved to ``[stdlib] requests`` because
+    ``is_relative_to(STDLIB)`` was True. After the fix, the dist lookup
+    classifies it as ``[external dist] requests``."""
+    stdlib = tmp_path / "lib" / "python3.13"
+    site_packages = stdlib / "site-packages"
+    site_packages.mkdir(parents=True)
+    requests_init = site_packages / "requests" / "__init__.py"
+    requests_init.parent.mkdir()
+    requests_init.write_text("")
+
+    spec = _make_spec("requests", str(requests_init))
+
+    with patch.object(_imports, "STDLIB", stdlib.resolve()):
+        with patch.object(_imports, "PURELIB", site_packages.resolve()):
+            with patch.object(_imports, "PLATLIB", site_packages.resolve()):
+                with patch.object(_imports, "safe_resolve_module", return_value=spec):
+                    with patch.object(
+                        _imports,
+                        "distribution_lookup",
+                        return_value={requests_init.resolve(): "requests"},
+                    ):
+                        with patch.object(_imports, "editable_distribution_roots", return_value=()):
+                            result = default_resolve_import("requests", [tmp_path])
+    assert result == "[external dist] requests"
+
+
+def test_default_resolve_import_unrecorded_thirdparty_under_stdlib_root(tmp_path: Path):
+    """Even when the dist lookup misses a file (rare but possible -- vendored
+    bundles, broken RECORD, ...), a third-party package nested under the
+    stdlib root must NOT be classified as stdlib."""
+    stdlib = tmp_path / "lib" / "python3.13"
+    site_packages = stdlib / "site-packages"
+    site_packages.mkdir(parents=True)
+    pkg_init = site_packages / "vendored" / "__init__.py"
+    pkg_init.parent.mkdir()
+    pkg_init.write_text("")
+
+    spec = _make_spec("vendored", str(pkg_init))
+
+    with patch.object(_imports, "STDLIB", stdlib.resolve()):
+        with patch.object(_imports, "PURELIB", site_packages.resolve()):
+            with patch.object(_imports, "PLATLIB", site_packages.resolve()):
+                with patch.object(_imports, "safe_resolve_module", return_value=spec):
+                    with patch.object(_imports, "distribution_lookup", return_value={}):
+                        with patch.object(_imports, "editable_distribution_roots", return_value=()):
+                            result = default_resolve_import("vendored", [tmp_path])
+    assert result == "[external file] vendored"
+
+
+def test_default_resolve_import_editable_dist_outside_search_paths(tmp_path: Path):
+    """An editable third-party install whose source dir is outside the
+    project's search paths must resolve to ``[external dist]`` rather than
+    raising ``Module ... resolved to an unexpected path``."""
+    editable_root = tmp_path / "external" / "dead-cst"
+    pkg_init = editable_root / "dead_cst" / "__init__.py"
+    pkg_init.parent.mkdir(parents=True)
+    pkg_init.write_text("")
+
+    project_root = tmp_path / "consumer"
+    project_root.mkdir()
+
+    spec = _make_spec("dead_cst", str(pkg_init))
+
+    with patch.object(_imports, "STDLIB", tmp_path / "stdlib"):
+        with patch.object(_imports, "PURELIB", None):
+            with patch.object(_imports, "PLATLIB", None):
+                with patch.object(_imports, "safe_resolve_module", return_value=spec):
+                    with patch.object(_imports, "distribution_lookup", return_value={}):
+                        with patch.object(
+                            _imports,
+                            "editable_distribution_roots",
+                            return_value=((editable_root.resolve(), "dead-cst"),),
+                        ):
+                            result = default_resolve_import("dead_cst", [project_root])
+    assert result == "[external dist] dead-cst"
+
+
+def test_default_resolve_import_first_party_still_returns_path(tmp_path: Path):
+    """Regression: the reordered checks must not steal first-party files
+    that happen to live near common install roots."""
+    project_src = tmp_path / "src" / "myproj"
+    init_py = project_src / "__init__.py"
+    init_py.parent.mkdir(parents=True)
+    init_py.write_text("")
+
+    spec = _make_spec("myproj", str(init_py))
+
+    with patch.object(_imports, "STDLIB", tmp_path / "stdlib"):
+        with patch.object(_imports, "PURELIB", None):
+            with patch.object(_imports, "PLATLIB", None):
+                with patch.object(_imports, "safe_resolve_module", return_value=spec):
+                    with patch.object(_imports, "distribution_lookup", return_value={}):
+                        with patch.object(_imports, "editable_distribution_roots", return_value=()):
+                            result = default_resolve_import("myproj", [tmp_path / "src"])
+    assert result == init_py.resolve()
+
+
+def test_default_resolve_import_genuine_stdlib_still_classified(tmp_path: Path):
+    stdlib = tmp_path / "lib" / "python3.13"
+    json_init = stdlib / "json" / "__init__.py"
+    json_init.parent.mkdir(parents=True)
+    json_init.write_text("")
+
+    spec = _make_spec("json", str(json_init))
+
+    with patch.object(_imports, "STDLIB", stdlib.resolve()):
+        with patch.object(_imports, "PURELIB", stdlib.resolve() / "site-packages"):
+            with patch.object(_imports, "PLATLIB", stdlib.resolve() / "site-packages"):
+                with patch.object(_imports, "safe_resolve_module", return_value=spec):
+                    with patch.object(_imports, "distribution_lookup", return_value={}):
+                        with patch.object(_imports, "editable_distribution_roots", return_value=()):
+                            result = default_resolve_import("json", [tmp_path])
+    assert result == "[stdlib] json"
+
+
+def test_default_resolve_import_builtin_module():
+    spec = ModuleSpec("sys", loader=None, origin="built-in")
+    with patch.object(_imports, "safe_resolve_module", return_value=spec):
+        assert default_resolve_import("sys", []) == "[stdlib] sys"
+
+
+def test_default_resolve_import_unresolvable_returns_none():
+    with patch.object(_imports, "safe_resolve_module", return_value=None):
+        assert default_resolve_import("nonexistent_zzz", []) is None
+
+
+def test_default_resolve_import_unexpected_path_still_raises(tmp_path: Path):
+    """When the resolved path falls outside *every* category we recognize
+    (stdlib / site-packages / dist lookup / editable roots / search paths),
+    the analyzer should still surface the surprise rather than silently
+    returning a wrong classification."""
+    stray = tmp_path / "stray" / "weird.py"
+    stray.parent.mkdir()
+    stray.write_text("")
+    spec = _make_spec("weird", str(stray))
+
+    with patch.object(_imports, "STDLIB", tmp_path / "stdlib"):
+        with patch.object(_imports, "PURELIB", None):
+            with patch.object(_imports, "PLATLIB", None):
+                with patch.object(_imports, "safe_resolve_module", return_value=spec):
+                    with patch.object(_imports, "distribution_lookup", return_value={}):
+                        with patch.object(_imports, "editable_distribution_roots", return_value=()):
+                            with pytest.raises(Exception, match="unexpected path"):
+                                default_resolve_import("weird", [tmp_path / "project"])
+
+
+def test_editable_distribution_roots_self_install():
+    """Smoke test against the live process: dead-cst itself is installed
+    editably in the test venv, so its source dir should be discoverable."""
+    roots = _imports.editable_distribution_roots()
+    # Look up dead-cst's actual source root via its module file.
+    import dead_cst
+
+    expected = Path(dead_cst.__file__).resolve().parent.parent
+    matching = [r for r, name in roots if name == "dead-cst"]
+    assert any(expected == r or expected.is_relative_to(r) for r in matching), (
+        f"expected dead-cst source root near {expected}, got {matching}"
+    )


### PR DESCRIPTION
Two bugs in default_resolve_import for non-venv layouts:

1. A system Python install nests purelib/platlib *inside* the stdlib
   root (e.g. /usr/local/lib/python3.13/site-packages under
   /usr/local/lib/python3.13). The naive `path.is_relative_to(STDLIB)`
   matched both, so every third-party package was misclassified as
   `[stdlib] <name>`.
2. Editable installs (pip / uv `-e`) only list a `.pth` shim plus
   dist-info in RECORD; the actual source isn't in distribution_lookup.
   When the editable source dir lived outside the project's search
   paths, default_resolve_import raised
   "Module ... resolved to an unexpected path".

Fix:
- Refine the stdlib check to exclude paths under purelib/platlib or
  any site-packages/dist-packages directory.
- Add editable_distribution_roots() that discovers editable source
  dirs via PEP 610 direct_url.json and `.pth` shims, then prefix-
  matches resolved paths against them so editable third-party deps
  attribute to `[external dist] <name>`.
- Reorder default_resolve_import: dist lookup -> editable roots ->
  stdlib -> site-packages -> search paths -> raise.
- Clear the new cache alongside distribution_lookup in
  _clear_resolver_caches.
- Bump version on every shipping resolver (venv, pyproject,
  uv_workspace, manual) so cached VisitorPayload blobs rebuild.

https://claude.ai/code/session_01KRRzZaXEw4jsYijXFhPTVB