### PR TITLE
docs: refresh ROADMAP, add ARCHITECTURE walkthrough, extend update-docs skill

### DIFF
--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: update-docs
-description: Use when the user wants to make sure documentation is up-to-date with the changes on the current branch — README, CHANGELOG, docstrings, and PR title/description. Trigger on phrasings like "make sure the docs are updated", "update the docs", "check docs", or after a feature/fix is complete and before merging.
+description: Use when the user wants to make sure documentation is up-to-date with the changes on the current branch — README, CHANGELOG, ROADMAP, ARCHITECTURE, docstrings, and PR title/description. Trigger on phrasings like "make sure the docs are updated", "update the docs", "check docs", or after a feature/fix is complete and before merging.
 ---
 
 # update-docs
 
-Audit and update the four documentation surfaces that need to stay in sync with code changes on the current branch:
+Audit and update the six documentation surfaces that need to stay in sync with code changes on the current branch:
 
 1. **README.md** — user-facing feature lists, install/usage examples, public API mentions.
 2. **CHANGELOG.md** — a `[Unreleased]` entry for any user-visible change (new feature, bug fix, deprecation, removal, behavior change). Follow the existing Keep-a-Changelog sections (`Added` / `Changed` / `Fixed` / `Removed` / `Deprecated`). Skip purely internal refactors that no consumer can observe.
