### PR TITLE
ci: trigger publish on GitHub Release published instead of tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,8 @@ name: Publish
 on:
   push:
     branches: [main]
-    tags: ["v*"]
+  release:
+    types: [published]
 
 permissions:
   id-token: write
@@ -38,7 +39,7 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
 
   publish-pypi:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'release'
     needs: build
     runs-on: ubuntu-latest
     environment: pypi
@@ -49,8 +50,8 @@ jobs:
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
 
-  github-release:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+  attach-release-assets:
+    if: github.event_name == 'release'
     needs: publish-pypi
     runs-on: ubuntu-latest
     permissions:
@@ -62,7 +63,5 @@ jobs:
           path: dist/
       - uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
           files: dist/*
-          prerelease: true
           fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ two versions.
 
 ## [Unreleased]
 
+### Changed
+- Release workflow now triggers on GitHub Release `published` instead of
+  on a `v*` tag push. Publishing a Release with a new `vX.Y.Z` tag name
+  (which the GitHub Releases UI creates for you, including from mobile)
+  builds the package, publishes to PyPI via OIDC, and attaches the
+  built sdist/wheel to the release. Tag-only pushes no longer publish.
+
 ### Fixed
 - `FastAPIPlugin` and `FlaskPlugin` now classify the factory pattern
   across packages when the factory uses `import fastapi; fastapi.FastAPI()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,6 @@ two versions.
 
 ## [Unreleased]
 
-### Changed
-- Release workflow now triggers on GitHub Release `published` instead of
-  on a `v*` tag push. Publishing a Release with a new `vX.Y.Z` tag name
-  (which the GitHub Releases UI creates for you, including from mobile)
-  builds the package, publishes to PyPI via OIDC, and attaches the
-  built sdist/wheel to the release. Tag-only pushes no longer publish.
-
 ### Fixed
 - `FastAPIPlugin` and `FlaskPlugin` now classify the factory pattern
   across packages when the factory uses `import fastapi; fastapi.FastAPI()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ Implement `UnreachableRegionDetector`: `name`, `version`, `find_regions(wrapper)
 - **Versioning is tag-driven via `hatch-vcs`** — never hand-edit a version. `local_scheme = "no-local-version"` is required because PyPI rejects PEP 440 local-version identifiers; `SETUPTOOLS_SCM_OVERRIDES_FOR_*` does not work here (only `Configuration.from_file()` reads it).
 - **Cache invalidation discipline**: any change to the visitor / plugin / detector's *output* for the same input requires bumping its `version` to a fresh epoch, or stale cache entries will be served. Resolvers and the package layout are *not* in the fingerprint — their effect flows through the (uncached) edge-stitching pass — so a resolver swap or update doesn't invalidate cached payloads (and `PathResolver` carries no `Cacheable` knob to bump). `__version__` deliberately is not a backstop. The schema-level `SCHEMA_VERSION` in `_cache.py` is for `VisitorPayload` shape breaks the unpickler can't handle.
 - **PRs**: one logical change per PR, add/update tests, add a `[Unreleased]` `CHANGELOG.md` entry for user-visible changes.
-- **Releases**: pushing a `vX.Y.Z` tag triggers `.github/workflows/publish.yml` (uv build + PyPI OIDC publish).
+- **Releases**: publishing a GitHub Release with a `vX.Y.Z` tag name triggers `.github/workflows/publish.yml` (uv build + PyPI OIDC publish + dist attached to the release). The Releases UI creates the tag, so a release can be cut from mobile.
 
 ## Known limitations to keep in mind
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,4 +154,4 @@ A good bug report contains a minimal `.py` file (or pair of files) and the entry
 
 ## Releasing
 
-Releases are tag-driven. Pushing a `vX.Y.Z` tag triggers `.github/workflows/publish.yml`, which builds the package with `uv build` and publishes to PyPI via OIDC. The version is read from the tag by `hatch-vcs`, so no manual version bumps in source files are needed.
+Releases are GitHub-Release-driven. Publishing a GitHub Release with a `vX.Y.Z` tag name (the Releases UI creates the tag for you, which makes it possible from mobile) triggers `.github/workflows/publish.yml`, which builds the package with `uv build`, publishes to PyPI via OIDC, and attaches the built sdist/wheel to the release. The version is read from the tag by `hatch-vcs`, so no manual version bumps in source files are needed.


### PR DESCRIPTION
Inverts the publish workflow so creating a GitHub Release (which the
Releases UI creates a tag for, including from mobile) drives the
build → PyPI publish → release-asset attach sequence. Tag-only pushes no
longer publish, which removes the need to push tags from a phone — not
something the GitHub mobile UI supports directly.

https://claude.ai/code/session_01FNFkgr57ygHhqWcrAZCgyr