### PR TITLE
refactor: compute SymbolNode/Import hash eagerly in __post_init__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,15 @@ two versions.
 ## [Unreleased]
 
 ### Changed
-- `SymbolNode` and `Import` now memoize their `__hash__` in a private
-  `_hash` slot. The instances are frozen so the result is stable;
-  hashing them goes from "walk six fields (and a nested `Import`) per
-  call" to a cached int load. Cuts edge-stitching time on large
-  multi-package workspaces where `resolve_edges._emit` re-hashes the
-  same `(src, dst, flags)` tuples into its dedup set. Cache entries
-  pickled before this change still load correctly -- the slot is
-  populated lazily on first hash via a `try`/`except AttributeError`
-  fallback, so no `SCHEMA_VERSION` bump is required.
+- `SymbolNode` and `Import` now pre-compute their hash in
+  `__post_init__` and store it in a private `_hash` slot; `__hash__`
+  becomes a single attribute read. The instances are frozen so the
+  result is stable. Cuts edge-stitching time on large multi-package
+  workspaces where `resolve_edges._emit` re-hashes the same
+  `(src, dst, flags)` tuples into its dedup set, and pays off again
+  every time a `SymbolNode` is hashed by networkx (graph insertion,
+  BFS traversal). `SCHEMA_VERSION` is bumped to 3 so cache rows
+  pickled before the slot existed are invalidated on first use.
 
 ### Fixed
 - Stdlib imports no longer emit a spurious ``Failed to resolve import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ two versions.
   every time a `SymbolNode` is hashed by networkx (graph insertion,
   BFS traversal). `SCHEMA_VERSION` is bumped to 3 so cache rows
   pickled before the slot existed are invalidated on first use.
-
 - Progress reporting is fully logger-driven and controlled by the root
   logger level. Per-file refresh status ``[i/N] ok|FAILED <file>`` goes
   through ``logger.debug`` on ``dead_cst._refresh``; off-TTY decile

--- a/dead_cst/cache.py
+++ b/dead_cst/cache.py
@@ -68,7 +68,7 @@ CACHE_DB_NAME = "cache.db"
 # mismatch on open drops ``file_cache`` so older databases from sibling
 # installs (or pre-per-base-fingerprint releases) are wiped on first
 # use even at the same package version.
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 
 def default_cache_path(project_root: Path) -> Path:

--- a/dead_cst/graph.py
+++ b/dead_cst/graph.py
@@ -111,12 +111,9 @@ class Import:
     decl: str | None = None
     star: bool = False
     speculative: bool = False
-    # Pre-computed hash. ``resolve_edges`` hashes ``(src, dst, flags)`` on
-    # every emission and an ``Import`` participates in ``SymbolNode``'s hash,
-    # so this gets re-hashed thousands of times per analysis on large
-    # workspaces. Computing eagerly in ``__post_init__`` keeps ``__hash__``
-    # to a single attribute read; the slot is fed into ``SCHEMA_VERSION``
-    # so old cache rows are invalidated.
+    # Memoized: ``resolve_edges._emit`` probes ``(src, dst, flags)`` once
+    # per emission and ``SymbolNode.__hash__`` recurses into this, so the
+    # same instance gets re-hashed many times per analysis.
     _hash: int = field(init=False, compare=False, hash=False, repr=False)
 
     def __post_init__(self) -> None:

--- a/dead_cst/graph.py
+++ b/dead_cst/graph.py
@@ -111,24 +111,21 @@ class Import:
     decl: str | None = None
     star: bool = False
     speculative: bool = False
-    # Lazily-populated hash cache. The instance is frozen so the hash
-    # is stable; recomputing it on every set/dict lookup shows up in
-    # ``resolve_edges`` profiles on large workspaces. The ``__hash__``
-    # read is wrapped in ``try``/``except AttributeError`` (rather than
-    # ``if self._hash is None``) so instances unpickled from caches
-    # written before this slot existed still hash correctly -- they
-    # get the slot populated on first read.
-    _hash: int | None = field(init=False, default=None, compare=False, hash=False, repr=False)
+    # Pre-computed hash. ``resolve_edges`` hashes ``(src, dst, flags)`` on
+    # every emission and an ``Import`` participates in ``SymbolNode``'s hash,
+    # so this gets re-hashed thousands of times per analysis on large
+    # workspaces. Computing eagerly in ``__post_init__`` keeps ``__hash__``
+    # to a single attribute read; the slot is fed into ``SCHEMA_VERSION``
+    # so old cache rows are invalidated.
+    _hash: int = field(init=False, compare=False, hash=False, repr=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "_hash", hash((self.module, self.decl, self.star, self.speculative))
+        )
 
     def __hash__(self) -> int:
-        try:
-            cached = self._hash
-        except AttributeError:
-            cached = None
-        if cached is None:
-            cached = hash((self.module, self.decl, self.star, self.speculative))
-            object.__setattr__(self, "_hash", cached)
-        return cached
+        return self._hash
 
 
 @dataclass(frozen=True, slots=True)
@@ -139,22 +136,18 @@ class SymbolNode:
     position: CodeRange
     imports: Import | None = None
     flags: NodeFlags = NodeFlags.NONE
-    # See ``Import._hash`` for the rationale; ``_edges._emit`` hashes
-    # ``(src, dst, flags)`` once per emitted edge, so the same node
-    # instance gets re-hashed many times per analysis.
-    _hash: int | None = field(init=False, default=None, compare=False, hash=False, repr=False)
+    # See ``Import._hash`` for the rationale.
+    _hash: int = field(init=False, compare=False, hash=False, repr=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "_hash",
+            hash((self.fqname, self.type, self.path, self.position, self.imports, self.flags)),
+        )
 
     def __hash__(self) -> int:
-        try:
-            cached = self._hash
-        except AttributeError:
-            cached = None
-        if cached is None:
-            cached = hash(
-                (self.fqname, self.type, self.path, self.position, self.imports, self.flags)
-            )
-            object.__setattr__(self, "_hash", cached)
-        return cached
+        return self._hash
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Summary

- The lazy `__hash__` form added in #104 carried two cosmetic warts (`try/except AttributeError` + a None-sentinel branch) purely to keep old pickled cache rows readable without bumping `SCHEMA_VERSION`. Move the computation into `__post_init__` so `__hash__` is a single attribute read, and bump `SCHEMA_VERSION` to 3 so pre-slot cache rows are invalidated on first use.
- Covers direct `SymbolNode(...)` / `Import(...)` construction uniformly — `__post_init__` runs on every fresh instance, where a hypothetical classmethod constructor would have left the raw `__init__` path as a footgun.
- The pickle bypasses `__post_init__` for restored instances, but the `SCHEMA_VERSION` bump ensures only pickles written after this commit (which carry the populated `_hash` slot) ever reach the unpickler.
- Follow-up commit trims the `Import._hash` field comment and drops the misleading "the slot is fed into `SCHEMA_VERSION`" phrasing — the bump is *motivated by* the slot, not consumed by it.

## Test plan

- [x] `uv run pytest` — 857 passed, 10 deselected
- [x] `uv run prek run --all-files` — ruff (lint+format), ty type-check all pass
- [x] Verified `Import` and `SymbolNode` hashing remains identity-preserving (equal instances still hash equal; `__post_init__` runs on every construction path including dataclass-default fields)
- [x] `SCHEMA_VERSION` bump validated by tracing `cache.py:213` — mismatched stored version wipes `file_cache` on next open

https://claude.ai/code/session_01HEFWsvebsfEQ9EgdiqPTX1