### PR TITLE
resolvers: first-party search paths win over editable-dist roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,14 @@ two versions.
   shipping resolvers (`venv`, `pyproject`, `uv_workspace`,
   `manual`) bump their `version` so cached `VisitorPayload` blobs
   rebuild against the corrected classification.
+- First-party search paths now win over editable distribution roots
+  in `default_resolve_import`. Previously a project whose source
+  happened to live inside another editable install's root (e.g. an
+  e2e fixture cloned into `.pytest_cache/` of an editable
+  `dead-cst` checkout) had every first-party file misclassified as
+  `[external dist] <host-pkg>`, severing cross-module edges and
+  reporting the entire surface as dead. The four shipping resolvers
+  bump their `version` again so cached payloads rebuild.
 
 ## [0.4.0] - 2026-05-03
 

--- a/dead_cst/_resolvers/_imports.py
+++ b/dead_cst/_resolvers/_imports.py
@@ -144,10 +144,16 @@ def editable_distribution_roots() -> tuple[tuple[Path, str], ...]:
     dist's ``RECORD``. The actual ``.py`` source lives in the user's
     project directory and never appears in :func:`distribution_lookup`.
     We surface it here by reading each dist's ``direct_url.json``
-    (PEP 610) and any ``.pth`` shims it ships, so an importer of, say,
-    an editable ``dead-cst`` resolves to ``[external dist] dead-cst``
+    (PEP 610) and any ``.pth`` shims it ships, so an importer of an
+    editable third-party package resolves to ``[external dist] <name>``
     instead of raising on an "unexpected path" or being silently
     misclassified.
+
+    :func:`default_resolve_import` consults this *after* the
+    ``search_paths`` check, so a first-party file that happens to nest
+    under an editable root (the project being analyzed living inside
+    another editable install's checkout) still classifies as
+    first-party.
 
     Returns ``(root, canonical_name)`` tuples sorted longest-path first
     so prefix-matching against nested editable layouts picks the most
@@ -260,6 +266,24 @@ def default_resolve_import(name: str, search_paths: list[Path]) -> str | Path | 
       ``[external file] <name>`` string when ``name`` resolves outside
       the project (collapsed into one synthetic node per group);
     * ``None`` when the importlib finders can't locate ``name`` at all.
+
+    Classification precedence (first match wins):
+
+    1. ``distribution_lookup`` -- the resolved path appears in an
+       installed dist's ``RECORD``.
+    2. stdlib (``_is_stdlib_path``).
+    3. site-packages (``_is_site_packages_path``).
+    4. ``search_paths`` -- first-party project file.
+    5. ``editable_distribution_roots`` -- editable third-party whose
+       source dir lives outside ``search_paths``.
+
+    Stdlib / site-packages precede ``search_paths`` because they're
+    interpreter-blessed locations a user-configured ``search_paths``
+    shouldn't overlap with. ``search_paths`` precedes editable roots so
+    that a project whose source happens to nest under another editable
+    install's root (e.g. an e2e fixture cloned into ``.pytest_cache/``
+    of an editable ``dead-cst`` checkout) is still treated as
+    first-party.
 
     This is the implementation every shipped :class:`PathResolver`
     delegates to. Third-party resolvers can call it as a fallback after

--- a/dead_cst/_resolvers/_imports.py
+++ b/dead_cst/_resolvers/_imports.py
@@ -280,9 +280,6 @@ def default_resolve_import(name: str, search_paths: list[Path]) -> str | Path | 
     # their distribution rather than swallowed into ``[stdlib]``.
     if dist := distribution_lookup().get(path):
         return f"{EXTERNAL_DIST_PREFIX}{dist}"
-    for root, dist in editable_distribution_roots():
-        if path.is_relative_to(root):
-            return f"{EXTERNAL_DIST_PREFIX}{dist}"
 
     if _is_stdlib_path(path):
         return f"{STDLIB_PREFIX}{name}"
@@ -290,7 +287,20 @@ def default_resolve_import(name: str, search_paths: list[Path]) -> str | Path | 
     if _is_site_packages_path(path):
         return f"{EXTERNAL_FILE_PREFIX}{name}"
 
+    # First-party wins over editable-dist matching: the project being
+    # analyzed may itself live under another editable install's root
+    # (e.g. an e2e fixture clones a third-party repo into
+    # ``.pytest_cache/`` inside an editable ``dead-cst`` checkout). Those
+    # files are first-party for the run, not third-party. ``stdlib`` /
+    # ``site-packages`` still win above because those are
+    # interpreter-blessed locations and shouldn't appear in a
+    # user-configured ``search_paths``.
     for search in search_paths:
         if path.is_relative_to(search):
             return path
+
+    for root, dist in editable_distribution_roots():
+        if path.is_relative_to(root):
+            return f"{EXTERNAL_DIST_PREFIX}{dist}"
+
     raise Exception(f"Module {name} resolved to an unexpected path: {path}")

--- a/dead_cst/_resolvers/manual.py
+++ b/dead_cst/_resolvers/manual.py
@@ -31,7 +31,7 @@ class ManualResolver:
 
     specs: list[str] = field(default_factory=list)
     name: str = "manual"
-    version: int = 1777973896
+    version: int = 1777985838
 
     def resolve(self, project_root: Path) -> PathMap:
         out: PathMap = {}

