### PR TITLE
visitor: collapse runtime-dunder access to a plain module dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,19 @@ two versions.
 ## [Unreleased]
 
 ### Fixed
-- `_edges.resolve_edges` no longer logs a spurious "Failed to resolve import
-  edge" warning for accesses to runtime module dunders (`__file__`,
-  `__name__`, `__doc__`, `__loader__`, `__spec__`, `__package__`,
-  `__path__`, `__builtins__`, `__cached__`). These attributes are injected
-  by the import machinery on every module object and never appear as
-  source decls, so the trie walk would otherwise miss on any
-  `Path(some_pkg.__file__).parent` idiom (the standard "find a data file
-  next to me" pattern). The module-level edge already covers the
-  dependency; the trie miss is now dropped silently.
+- Attribute access on a runtime module dunder (`some_pkg.__file__`,
+  `some_pkg.__name__`, `some_pkg.__spec__`, etc.) no longer surfaces a
+  "Failed to resolve import edge" warning. The import machinery injects
+  these attributes on every module object at runtime, so the chain past
+  them is a path / string op, not a symbol reference. The visitor now
+  truncates the access chain at the dunder and emits a clean
+  `Import(module=X, decl=None)` instead of a speculative
+  `Import(module=X, decl="__file__")`. Reachability is unchanged -- the
+  module-level edge that previously rode alongside the failed lookup is
+  the same edge that's now emitted directly. Recognised dunders:
+  `__file__`, `__name__`, `__doc__`, `__loader__`, `__spec__`,
+  `__package__`, `__path__`, `__builtins__`, `__cached__`. Visitor
+  `version` is bumped so cached payloads rebuild.
 
 ## [0.9.2] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ two versions.
 
 ## [Unreleased]
 
+### Fixed
+- `_edges.resolve_edges` no longer logs a spurious "Failed to resolve import
+  edge" warning for accesses to runtime module dunders (`__file__`,
+  `__name__`, `__doc__`, `__loader__`, `__spec__`, `__package__`,
+  `__path__`, `__builtins__`, `__cached__`). These attributes are injected
+  by the import machinery on every module object and never appear as
+  source decls, so the trie walk would otherwise miss on any
+  `Path(some_pkg.__file__).parent` idiom (the standard "find a data file
+  next to me" pattern). The module-level edge already covers the
+  dependency; the trie miss is now dropped silently.
+
 ## [0.9.2] - 2026-05-12
 
 ### Added

--- a/dead_cst/_edges.py
+++ b/dead_cst/_edges.py
@@ -39,26 +39,6 @@ from .resolvers import ImportResolver, default_resolve_import
 
 logger = logging.getLogger(__name__)
 
-# Dunder attributes the import machinery injects on every module
-# object at runtime. They never appear in source as decls, so
-# ``some_module.__file__`` and friends always miss the trie -- but
-# they're real, valid attribute accesses, not unresolved symbols.
-# Silently drop the lookup so the module-level edge (already emitted
-# by the caller before ``_walk``) carries the dependency on its own.
-_MODULE_RUNTIME_DUNDERS = frozenset(
-    {
-        "__file__",
-        "__name__",
-        "__doc__",
-        "__loader__",
-        "__spec__",
-        "__package__",
-        "__path__",
-        "__builtins__",
-        "__cached__",
-    }
-)
-
 
 def _canonicalize(imp: Import, symbol_lookup: SymbolTrie) -> tuple[Import, SymbolTrie | None]:
     """Canonicalize ``imp`` and return the trie node its module lands on.
@@ -259,14 +239,6 @@ def resolve_edges(
             # that resolves as a submodule into ``Import.module``.
             if child := cur.children.get(part):
                 _enqueue(child, parts_now[1:])
-                continue
-
-            # ``some_module.__file__`` / ``__name__`` / ``__spec__`` /
-            # etc. are runtime attributes the import machinery injects
-            # on every module object -- never source decls, so they
-            # never appear in the trie. Drop silently; the module-level
-            # edge already covers the dependency.
-            if part in _MODULE_RUNTIME_DUNDERS:
                 continue
 
             logger.warning(

--- a/dead_cst/_edges.py
+++ b/dead_cst/_edges.py
@@ -39,6 +39,26 @@ from .resolvers import ImportResolver, default_resolve_import
 
 logger = logging.getLogger(__name__)
 
+# Dunder attributes the import machinery injects on every module
+# object at runtime. They never appear in source as decls, so
+# ``some_module.__file__`` and friends always miss the trie -- but
+# they're real, valid attribute accesses, not unresolved symbols.
+# Silently drop the lookup so the module-level edge (already emitted
+# by the caller before ``_walk``) carries the dependency on its own.
+_MODULE_RUNTIME_DUNDERS = frozenset(
+    {
+        "__file__",
+        "__name__",
+        "__doc__",
+        "__loader__",
+        "__spec__",
+        "__package__",
+        "__path__",
+        "__builtins__",
+        "__cached__",
+    }
+)
+
 
 def _canonicalize(imp: Import, symbol_lookup: SymbolTrie) -> tuple[Import, SymbolTrie | None]:
     """Canonicalize ``imp`` and return the trie node its module lands on.
@@ -239,6 +259,14 @@ def resolve_edges(
             # that resolves as a submodule into ``Import.module``.
             if child := cur.children.get(part):
                 _enqueue(child, parts_now[1:])
+                continue
+
+            # ``some_module.__file__`` / ``__name__`` / ``__spec__`` /
+            # etc. are runtime attributes the import machinery injects
+            # on every module object -- never source decls, so they
+            # never appear in the trie. Drop silently; the module-level
+            # edge already covers the dependency.
+            if part in _MODULE_RUNTIME_DUNDERS:
                 continue
 
             logger.warning(

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -29,15 +29,11 @@ from .graph import Import, NodeFlags, SymbolNode, SymbolTrie, VisitorPayload
 logger = logging.getLogger(__name__)
 
 # Attributes the import machinery injects on every module object at
-# runtime. They never appear in source, so attribute access like
-# ``some_module.__file__`` (the standard "find a data file next to me"
-# idiom) is a module-level dependency, not a symbol dependency --
-# attribute chains past these dunders are runtime string / path
-# operations, not symbol references. Truncating the access chain
-# before the dunder lets the visitor emit a clean
-# ``Import(module=X, decl=None)`` instead of a speculative
-# ``Import(module=X, decl="__file__")`` that the edge stitcher would
-# fail to resolve.
+# runtime. They never appear in source, so attribute access past one
+# of these (``some_pkg.__file__``, ``some_pkg.__spec__``, ...) is a
+# path / string op, not a symbol reference -- the access chain is
+# truncated at the dunder so the Import collapses to a module-level
+# dep.
 _MODULE_RUNTIME_DUNDERS = frozenset(
     {
         "__file__",
@@ -916,13 +912,6 @@ class SymbolVisitor(cst.CSTVisitor):
                             accessed_attrs.append(parent.attr.value)
                             curr_access = parent
 
-                    # ``slurm_pkg.__file__`` and friends: the import
-                    # machinery's runtime dunders aren't source decls,
-                    # so the chain past them is path / string ops, not
-                    # symbol references. Drop the dunder (and anything
-                    # after it) so the edge stitcher sees a plain
-                    # module-level Import instead of a speculative
-                    # ``decl="__file__"`` it can't resolve.
                     for i, attr in enumerate(accessed_attrs):
                         if attr in _MODULE_RUNTIME_DUNDERS:
                             del accessed_attrs[i:]

--- a/dead_cst/_visitor.py
+++ b/dead_cst/_visitor.py
@@ -28,6 +28,30 @@ from .graph import Import, NodeFlags, SymbolNode, SymbolTrie, VisitorPayload
 
 logger = logging.getLogger(__name__)
 
+# Attributes the import machinery injects on every module object at
+# runtime. They never appear in source, so attribute access like
+# ``some_module.__file__`` (the standard "find a data file next to me"
+# idiom) is a module-level dependency, not a symbol dependency --
+# attribute chains past these dunders are runtime string / path
+# operations, not symbol references. Truncating the access chain
+# before the dunder lets the visitor emit a clean
+# ``Import(module=X, decl=None)`` instead of a speculative
+# ``Import(module=X, decl="__file__")`` that the edge stitcher would
+# fail to resolve.
+_MODULE_RUNTIME_DUNDERS = frozenset(
+    {
+        "__file__",
+        "__name__",
+        "__doc__",
+        "__loader__",
+        "__spec__",
+        "__package__",
+        "__path__",
+        "__builtins__",
+        "__cached__",
+    }
+)
+
 
 def _dotted_name_parts(
     prefix: str, node: cst.BaseExpression
@@ -144,7 +168,7 @@ class SymbolVisitor(cst.CSTVisitor):
     # edge-attribution rules, flow-analysis fixes, etc. Concurrent
     # bumps on different branches merge with ``max()`` semantics.
     name: str = "default"
-    version: int = 1778326719
+    version: int = 1778573113
 
     def _pos(self, node: cst.CSTNode):
         return self.get_metadata(PositionProvider, node, default=None)
@@ -891,6 +915,18 @@ class SymbolVisitor(cst.CSTVisitor):
                                 break
                             accessed_attrs.append(parent.attr.value)
                             curr_access = parent
+
+                    # ``slurm_pkg.__file__`` and friends: the import
+                    # machinery's runtime dunders aren't source decls,
+                    # so the chain past them is path / string ops, not
+                    # symbol references. Drop the dunder (and anything
+                    # after it) so the edge stitcher sees a plain
+                    # module-level Import instead of a speculative
+                    # ``decl="__file__"`` it can't resolve.
+                    for i, attr in enumerate(accessed_attrs):
+                        if attr in _MODULE_RUNTIME_DUNDERS:
+                            del accessed_attrs[i:]
+                            break
 
                     # Create the new Import with the specific symbol being accessed
                     resolved_import = Import(

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -575,6 +575,39 @@ def test_unresolved_import_emits_synthetic_silently(build_decl_graph, caplog):
     )
 
 
+def test_module_runtime_dunder_access_is_silent(build_decl_graph, caplog):
+    """``pkg.__file__`` (and other runtime dunders) don't warn or surface synthetics.
+
+    The import machinery injects ``__file__`` / ``__name__`` / ``__spec__`` /
+    etc. onto every module object at runtime; they're never source decls, so
+    the trie walker would otherwise log "Failed to resolve import edge" for
+    a valid ``Path(some_pkg.__file__).parent`` idiom. The module-level edge
+    already covers the dependency.
+    """
+    with caplog.at_level(logging.WARNING, logger="dead_cst._edges"):
+        graph = build_decl_graph(
+            {
+                "pkg/__init__.py": "",
+                "pkg/config.py": (
+                    "from pathlib import Path\n"
+                    "import pkg as pkg_alias\n"
+                    "FILE_PATH = Path(pkg_alias.__file__).parent\n"
+                    "NAME = pkg_alias.__name__\n"
+                    "SPEC = pkg_alias.__spec__\n"
+                ),
+            }
+        )
+
+    failure_messages = [
+        r.getMessage() for r in caplog.records if "Failed to resolve import edge" in r.getMessage()
+    ]
+    assert failure_messages == [], failure_messages
+    # ``pkg`` stays alive via the module-level edge from ``pkg_alias``.
+    pkg_fqnames = {n.fqname for n in graph.nodes}
+    assert "pkg" in pkg_fqnames
+    assert "pkg.config.pkg_alias" in pkg_fqnames
+
+
 def test_cyclic_reexport_terminates(build_decl_graph, assert_edges):
     """Re-export cycle (``A.x: from B import x``, ``B.x: from A import x``) terminates with both legs emitted."""
     graph = build_decl_graph(

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -575,14 +575,15 @@ def test_unresolved_import_emits_synthetic_silently(build_decl_graph, caplog):
     )
 
 
-def test_module_runtime_dunder_access_is_silent(build_decl_graph, caplog):
-    """``pkg.__file__`` (and other runtime dunders) don't warn or surface synthetics.
+def test_module_runtime_dunder_access_is_module_dep(build_decl_graph, assert_edges, caplog):
+    """``pkg.__file__`` collapses to a plain ``Import(module=pkg, decl=None)``.
 
     The import machinery injects ``__file__`` / ``__name__`` / ``__spec__`` /
-    etc. onto every module object at runtime; they're never source decls, so
-    the trie walker would otherwise log "Failed to resolve import edge" for
-    a valid ``Path(some_pkg.__file__).parent`` idiom. The module-level edge
-    already covers the dependency.
+    etc. onto every module object at runtime -- attribute access past one of
+    these is a path / string op, not a symbol reference. The visitor truncates
+    the access chain at the dunder so the edge stitcher sees a clean module-
+    level dependency (no speculative ``decl="__file__"`` that it would warn
+    about, no synthetic node for the missing attribute).
     """
     with caplog.at_level(logging.WARNING, logger="dead_cst._edges"):
         graph = build_decl_graph(
@@ -598,14 +599,33 @@ def test_module_runtime_dunder_access_is_silent(build_decl_graph, caplog):
             }
         )
 
-    failure_messages = [
-        r.getMessage() for r in caplog.records if "Failed to resolve import edge" in r.getMessage()
-    ]
-    assert failure_messages == [], failure_messages
-    # ``pkg`` stays alive via the module-level edge from ``pkg_alias``.
-    pkg_fqnames = {n.fqname for n in graph.nodes}
-    assert "pkg" in pkg_fqnames
-    assert "pkg.config.pkg_alias" in pkg_fqnames
+    assert [r.getMessage() for r in caplog.records] == []
+    # No synthetic was minted for the missing-dunder lookup.
+    assert not [n.fqname for n in graph.nodes if n.fqname.endswith(".__file__")]
+    # The module-level dependency edges remain intact for each user of a dunder.
+    edge_strs = {f"{src.fqname} -> {dst.fqname}" for src, dst in graph.edges(keys=False)}
+    assert "pkg.config.FILE_PATH -> pkg" in edge_strs
+    assert "pkg.config.NAME -> pkg" in edge_strs
+    assert "pkg.config.SPEC -> pkg" in edge_strs
+
+
+def test_dunder_on_imported_symbol_strips_dunder_tail(build_decl_graph, assert_edges):
+    """``from pkg import Cls; Cls.__name__`` -> edge to ``Cls``, not ``Cls.__name__``.
+
+    Regression guard for the visitor-level dunder strip: the truncation
+    drops the dunder *and everything after it*, so an access through an
+    imported symbol still resolves to that symbol (not past it).
+    """
+    graph = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/lib.py": "class Cls:\n    pass\n",
+            "pkg/uses.py": ("from pkg.lib import Cls\nWHO = Cls.__name__\nDOCSTR = Cls.__doc__\n"),
+        }
+    )
+    edge_strs = {f"{src.fqname} -> {dst.fqname}" for src, dst in graph.edges(keys=False)}
+    assert "pkg.uses.WHO -> pkg.lib.Cls" in edge_strs
+    assert "pkg.uses.DOCSTR -> pkg.lib.Cls" in edge_strs
 
 
 def test_cyclic_reexport_terminates(build_decl_graph, assert_edges):


### PR DESCRIPTION
## Summary

- `Path(some_pkg.__file__).parent` (the standard "find a data file next to me" idiom) and friends — `some_pkg.__name__`, `some_pkg.__spec__`, `some_pkg.__path__`, etc. — surfaced a "Failed to resolve import edge" warning from `_edges.resolve_edges`. The import machinery injects these attributes on every module object at runtime, so they never appear as source decls; the trie walk would miss every time.
- The visitor now truncates the attribute-access chain at any runtime module dunder before building the `Import`. `slurm_pkg.__file__` collapses to `Import(module=...slurm, decl=None)` instead of a speculative `Import(module=...slurm, decl="__file__")` that the stitcher had to give up on. Recognized dunders: `__file__`, `__name__`, `__doc__`, `__loader__`, `__spec__`, `__package__`, `__path__`, `__builtins__`, `__cached__`.
- Reachability is unchanged. The module-level edge that `_resolve_targets` previously emitted *before* calling `_walk` is the same edge that's now emitted directly — the failing walk was only ever noise; the dependency itself was already in the graph.
- `SymbolVisitor.version` is bumped so cached `VisitorPayload` blobs rebuild against the new shape (stale payloads would emit ghost `decl="__file__"` Imports forever).

## Why visitor-level vs edge-stitcher-level

An earlier commit on this branch silenced the warning inside `_walk` (same shape as the 0.9.0 stdlib-import silencing in 35cac98). That fix was correct but masked the real issue at the wrong layer — every plugin and cache consumer downstream saw the speculative `decl="__file__"` Import. Moving the strip into the visitor makes the per-file payload semantically clean, eliminates the speculative trie walk entirely, and lets the `_edges.py` defense be deleted. Net diff is smaller too.

## Test plan

- [x] `uv run pytest` — 880 passed, 10 deselected
- [x] `uv run prek run --all-files` — ruff (lint+format), ty, pre-commit hooks all green
- [x] New regression test `test_module_runtime_dunder_access_is_module_dep` — pins that `pkg.__file__` / `.__name__` / `.__spec__` produce a clean module-level edge with no warning and no synthetic node
- [x] New regression test `test_dunder_on_imported_symbol_strips_dunder_tail` — guards that `from pkg import Cls; Cls.__name__` still resolves to `Cls` (the strip drops the dunder *and everything after it*, but the symbol before the dunder is preserved)
- [x] Manual repro against the original `midjourney.cluster.platforms.slurm` shape — warning gone, `slurm` still reachable from `CLUSTERS`

https://claude.ai/code/session_012oyMf7ysVAb2nVweUiyVEW