### PR TITLE
docs: prep CHANGELOG for v0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ two versions.
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-09
+
 ### Added
 - The visitor now honors ruff/pyflakes ``# noqa`` directives that
   silence F401 (unused-import). A per-line ``# noqa``,
@@ -979,7 +981,8 @@ versions until the first stable release.
 - `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, and `ROADMAP.md` with a
   stack-ranked plan from alpha to 1.0.
 
-[Unreleased]: https://github.com/lpetre/dead-cst/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/lpetre/dead-cst/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/lpetre/dead-cst/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/lpetre/dead-cst/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/lpetre/dead-cst/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/lpetre/dead-cst/compare/v0.4.0...v0.5.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -155,16 +155,59 @@ demand.
 
 Folded down from earlier tiers as they landed:
 
-- **Unreleased**: `dead-cst remove` is now non-destructive — it emits a
+- **v0.8.0**: `dead-cst remove` is now non-destructive — it emits a
   `git apply`-compatible unified diff to stdout (or `--output PATH`)
-  and never touches source files. The `--dry-run` flag and the
-  confirmation prompt are gone. New public function
+  and never touches source files (breaking; `--dry-run` and the
+  confirmation prompt are gone). New public function
   `dead_cst.codemod.generate_patch(G, root)` returns the same diff for
   any subgraph slice, so callers can render per-SCC (or per-WCC)
   patches by passing `G.subgraph(scc)` for incremental review of large
   codebases. This lays the foundation for the `dead-cst preview`
   subcommand in tier 7 — automatic WCC clustering and blast-radius
   headers are the remaining work.
+- **v0.8.0**: The visitor now honors ruff/pyflakes ``# noqa`` directives
+  that silence F401. Per-line variants (bare ``# noqa``,
+  ``# noqa: F401``, multi-rule ``# noqa: E501, F401``, case-variant
+  ``# NOQA``) and file-level pins (``# ruff: noqa``, ``# flake8: noqa``)
+  flag the resulting import nodes ``ENTRYPOINT | NOQA`` so reachability
+  keeps them alive — bringing dead-cst's unused-import semantics in
+  line with ruff's. The new ``NodeFlags.NOQA`` flag layers on
+  ``NodeFlags.ENTRYPOINT`` parallel to ``NodeFlags.TESTCASE``, and the
+  two ``kept_alive_by_*_only`` methods collapse into a single
+  ``kept_alive_by_flags_only(flags: NodeFlags)`` (breaking) that takes
+  any flag combination — pass ``NodeFlags.TESTCASE`` for the old
+  test-blast-radius behavior, ``NodeFlags.NOQA`` for the F401 pin
+  blast radius, or both ORed together.
+- **v0.8.0**: What-if graph surgery via
+  ``Analysis.preview(files, *, detector=None)`` — regenerates per-file
+  payloads for a hand-picked file set (bypassing the on-disk cache,
+  no read or write), splices them into a fresh overlay graph leaving
+  the baseline untouched, and returns a ``GraphView`` exposing the
+  same ``reachable`` / ``dead`` / ``kept_alive_by_dead_branches`` /
+  ``kept_alive_by_flags_only`` / ``count_nodes`` surface as
+  ``Analysis``. Pairs with the new
+  ``TruthinessResolver.resolve_constant(expr) -> Const | None`` (the
+  literal-value sibling of ``evaluate``, wrapped in ``Const`` so a
+  proved-``None`` literal stays distinct from a bare ``None`` "unknown"
+  return) so a custom detector can fold a flag-name ``Name``
+  (``check_flag(FEATURE_A)`` where ``FEATURE_A = "feature_a"``) before
+  pattern-matching. ``DefaultUnreachableRegionDetector.resolve(expr)``
+  is now ``resolve(expr, resolver)`` (breaking — subclasses with a
+  one-arg ``resolve`` need to add the parameter) so overrides can call
+  ``resolver.resolve_constant`` recursively.
+- **v0.8.0**: ``DefaultUnreachableRegionDetector`` recognizes compound
+  statements as terminators when every reachable branch terminates —
+  ``if True: return``, ``if FLAG: return`` with ``FLAG = True``,
+  ``if cond: return; else: return``, ``with`` whose body terminates,
+  and ``try``/``except``/``finally`` where every path terminates all
+  kill statements that follow them in the enclosing suite. Constant-
+  folded early returns now flag trailing dead code as expected. The
+  resolver also no longer folds a ``Name`` whose binding's RHS is a
+  mutable container literal (``[]``, ``{}``, comprehension RHS): the
+  binding-only flow walk is invisible to ``.append`` / item assignment
+  / ``.update``, so an ``edges = []; edges.append(x); if not edges:``
+  chain used to fold incorrectly. Tuples and primitives stay safe to
+  fold. Detector ``version`` bumped so cached payloads rebuild.
 - **v0.7.0**: `DefaultUnreachableRegionDetector` rewrite — the
   `fold_constants` fixpoint pre-pass is replaced by the goal-directed
   `TruthinessResolver`, which lazily walks only the binding slices a


### PR DESCRIPTION
Cut [Unreleased] to [0.8.0] - 2026-05-09, refresh compare links, and
fold v0.8.0 entries into ROADMAP's "Recently shipped" covering the
non-destructive `dead-cst remove` (now a unified diff to stdout, with
generate_patch as the non-destructive twin), ruff/pyflakes noqa F401
support and the kept_alive_by_flags_only collapse, what-if graph
surgery via Analysis.preview / GraphView with the
TruthinessResolver.resolve_constant + detector resolve(expr, resolver)
hook, and the compound-terminator + mutable-container fixes.

Three documented breaking changes this cycle (kept_alive_by_*_only
collapse, dead-cst remove no longer in place, detector resolve
signature) make this a minor bump rather than a patch. README,
ARCHITECTURE, and CLAUDE were already updated as each PR landed; no
other doc surfaces drifted this cycle.