### PR TITLE
edges: cycle-protect + memoize the re-export DFS in resolve_edges

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -242,6 +242,18 @@ Re-running this every analysis is what makes single-file edits cheap:
 only the edited file's payload is recomputed; importers re-stitch for
 free.
 
+Resolution is memoized at three nested layers per call so the per-
+package compose loop stays additive in importer count: equal-spelling
+`Import` instances (the visitor builds fresh objects per file but they
+hash equal because `Import` is frozen) share one `_resolve_targets`
+entry; different `Import` shapes that canonicalize to the same trie
+state share one `_walk` entry; and the resolver fallback runs once per
+unique `(module, speculative)` external. The walk's worklist DFS is
+cycle-protected via a per-walk `visited` set keyed on
+`(id(SymbolTrie), parts_tail)`, so a pathological re-export cycle
+(`A.x: from B import x` / `B.x: from A import x`) terminates after one
+trip with the encountered decls still emitted.
+
 ### 6. Plugins — `dead_cst/plugins/`
 
 Two phases per `EdgePlugin`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ two versions.
 
 ## [Unreleased]
 
+### Fixed
+- `resolve_edges` no longer spins forever on cyclic re-exports. The
+  worklist DFS now carries a per-walk `visited` set keyed on
+  `(id(SymbolTrie), parts_tail)`, so a pathological pair like
+  `A.x: from B import x` / `B.x: from A import x` terminates after one
+  trip around the cycle instead of repeatedly chaining back to its
+  starting state. The decls actually encountered along the cycle are
+  still emitted, so first-party reachability through the chain is
+  preserved.
+
+### Changed
+- `resolve_edges` now memoizes the re-export DFS by
+  `(start_node, decl_parts)` and the external-classification fallback
+  by `(import.module, import.speculative)`. The walk's output depends
+  only on the trie state, so N importers traversing the same chain now
+  share one walk (and one resolver hit per unique external name)
+  instead of redoing each step per importer. On large multi-package
+  workspaces where one big package's edge contribution dominates
+  composition (the case `compute_fingerprint` / hash precomputation
+  helped on but did not change the algorithmic shape of), this turns
+  the per-package compose loop's growth in importer count from
+  multiplicative to additive.
+
 ## [0.9.0] - 2026-05-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ two versions.
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-05-11
+
 ### Fixed
 - `resolve_edges` no longer spins forever on cyclic re-exports. The
   worklist DFS now carries a per-walk `visited` set keyed on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,17 +20,21 @@ two versions.
   preserved.
 
 ### Changed
-- `resolve_edges` now memoizes the re-export DFS by
-  `(start_node, decl_parts)` and the external-classification fallback
-  by `(import.module, import.speculative)`. The walk's output depends
-  only on the trie state, so N importers traversing the same chain now
-  share one walk (and one resolver hit per unique external name)
-  instead of redoing each step per importer. On large multi-package
-  workspaces where one big package's edge contribution dominates
-  composition (the case `compute_fingerprint` / hash precomputation
-  helped on but did not change the algorithmic shape of), this turns
-  the per-package compose loop's growth in importer count from
-  multiplicative to additive.
+- `resolve_edges` now memoizes the full per-import resolution at three
+  layers: ``_resolve_targets`` keyed by ``Import`` value (so equal
+  spellings across files share the precomputed dst list — the visitor
+  builds fresh ``Import`` objects per file, but they hash equal because
+  ``Import`` is frozen with an eager ``__hash__``); ``_walk`` keyed by
+  ``(start_node, decl_parts)`` (so different ``Import`` shapes that
+  canonicalize to the same trie state share the re-export DFS); and
+  ``_classify`` keyed by ``(import.module, import.speculative)`` (so
+  the resolver runs once per unique external name). The per-src loop
+  collapses to ``for dst in cached_targets: emit(...)``. On large
+  multi-package workspaces where one big package's edge contribution
+  dominates composition (the case `compute_fingerprint` / hash
+  precomputation helped on but did not change the algorithmic shape
+  of), this turns the per-package compose loop's growth in importer
+  count from multiplicative to additive.
 
 ## [0.9.0] - 2026-05-11
 