--- a/dead_cst/_resolvers/pyproject.py
+++ b/dead_cst/_resolvers/pyproject.py
@@ -27,7 +27,7 @@ class PyprojectResolver:
     """
 
     name: str = "pyproject"
-    version: int = 1777973896
+    version: int = 1777985838
 
     def resolve(self, project_root: Path) -> PathMap:
         project_root = project_root.resolve()

--- a/dead_cst/_resolvers/uv_workspace.py
+++ b/dead_cst/_resolvers/uv_workspace.py
@@ -48,7 +48,7 @@ class UvWorkspaceResolver:
 
     lock_path: Path | None = None
     name: str = "uv_workspace"
-    version: int = 1777973896
+    version: int = 1777985838
 
     def resolve(self, project_root: Path) -> PathMap:
         project_root = project_root.resolve()

--- a/dead_cst/_resolvers/venv.py
+++ b/dead_cst/_resolvers/venv.py
@@ -41,7 +41,7 @@ class VenvResolver:
 
     venv_dir: str | None = None
     name: str = "venv"
-    version: int = 1777973896
+    version: int = 1777985838
 
     def resolve(self, project_root: Path) -> PathMap:
         project_root = project_root.resolve()

--- a/tests/test_resolvers/test_imports.py
+++ b/tests/test_resolvers/test_imports.py
@@ -265,6 +265,34 @@ def test_default_resolve_import_editable_dist_outside_search_paths(tmp_path: Pat
     assert result == "[external dist] dead-cst"
 
 
+def test_default_resolve_import_first_party_wins_over_editable_root(tmp_path: Path):
+    """Regression: a first-party path that happens to nest under an editable
+    distribution's source root must classify as first-party, not as that
+    dist. Reproduces the e2e flux0 failure where ``.pytest_cache/d/e2e-clones/``
+    sat under the editable ``dead-cst`` root and every cloned module
+    misclassified as ``[external dist] dead-cst``."""
+    editable_root = tmp_path / "host"
+    project_src = editable_root / "fixtures" / "clones" / "pkg" / "src"
+    init_py = project_src / "myproj" / "__init__.py"
+    init_py.parent.mkdir(parents=True)
+    init_py.write_text("")
+
+    spec = _make_spec("myproj", str(init_py))
+
+    with patch.object(_imports, "STDLIB", tmp_path / "stdlib"):
+        with patch.object(_imports, "PURELIB", None):
+            with patch.object(_imports, "PLATLIB", None):
+                with patch.object(_imports, "safe_resolve_module", return_value=spec):
+                    with patch.object(_imports, "distribution_lookup", return_value={}):
+                        with patch.object(
+                            _imports,
+                            "editable_distribution_roots",
+                            return_value=((editable_root.resolve(), "host-pkg"),),
+                        ):
+                            result = default_resolve_import("myproj", [project_src])
+    assert result == init_py.resolve()
+
+
 def test_default_resolve_import_first_party_still_returns_path(tmp_path: Path):
     """Regression: the reordered checks must not steal first-party files
     that happen to live near common install roots."""


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #69. `editable_distribution_roots()` was consulted before `search_paths` in `default_resolve_import`, so a project whose source happened to nest under another editable install's root got every first-party file misclassified as `[external dist] <host-pkg>`. The flux0 e2e fixture clones into `.pytest_cache/d/e2e-clones/` — inside the editable `dead-cst` checkout — which severed cross-module edges and reported the entire `flux0_server` surface as dead. Two e2e tests caught it (`test_flux0_server_dead_set_pins_to_real_findings`, `test_flux0_internal_modules_survives_cache_round_trip`).

## Fix

Reorder `default_resolve_import`:

1. `distribution_lookup` (RECORD-listed installs)
2. stdlib (`_is_stdlib_path`)
3. site-packages (`_is_site_packages_path`)
4. **`search_paths`** (first-party)
5. `editable_distribution_roots` (editable third-party whose source is outside `search_paths`)
6. raise

Stdlib / site-packages still precede `search_paths` — they're interpreter-blessed locations a user-configured `search_paths` shouldn't overlap with. `search_paths` precedes editable roots so a first-party project nested under another editable install stays first-party. Existing test `test_default_resolve_import_editable_dist_outside_search_paths` keeps the editable-third-party case green.

## Changes

- `dead_cst/_resolvers/_imports.py`: reorder checks in `default_resolve_import`; document the precedence in its docstring; clarify the new invariant in `editable_distribution_roots`'s docstring.
- `tests/test_resolvers/test_imports.py`: new `test_default_resolve_import_first_party_wins_over_editable_root` pins the ordering against the exact e2e scenario.
- All four shipping resolvers (`venv`, `pyproject`, `uv_workspace`, `manual`) bump their `version` to invalidate cached `VisitorPayload` blobs against the corrected classification.
- `CHANGELOG.md`: `[Unreleased]` → `Fixed`.

## Test plan

- [x] `uv run pytest tests/test_resolvers/test_imports.py` — 19 passed (incl. new regression test)
- [x] `uv run pytest -m e2e` — 10 passed (was 8 passed, 2 failed before the fix)
- [x] `uv run pytest` — 690 passed
- [x] `uv run prek run --all-files` — ruff, ruff-format, ty, hooks all green

https://claude.ai/code/session_01NNxjwVr3Dxb63MTqbRRhNq