### PR TITLE
Add Changelog link to project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 Homepage = "https://github.com/lpetre/dead-cst"
 Repository = "https://github.com/lpetre/dead-cst"
 Issues = "https://github.com/lpetre/dead-cst/issues"
+Changelog = "https://github.com/lpetre/dead-cst/blob/main/CHANGELOG.md"
 
 [project.scripts]
 dead-cst = "dead_cst.cli:main_cli"


### PR DESCRIPTION
## Summary
Added a Changelog link to the project metadata in `pyproject.toml` to improve project discoverability and documentation.

## Changes
- Added `Changelog` URL pointing to `CHANGELOG.md` in the project's GitHub repository under the `[project.urls]` section

## Details
This change follows Python packaging best practices by including a changelog URL in the project metadata. This allows package managers and documentation sites to automatically link to the project's changelog, making it easier for users to track changes and updates.

https://claude.ai/code/session_019ot5iC17njt7RxbKfq3gTW