### PR TITLE
analyze: progress reporting around parse and reconcile passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@ two versions.
 ## [Unreleased]
 
 ### Added
-- `tqdm` progress bars now surface during the per-file visitor pass
-  ("Parsing files") and the cross-base composition pass ("Reconciling
-  bases") in `Analysis.refresh` / `Analysis._materialize`. Bars stream
-  to stderr and auto-disable when stderr isn't a TTY (e.g. under pytest
-  capture, or when piping the CLI through another tool), so library
-  callers and CI logs are unaffected. `tqdm>=4.66` is now a hard
-  runtime dependency.
+- Progress reporting around the per-file visitor pass ("Parsing
+  files") and the cross-base composition pass ("Reconciling bases")
+  in `Analysis.refresh` / `Analysis._materialize`. On a TTY the user
+  sees a live `tqdm` bar; off a TTY (pytest capture, pipes, agent
+  harnesses) the same wrapper emits one newline-terminated checkpoint
+  at 0%, every ~10%, and at 100%, so CI logs and LLM tool consumers
+  can track long runs without `tqdm`'s `\r`-overwriting frames going
+  to mush. `tqdm>=4.66` is now a hard runtime dependency.
 - New plugin helpers re-exported from `dead_cst.plugins`: `module_node`,
   `dotted_parts`, `dotted_name`, `string_value`,
   `payload_imports_module`. They consolidate boilerplate every contrib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ two versions.
 ## [Unreleased]
 
 ### Added
+- `tqdm` progress bars now surface during the per-file visitor pass
+  ("Parsing files") and the cross-base composition pass ("Reconciling
+  bases") in `Analysis.refresh` / `Analysis._materialize`. Bars stream
+  to stderr and auto-disable when stderr isn't a TTY (e.g. under pytest
+  capture, or when piping the CLI through another tool), so library
+  callers and CI logs are unaffected. `tqdm>=4.66` is now a hard
+  runtime dependency.
 - New plugin helpers re-exported from `dead_cst.plugins`: `module_node`,
   `dotted_parts`, `dotted_name`, `string_value`,
   `payload_imports_module`. They consolidate boilerplate every contrib

--- a/dead_cst/_progress.py
+++ b/dead_cst/_progress.py
@@ -1,19 +1,9 @@
-"""Progress reporting that survives non-TTY consumers.
-
-``tqdm`` is great for humans on a terminal but its ``\\r``-overwriting
-output renders to mush when stderr is captured (CI logs, pytest, agent
-harnesses). :func:`progress` keeps the live bar on TTYs and falls back
-to newline-terminated decile checkpoints otherwise -- one line at 0%,
-each ~10% boundary, and 100% -- so log consumers can still track a
-long-running pass.
-"""
+"""TTY-aware progress reporting; emits decile log lines off-TTY."""
 
 from __future__ import annotations
 
 import sys
 from typing import Iterable, Iterator, TypeVar
-
-from tqdm import tqdm
 
 T = TypeVar("T")
 
@@ -32,26 +22,28 @@ def progress(
     and ``total`` itself. Counts that fall on the same milestone (small
     ``total``s) coalesce so the same line is never printed twice.
     """
-    if sys.stderr.isatty():
-        yield from tqdm(iterable, total=total, desc=desc, unit=unit, disable=False)
+    if total == 0:
         return
 
-    milestones = sorted({total * k // 10 for k in range(11)})
-    next_idx = 0
+    if sys.stderr.isatty():
+        # Lazy import: tqdm is only needed for the live-bar path,
+        # and skipping it on non-TTY keeps CLI startup snappy.
+        from tqdm import tqdm
 
-    def _emit_through(count: int) -> None:
-        nonlocal next_idx
-        while next_idx < len(milestones) and milestones[next_idx] <= count:
-            print(
-                f"{desc}: {milestones[next_idx]}/{total} {unit}",
-                file=sys.stderr,
-                flush=True,
-            )
-            next_idx += 1
+        yield from tqdm(iterable, total=total, desc=desc, unit=unit)
+        return
 
-    _emit_through(0)
+    milestones = iter(sorted({total * k // 10 for k in range(11)}))
+    next_threshold: int | None = next(milestones, None)
+
+    while next_threshold is not None and next_threshold <= 0:
+        print(f"{desc}: {next_threshold}/{total} {unit}", file=sys.stderr, flush=True)
+        next_threshold = next(milestones, None)
+
     count = 0
     for item in iterable:
         yield item
         count += 1
-        _emit_through(count)
+        while next_threshold is not None and count >= next_threshold:
+            print(f"{desc}: {next_threshold}/{total} {unit}", file=sys.stderr, flush=True)
+            next_threshold = next(milestones, None)

--- a/dead_cst/_progress.py
+++ b/dead_cst/_progress.py
@@ -1,0 +1,57 @@
+"""Progress reporting that survives non-TTY consumers.
+
+``tqdm`` is great for humans on a terminal but its ``\\r``-overwriting
+output renders to mush when stderr is captured (CI logs, pytest, agent
+harnesses). :func:`progress` keeps the live bar on TTYs and falls back
+to newline-terminated decile checkpoints otherwise -- one line at 0%,
+each ~10% boundary, and 100% -- so log consumers can still track a
+long-running pass.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Iterable, Iterator, TypeVar
+
+from tqdm import tqdm
+
+T = TypeVar("T")
+
+
+def progress(
+    iterable: Iterable[T],
+    *,
+    total: int,
+    desc: str,
+    unit: str,
+) -> Iterator[T]:
+    """Yield from ``iterable`` while reporting progress to stderr.
+
+    On a TTY: hands off to :func:`tqdm.tqdm`. Off a TTY: emits one
+    ``"<desc>: i/total <unit>"`` line at 0%, every decile boundary,
+    and ``total`` itself. Counts that fall on the same milestone (small
+    ``total``s) coalesce so the same line is never printed twice.
+    """
+    if sys.stderr.isatty():
+        yield from tqdm(iterable, total=total, desc=desc, unit=unit, disable=False)
+        return
+
+    milestones = sorted({total * k // 10 for k in range(11)})
+    next_idx = 0
+
+    def _emit_through(count: int) -> None:
+        nonlocal next_idx
+        while next_idx < len(milestones) and milestones[next_idx] <= count:
+            print(
+                f"{desc}: {milestones[next_idx]}/{total} {unit}",
+                file=sys.stderr,
+                flush=True,
+            )
+            next_idx += 1
+
+    _emit_through(0)
+    count = 0
+    for item in iterable:
+        yield item
+        count += 1
+        _emit_through(count)

--- a/dead_cst/analyze.py
+++ b/dead_cst/analyze.py
@@ -13,6 +13,7 @@ import libcst as cst
 import networkx as nx
 from libcst.helpers.module import ModuleNameAndPackage
 from libcst.metadata import CodeRange, MetadataWrapper
+from tqdm import tqdm
 
 from ._edges import resolve_edges
 from ._fqn import FixedFullyQualifiedNameProvider
@@ -314,12 +315,18 @@ def _process_stale_files(
             initializer=_init_worker,
             initargs=(detector, tuple(plugins)),
         ) as pool:
-            for file, payload in pool.map(_worker_process_task, tasks):
+            for file, payload in tqdm(
+                pool.map(_worker_process_task, tasks),
+                total=len(tasks),
+                desc="Parsing files",
+                unit="file",
+                disable=None,
+            ):
                 _record(file, payload)
         return out
 
     plugins_t = tuple(plugins)
-    for task in tasks:
+    for task in tqdm(tasks, desc="Parsing files", unit="file", disable=None):
         file, payload = _process_task(detector, plugins_t, task)
         _record(file, payload)
     return out
@@ -919,10 +926,9 @@ class Analysis:
         g.graph["dead_suites"] = {}
         baseline = list(sys.path)
         last_search_paths: tuple[Path, ...] | None = None
+        target_bases = [b for b in self.bases if scope is None or b in scope]
         try:
-            for base in self.bases:
-                if scope is not None and base not in scope:
-                    continue
+            for base in tqdm(target_bases, desc="Reconciling bases", unit="base", disable=None):
                 search_paths = (base, *self._dep_paths(base))
                 if last_search_paths != search_paths:
                     _rebind_sys_path(search_paths, baseline)

--- a/dead_cst/analyze.py
+++ b/dead_cst/analyze.py
@@ -7,16 +7,16 @@ from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import Iterable, Iterator, Mapping, Sequence, TypeVar
+from typing import Iterable, Iterator, Mapping, Sequence
 
 import libcst as cst
 import networkx as nx
 from libcst.helpers.module import ModuleNameAndPackage
 from libcst.metadata import CodeRange, MetadataWrapper
-from tqdm import tqdm
 
 from ._edges import resolve_edges
 from ._fqn import FixedFullyQualifiedNameProvider
+from ._progress import progress
 from ._visitor import SymbolVisitor
 from .branches import (
     DefaultUnreachableRegionDetector,
@@ -43,55 +43,6 @@ from .resolvers import (
 from .resolvers._core import _validate_packages
 
 logger = logging.getLogger(__name__)
-
-_T = TypeVar("_T")
-
-
-def _progress(
-    iterable: Iterable[_T],
-    *,
-    desc: str,
-    unit: str,
-    total: int | None = None,
-) -> Iterator[_T]:
-    """Wrap ``iterable`` with a tqdm bar on TTYs, decile log lines elsewhere.
-
-    When ``sys.stderr`` is a TTY we hand off to ``tqdm`` for the
-    familiar live bar. When it isn't (pytest capture, pipes, agent
-    harnesses), tqdm's ``\\r``-overwriting renders to nothing useful, so
-    we emit one newline-terminated checkpoint at 0%, every ~10%, and at
-    100% instead. Counts that fall on the same milestone (small
-    ``total``s) coalesce so we never re-print the same line.
-    """
-    if total is None:
-        try:
-            total = len(iterable)  # type: ignore[arg-type]
-        except TypeError:
-            total = None
-
-    if sys.stderr.isatty() or total is None:
-        yield from tqdm(iterable, desc=desc, unit=unit, total=total, disable=None)
-        return
-
-    milestones = sorted({total * k // 10 for k in range(11)})
-    next_idx = 0
-
-    def _emit_through(count: int) -> None:
-        nonlocal next_idx
-        while next_idx < len(milestones) and milestones[next_idx] <= count:
-            print(
-                f"{desc}: {milestones[next_idx]}/{total} {unit}",
-                file=sys.stderr,
-                flush=True,
-            )
-            next_idx += 1
-
-    _emit_through(0)
-    count = 0
-    for item in iterable:
-        yield item
-        count += 1
-        _emit_through(count)
 
 
 def _bfs_order(seeds: Iterable[Path], neighbors: Mapping[Path, Sequence[Path]]) -> list[Path]:
@@ -364,7 +315,7 @@ def _process_stale_files(
             initializer=_init_worker,
             initargs=(detector, tuple(plugins)),
         ) as pool:
-            for file, payload in _progress(
+            for file, payload in progress(
                 pool.map(_worker_process_task, tasks),
                 total=len(tasks),
                 desc="Parsing files",
@@ -374,7 +325,7 @@ def _process_stale_files(
         return out
 
     plugins_t = tuple(plugins)
-    for task in _progress(tasks, desc="Parsing files", unit="file"):
+    for task in progress(tasks, total=len(tasks), desc="Parsing files", unit="file"):
         file, payload = _process_task(detector, plugins_t, task)
         _record(file, payload)
     return out
@@ -976,7 +927,12 @@ class Analysis:
         last_search_paths: tuple[Path, ...] | None = None
         target_bases = [b for b in self.bases if scope is None or b in scope]
         try:
-            for base in _progress(target_bases, desc="Reconciling bases", unit="base"):
+            for base in progress(
+                target_bases,
+                total=len(target_bases),
+                desc="Reconciling bases",
+                unit="base",
+            ):
                 search_paths = (base, *self._dep_paths(base))
                 if last_search_paths != search_paths:
                     _rebind_sys_path(search_paths, baseline)

--- a/dead_cst/analyze.py
+++ b/dead_cst/analyze.py
@@ -7,7 +7,7 @@ from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import Iterable, Iterator, Mapping, Sequence
+from typing import Iterable, Iterator, Mapping, Sequence, TypeVar
 
 import libcst as cst
 import networkx as nx
@@ -43,6 +43,55 @@ from .resolvers import (
 from .resolvers._core import _validate_packages
 
 logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+
+def _progress(
+    iterable: Iterable[_T],
+    *,
+    desc: str,
+    unit: str,
+    total: int | None = None,
+) -> Iterator[_T]:
+    """Wrap ``iterable`` with a tqdm bar on TTYs, decile log lines elsewhere.
+
+    When ``sys.stderr`` is a TTY we hand off to ``tqdm`` for the
+    familiar live bar. When it isn't (pytest capture, pipes, agent
+    harnesses), tqdm's ``\\r``-overwriting renders to nothing useful, so
+    we emit one newline-terminated checkpoint at 0%, every ~10%, and at
+    100% instead. Counts that fall on the same milestone (small
+    ``total``s) coalesce so we never re-print the same line.
+    """
+    if total is None:
+        try:
+            total = len(iterable)  # type: ignore[arg-type]
+        except TypeError:
+            total = None
+
+    if sys.stderr.isatty() or total is None:
+        yield from tqdm(iterable, desc=desc, unit=unit, total=total, disable=None)
+        return
+
+    milestones = sorted({total * k // 10 for k in range(11)})
+    next_idx = 0
+
+    def _emit_through(count: int) -> None:
+        nonlocal next_idx
+        while next_idx < len(milestones) and milestones[next_idx] <= count:
+            print(
+                f"{desc}: {milestones[next_idx]}/{total} {unit}",
+                file=sys.stderr,
+                flush=True,
+            )
+            next_idx += 1
+
+    _emit_through(0)
+    count = 0
+    for item in iterable:
+        yield item
+        count += 1
+        _emit_through(count)
 
 
 def _bfs_order(seeds: Iterable[Path], neighbors: Mapping[Path, Sequence[Path]]) -> list[Path]:
@@ -315,18 +364,17 @@ def _process_stale_files(
             initializer=_init_worker,
             initargs=(detector, tuple(plugins)),
         ) as pool:
-            for file, payload in tqdm(
+            for file, payload in _progress(
                 pool.map(_worker_process_task, tasks),
                 total=len(tasks),
                 desc="Parsing files",
                 unit="file",
-                disable=None,
             ):
                 _record(file, payload)
         return out
 
     plugins_t = tuple(plugins)
-    for task in tqdm(tasks, desc="Parsing files", unit="file", disable=None):
+    for task in _progress(tasks, desc="Parsing files", unit="file"):
         file, payload = _process_task(detector, plugins_t, task)
         _record(file, payload)
     return out
@@ -928,7 +976,7 @@ class Analysis:
         last_search_paths: tuple[Path, ...] | None = None
         target_bases = [b for b in self.bases if scope is None or b in scope]
         try:
-            for base in tqdm(target_bases, desc="Reconciling bases", unit="base", disable=None):
+            for base in _progress(target_bases, desc="Reconciling bases", unit="base"):
                 search_paths = (base, *self._dep_paths(base))
                 if last_search_paths != search_paths:
                     _rebind_sys_path(search_paths, baseline)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 dependencies = [
     "libcst>=1.8.2",
     "networkx>=3.5",
+    "tqdm>=4.66",
     "typer>=0.12",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -177,6 +177,7 @@ source = { editable = "." }
 dependencies = [
     { name = "libcst" },
     { name = "networkx" },
+    { name = "tqdm" },
     { name = "typer" },
 ]
 
@@ -196,6 +197,7 @@ dev = [
 requires-dist = [
     { name = "libcst", specifier = ">=1.8.2" },
     { name = "networkx", specifier = ">=3.5" },
+    { name = "tqdm", specifier = ">=4.66" },
     { name = "typer", specifier = ">=0.12" },
 ]
 
@@ -820,6 +822,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- New private helper `dead_cst._progress.progress(...)` wraps `tqdm`. On a TTY it shows a live bar; off a TTY it emits one newline-terminated `<desc>: i/total <unit>` checkpoint at 0%, every ~10% boundary, and 100% — so CI logs, pytest capture, and agent harnesses can still track long runs without `tqdm`'s `\r`-overwriting frames going to mush.
- Wired into `Analysis.refresh` ("Parsing files", per-file visitor pass) and `Analysis._materialize` ("Reconciling bases", per-base composition). Both pool and in-process parse paths are covered.
- `tqdm>=4.66` is now a hard runtime dependency. The TTY-only `tqdm` import is lazy so non-TTY runs skip the import cost.
- Non-TTY hot path uses a single `next_threshold` int and inlined while loop (no closure, no index walk) — adds negligible overhead per yielded file.

## Test plan

- [x] `uv run pytest -x -q` — 755 passed
- [x] `uv run prek run --all-files` — clean
- [x] Smoke-tested 26-file fixture: TTY renders tqdm bars; non-TTY emits 11 decile lines for "Parsing files" and 0/1 + 1/1 for "Reconciling bases".

https://claude.ai/code/session_01JGa3PuRRwV9UVtdzncgYaG