### PR TITLE
refresh: handle foo.py shadowed by sibling foo/__init__.py package

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -387,6 +387,13 @@ entirely.
 * `.pyi` stubs are ingested only for the compiled-extension layout
   (`_native.so` + `_native.pyi`, no `.py` twin). Peer-mode `.pyi` is
   dropped at file-enumeration time — the runtime always wins.
+* A `foo.py` next to a `foo/__init__.py` is shadowed by the package
+  (mirroring CPython's `FileFinder`). `_refresh.shadowed_paths` flags
+  the `.py` before `_apply_payload` runs, and the apply pass skips its
+  trie additions only — its nodes still land in the graph so
+  observe-time entrypoints (`__main__`, plugin synthetics) keep
+  working, but cross-module imports of `pkg.foo` route to the
+  package's `__init__.py` alone.
 * `[unparseable] <module>` synthetics stand in for files `libcst`
   cannot parse. They carry `NodeFlags.ENTRYPOINT` and edge at the real
   module node, so the file stays alive even though its decls are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ two versions.
 
 ## [Unreleased]
 
+### Fixed
+- A `foo.py` sibling of a `foo/__init__.py` package no longer asserts
+  out of `SymbolTrie.add_declaration`. The new
+  `dead_cst._refresh.shadowed_paths` pre-pass mirrors CPython's
+  `FileFinder` precedence (regular package wins over a same-named
+  module file), so the trie holds the package and cross-module imports
+  of `pkg.foo` route there. The shadowed `.py` is still parsed and its
+  nodes still appear in the package graph -- observe-time entrypoints
+  (`__main__` blocks, plugin synthetics) keep working -- but consumer
+  imports never see its decls. A WARNING is logged per shadowed file
+  so the layout (almost always a bug) surfaces during analysis.
+
 ## [0.9.1] - 2026-05-11
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ Three moving pieces — `SymbolVisitor` itself plus two of the three extension p
 - `EdgeFlags.DEAD_BRANCH` is metadata only; tests using the `assert_edges` fixture see those edges, while `assert_dead_branch_edges` filters to just them.
 - `NodeFlags.SHADOWED` decls are emitted into the graph (with their parent module edge) but excluded from the trie, so cross-module imports never resolve to them. `NodeFlags.OVERLOAD` follows the same trie-exclusion rule but its lifetime is anchored to the matching same-file impl via explicit `impl -> overload` edges emitted by the visitor.
 - `.pyi` stub files are ingested only for the compiled-extension layout (`_native.so` + `_native.pyi`, no `.py` twin). The stub is parsed under its natural module FQN (`mypkg._native`), so `from mypkg._native import X` resolves through the normal trie path. Peer-mode `.pyi` (alongside a real `.py`) is dropped at `enumerate_files` time — the runtime always wins, and ingesting both would collide on the same FQN in the trie.
+- A `.py` whose stem matches a sibling regular package (`pkg/foo.py` next to `pkg/foo/__init__.py`) is shadowed: `_refresh.shadowed_paths` flags it before `_apply_payload`, and the apply pass sets `add_to_trie=False` so its decls never enter the trie. The file's nodes still land in the package graph (so observe-time entrypoints like `__main__` blocks keep working in the shadowed file), but consumer imports of `pkg.foo` route to the package's `__init__.py` alone — matching CPython's `FileFinder` precedence. A WARNING is logged per shadow.
 
 ### Public API surface
 

--- a/dead_cst/_refresh.py
+++ b/dead_cst/_refresh.py
@@ -650,14 +650,11 @@ def _apply_payload(
             continue
         if n.type != "module":
             symbol_graph.add_edge(n, module, flags=EdgeFlags.NONE)
-        # ``OVERLOAD`` and ``SHADOWED`` both keep the decl out of the
-        # cross-module lookup trie; the graph keeps the parent edge so
-        # the decl is well-formed but consumer imports route to the
-        # impl, never the stub. ``add_to_trie=False`` is the file-level
-        # equivalent: a sibling package shadows this whole file
-        # (``foo.py`` next to ``foo/__init__.py``), so its decls are
-        # graphed for entrypoint reachability but never resolved as
-        # ``pkg.foo.<name>`` from outside.
+        # ``OVERLOAD`` and ``SHADOWED`` exclude a single decl from the
+        # cross-module lookup trie; ``add_to_trie=False`` is the
+        # file-level equivalent for a ``.py`` whose sibling package
+        # shadows it. Either way the graph keeps the parent edge so
+        # the decl is well-formed -- only consumer FQN lookups change.
         if add_to_trie and not (n.flags & (NodeFlags.SHADOWED | NodeFlags.OVERLOAD)):
             current_trie.add_declaration(n)
             if file_exported:

--- a/dead_cst/_refresh.py
+++ b/dead_cst/_refresh.py
@@ -322,6 +322,12 @@ def build_contribution(
     cheap: composing it into the full graph or a closure graph doesn't
     redo per-file apply work. Empty :attr:`Package.exported` means
     "no restriction" (every file in the package is exported to consumers).
+
+    A pre-pass identifies module-FQN collisions (``foo.py`` alongside
+    ``foo/__init__.py``) via :func:`shadowed_paths` so the loser is
+    skipped at the trie -- the visitor still graphs its nodes so any
+    observe-time entrypoints (``__main__``, plugin synthetics) keep
+    working, but cross-module imports route to the package winner.
     """
     current_trie = SymbolTrie()
     export_trie = SymbolTrie()
@@ -329,6 +335,7 @@ def build_contribution(
     import_edges: set[tuple[SymbolNode, Import, EdgeFlags]] = set()
     package_graph: nx.MultiDiGraph = nx.MultiDiGraph()
     package_graph.graph["dead_suites"] = {}
+    shadowed = shadowed_paths(package_files.files)
     for file in package_files.files:
         payload = package_files.hits.get(file)
         if payload is None:
@@ -345,6 +352,7 @@ def build_contribution(
             current_trie=current_trie,
             export_trie=export_trie,
             file_exported=file_exported,
+            add_to_trie=file not in shadowed,
             symbol_graph=package_graph,
             import_edges=import_edges,
         )
@@ -356,6 +364,40 @@ def build_contribution(
         package_graph=package_graph,
         import_edges=frozenset(import_edges),
     )
+
+
+def shadowed_paths(files: Sequence[Path]) -> frozenset[Path]:
+    """Return every ``.py`` / ``.pyi`` in ``files`` shadowed by a sibling package.
+
+    Mirrors CPython's :class:`importlib.machinery.FileFinder` precedence:
+    a regular package (``__init__.py``) shadows a sibling module file
+    that would claim the same dotted name. Given a directory containing
+    both ``foo.py`` and ``foo/__init__.py``, ``foo.py`` is returned --
+    Python's import machinery loads the package, so resolving
+    ``pkg.foo`` to the ``.py`` would mis-route every consumer import.
+
+    Logs a warning per shadowed file: this layout is almost always a
+    bug, and surfacing it during analysis helps users notice before
+    the dead-code report blames the wrong half.
+    """
+    init_dirs = {f.parent for f in files if f.name == "__init__.py"}
+    shadowed: set[Path] = set()
+    for f in files:
+        if f.name == "__init__.py":
+            continue
+        candidate = f.with_suffix("")
+        if candidate in init_dirs:
+            init_path = candidate / "__init__.py"
+            logger.warning(
+                "Module %s shadowed by sibling package %s; "
+                "Python loads the package, so %s will not be "
+                "reachable as an importable module",
+                f,
+                init_path,
+                f.name,
+            )
+            shadowed.add(f)
+    return frozenset(shadowed)
 
 
 # ---------------------------------------------------------------------------
@@ -537,6 +579,7 @@ def _apply_payload(
     current_trie: SymbolTrie,
     export_trie: SymbolTrie,
     file_exported: bool,
+    add_to_trie: bool,
     symbol_graph: nx.MultiDiGraph,
     import_edges: set[tuple[SymbolNode, Import, EdgeFlags]],
 ) -> None:
@@ -610,8 +653,12 @@ def _apply_payload(
         # ``OVERLOAD`` and ``SHADOWED`` both keep the decl out of the
         # cross-module lookup trie; the graph keeps the parent edge so
         # the decl is well-formed but consumer imports route to the
-        # impl, never the stub.
-        if not (n.flags & (NodeFlags.SHADOWED | NodeFlags.OVERLOAD)):
+        # impl, never the stub. ``add_to_trie=False`` is the file-level
+        # equivalent: a sibling package shadows this whole file
+        # (``foo.py`` next to ``foo/__init__.py``), so its decls are
+        # graphed for entrypoint reachability but never resolved as
+        # ``pkg.foo.<name>`` from outside.
+        if add_to_trie and not (n.flags & (NodeFlags.SHADOWED | NodeFlags.OVERLOAD)):
             current_trie.add_declaration(n)
             if file_exported:
                 export_trie.add_declaration(n)

--- a/dead_cst/graph.py
+++ b/dead_cst/graph.py
@@ -211,6 +211,12 @@ class SymbolTrie:
         visitor flags them and routes them around the trie. De-duplicates
         so the visitor's double-push for ``Assign`` (one push for the LHS
         name, one for the RHS value) does not register the same decl twice.
+
+        Module-FQN collisions across files (``foo.py`` alongside
+        ``foo/__init__.py``) are resolved upstream by
+        :func:`dead_cst._refresh.shadowed_paths`: the loser's payload is
+        applied to the graph but skipped at the trie, so this method
+        never sees two ``module`` decls at the same node.
         """
         parts = decl.fqname.split(".")
         match decl.type:

--- a/tests/test_shadowed_modules.py
+++ b/tests/test_shadowed_modules.py
@@ -1,0 +1,99 @@
+"""Tests for ``foo.py`` shadowed by a sibling ``foo/__init__.py`` package.
+
+CPython's ``FileFinder`` resolves ``import pkg.foo`` to the package
+directory whenever both shapes coexist, so the analyzer mirrors that
+precedence: the trie holds the ``__init__.py`` and any cross-module
+import of ``pkg.foo`` (or of a name re-exported from it) routes to the
+package alone. The shadowed file is still parsed -- its nodes appear in
+the graph and observe-time entrypoints (``__main__``, plugin
+synthetics) keep working -- but consumer imports never see its decls.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from dead_cst.analyze import _find_reachable as find_reachable
+from dead_cst.plugins import ExplicitEntrypointPlugin, MainBlockPlugin
+
+
+def test_package_wins_trie_slot_for_cross_module_imports(
+    tmp_path, write_files, make_analysis, caplog
+):
+    write_files(
+        {
+            "pkg/__init__.py": "",
+            "pkg/foo.py": "def x(): pass\n",
+            "pkg/foo/__init__.py": "def x(): pass\n",
+            "caller.py": "from pkg.foo import x\nx()\n",
+        }
+    )
+    with caplog.at_level(logging.WARNING, logger="dead_cst._refresh"):
+        analysis = make_analysis(plugins=[ExplicitEntrypointPlugin(specs=["caller"])])
+        graph = analysis.materialize_all()
+
+    assert any("shadowed by sibling package" in r.getMessage() for r in caplog.records)
+
+    caller_x = next(n for n in graph.nodes if n.fqname == "caller.x")
+    targets = [s for s in graph.successors(caller_x) if s.fqname == "pkg.foo.x"]
+    assert len(targets) == 1
+    assert targets[0].path.name == "__init__.py"
+
+    reachable = find_reachable(graph)
+    package_x = next(
+        n for n in graph.nodes if n.fqname == "pkg.foo.x" and n.path.name == "__init__.py"
+    )
+    shadowed_x = next(n for n in graph.nodes if n.fqname == "pkg.foo.x" and n.path.name == "foo.py")
+    assert package_x in reachable
+    assert shadowed_x not in reachable
+
+
+def test_shadowed_file_keeps_main_block_entrypoint(tmp_path, write_files, make_analysis):
+    write_files(
+        {
+            "pkg/__init__.py": "",
+            "pkg/foo.py": ("def helper():\n    pass\nif __name__ == '__main__':\n    helper()\n"),
+            "pkg/foo/__init__.py": "value = 1\n",
+        }
+    )
+    analysis = make_analysis(plugins=[MainBlockPlugin()])
+    graph = analysis.materialize_all()
+    reachable = find_reachable(graph)
+
+    helper = next(n for n in graph.nodes if n.fqname == "pkg.foo.helper")
+    shadowed_module = next(
+        n for n in graph.nodes if n.fqname == "pkg.foo" and n.path.name == "foo.py"
+    )
+    package_module = next(
+        n for n in graph.nodes if n.fqname == "pkg.foo" and n.path.name == "__init__.py"
+    )
+    main_synth = next(
+        n for n in graph.nodes if n.type == "synthetic" and n.fqname.endswith(":pkg.foo")
+    )
+
+    assert main_synth in reachable, "MainBlockPlugin synthetic must seed reachability"
+    assert helper in reachable, "decls in the shadowed file are alive when the synth reaches them"
+    assert shadowed_module in reachable, "shadowed module node stays alive via the synth"
+    # The package itself is unreached: nothing imports pkg.foo from outside.
+    assert package_module not in reachable
+
+
+def test_name_only_in_shadowed_file_is_unresolvable(tmp_path, write_files, make_analysis, caplog):
+    """A name only the shadowed ``.py`` defines does not satisfy a consumer
+    import -- mirrors what Python would do at runtime (``ImportError``)."""
+    write_files(
+        {
+            "pkg/__init__.py": "",
+            "pkg/foo.py": "ONLY_IN_PY = 1\n",
+            "pkg/foo/__init__.py": "ONLY_IN_PKG = 2\n",
+            "caller.py": "from pkg.foo import ONLY_IN_PY\n",
+        }
+    )
+    with caplog.at_level(logging.WARNING, logger="dead_cst._edges"):
+        analysis = make_analysis(plugins=[ExplicitEntrypointPlugin(specs=["caller"])])
+        analysis.materialize_all()
+
+    assert any(
+        "Failed to resolve import" in r.getMessage() and "ONLY_IN_PY" in r.getMessage()
+        for r in caplog.records
+    )

--- a/tests/test_shadowed_modules.py
+++ b/tests/test_shadowed_modules.py
@@ -52,7 +52,7 @@ def test_shadowed_file_keeps_main_block_entrypoint(tmp_path, write_files, make_a
     write_files(
         {
             "pkg/__init__.py": "",
-            "pkg/foo.py": ("def helper():\n    pass\nif __name__ == '__main__':\n    helper()\n"),
+            "pkg/foo.py": "def helper():\n    pass\nif __name__ == '__main__':\n    helper()\n",
             "pkg/foo/__init__.py": "value = 1\n",
         }
     )


### PR DESCRIPTION
## Summary

- `foo.py` next to `foo/__init__.py` no longer crashes `SymbolTrie.add_declaration`. A new `dead_cst._refresh.shadowed_paths` pre-pass mirrors CPython's `FileFinder` precedence (regular package wins over a same-named module file). `_apply_payload` gains an `add_to_trie` bool: the loser's nodes/edges still land in the package graph -- so observe-time entrypoints (`__main__` blocks, `MainBlockPlugin` synthetics, etc.) keep working in the shadowed file -- but its decls never enter the trie, so cross-module imports of `pkg.foo` route to the package's `__init__.py` alone.
- A WARNING is logged per shadowed file (the layout is almost always a bug).
- Docs: new `[Unreleased]` `Fixed` entry in `CHANGELOG.md`, new bullets in `ARCHITECTURE.md` and `CLAUDE.md` (Graph model invariants list, sibling to the `.pyi`-peer rule).
- Three new tests in `tests/test_shadowed_modules.py`: cross-module import routes to the package, `__main__` block in the shadowed file still seeds reachability, a name only the shadowed `.py` defines is unresolvable (matches Python's `ImportError`).

## Test plan

- [x] `uv run pytest -q` -- 861 passed
- [x] `uv run prek run --all-files` -- clean
- [x] Manual repro: a `pkg/foo.py` + `pkg/foo/__init__.py` setup that previously hit `AssertionError: Module already exists at this node` now produces the expected graph + WARNING.

https://claude.ai/code/session_018CGPE3rGRiyQ6pR13Z8jmN