-3. **Docstrings** — every symbol added or whose behavior was changed in this branch. Prefer updating an existing docstring over writing a new module-level comment. Match the surrounding style (this codebase favors short, no-nonsense docstrings; do not invent multi-paragraph essays).
-4. **PR title and description** — if a PR exists, make sure the title summarizes the change (under ~70 chars) and the body covers Summary + Test plan and reflects everything actually in the diff (not just the first commit).
+3. **ROADMAP.md** — when a tiered item lands, fold its bullet down into "Recently shipped" (don't just delete it; the section is intentionally kept for context). When the shipped section claims something that newer work has changed (e.g. cache-fingerprint shape, public-API names, plugin coverage), correct it. Keep tier ordering and the rationale prose otherwise untouched.
+4. **ARCHITECTURE.md** — the developer-facing pipeline walkthrough. Update the affected stage when the diff changes how a stage behaves (visitor output shape, cache-fingerprint inputs, edge-stitching rules, plugin contract, codemod behavior). Update the "Where to make changes" cheat sheet when new extension points land. Update the ASCII diagram only if data flow between stages actually moved. Internal refactors that don't change observable stage behavior don't need an entry.
+5. **Docstrings** — every symbol added or whose behavior was changed in this branch. Prefer updating an existing docstring over writing a new module-level comment. Match the surrounding style (this codebase favors short, no-nonsense docstrings; do not invent multi-paragraph essays).
+6. **PR title and description** — if a PR exists, make sure the title summarizes the change (under ~70 chars) and the body covers Summary + Test plan and reflects everything actually in the diff (not just the first commit).
 
 ## How to run the skill
 
@@ -18,6 +20,8 @@ Audit and update the four documentation surfaces that need to stay in sync with 
 2. **For each surface, check then act:**
    - Read README.md and decide whether any of the changed/added behavior belongs there. Edit if so.
    - Read CHANGELOG.md's `[Unreleased]` block. If a user-visible change is missing an entry, add one in the right subsection. If the section doesn't exist yet, create it. Match the wrapping/voice of the existing entries.
+   - Read ROADMAP.md. If a tiered item shipped on this branch, fold it into "Recently shipped" with a one-paragraph summary. If "Recently shipped" describes anything in stale terms (renamed APIs, shifted invariants, cache-fingerprint inputs, plugin coverage), correct those bullets. Don't reorder live tiers unless the user asks.
+   - Read ARCHITECTURE.md. For each pipeline stage the diff touches, confirm the section still describes that stage correctly — file paths, data shapes, cache boundaries, invariants, and the "Where to make changes" table. Update where it's drifted; leave untouched stages alone.
    - For each new or modified public symbol (anything reachable from `dead_cst/__init__.py` or a non-`_`-prefixed submodule), open the file and confirm the docstring is accurate. Update or add as needed. Skip private (`_`-prefixed) modules unless the user asks.
    - If a PR exists for this branch (`gh pr view` or the GitHub MCP tools), compare the title/body against the diff and update via `mcp__github__update_pull_request` if they're stale or missing the new changes. Only do this if a PR is already open — do **not** create a PR.
 3. **Report back** with a short bulleted summary: which files you touched, which surfaces were already up to date, and any items you intentionally skipped (with the reason).
@@ -26,5 +30,7 @@ Audit and update the four documentation surfaces that need to stay in sync with 
 
 - Never amend prior commits — make a new commit with the doc updates.
 - Don't add CHANGELOG entries for changes you can't see in the diff.
+- Don't fold a ROADMAP tier item into "Recently shipped" unless the diff actually contains the work — partial progress stays in its tier.
+- Don't rewrite ARCHITECTURE sections for stages the branch didn't touch.
 - Don't create a PR if none exists. Don't push unless the user asks.
 - Respect the project's "no comments unless they explain non-obvious why" rule from CLAUDE.md — that applies to docstrings too. Short and accurate beats long and aspirational.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,325 @@
+# Architecture / program flow
+
+This doc walks the code path a single `dead-cst` invocation takes, from CLI
+arguments to a written file. It's the developer-facing companion to
+[`README.md`](README.md) (user-facing) and [`CLAUDE.md`](CLAUDE.md) (LLM-
+oriented summary). Read this before adding a plugin, resolver, or detector,
+or before touching the visitor.
+
+## At a glance
+
+```
+   CLI / Python API
+        │
+        ▼
+┌──────────────────┐
+│   PathResolver   │  resolve(project_root) -> tuple[Package, ...]
+└─────────┬────────┘
+          │ Packages (path, name, exported, deps)
+          ▼
+┌──────────────────┐
+│     Analysis     │  cheap construction; everything below is lazy
+└─────────┬────────┘
+          │ refresh(packages=…)
+          ▼
+┌──────────────────────────────────────────────────────────────┐
+│  per-file pipeline (cached in SQLite by file SHA-256)        │
+│                                                              │
+│   source ─► SymbolVisitor ─► VisitorPayload                  │
+│                  │                                           │
+│                  └─► UnreachableRegionDetector.find_regions  │
+│                                                              │
+│   each EdgePlugin.observe(ctx) -> VisitorPayload | None      │
+│   ────────────────────────────────────────────────────────   │
+│   combined payload pickled into GraphCache                   │
+└────────────────────────────┬─────────────────────────────────┘
+                             │
+                             ▼
+┌──────────────────────────────────────────────────────────────┐
+│  per-package contribution                                    │
+│  (SymbolTrie + package-local graph slice + unresolved imps)  │
+└────────────────────────────┬─────────────────────────────────┘
+                             │
+                             ▼
+┌──────────────────────────────────────────────────────────────┐
+│  cross-package composition (uncached)                        │
+│                                                              │
+│   merge contributions ─► resolve_edges (against merged trie  │
+│                          + PathResolver fallback)            │
+│                                                              │
+│   each EdgePlugin.finalize(ctx) -> Iterable[GraphOp]         │
+└────────────────────────────┬─────────────────────────────────┘
+                             │ MultiDiGraph
+                             ▼
+                ┌────────────┴────────────┐
+                ▼                         ▼
+        reachability BFS         codemod (remove_code)
+        from entrypoint=True
+```
+
+The cache boundary is the line that matters most when reasoning about
+performance: stages 1–4 ride the per-file SQLite cache; stage 5 onward
+runs every invocation. That's why import classification deliberately
+moved out of the visitor — keeping the cache survival surface as small
+as possible was worth re-stitching edges every run.
+
+## The `Cacheable` contract
+
+Four moving parts satisfy `Cacheable` (`dead_cst/_cacheable.py`) — just
+`name: str` + `version: int`:
+
+| Component                    | Where                       | In the fingerprint? |
+| ---------------------------- | --------------------------- | ------------------- |
+| `SymbolVisitor`              | `dead_cst/_visitor.py`      | yes                 |
+| `EdgePlugin`                 | `dead_cst/plugins/`         | yes                 |
+| `UnreachableRegionDetector`  | `dead_cst/branches.py`      | yes                 |
+| `PathResolver`               | `dead_cst/resolvers/`       | **no**              |
+
+Only the visitor / plugin / detector triple feeds `compute_fingerprint`
+(`dead_cst/cache.py`); resolver and package-layout swaps re-stitch edges
+through the (uncached) stage 5 pass instead of invalidating the per-file
+cache. `version` is a Unix epoch int *by convention* — concurrent bumps
+on different branches merge with `max()`-wins semantics rather than
+colliding on a re-used label. The package `__version__` is **not** in
+the fingerprint: every component whose output can shift between releases
+owns its own knob.
+
+## The pipeline, top-down
+
+### 1. Path resolution — `dead_cst/resolvers/`
+
+A `PathResolver` answers two questions about the project layout:
+
+* `resolve(project_root) -> tuple[Package, ...]` — what packages exist,
+  what subdirs do they export to consumers, and which other packages
+  do they depend on (referenced by `name`).
+* `resolve_import(name, search_paths) -> str | Path | None` — fallback
+  classifier when an import misses the per-package symbol trie.
+
+Builtins:
+
+* `ManualResolver` (`dead_cst/resolvers/manual.py`) — explicit
+  `package:dep1,dep2` specs from the CLI's `-p` flag. Auto-promotes
+  inline dep paths to their own `Package` records.
+* `UvResolver` (`dead_cst/contrib/uv.py`, re-exported from
+  `dead_cst.resolvers`) — parses `uv.lock` to discover workspace
+  members and inter-member edges; lazily splices the workspace
+  `.venv/site-packages` onto `sys.path` inside its own
+  `resolve_import`.
+
+`Analysis` takes exactly one resolver — no chain. CLI flags `-p` and
+`--resolver` are mutually exclusive. Construction validates the
+resolver's output (name uniqueness, dep references, `exported` entries
+under `path`) via `_validate_packages`.
+
+### 2. Per-file visitor — `dead_cst/_visitor.py`
+
+`SymbolVisitor` walks one `.py` (or `.pyi`) file and returns a
+`VisitorPayload` (defined in `dead_cst/graph.py`) with four fields:
+
+| Field          | Shape                                          | Notes                                   |
+| -------------- | ---------------------------------------------- | --------------------------------------- |
+| `nodes`        | `tuple[SymbolNode, ...]`                       | every real decl, including `SHADOWED`   |
+| `edges`        | `tuple[(src, dst, EdgeFlags), ...]`            | resolved decl-to-decl refs in this file |
+| `imports`      | `tuple[(src, Import, EdgeFlags), ...]`         | **raw** — just the dotted name written  |
+| `dead_suites`  | `tuple[CodeRange, ...]`                        | every statically-dead suite             |
+
+Crucially the visitor never calls a resolver and never reads `sys.path` —
+its output is purely a function of the file's source plus the plugin /
+detector chain. That's what lets the per-file cache survive
+`search_paths` / resolver swaps.
+
+Heavy lifting comes from LibCST `ScopeProvider`,
+`FullyQualifiedNameProvider` (wrapped via `_fqn.FixedFullyQualifiedNameProvider`),
+and the flow-sensitive shadowing in `_flow.py`.
+
+### 3. Unreachable-region detection — `dead_cst/branches.py`
+
+Invoked once per file from inside `SymbolVisitor.visit_Module` reusing
+the analyzer's resolved `PositionProvider`. The shipped
+`DefaultUnreachableRegionDetector` runs three passes:
+
+1. Literal-truthiness `unreachable_suites` walk over `if` / `while`
+   tests and `assert`.
+2. Fixpoint `fold_constants` pre-pass (`dead_cst/_const_fold.py`):
+   propagates simple `Name = literal` bindings through chained `or` /
+   `and` / `not` until quiescent.
+3. Post-terminator scan: statements after an unconditional `return` /
+   `raise` / `break` / `continue` / `assert <falsy>` are marked dead
+   *within the same suite* — a `raise` in a `try` body doesn't kill
+   the matching `except`.
+
+The apply step compares each `access_pos` in `edges` against
+`dead_suites` to flag `EdgeFlags.DEAD_BRANCH`. Reachability still
+follows those edges by default; `Analysis.kept_alive_by_dead_branches`
+is the opt-in inverse.
+
+To layer in domain knowledge, subclass `DefaultUnreachableRegionDetector`
+and override `resolve(self, expr) -> bool | None` — it gets first crack
+at every non-keyword expression in `if` / `while` / `assert` tests and
+every foldable RHS. Pass an instance via
+`Analysis(unreachable_detector=...)`. Bump `version` whenever the
+override's logic changes.
+
+### 4. Visitor + observe cache — `dead_cst/cache.py`
+
+SQLite-backed `GraphCache` at `<root>/.dead-cst-cache/cache.db` stores
+pickled per-file payloads keyed by file SHA-256. Each row carries a
+single analysis-wide fingerprint over Python version, schema version,
+and every visitor / plugin / detector `(name, version)` pair.
+
+A cache row covers both the visitor's payload **and** every plugin's
+`observe()` output for that file — warm runs skip both. Bypass with
+`--no-cache`; force-clear with `dead-cst cache clear`.
+
+The orchestration around this stage — file enumeration, stale detection,
+the parallel worker pool, payload application into the per-package
+contribution — lives in `dead_cst/_refresh.py` so `analyze.py` can stay
+focused on cross-package composition.
+
+### 5. Edge stitching — `dead_cst/_edges.py`
+
+`resolve_edges` runs **unconditionally** every analysis (it isn't
+cached). It walks the raw `(src, Import, flags)` triples against the
+per-package `SymbolTrie`, **canonicalizing** each `Import` first by
+pushing decl parts into `module` while they resolve as submodules in
+the trie:
+
+```
+from p import functions
+   trie has p.functions as a submodule?
+   -> module="p.functions", decl=None
+```
+
+Trie misses fall back to the `PathResolver` chain for stdlib /
+external-dist / external-file / unresolved classification — the *only*
+place that reads `sys.path` and the resolver LRU caches.
+`Analysis._materialize` rebinds `sys.path` to each package's
+`(path, *deps)` view before composing it and clears the resolver caches
+at every transition, restoring `sys.path` on the way out.
+
+Star imports follow the same path; `Import.speculative` (set on
+`__import__` fromlist synthesis) silences the warning when both the
+trie and resolver miss.
+
+Re-running this every analysis is what makes single-file edits cheap:
+only the edited file's payload is recomputed; importers re-stitch for
+free.
+
+### 6. Plugins — `dead_cst/plugins/`
+
+Two phases per `EdgePlugin`:
+
+* `observe(ctx: ObserveContext) -> VisitorPayload | None` — runs once
+  per file inside the visitor loop, with the parsed `cst.Module` and
+  the visitor's just-built payload. Returns a new payload (or `None`)
+  whose `nodes` / `edges` extend the file's contribution; the result
+  is cached alongside the visitor's output. **Cross-file work does
+  not belong here.**
+* `finalize(ctx: PluginContext) -> Iterable[GraphOp]` — runs once per
+  package after `resolve_edges` has stitched cross-file imports.
+  Operates purely on the assembled graph (no CST access) and emits
+  `AddNode` / `AddEdge` / `RemoveEdge` ops.
+
+`PluginContext` provides helpers (`find_module`, `find_declarations`,
+`module_surface`, `package_modules`, `package_nodes`, `importers`, …)
+and exposes the current `Package` via `ctx.package`.
+
+Builtins ship in `BUILTIN_PLUGINS`. Generic-Python plugins live as
+siblings of `plugins/__init__.py` (`MainBlockPlugin`,
+`ProjectScriptsPlugin`, `ExplicitEntrypointPlugin`,
+`ModuleDundersPlugin`, `InitSubclassPlugin`). Third-party-aware
+plugins live under `dead_cst/contrib/` and are re-exported from
+`dead_cst.plugins`. `FastAPIPlugin` is the full-featured reference for
+two-phase plugins; `ClickPlugin` for the `DecoratedDeclPlugin`
+subclass shape; `TyperPlugin` / `CycloptsPlugin` for the
+`DispatchAppPlugin` shape.
+
+For the common dynamic-import idioms, three abstract bases ship as
+scaffolding (`plugins/decl_shapes.py`):
+
+* `DecoratedDeclPlugin` — "decorated decls in files matching a search path."
+* `LiteralListPlugin` — "read `<owner>.<var> = ['fqn', ...]` and revive each entry."
+* `DispatchAppPlugin` — "wire `@<instance>.<reg>(...)` handlers to a CLI app."
+
+### 7. Reachability — `Analysis.reachable` / `PackageView.reachable`
+
+BFS from every node with `entrypoint=True`. Default traversal **does**
+follow `DEAD_BRANCH` edges (preserving today's behavior).
+`Analysis.kept_alive_by_dead_branches()` is the opt-in inverse, returning
+the blast radius of removing every dead suite by skipping those edges.
+`Analysis.kept_alive_by_tests_only()` / the per-package `PackageView`
+twin returns the blast radius of dropping the test suite — production
+code currently kept alive only because tests still touch it
+(`PytestPlugin` and `UnittestPlugin` stamp `ENTRYPOINT | TESTCASE` on
+their seeds).
+
+### 8. Codemod — `dead_cst/codemod.py`
+
+`remove_code` runs a LibCST `RemoveDeadSymbols` transformer keyed on
+`(fqname, CodeRange)` pairs (position disambiguates shadowed decls),
+then prunes now-unused imports via `RemoveImportsVisitor`. Position
+keying is critical — losing it conflates a dead decl with a live shadow.
+
+The high-level entry point is `PackageView.remove_dead_code()`, which
+materializes the package's interesting-set closure, computes
+reachability, and feeds the unreachable subgraph into `remove_code`.
+
+## Lazy materialization on `Analysis`
+
+`Analysis` is cheap to construct — the resolver runs once at `__init__`,
+but no source files are read or parsed until you ask. Three coarse
+stages happen on demand:
+
+1. **File enumeration + visitor pass** — `refresh()`. Walks each
+   requested package's tree, collapses every package's cache misses
+   into one global stale-file list, and runs the visitor + observe
+   pass once across the whole batch.
+2. **Per-package contribution build** — the per-package
+   `SymbolTrie` + a package-local graph slice + the unresolved
+   cross-file import set. Built once per package from the payloads
+   above, memoized for the lifetime of the `Analysis`.
+3. **Cross-package composition** — `materialize_all()` (every package)
+   or `materialize_closure(package)` (the "interesting set" of one
+   package — the forward dep closure of that package's reverse-consumer
+   closure). Composing a graph is much cheaper than recomputing
+   payloads, so warm per-package queries stay fast.
+
+Per-package queries that don't need the assembled graph
+(`PackageView.modules` / `PackageView.declarations`) skip stage 3
+entirely.
+
+## Graph model invariants
+
+* One node per top-level declaration plus one synthetic module node per
+  file. Nested defs (inner functions, methods, nested classes) are
+  deliberately not given their own nodes — refs from inside them
+  attribute to the enclosing top-level decl.
+* A module-level `import` / `from ... import ...` is itself a node of
+  type `"import"`. Local uses of an imported name go through the import
+  node, which points at the upstream module / symbol. This is how
+  `dead-cst remove` knows to drop now-unused imports.
+* Submodules edge to their parent package, so `__init__.py` stays alive
+  as long as anything in the package does.
+* `EdgeFlags.DEAD_BRANCH` is metadata only.
+* `NodeFlags.SHADOWED` decls are emitted into the graph but excluded
+  from the trie, so cross-module imports never resolve to them.
+  `NodeFlags.OVERLOAD` follows the same trie-exclusion rule but its
+  lifetime is anchored to the matching same-file impl via explicit
+  `impl -> overload` edges.
+* `.pyi` stubs are ingested only for the compiled-extension layout
+  (`_native.so` + `_native.pyi`, no `.py` twin). Peer-mode `.pyi` is
+  dropped at file-enumeration time — the runtime always wins.
+
+## Where to make changes
+
+| If you want to…                                          | Touch                                          |
+| -------------------------------------------------------- | ---------------------------------------------- |
+| Recognize a new decl shape                               | `_visitor.py` (bump `SymbolVisitor.version`)   |
+| Fold a domain-specific expression to a known truthiness  | subclass `DefaultUnreachableRegionDetector`    |
+| Keep alive symbols a framework registers dynamically     | new `EdgePlugin` under `contrib/`              |
+| Support a new project layout / lockfile                  | new `PathResolver` under `contrib/`            |
+| Change how cross-file imports get classified             | `_edges.resolve_edges` + the resolver fallback |
+| Change codemod output shape                              | `codemod.py` (`RemoveDeadSymbols`)             |
+
+See `CLAUDE.md` for the per-stage cache-invalidation discipline.

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ uv run pytest
 uv run prek run --all-files
 ```
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev guide, [`CHANGELOG.md`](CHANGELOG.md) for release notes, and [`ROADMAP.md`](ROADMAP.md) for the stack-ranked plan toward 1.0.
+See [`ARCHITECTURE.md`](ARCHITECTURE.md) for a walkthrough of the analyzer pipeline, [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev guide, [`CHANGELOG.md`](CHANGELOG.md) for release notes, and [`ROADMAP.md`](ROADMAP.md) for the stack-ranked plan toward 1.0.
 
 ## TODO
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,14 +17,16 @@ for the full record.
 
 ### 1. Finish the framework-aware plugin presets
 
-`PytestPlugin`, `UnittestPlugin`, `FastAPIPlugin`, `FlaskPlugin`,
-`TyperPlugin`, `ClickPlugin`, and `InitSubclassPlugin` shipped, but the
-existential risk is still "I tried it and it flagged half my codebase."
-The remaining common offenders:
+`PytestPlugin`, `UnittestPlugin` (with transitive `TestCase` discovery),
+`FastAPIPlugin`, `FlaskPlugin`, `TyperPlugin`, `ClickPlugin`,
+`CycloptsPlugin`, `MockPatchPlugin`, and `InitSubclassPlugin` shipped,
+but the existential risk is still "I tried it and it flagged half my
+codebase." The remaining common offenders:
 
 - Django URLConf, admin registration, signal handlers, management commands
 - Pydantic validators and field serializers
 - Descriptor-style hooks: `__set_name__`, dataclass `__post_init__`
+- SQLAlchemy declarative models / event listeners; Celery tasks / signals
 
 Surface a `--preset pytest,fastapi,django` shortcut that expands to the
 existing `--plugin` wiring, and document the entry-point group so third
@@ -148,6 +150,60 @@ demand.
 
 Folded down from earlier tiers as they landed:
 
+- **v0.6.0**: Compiled-extension `.pyi` stub ingestion (`mypkg/_native.so`
+  + `mypkg/_native.pyi`); peer-mode stubs alongside a real `.py` are
+  intentionally dropped. `@typing.overload`-decorated decls flagged with
+  `NodeFlags.OVERLOAD`, excluded from the cross-module trie, and anchored
+  to their same-file impl via explicit `impl -> overload` edges so the
+  codemod removes overloads with their impl.
+- **v0.6.0**: `NodeFlags.TESTCASE` plus
+  `Analysis.kept_alive_by_tests_only()` /
+  `PackageView.kept_alive_by_tests_only()` for "blast radius of dropping
+  the test suite" queries. `PytestPlugin` and `UnittestPlugin` stamp
+  `ENTRYPOINT | TESTCASE` on their synthetic seeds.
+- **v0.6.0**: `UnittestPlugin` resolves transitive `TestCase` subclasses
+  through bucket markers in `observe` + a `finalize` walk from
+  `unittest.TestCase` / `IsolatedAsyncioTestCase` (and every alias) so
+  project-local mixins and re-exported `TestCase` bases keep their
+  subclasses alive.
+- **v0.6.0**: Per-file refresh logic extracted into
+  `dead_cst/_refresh.py` (file enumeration, stale detection, worker
+  pool, payload application). `analyze.py` keeps cross-package
+  composition only. "Base" -> "package" rename across the public API.
+- **v0.6.0**: `tqdm` progress reporting around the parse and reconcile
+  passes; off-TTY consumers get newline-terminated checkpoints instead
+  of `\r`-overwriting frames.
+- **v0.6.0**: `CycloptsPlugin` plus a generalized `DispatchAppPlugin`
+  base for `X = App(); @X.command(...)` shapes (Typer migrated onto
+  it). `MockPatchPlugin` resolves string-fqname targets for
+  `mock.patch` / `mocker.patch` / `monkeypatch.setattr`.
+- **v0.5.0**: Cross-file import resolution moved out of `SymbolVisitor`
+  and into `_edges.resolve_edges`. `Import` is now raw (just the
+  written-down dotted name); the per-file cache survives `search_paths`
+  / resolver / package-layout swaps. Single resolver per `Analysis`
+  (no chain). `PathResolver.resolve` returns `tuple[Package, ...]`
+  with explicit `name` / `exported` / `deps`. `VenvResolver` and
+  `PyprojectResolver` retired (use `-p` / `ManualResolver`);
+  `UvWorkspaceResolver` renamed to `UvResolver`.
+- **v0.5.0**: Parallel visitor pass via `--workers` / `-j`. Workers
+  return `VisitorPayload` blobs; cache writes, trie stitching, and
+  edge resolution stay in the parent. FQN cache built once over miss
+  files only and shipped per-task.
+- **v0.5.0**: Public API split into focused submodules
+  (`dead_cst.graph`, `dead_cst.analyze`, `dead_cst.codemod`,
+  `dead_cst.cache`, `dead_cst.branches`, `dead_cst.plugins`,
+  `dead_cst.resolvers`, `dead_cst.contrib`).
+  `tests/test_public_api.py` pins each module's `__all__`. The lazy
+  `Analysis` / `PackageView` shape replaces the `build_symbol_graph` /
+  `find_reachable` / `count_nodes` / `order_paths` /
+  `find_kept_alive_by_dead_branches` / top-level `remove_code` API.
+- **v0.5.0**: Path-classification fixes for system-Python layouts
+  (site-packages nested inside the stdlib root) and editable installs
+  (`pip install -e`); first-party search paths win over editable dist
+  roots so e2e fixtures cloned inside another project don't blow away
+  reachability. `__import__` / `importlib.import_module` with a
+  string-literal name (including relative names and `fromlist=[...]`
+  literals) fanned out as star imports.
 - PEP 695 `type` statements: `type Foo = list[int]` (and the generic
   `type Pair[T] = tuple[T, T]` form) now surface as top-level
   `"type_alias"` decls. RHS references attribute to the alias, so
@@ -184,11 +240,12 @@ Folded down from earlier tiers as they landed:
 - SQLite-cached graph with partial rebuilds: `GraphCache` stores
   pickled `VisitorPayload` blobs keyed by per-file content hash under
   `<root>/.dead-cst-cache/cache.db`. Cache hits skip the per-file
-  visitor pass; per-base edge resolution and the plugin pass run
-  every analysis. Fingerprint over `(__version__, python version,
-  PathMap, resolver chain)` invalidates the whole file_cache on
-  layout / version change. `--no-cache` flag and
-  `dead-cst cache clear` subcommand.
+  visitor pass; edge resolution and plugin `finalize` run every
+  analysis. The fingerprint covers Python version, schema version,
+  and each visitor / plugin / detector `(name, version)` pair --
+  resolver, `search_paths`, and the package layout deliberately do
+  not enter it (their effect flows through the uncached edge stitcher).
+  `--no-cache` flag and `dead-cst cache clear` subcommand.
 - Resolver logic as a protocol: `PathResolver.resolve_import` folds
   `name -> path` lookup into the resolver, so custom resolvers can
   override import resolution for their own layouts. `_resolve.py`


### PR DESCRIPTION
## Summary

- **`ROADMAP.md`** — refreshed the stale "Recently shipped" log with v0.5.0 and v0.6.0 work that wasn't reflected: parallel workers, public-API split, raw imports + edge-stitcher classification, single-resolver `Analysis`, `Package` dataclass, `.pyi` stubs, `OVERLOAD`/`TESTCASE` flags, `_refresh.py` extraction, tqdm progress, `CycloptsPlugin`/`MockPatchPlugin`/`DispatchAppPlugin`, transitive `TestCase` discovery. Fixed the cache-fingerprint description that still mentioned `(__version__, PathMap, resolver chain)`. Tier 1 framework-presets bullet adjusted to acknowledge transitive unittest discovery already shipped.
- **`ARCHITECTURE.md`** (new) — developer-facing walkthrough of the eight-stage pipeline (path resolution → visitor → detector → cache → edge stitching → plugins → reachability → codemod), the `Cacheable` contract, lazy materialization on `Analysis`, the graph-model invariants, and a "Where to make changes" cheat sheet. Same content CLAUDE.md has for LLMs, restructured for human readers. Linked from the README.
- **`.claude/skills/update-docs/SKILL.md`** — extended the doc-audit skill from four surfaces to six: it now also folds shipped tier items into ROADMAP's "Recently shipped" and updates the affected stage in ARCHITECTURE.md when a diff changes pipeline behavior. Added matching guardrails so the skill won't fold tier items without diff evidence or rewrite stage docs the branch didn't touch.

## Test plan

- [ ] `cat ROADMAP.md` — "Recently shipped" reflects v0.5.0 / v0.6.0; tier ordering and rationale unchanged.
- [ ] `cat ARCHITECTURE.md` — eight stages match the code (`dead_cst/_visitor.py`, `dead_cst/_edges.py`, `dead_cst/cache.py`, `dead_cst/_refresh.py`, `dead_cst/codemod.py`); ASCII diagram is readable in monospace.
- [ ] README.md "Development" section links to ARCHITECTURE.md and the link resolves.
- [ ] Invoke `/update-docs` (or trigger the skill via natural-language phrasing) and confirm it now mentions ROADMAP and ARCHITECTURE in its surface list.