### PR TITLE
docs: prep CHANGELOG for v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ two versions.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-05
+
 ### Added
 - New public surface: `GraphCache`, `compute_fingerprint`,
   `clear_cache`, `default_cache_path`, and `SCHEMA_VERSION` from
@@ -510,7 +512,8 @@ versions until the first stable release.
 - `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, and `ROADMAP.md` with a
   stack-ranked plan from alpha to 1.0.
 
-[Unreleased]: https://github.com/lpetre/dead-cst/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/lpetre/dead-cst/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/lpetre/dead-cst/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/lpetre/dead-cst/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/lpetre/dead-cst/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/lpetre/dead-cst/compare/v0.1.0...v0.2.0


### PR DESCRIPTION
Promote the Unreleased section to 0.5.0 and refresh the link refs.
Covers the parallel visitor (#67), dynamic-import resolution (#68),
path-classification fixes for system-Python and editable installs
(#69, #71), and the public API split into focused submodules with
top-level `dead_cst.contrib` (#70).