### PR TITLE
Document v0.9.0 release with parallel refresh and stdlib improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ two versions.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-11
+
 ### Changed
 - The parallel refresh pool (``--workers >= 2``) now drains worker
   results via ``concurrent.futures.as_completed`` instead of
@@ -1032,7 +1034,8 @@ versions until the first stable release.
 - `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, and `ROADMAP.md` with a
   stack-ranked plan from alpha to 1.0.
 
-[Unreleased]: https://github.com/lpetre/dead-cst/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/lpetre/dead-cst/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/lpetre/dead-cst/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/lpetre/dead-cst/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/lpetre/dead-cst/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/lpetre/dead-cst/compare/v0.5.0...v0.6.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -155,6 +155,45 @@ demand.
 
 Folded down from earlier tiers as they landed:
 
+- **v0.9.0**: Parallel refresh (``--workers >= 2``) is now resilient and
+  observable. Worker results stream via ``concurrent.futures.as_completed``
+  instead of ``pool.map``, so cache writes and progress ticks land in
+  completion order and a single slow file no longer blocks the cache from
+  warming with the fast files behind it. Per-task failures are collected
+  and re-raised as one ``ExceptionGroup`` after every other task finishes
+  (successfully-parsed files are still cache-warmed before the group is
+  raised, so a re-run after fixing the bad file only re-parses what
+  failed). The pool installs SIGTERM/SIGINT handlers for the lifetime of
+  the run; on signal it cancels every pending future and raises
+  ``KeyboardInterrupt``, with completed files still cache-warmed.
+- **v0.9.0**: Progress reporting is fully logger-driven and controlled by
+  the root logger level. Per-file refresh status goes through
+  ``logger.debug`` on ``dead_cst._refresh``; off-TTY decile checkpoints
+  go through ``logger.info`` on ``dead_cst._progress``; the on-TTY tqdm
+  bar wraps its iteration in ``logging_redirect_tqdm`` so concurrent log
+  records print above the bar without shattering it. ``dead-cst -v``
+  keeps its meaning; library users get the same firehose by configuring
+  their root logger.
+- **v0.9.0**: ``SymbolNode`` and ``Import`` pre-compute their hash in
+  ``__post_init__`` and store it in a private ``_hash`` slot, so
+  ``__hash__`` is a single attribute read. Cuts edge-stitching time on
+  large multi-package workspaces where ``resolve_edges._emit`` re-hashes
+  the same ``(src, dst, flags)`` tuples into its dedup set, and pays off
+  again every time a ``SymbolNode`` is hashed by networkx (graph
+  insertion, BFS traversal). ``SCHEMA_VERSION`` bumped to 3 so cache
+  rows pickled before the slot existed are invalidated on first use.
+- **v0.9.0**: Edge stitching no longer emits a spurious "Failed to
+  resolve import module: <name>" warning for stdlib imports
+  (``import datetime``, ``from pathlib import Path``); the orphaned
+  warning fired for every successfully-classified stdlib import because
+  the silent-drop and speculative-miss branches both returned ``None``.
+  Truly-unresolved non-speculative imports already surface as
+  ``[unresolved] <top-level>`` synthetic nodes.
+  ``default_resolve_import`` also now falls back to the parent module
+  when a dotted name can't be resolved directly, so
+  ``collections.abc``, ``importlib.resources.abc``, and similar
+  synthesized-in-``__init__`` submodules classify as ``[stdlib] <name>``
+  instead of being misfiled as ``[unresolved] <top>``.
 - **v0.8.0**: `dead-cst remove` is now non-destructive — it emits a
   `git apply`-compatible unified diff to stdout (or `--output PATH`)
   and never touches source files (breaking; `--dry-run` and the


### PR DESCRIPTION
This PR updates the ROADMAP and CHANGELOG to document the v0.9.0 release, which includes significant improvements to parallel refresh resilience, progress reporting, and import resolution.

## Summary
Adds comprehensive release notes for v0.9.0 covering four major feature areas that enhance the tool's reliability, observability, and correctness when processing large codebases.

## Key Changes

- **Parallel refresh resilience**: Worker results now stream via `concurrent.futures.as_completed` instead of `pool.map`, allowing cache writes and progress updates to land in completion order. Slow files no longer block cache warming, and per-task failures are collected and re-raised as an `ExceptionGroup` after all tasks complete. Signal handlers (SIGTERM/SIGINT) gracefully cancel pending futures while preserving cache writes for completed files.

- **Logger-driven progress reporting**: Progress reporting is now fully controlled by the root logger level. Per-file refresh status uses `logger.debug`, off-TTY checkpoints use `logger.info`, and on-TTY progress uses tqdm with `logging_redirect_tqdm` to prevent log records from corrupting the progress bar. Library users can now configure logging directly instead of relying on CLI flags.

- **Hash pre-computation optimization**: `SymbolNode` and `Import` now pre-compute their hash in `__post_init__` and store it in a private `_hash` slot, reducing repeated hashing during edge stitching and graph operations. `SCHEMA_VERSION` bumped to 3 to invalidate old pickled cache rows.

- **Stdlib import resolution fixes**: Eliminates spurious "Failed to resolve import module" warnings for stdlib imports by fixing the silent-drop logic. Adds fallback to parent module resolution for dotted names (e.g., `collections.abc`, `importlib.resources.abc`), properly classifying them as stdlib instead of unresolved.

## Documentation Updates
- Added v0.9.0 section to ROADMAP.md with detailed feature descriptions
- Created v0.9.0 entry in CHANGELOG.md with release date
- Updated version comparison links in both documents

https://claude.ai/code/session_017XgVjeUE1LFfQSfuUPuwaA