### PR TITLE
perf: share live_referents descendant cache across SymbolVisitor calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ two versions.
 
 ## [Unreleased]
 
+### Changed
+- `SymbolVisitor` now hoists the `_descendant_ids` cache used by
+  `live_referents` / `live_at_exit` onto the visitor instance, so a
+  single shared cache covers every flow-analysis call the visitor
+  makes for a file. Previously each multi-referent access in
+  `on_leave` triggered a fresh cache allocation, so large files with
+  many reassignments re-walked the same statement subtrees from
+  scratch on every access. Pure performance change — output and
+  payload-cache fingerprint are unchanged.
+
 ## [0.9.1] - 2026-05-11
 
 ### Fixed

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -216,6 +216,12 @@ class SymbolVisitor(cst.CSTVisitor):
         # because comments may precede the import statements they cover.
         self._pinned_imports: set[SymbolNode] = set()
         self._file_pins_imports: bool = False
+        # Hoisted ``_descendant_ids`` cache shared across every
+        # ``live_referents`` / ``live_at_exit`` call this visitor makes.
+        # Big files with many reassignments fire one ``live_referents``
+        # per multi-referent access; without sharing, each call re-walks
+        # the same statement subtrees from scratch.
+        self._descendant_cache: dict[int, set[int]] = {}
 
     @property
     def module_node(self) -> SymbolNode:
@@ -770,7 +776,12 @@ class SymbolVisitor(cst.CSTVisitor):
                 if ref is not None:
                     referent_nodes.append(ref)
 
-            live_ids = {id(n) for n in live_at_exit(list(module_node.body), referent_nodes)}
+            live_ids = {
+                id(n)
+                for n in live_at_exit(
+                    list(module_node.body), referent_nodes, cache=self._descendant_cache
+                )
+            }
 
             live_decls: list[SymbolNode] = []
             shadowed_here: list[SymbolNode] = []
@@ -850,7 +861,12 @@ class SymbolVisitor(cst.CSTVisitor):
                     if body is not None:
                         live_ids = {
                             id(n)
-                            for n in live_referents(body, access.node, [r.node for r in referents])
+                            for n in live_referents(
+                                body,
+                                access.node,
+                                [r.node for r in referents],
+                                cache=self._descendant_cache,
+                            )
                         }
                         referents = [r for r in referents if id(r.node) in live_ids]
                 for referent in referents:

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -216,11 +216,9 @@ class SymbolVisitor(cst.CSTVisitor):
         # because comments may precede the import statements they cover.
         self._pinned_imports: set[SymbolNode] = set()
         self._file_pins_imports: bool = False
-        # Hoisted ``_descendant_ids`` cache shared across every
-        # ``live_referents`` / ``live_at_exit`` call this visitor makes.
-        # Big files with many reassignments fire one ``live_referents``
-        # per multi-referent access; without sharing, each call re-walks
-        # the same statement subtrees from scratch.
+        # Shared ``_descendant_ids`` cache for every ``live_referents`` /
+        # ``live_at_exit`` call. Visitor lifetime pins every CST node,
+        # so ``id()`` reuse can't poison entries.
         self._descendant_cache: dict[int, set[int]] = {}
 
     @property
@@ -779,7 +777,7 @@ class SymbolVisitor(cst.CSTVisitor):
             live_ids = {
                 id(n)
                 for n in live_at_exit(
-                    list(module_node.body), referent_nodes, cache=self._descendant_cache
+                    module_node.body, referent_nodes, cache=self._descendant_cache
                 )
             }
 


### PR DESCRIPTION
## Summary

`SymbolVisitor.on_leave` fires one `live_referents` call per multi-referent access and one `live_at_exit` call per multi-decl name. Both functions accept an optional `cache=` arg for `_descendant_ids` memoization, but the visitor was passing nothing — so every call allocated a fresh cache and re-walked the same statement subtrees from scratch. Big files with many reassignments paid that cost O(accesses) times.

Fix: hoist a single `_descendant_cache: dict[int, set[int]]` onto the `SymbolVisitor` instance and thread it through both call sites. Visitor lifetime pins every CST node, so `id()` reuse can't poison entries (same lifetime argument that justifies the parallel `TruthinessResolver._descendant_cache` in `branches.py`).

While here, dropped a defensive `list(module_node.body)` wrapper inside the per-name loop in `_finalize_module_declarations` — `live_at_exit` takes a `Sequence`, so the copy was pure overhead per multi-decl name.

Pure performance change — output and the per-file payload-cache fingerprint are unchanged. No `version` bump needed.

## Benchmark

Synthetic modules with many reassignments, timing the inner `live_referents` loop (per-call cache = pre-fix, shared cache = post-fix):

| Case   | Module lines | `live_referents` calls | Per-call cache | Shared cache | Speedup    |
|--------|-------------:|-----------------------:|---------------:|-------------:|-----------:|
| tiny   |          63  |                    30  |       128.3 ms |       8.9 ms |  **14.5x** |
| small  |         205  |                   100  |     1 321.5 ms |      68.1 ms |  **19.4x** |
| medium |         810  |                   400  |    22 311.9 ms |   1 215.9 ms |  **18.4x** |

Per-call growth is super-quadratic in module size because each call re-walks every statement subtree to compute descendant ids. The shared cache amortizes that walk to once-per-node across the file.

## Test plan

- [x] `uv run pytest` — all 861 tests pass (includes the 3 from the merged shadowed-modules PR)
- [x] `uv run prek run --all-files` — ruff + ty clean
- [x] Existing `tests/test_flow_sensitive_filter.py` covers the `live_referents` contract; the cache is a transparent memo so no new test was added (a perf regression test would be flaky in CI)

https://claude.ai/code/session_012CUjfKzCfo587iB1iETspK