--- a/dead_cst/_edges.py
+++ b/dead_cst/_edges.py
@@ -216,10 +216,7 @@ def resolve_edges(
             if decls:
                 for decl in decls:
                     results.append(decl)
-                    # Only ``import`` decls re-export through the
-                    # chain; concrete decls (function / class /
-                    # variable / type_alias) terminate this
-                    # continuation.
+                    # Only ``import`` decls re-export; concrete decls terminate.
                     if decl.type != "import":
                         continue
                     assert decl.imports is not None, "import symbol needs Import"
@@ -246,7 +243,7 @@ def resolve_edges(
 
             logger.warning(
                 "Failed to resolve import edge: %s + %s via %s in %s",
-                start_node.module.fqname,  # caller guarantees non-None
+                start_node.module.fqname,
                 ".".join(parts),
                 part,
                 cur.module.fqname if cur.module else "<no module>",
@@ -267,28 +264,20 @@ def resolve_edges(
         if cached is not None:
             return cached
         dst, node = _canonicalize(raw, symbol_lookup)
-        seen: set[SymbolNode] = set()
-        targets: list[SymbolNode] = []
-
-        def _add(n: SymbolNode) -> None:
-            if n not in seen:
-                seen.add(n)
-                targets.append(n)
-
+        targets: dict[SymbolNode, None] = {}
         if node is None or node.module is None:
             ext = _classify(dst)
             if ext is not None:
-                _add(ext)
+                targets[ext] = None
         else:
-            _add(node.module)
+            targets[node.module] = None
             if dst.star:
-                # Fan out to every top-level declaration in the target module.
                 for decls in node.declarations.values():
                     for decl in decls:
-                        _add(decl)
+                        targets[decl] = None
             elif dst.decl:
                 for n in _walk(node, tuple(dst.decl.split("."))):
-                    _add(n)
+                    targets[n] = None
         out = tuple(targets)
         target_memo[raw] = out
         return out

--- a/dead_cst/_edges.py
+++ b/dead_cst/_edges.py
@@ -135,17 +135,32 @@ def resolve_edges(
     purely trie-driven. The default resolver + empty search paths
     suffice for tests; the analyzer wires its configured resolver
     through here.
+
+    The walk through a re-export chain depends only on the trie state
+    (not on which ``src`` initiated it), so the result of resolving a
+    given ``(start_node, decl_parts)`` is memoized once per call and
+    reused for every importer that lands on the same path -- N
+    importers of one chain become N + chain-depth instead of N *
+    chain-depth. The walk is also cycle-protected: a pathological
+    pair like ``A.x: from B import x`` / ``B.x: from A import x``
+    terminates after one trip around the cycle instead of spinning.
     """
     if search_paths is None:
         search_paths = []
 
     emitted: set[tuple[SymbolNode, SymbolNode, EdgeFlags]] = set()
     # Per-call memos: imports get canonicalized once (re-exports walk
-    # the same ``decl.imports`` repeatedly) and each synthetic fqname
+    # the same ``decl.imports`` repeatedly), each synthetic fqname
     # produces one ``SymbolNode`` regardless of how many edges land
-    # on it.
+    # on it, each external classification keeps one resolver call per
+    # unique ``(module, speculative)`` shape, and the deepest memo --
+    # ``walk_memo`` -- caches the full re-export DFS result so the
+    # same ``(start_node, decl_parts)`` resolves once per call no
+    # matter how many importers traverse it.
     canon_memo: dict[int, tuple[Import, SymbolTrie | None]] = {}
     synthetic_memo: dict[str, SymbolNode] = {}
+    external_memo: dict[tuple[str, bool], SymbolNode | None] = {}
+    walk_memo: dict[tuple[int, tuple[str, ...]], tuple[SymbolNode, ...]] = {}
 
     def _canon(imp: Import) -> tuple[Import, SymbolTrie | None]:
         iid = id(imp)
@@ -162,6 +177,20 @@ def resolve_edges(
             synthetic_memo[fqname] = node
         return node
 
+    def _classify(imp: Import) -> SymbolNode | None:
+        # The classifier's inputs that vary across calls are the
+        # import's ``module`` and ``speculative`` fields; the resolver
+        # and ``search_paths`` are loop-invariant. Memoizing on the
+        # varying pair collapses N importers of the same external
+        # name to one resolver hit.
+        key = (imp.module, imp.speculative)
+        if key in external_memo:
+            return external_memo[key]
+        synth_fqname = _classify_external(imp, import_resolver, search_paths)
+        node = _synth(synth_fqname) if synth_fqname is not None else None
+        external_memo[key] = node
+        return node
+
     def _emit(
         src: SymbolNode, dst: SymbolNode, flags: EdgeFlags
     ) -> Generator[tuple[SymbolNode, SymbolNode, EdgeFlags], None, None]:
@@ -171,18 +200,95 @@ def resolve_edges(
         emitted.add(key)
         yield key
 
-    def _emit_external(
-        src: SymbolNode, imp: Import, flags: EdgeFlags
-    ) -> Generator[tuple[SymbolNode, SymbolNode, EdgeFlags], None, None]:
-        synth_fqname = _classify_external(imp, import_resolver, search_paths)
-        if synth_fqname is None:
-            return
-        yield from _emit(src, _synth(synth_fqname), flags)
+    def _walk(start_node: SymbolTrie, parts: tuple[str, ...]) -> tuple[SymbolNode, ...]:
+        """Resolve ``(start_node, parts)`` to the dst SymbolNodes it touches.
+
+        Output is purely a function of the trie state, so the result
+        is memoized per call and reused across every src that lands on
+        the same ``(start_node, parts)``. A per-walk ``visited`` set
+        keyed on ``(id(SymbolTrie), parts_tail)`` makes the DFS
+        cycle-safe: re-export cycles (``A.x: from B import x``,
+        ``B.x: from A import x``) terminate after one trip instead of
+        spinning, and the still-emitted decls remain correct.
+        """
+        cache_key = (id(start_node), parts)
+        cached = walk_memo.get(cache_key)
+        if cached is not None:
+            return cached
+        results: list[SymbolNode] = []
+        worklist: list[tuple[SymbolTrie, tuple[str, ...]]] = [(start_node, parts)]
+        visited: set[tuple[int, tuple[str, ...]]] = {cache_key}
+        while worklist:
+            cur, parts_now = worklist.pop()
+            if not parts_now:
+                continue
+            part = parts_now[0]
+
+            decls = cur.declarations.get(part, [])
+            if decls:
+                for decl in decls:
+                    results.append(decl)
+
+                    # Concrete decl terminates this continuation;
+                    # trailing attrs like ``.build`` are ignored.
+                    # ``type_alias`` (PEP 695 ``type X = ...``) is a
+                    # concrete declaration, not an import re-export.
+                    if decl.type in {"function", "class", "variable", "type_alias"}:
+                        continue
+
+                    # Import re-export: follow it without advancing
+                    # ``parts`` so the remaining attrs resolve in the
+                    # destination module.
+                    assert decl.type == "import"
+                    assert decl.imports is not None, "import symbol needs Import"
+
+                    chained, dest = _canon(decl.imports)
+                    if dest is None or dest.module is None:
+                        ext = _classify(chained)
+                        if ext is not None:
+                            results.append(ext)
+                        continue
+
+                    next_parts: tuple[str, ...] = parts_now[1:]
+                    if chained.decl:
+                        next_parts = (*chained.decl.split("."), *next_parts)
+                    next_state = (id(dest), next_parts)
+                    if next_state in visited:
+                        continue
+                    visited.add(next_state)
+                    worklist.append((dest, next_parts))
+                continue
+
+            # Maybe ``part`` is a submodule under the current package/module.
+            # Don't emit the intermediate-module edge here -- canonicalize
+            # already pushed every decl prefix that resolves as a submodule
+            # into ``Import.module``, so any submodule we still hit during
+            # the walk only matters for reaching its descendants.
+            if child := cur.children.get(part):
+                next_parts = parts_now[1:]
+                next_state = (id(child), next_parts)
+                if next_state not in visited:
+                    visited.add(next_state)
+                    worklist.append((child, next_parts))
+                continue
+
+            logger.warning(
+                "Failed to resolve import edge: %s + %s via %s in %s",
+                start_node.module.fqname if start_node.module else "<no module>",
+                ".".join(parts),
+                part,
+                cur.module.fqname if cur.module else "<no module>",
+            )
+        out = tuple(results)
+        walk_memo[cache_key] = out
+        return out
 
     for src, raw, flags in import_edges:
         dst, node = _canon(raw)
         if node is None or node.module is None:
-            yield from _emit_external(src, dst, flags)
+            ext = _classify(dst)
+            if ext is not None:
+                yield from _emit(src, ext, flags)
             continue
 
         yield from _emit(src, node.module, flags)
@@ -202,66 +308,9 @@ def resolve_edges(
         # ``node.declarations[name]`` may have multiple entries when each
         # branch of a conditional binds the same name (``if X: from a
         # import f else: from b import f``); each one is a separate
-        # continuation, so the walk is a small DFS.
-        worklist: list[tuple[SymbolTrie, list[str]]] = [(node, dst.decl.split("."))]
-        while worklist:
-            cur, parts = worklist.pop()
-            if not parts:
-                continue
-            part = parts[0]
-
-            decls = cur.declarations.get(part, [])
-            if decls:
-                for decl in decls:
-                    yield from _emit(src, decl, flags)
-
-                    # Concrete decl terminates this continuation;
-                    # trailing attrs like ``.build`` are ignored.
-                    # ``type_alias`` (PEP 695 ``type X = ...``) is a
-                    # concrete declaration, not an import re-export.
-                    if decl.type in {"function", "class", "variable", "type_alias"}:
-                        continue
-
-                    # Import re-export: follow it without advancing
-                    # ``parts`` so the remaining attrs resolve in the
-                    # destination module.
-                    assert decl.type == "import"
-                    assert decl.imports is not None, "import symbol needs Import"
-
-                    # Canonicalize the re-export against the lookup
-                    # before chasing it -- the visitor captured it raw
-                    # too, so ``Import(module="p", decl="functions")``
-                    # needs to flatten to ``module="p.functions"``
-                    # before we walk on. ``_canon`` memoizes per
-                    # unique ``Import`` so chains revisited via
-                    # parallel re-exports stay cheap.
-                    chained, dest = _canon(decl.imports)
-                    if dest is None or dest.module is None:
-                        yield from _emit_external(src, chained, flags)
-                        continue
-
-                    next_parts = parts[1:]
-                    if chained.decl:
-                        next_parts = chained.decl.split(".") + next_parts
-                    worklist.append((dest, next_parts))
-                continue
-
-            # Maybe ``part`` is a submodule under the current package/module.
-            # Don't emit the intermediate-module edge here -- canonicalize
-            # already pushed every decl prefix that resolves as a submodule
-            # into ``Import.module``, so any submodule we still hit during
-            # the walk only matters for reaching its descendants.
-            if child := cur.children.get(part):
-                worklist.append((child, parts[1:]))
-                continue
-
-            logger.warning(
-                "Failed to resolve import edge: %s + %s via %s in %s",
-                dst.module,
-                dst.decl,
-                part,
-                cur.module.fqname if cur.module else "<no module>",
-            )
+        # continuation handled inside the memoized walk.
+        for dst_node in _walk(node, tuple(dst.decl.split("."))):
+            yield from _emit(src, dst_node, flags)
 
 
 # Keep these re-exports stable for callers that historically reached

--- a/dead_cst/_edges.py
+++ b/dead_cst/_edges.py
@@ -136,39 +136,28 @@ def resolve_edges(
     suffice for tests; the analyzer wires its configured resolver
     through here.
 
-    The walk through a re-export chain depends only on the trie state
-    (not on which ``src`` initiated it), so the result of resolving a
-    given ``(start_node, decl_parts)`` is memoized once per call and
-    reused for every importer that lands on the same path -- N
-    importers of one chain become N + chain-depth instead of N *
-    chain-depth. The walk is also cycle-protected: a pathological
-    pair like ``A.x: from B import x`` / ``B.x: from A import x``
-    terminates after one trip around the cycle instead of spinning.
+    Resolution is memoized at three nested layers so the per-package
+    compose loop's growth in importer count is additive rather than
+    multiplicative. Equal-spelling :class:`Import` instances (the
+    visitor produces fresh objects per file) share one
+    :func:`_resolve_targets` entry; different :class:`Import` shapes
+    that canonicalize to the same trie state share one ``_walk``
+    entry; the re-export DFS itself is cycle-protected so a
+    pathological pair like ``A.x: from B import x`` /
+    ``B.x: from A import x`` terminates after one trip instead of
+    spinning.
     """
     if search_paths is None:
         search_paths = []
 
     emitted: set[tuple[SymbolNode, SymbolNode, EdgeFlags]] = set()
-    # Per-call memos: imports get canonicalized once (re-exports walk
-    # the same ``decl.imports`` repeatedly), each synthetic fqname
-    # produces one ``SymbolNode`` regardless of how many edges land
-    # on it, each external classification keeps one resolver call per
-    # unique ``(module, speculative)`` shape, and the deepest memo --
-    # ``walk_memo`` -- caches the full re-export DFS result so the
-    # same ``(start_node, decl_parts)`` resolves once per call no
-    # matter how many importers traverse it.
-    canon_memo: dict[int, tuple[Import, SymbolTrie | None]] = {}
     synthetic_memo: dict[str, SymbolNode] = {}
     external_memo: dict[tuple[str, bool], SymbolNode | None] = {}
+    # ``id(SymbolTrie)`` is safe as a key here: each trie node is held
+    # alive for the call by ``symbol_lookup``'s child chain, so id
+    # reuse is impossible inside one ``resolve_edges`` invocation.
     walk_memo: dict[tuple[int, tuple[str, ...]], tuple[SymbolNode, ...]] = {}
-
-    def _canon(imp: Import) -> tuple[Import, SymbolTrie | None]:
-        iid = id(imp)
-        result = canon_memo.get(iid)
-        if result is None:
-            result = _canonicalize(imp, symbol_lookup)
-            canon_memo[iid] = result
-        return result
+    target_memo: dict[Import, tuple[SymbolNode, ...]] = {}
 
     def _synth(fqname: str) -> SymbolNode:
         node = synthetic_memo.get(fqname)
@@ -178,11 +167,6 @@ def resolve_edges(
         return node
 
     def _classify(imp: Import) -> SymbolNode | None:
-        # The classifier's inputs that vary across calls are the
-        # import's ``module`` and ``speculative`` fields; the resolver
-        # and ``search_paths`` are loop-invariant. Memoizing on the
-        # varying pair collapses N importers of the same external
-        # name to one resolver hit.
         key = (imp.module, imp.speculative)
         if key in external_memo:
             return external_memo[key]
@@ -201,23 +185,27 @@ def resolve_edges(
         yield key
 
     def _walk(start_node: SymbolTrie, parts: tuple[str, ...]) -> tuple[SymbolNode, ...]:
-        """Resolve ``(start_node, parts)`` to the dst SymbolNodes it touches.
-
-        Output is purely a function of the trie state, so the result
-        is memoized per call and reused across every src that lands on
-        the same ``(start_node, parts)``. A per-walk ``visited`` set
-        keyed on ``(id(SymbolTrie), parts_tail)`` makes the DFS
-        cycle-safe: re-export cycles (``A.x: from B import x``,
-        ``B.x: from A import x``) terminate after one trip instead of
-        spinning, and the still-emitted decls remain correct.
-        """
         cache_key = (id(start_node), parts)
         cached = walk_memo.get(cache_key)
         if cached is not None:
             return cached
+        # Caller (``_resolve_targets``) only invokes ``_walk`` for trie
+        # nodes that already passed the ``node.module is None`` gate.
+        assert start_node.module is not None
         results: list[SymbolNode] = []
         worklist: list[tuple[SymbolTrie, tuple[str, ...]]] = [(start_node, parts)]
+        # ``visited`` breaks re-export cycles by gating every push;
+        # the per-walk scope means the still-emitted decls along the
+        # cycle remain correct.
         visited: set[tuple[int, tuple[str, ...]]] = {cache_key}
+
+        def _enqueue(target: SymbolTrie, next_parts: tuple[str, ...]) -> None:
+            state = (id(target), next_parts)
+            if state in visited:
+                return
+            visited.add(state)
+            worklist.append((target, next_parts))
+
         while worklist:
             cur, parts_now = worklist.pop()
             if not parts_now:
@@ -228,21 +216,15 @@ def resolve_edges(
             if decls:
                 for decl in decls:
                     results.append(decl)
-
-                    # Concrete decl terminates this continuation;
-                    # trailing attrs like ``.build`` are ignored.
-                    # ``type_alias`` (PEP 695 ``type X = ...``) is a
-                    # concrete declaration, not an import re-export.
-                    if decl.type in {"function", "class", "variable", "type_alias"}:
+                    # Only ``import`` decls re-export through the
+                    # chain; concrete decls (function / class /
+                    # variable / type_alias) terminate this
+                    # continuation.
+                    if decl.type != "import":
                         continue
-
-                    # Import re-export: follow it without advancing
-                    # ``parts`` so the remaining attrs resolve in the
-                    # destination module.
-                    assert decl.type == "import"
                     assert decl.imports is not None, "import symbol needs Import"
 
-                    chained, dest = _canon(decl.imports)
+                    chained, dest = _canonicalize(decl.imports, symbol_lookup)
                     if dest is None or dest.module is None:
                         ext = _classify(chained)
                         if ext is not None:
@@ -252,29 +234,19 @@ def resolve_edges(
                     next_parts: tuple[str, ...] = parts_now[1:]
                     if chained.decl:
                         next_parts = (*chained.decl.split("."), *next_parts)
-                    next_state = (id(dest), next_parts)
-                    if next_state in visited:
-                        continue
-                    visited.add(next_state)
-                    worklist.append((dest, next_parts))
+                    _enqueue(dest, next_parts)
                 continue
 
-            # Maybe ``part`` is a submodule under the current package/module.
-            # Don't emit the intermediate-module edge here -- canonicalize
-            # already pushed every decl prefix that resolves as a submodule
-            # into ``Import.module``, so any submodule we still hit during
-            # the walk only matters for reaching its descendants.
+            # Submodule descent: don't emit the intermediate-module
+            # edge -- canonicalize already pushed every decl prefix
+            # that resolves as a submodule into ``Import.module``.
             if child := cur.children.get(part):
-                next_parts = parts_now[1:]
-                next_state = (id(child), next_parts)
-                if next_state not in visited:
-                    visited.add(next_state)
-                    worklist.append((child, next_parts))
+                _enqueue(child, parts_now[1:])
                 continue
 
             logger.warning(
                 "Failed to resolve import edge: %s + %s via %s in %s",
-                start_node.module.fqname if start_node.module else "<no module>",
+                start_node.module.fqname,  # caller guarantees non-None
                 ".".join(parts),
                 part,
                 cur.module.fqname if cur.module else "<no module>",
@@ -283,33 +255,46 @@ def resolve_edges(
         walk_memo[cache_key] = out
         return out
 
-    for src, raw, flags in import_edges:
-        dst, node = _canon(raw)
+    def _resolve_targets(raw: Import) -> tuple[SymbolNode, ...]:
+        """Unique dst SymbolNodes a ``raw`` Import contributes, by value.
+
+        ``Import`` is frozen with an eager ``__hash__``, so equal
+        spellings across files (the visitor builds fresh objects per
+        file) collapse to one cache entry. The result is pre-deduped
+        so the per-src ``_emit`` loop stays short.
+        """
+        cached = target_memo.get(raw)
+        if cached is not None:
+            return cached
+        dst, node = _canonicalize(raw, symbol_lookup)
+        seen: set[SymbolNode] = set()
+        targets: list[SymbolNode] = []
+
+        def _add(n: SymbolNode) -> None:
+            if n not in seen:
+                seen.add(n)
+                targets.append(n)
+
         if node is None or node.module is None:
             ext = _classify(dst)
             if ext is not None:
-                yield from _emit(src, ext, flags)
-            continue
+                _add(ext)
+        else:
+            _add(node.module)
+            if dst.star:
+                # Fan out to every top-level declaration in the target module.
+                for decls in node.declarations.values():
+                    for decl in decls:
+                        _add(decl)
+            elif dst.decl:
+                for n in _walk(node, tuple(dst.decl.split("."))):
+                    _add(n)
+        out = tuple(targets)
+        target_memo[raw] = out
+        return out
 
-        yield from _emit(src, node.module, flags)
-
-        # Star import: fan out to every top-level declaration in the target module
-        if dst.star:
-            for decls in node.declarations.values():
-                for decl in decls:
-                    yield from _emit(src, decl, flags)
-            continue
-
-        # No decl? the edge points at a module
-        if not dst.decl:
-            continue
-
-        # Resolve the access to the deepest declaration(s) we can find.
-        # ``node.declarations[name]`` may have multiple entries when each
-        # branch of a conditional binds the same name (``if X: from a
-        # import f else: from b import f``); each one is a separate
-        # continuation handled inside the memoized walk.
-        for dst_node in _walk(node, tuple(dst.decl.split("."))):
+    for src, raw, flags in import_edges:
+        for dst_node in _resolve_targets(raw):
             yield from _emit(src, dst_node, flags)
 
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -576,12 +576,7 @@ def test_unresolved_import_emits_synthetic_silently(build_decl_graph, caplog):
 
 
 def test_cyclic_reexport_terminates(build_decl_graph, assert_edges):
-    """Re-export cycle (``A.x: from B import x``, ``B.x: from A import x``) terminates.
-
-    Before the per-walk ``visited`` set in ``_walk``, this DFS spun
-    forever; the still-emitted decls along the cycle remain in the
-    graph.
-    """
+    """Re-export cycle (``A.x: from B import x``, ``B.x: from A import x``) terminates with both legs emitted."""
     graph = build_decl_graph(
         {
             "A.py": "from B import x",

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -578,11 +578,9 @@ def test_unresolved_import_emits_synthetic_silently(build_decl_graph, caplog):
 def test_cyclic_reexport_terminates(build_decl_graph, assert_edges):
     """Re-export cycle (``A.x: from B import x``, ``B.x: from A import x``) terminates.
 
-    Before cycle protection in ``resolve_edges``, the worklist DFS
-    spun forever following ``A.x -> B.x -> A.x -> ...``. The fix adds
-    a per-walk ``visited`` set keyed on ``(id(SymbolTrie), parts)`` so
-    each state is processed at most once; the still-emitted decls
-    along the cycle remain in the graph.
+    Before the per-walk ``visited`` set in ``_walk``, this DFS spun
+    forever; the still-emitted decls along the cycle remain in the
+    graph.
     """
     graph = build_decl_graph(
         {
@@ -592,9 +590,6 @@ def test_cyclic_reexport_terminates(build_decl_graph, assert_edges):
         }
     )
 
-    # Both legs of the cycle are emitted (one trip around terminates
-    # the walk via the visited check) and the importer still reaches
-    # both intermediate re-export nodes.
     assert_edges(
         graph,
         {

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -575,6 +575,49 @@ def test_unresolved_import_emits_synthetic_silently(build_decl_graph, caplog):
     )
 
 
+def test_cyclic_reexport_terminates(build_decl_graph, assert_edges):
+    """Re-export cycle (``A.x: from B import x``, ``B.x: from A import x``) terminates.
+
+    Before cycle protection in ``resolve_edges``, the worklist DFS
+    spun forever following ``A.x -> B.x -> A.x -> ...``. The fix adds
+    a per-walk ``visited`` set keyed on ``(id(SymbolTrie), parts)`` so
+    each state is processed at most once; the still-emitted decls
+    along the cycle remain in the graph.
+    """
+    graph = build_decl_graph(
+        {
+            "A.py": "from B import x",
+            "B.py": "from A import x",
+            "main.py": "from A import x\nx()",
+        }
+    )
+
+    # Both legs of the cycle are emitted (one trip around terminates
+    # the walk via the visited check) and the importer still reaches
+    # both intermediate re-export nodes.
+    assert_edges(
+        graph,
+        {
+            "A.x -> A",
+            "A.x -> A.x",
+            "A.x -> B",
+            "A.x -> B.x",
+            "B.x -> A",
+            "B.x -> A.x",
+            "B.x -> B",
+            "B.x -> B.x",
+            "main -> A",
+            "main -> A.x",
+            "main -> B.x",
+            "main -> main.x",
+            "main.x -> A",
+            "main.x -> A.x",
+            "main.x -> B.x",
+            "main.x -> main",
+        },
+    )
+
+
 def test_cross_dep_submodule_import(tmp_path, make_analysis, assert_edges):
     """Importing a submodule from a dep base resolves through the dep's exported trie.
 


### PR DESCRIPTION
The worklist DFS in `resolve_edges` had no cycle protection: a
pathological pair like `A.x: from B import x` / `B.x: from A import x`
made it spin forever, repeatedly chaining back to the starting state.
On a 1470-file monorepo this manifested as a 22-minute hang at 100%
CPU stuck inside the per-package compose loop.

Two changes, in one place, address the report:

- A per-walk `visited` set keyed on `(id(SymbolTrie), parts_tail)`
  terminates re-export cycles after one trip. The decls actually
  encountered along the cycle are still emitted, so first-party
  reachability through the chain is preserved.
- The walk's output depends only on the trie state, so we memoize it
  by `(start_node, decl_parts)` for the lifetime of one
  `resolve_edges` call. The external-classification fallback is
  memoized similarly by `(import.module, import.speculative)`. N
  importers traversing the same chain now share one walk (and one
  resolver hit per unique external name), turning the per-package
  compose loop's growth in importer count from multiplicative to
  additive.

The CLAUDE.md note that `resolve_edges` runs unconditionally and is
not part of the cache fingerprint still holds: this is a pure
algorithmic change inside the (uncached) edge-stitching pass, so no
schema or `Cacheable.version` bump is needed.