### PR TITLE
contrib: add CycloptsPlugin for cyclopts CLI app handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ two versions.
 
 ## [Unreleased]
 
+### Added
+- `CycloptsPlugin` (`dead_cst.contrib.cyclopts`, re-exported from
+  `dead_cst.plugins` and `dead_cst.contrib`) wires
+  `@<app>.command` and `@<app>.default` handlers through their owning
+  `cyclopts.App` instance, mirroring the Typer/Click plugins.
+  Registered in `BUILTIN_PLUGINS` under the name `cyclopts` and
+  loadable via `--plugin cyclopts`.
+
 ## [0.5.0] - 2026-05-05
 
 ### Added

--- a/dead_cst/contrib/__init__.py
+++ b/dead_cst/contrib/__init__.py
@@ -29,6 +29,7 @@ work alongside
 from __future__ import annotations
 
 from .click import ClickPlugin
+from .cyclopts import CycloptsPlugin
 from .fastapi import FastAPIPlugin
 from .flask import FlaskPlugin
 from .pytest import PytestPlugin
@@ -46,6 +47,7 @@ from .unittest import UnittestPlugin
 # pulled.
 __all__ = [
     "ClickPlugin",
+    "CycloptsPlugin",
     "FastAPIPlugin",
     "FlaskPlugin",
     "PytestPlugin",

--- a/dead_cst/contrib/cyclopts.py
+++ b/dead_cst/contrib/cyclopts.py
@@ -1,0 +1,107 @@
+"""Plugin: keep cyclopts command and default handlers alive.
+
+Strategy: find top-level ``App()`` instances in each module and emit
+inverse edges (instance -> handler) for every ``@<instance>.command(...)``
+and ``@<instance>.default(...)`` decorator. Cyclopts apps are *not*
+seeded as entrypoints; reachability is expected to flow through
+``[project.scripts]`` (handled by :class:`ProjectScriptsPlugin`) or an
+``if __name__ == "__main__": app()`` block (handled by
+:class:`MainBlockPlugin`). Sub-apps attached via ``app.command(sub)``
+are kept alive through the ordinary reference tracked on that call.
+
+This routes ``why-alive`` chains through the cyclopts app variable
+users recognize ("alive because it's a command on ``app``") and lets a
+sub-app that's never registered surface as dead code, mirroring the
+behavior of :class:`TyperPlugin`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Iterable
+
+from libcst.metadata import CodeRange
+
+from ..graph import SymbolNode
+from ..plugins._core import (
+    SYNTHETIC_POSITION,
+    GraphOp,
+    ObserveContext,
+    PluginContext,
+    collect_module_imports,
+    decls_by_simple_name,
+    find_call_assignments,
+    find_handlers,
+    make_payload,
+)
+
+if TYPE_CHECKING:
+    from ..graph import VisitorPayload
+
+# Attribute names a cyclopts ``App`` uses to register a callable.
+# Matched as the rightmost attribute of ``@<instance>.<name>(...)``.
+# ``command`` registers a subcommand; ``default`` registers the
+# no-subcommand handler.
+_REGISTRATION_DECORATORS: frozenset[str] = frozenset({"command", "default"})
+
+_CYCLOPTS_TARGETS: frozenset[str] = frozenset({"App"})
+
+
+@dataclass
+class CycloptsPlugin:
+    """Wire cyclopts command and default handlers through their app instance.
+
+    For each module the plugin:
+
+    1. Inspects ``from cyclopts import ...`` / ``import cyclopts`` to
+       learn which local names refer to ``App``.
+    2. Finds top-level assignments ``X = App(...)`` (including
+       ``AnnAssign`` and aliased / module-prefixed forms) and records
+       ``X`` as a cyclopts instance.
+    3. For every top-level function decorated ``@X.command(...)`` or
+       ``@X.default(...)``, emits an edge ``X -> handler`` so the
+       handler is reachable whenever ``X`` is.
+
+    Pure per-file work: instance detection and decorator scanning are
+    both file-local CST passes; the corresponding ``SymbolNode`` decls
+    are looked up in this file's :class:`VisitorPayload`. Cyclopts
+    instances are not auto-marked as entrypoints; reachability flows
+    through ``[project.scripts]`` or a ``__main__`` block as in the
+    Typer plugin.
+
+    Limitations: only top-level ``X = App(...)`` assignments with a
+    single ``Name`` target are detected. Factory-style apps
+    (``def make_app(): return App()``) and class-attribute apps
+    (``self.app = App()``) are not handled; users can still keep those
+    alive with explicit ``-e`` entrypoints. Nested-attribute decorators
+    such as ``@app.meta.default`` are not recognized -- ``app.meta`` is
+    not itself a tracked instance.
+    """
+
+    name: str = "cyclopts"
+    version: int = 1778020575
+
+    def observe(self, ctx: ObserveContext) -> VisitorPayload | None:
+        cyclopts_imports = collect_module_imports(ctx.module, "cyclopts", _CYCLOPTS_TARGETS)
+        if not cyclopts_imports:
+            return None
+        instances = set(find_call_assignments(ctx.module, cyclopts_imports, _CYCLOPTS_TARGETS))
+        if not instances:
+            return None
+        handlers = find_handlers(ctx.module, instances, _REGISTRATION_DECORATORS)
+        if not handlers:
+            return None
+
+        decls_by_name = decls_by_simple_name(ctx.payload.nodes)
+        edges: list[tuple[SymbolNode, SymbolNode, CodeRange]] = []
+        for var_name, handler_names in handlers.items():
+            for instance_decl in decls_by_name.get(var_name, []):
+                for handler_name in handler_names:
+                    for handler_decl in decls_by_name.get(handler_name, []):
+                        edges.append((instance_decl, handler_decl, SYNTHETIC_POSITION))
+        if not edges:
+            return None
+        return make_payload(edges=edges)
+
+    def finalize(self, ctx: PluginContext) -> Iterable[GraphOp]:
+        return ()

--- a/dead_cst/plugins/__init__.py
+++ b/dead_cst/plugins/__init__.py
@@ -76,6 +76,7 @@ from ._core import (
     walk_to_instance_kind,
 )
 from ..contrib.click import ClickPlugin
+from ..contrib.cyclopts import CycloptsPlugin
 from ..contrib.fastapi import FastAPIPlugin
 from ..contrib.flask import FlaskPlugin
 from ..contrib.pytest import PytestPlugin
@@ -99,6 +100,7 @@ BUILTIN_PLUGINS: dict[str, type] = {
     FlaskPlugin.name: FlaskPlugin,
     TyperPlugin.name: TyperPlugin,
     ClickPlugin.name: ClickPlugin,
+    CycloptsPlugin.name: CycloptsPlugin,
     InitSubclassPlugin.name: InitSubclassPlugin,
 }
 
@@ -122,6 +124,7 @@ __all__ = [
     "AddNode",
     "BUILTIN_PLUGINS",
     "ClickPlugin",
+    "CycloptsPlugin",
     "DecoratedDeclPlugin",
     "EXTERNAL_DIST_PREFIX",
     "EXTERNAL_FILE_PREFIX",

--- a/tests/test_plugins/test_cyclopts.py
+++ b/tests/test_plugins/test_cyclopts.py
@@ -1,0 +1,456 @@
+"""Tests for :class:`CycloptsPlugin`."""
+
+from __future__ import annotations
+
+from dead_cst import build_symbol_graph
+from dead_cst.plugins import (
+    CycloptsPlugin,
+    ExplicitEntrypointPlugin,
+    MainBlockPlugin,
+)
+
+
+def test_cyclopts_plugin_marks_command_handlers(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/main.py": """
+            import cyclopts
+
+            app = cyclopts.App()
+
+            @app.command
+            def hello(): pass
+
+            @app.command(name="bye")
+            def goodbye(): pass
+
+            @app.default
+            def root(): pass
+
+            def helper(): pass
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), CycloptsPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    assert "cli.main.app" in reached
+    assert "cli.main.hello" in reached
+    assert "cli.main.goodbye" in reached
+    assert "cli.main.root" in reached
+    # Undecorated helper not referenced by any handler stays dead
+    assert "cli.main.helper" not in reached
+
+
+def test_cyclopts_plugin_keeps_handler_dependencies_alive(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/models.py": """
+            class Item:
+                pass
+
+            class Unused:
+                pass
+            """,
+            "cli/main.py": """
+            from cyclopts import App
+            from cli.models import Item
+
+            app = App()
+
+            def build_item() -> Item:
+                return Item()
+
+            @app.command
+            def show():
+                return build_item()
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), CycloptsPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    assert "cli.main.show" in reached
+    # Symbols transitively referenced from the handler stay alive
+    assert "cli.main.build_item" in reached
+    assert "cli.models.Item" in reached
+    # Unrelated module symbol is still dead
+    assert "cli.models.Unused" not in reached
+
+
+def test_cyclopts_plugin_reachable_via_explicit_entrypoint(
+    tmp_path, write_files, reachable_fqnames
+):
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/main.py": """
+            from cyclopts import App
+
+            app = App()
+
+            @app.command
+            def hello(): pass
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[ExplicitEntrypointPlugin(specs=["cli.main.app"]), CycloptsPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    assert "cli.main.app" in reached
+    assert "cli.main.hello" in reached
+
+
+def test_cyclopts_plugin_does_not_seed_entrypoint(tmp_path, write_files, reachable_fqnames):
+    """Without an external reach (no main block, no project.scripts, no -e),
+    the cyclopts instance itself stays dead -- and so do its commands."""
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/main.py": """
+            from cyclopts import App
+
+            app = App()
+
+            @app.command
+            def orphan(): pass
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[CycloptsPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    assert "cli.main.app" not in reached
+    assert "cli.main.orphan" not in reached
+
+
+def test_cyclopts_plugin_unused_subapp_stays_dead(tmp_path, write_files, reachable_fqnames):
+    """A sub-App that's never registered has no path from the root app and
+    stays dead, along with its commands."""
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/sub.py": """
+            from cyclopts import App
+
+            sub = App()
+
+            @sub.command
+            def orphan(): pass
+            """,
+            "cli/main.py": """
+            from cyclopts import App
+
+            app = App()
+
+            @app.command
+            def hello(): pass
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), CycloptsPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    assert "cli.main.hello" in reached
+    assert "cli.sub.sub" not in reached
+    assert "cli.sub.orphan" not in reached
+
+
+def test_cyclopts_plugin_subapp_reachable_via_command_attach(
+    tmp_path, write_files, reachable_fqnames
+):
+    """``app.command(sub)`` attaches a sub-App by reference -- the analyzer
+    tracks that ordinary call argument, so the sub-App becomes reachable
+    through the root app and its own ``@sub.command`` handlers go live."""
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/sub.py": """
+            from cyclopts import App
+
+            sub = App()
+
+            @sub.command
+            def index(): pass
+
+            @sub.command
+            def things(): pass
+            """,
+            "cli/main.py": """
+            from cyclopts import App
+            from cli.sub import sub
+
+            app = App()
+            app.command(sub)
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), CycloptsPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    assert "cli.main.app" in reached
+    assert "cli.sub.sub" in reached
+    assert "cli.sub.index" in reached
+    assert "cli.sub.things" in reached
+
+
+def test_cyclopts_plugin_handles_aliased_class_import(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/main.py": """
+            from cyclopts import App as A
+
+            app = A()
+
+            @app.command
+            def hello(): pass
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), CycloptsPlugin()],
+        project_root=tmp_path,
+    )
+    assert "cli.main.hello" in reachable_fqnames(graph)
+
+
+def test_cyclopts_plugin_handles_aliased_module_import(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/main.py": """
+            import cyclopts as cy
+
+            app = cy.App()
+
+            @app.command
+            def hello(): pass
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), CycloptsPlugin()],
+        project_root=tmp_path,
+    )
+    assert "cli.main.hello" in reachable_fqnames(graph)
+
+
+def test_cyclopts_plugin_handles_annotated_assignment(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/main.py": """
+            import cyclopts
+
+            app: cyclopts.App = cyclopts.App()
+
+            @app.command
+            def hello(): pass
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), CycloptsPlugin()],
+        project_root=tmp_path,
+    )
+    assert "cli.main.hello" in reachable_fqnames(graph)
+
+
+def test_cyclopts_plugin_ignores_bare_decorators(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "pkg/__init__.py": "",
+            "pkg/mod.py": """
+            from cyclopts import App
+
+            app = App()
+
+            def command(fn):
+                return fn
+
+            @command
+            def looks_like_command(): pass
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), CycloptsPlugin()],
+        project_root=tmp_path,
+    )
+    # Bare ``@command`` (no attribute access) is not a cyclopts registration --
+    # matching it would clobber unrelated decorators with the same name.
+    assert "pkg.mod.looks_like_command" not in reachable_fqnames(graph)
+
+
+def test_cyclopts_plugin_ignores_unrelated_decorators(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "pkg/__init__.py": "",
+            "pkg/mod.py": """
+            class Thing:
+                def command(self, fn):
+                    return fn
+
+            t = Thing()
+
+            @t.command
+            def not_a_command(): pass
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[CycloptsPlugin()],
+        project_root=tmp_path,
+    )
+    # ``t`` isn't a cyclopts ``App`` instance, so its ``.command`` decorator is ignored.
+    assert "pkg.mod.not_a_command" not in reachable_fqnames(graph)
+
+
+def test_cyclopts_plugin_does_nothing_without_cyclopts_imports(
+    tmp_path, write_files, reachable_fqnames
+):
+    write_files(
+        {
+            "pkg/__init__.py": "",
+            "pkg/mod.py": """
+            class App:
+                def command(self, fn):
+                    return fn
+
+            app = App()
+
+            @app.command
+            def looks_like_command(): pass
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[CycloptsPlugin()],
+        project_root=tmp_path,
+    )
+    # ``app`` here is not a cyclopts instance -- no ``cyclopts`` import in scope.
+    assert "pkg.mod.looks_like_command" not in reachable_fqnames(graph)
+
+
+def test_cyclopts_plugin_multiple_instances_in_one_module(tmp_path, write_files, reachable_fqnames):
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/main.py": """
+            from cyclopts import App
+
+            app = App()
+            other = App()
+
+            @app.command
+            def from_app(): pass
+
+            @other.command
+            def from_other(): pass
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), CycloptsPlugin()],
+        project_root=tmp_path,
+    )
+    reached = reachable_fqnames(graph)
+    # ``app`` is reached via the main block; its command is alive.
+    assert "cli.main.from_app" in reached
+    # ``other`` is never reached, so its command stays dead -- handler edges
+    # are scoped to their own instance.
+    assert "cli.main.other" not in reached
+    assert "cli.main.from_other" not in reached
+
+
+def test_cyclopts_plugin_ignores_import_star(tmp_path, write_files, reachable_fqnames):
+    """``from cyclopts import *`` doesn't bind ``App`` for the plugin's
+    purposes. The ``import *`` analyzer logic is pessimistic enough on its
+    own; the plugin shouldn't infer cyclopts wiring from the star import."""
+    write_files(
+        {
+            "cli/__init__.py": "",
+            "cli/main.py": """
+            from cyclopts import *
+
+            app = App()
+
+            @app.command
+            def hello(): pass
+
+            if __name__ == "__main__":
+                app()
+            """,
+        }
+    )
+    graph = build_symbol_graph(
+        {tmp_path: []},
+        plugins=[MainBlockPlugin(), CycloptsPlugin()],
+        project_root=tmp_path,
+    )
+    # No instance edge from ``app`` to ``hello`` because the plugin ignores
+    # star imports. ``hello`` is not referenced by anything reachable.
+    assert "cli.main.hello" not in reachable_fqnames(graph)
+
+
+def test_cyclopts_plugin_loads_via_load_plugin():
+    from dead_cst.plugins import load_plugin
+
+    plugin = load_plugin("cyclopts")
+    assert isinstance(plugin, CycloptsPlugin)
+    assert plugin.name == "cyclopts"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -71,6 +71,7 @@ EXPECTED_PUBLIC_API: dict[str, list[str]] = {
         "AddNode",
         "BUILTIN_PLUGINS",
         "ClickPlugin",
+        "CycloptsPlugin",
         "DecoratedDeclPlugin",
         "EXTERNAL_DIST_PREFIX",
         "EXTERNAL_FILE_PREFIX",
@@ -117,6 +118,7 @@ EXPECTED_PUBLIC_API: dict[str, list[str]] = {
     ],
     "dead_cst.contrib": [
         "ClickPlugin",
+        "CycloptsPlugin",
         "FastAPIPlugin",
         "FlaskPlugin",
         "PytestPlugin",


### PR DESCRIPTION
Mirrors TyperPlugin: discovers top-level ``X = cyclopts.App(...)``
instances and emits ``X -> handler`` edges for every
``@X.command(...)`` and ``@X.default(...)`` decorator, so handlers
stay alive whenever the app does. Reachability still has to flow in
through ``[project.scripts]`` / a ``__main__`` block / an explicit
``-e`` -- the plugin doesn't seed the app itself as an entrypoint.

https://claude.ai/code/session_01XP31DjMrNcwnqywyZdSguP