### PR TITLE
plugins: precompute package_graph / module_nodes on PluginContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,15 @@ two versions.
 ## [0.9.4] - 2026-05-12
 
 ### Changed
-- `PluginContext` now requires a `package_graph` field (the per-package
-  contribution graph). `package_nodes` / `package_modules` iterate it
-  directly, dropping the `Path.is_relative_to` filter over the merged
-  cross-package `graph`. The analyzer wires this through automatically;
-  custom callers that construct `PluginContext` directly must pass
-  `package_graph=`.
+- `PluginContext` now requires `package_graph` (the per-package
+  contribution graph) and `module_nodes` (its module-typed entries,
+  precomputed in `_apply_payload` from the `next(...)` it already does
+  per file). `package_nodes` iterates `package_graph.nodes` directly
+  and `package_modules` iterates the `module_nodes` tuple -- both drop
+  the `Path.is_relative_to` filter over the merged cross-package
+  `graph`, and `package_modules` also drops the `type == "module"`
+  scan. The analyzer wires these through automatically; custom
+  callers that construct `PluginContext` directly must pass both.
 
 ## [0.9.3] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ two versions.
 
 ## [Unreleased]
 
+### Changed
+- `PluginContext` accepts an optional `package_graph` constructor
+  argument; when set, `package_nodes` / `package_modules` seed their
+  caches directly from the per-package contribution graph instead of
+  filtering the merged cross-package graph by `Path.is_relative_to`.
+  The analyzer wires `PackageContribution.package_graph` through
+  automatically during `_compose_contribution`, so plugins inside
+  `finalize` skip the O(N_total) walk that previously dominated the
+  first `package_nodes` call in each pass (~235× faster on the
+  dead-cst self-analysis: 9.2 ms → 39 µs). Behavior is unchanged for
+  tests and custom pipelines that construct `PluginContext` without
+  the hint -- the filter path still works.
+
 ## [0.9.3] - 2026-05-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ two versions.
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-05-12
+
 ### Changed
 - `PluginContext` now requires a `package_graph` field (the per-package
   contribution graph). `package_nodes` / `package_modules` iterate it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,12 @@ two versions.
 ## [Unreleased]
 
 ### Changed
-- `PluginContext` now requires a `package_graph` argument: the
-  pre-merge per-package contribution graph. `package_nodes` /
-  `package_modules` source their snapshot from it directly, replacing
-  the previous `Path.is_relative_to` filter over the merged
-  cross-package `graph` -- an O(N_total) walk that dominated the first
-  plugin call in each finalize pass (~235× faster on the dead-cst
-  self-analysis: 9.2 ms → 39 µs). The analyzer wires
-  `PackageContribution.package_graph` through automatically. **Custom
-  callers that construct `PluginContext` directly (in tests or
-  out-of-tree pipelines) must pass `package_graph=`** -- for tests with
-  a single graph, `package_graph=graph` reuses the existing input.
+- `PluginContext` now requires a `package_graph` field (the per-package
+  contribution graph). `package_nodes` / `package_modules` iterate it
+  directly, dropping the `Path.is_relative_to` filter over the merged
+  cross-package `graph`. The analyzer wires this through automatically;
+  custom callers that construct `PluginContext` directly must pass
+  `package_graph=`.
 
 ## [0.9.3] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,14 @@ two versions.
 
 ### Changed
 - `PluginContext` now requires `package_graph` (the per-package
-  contribution graph) and `module_nodes` (its module-typed entries,
-  precomputed in `_apply_payload` from the `next(...)` it already does
-  per file). `package_nodes` iterates `package_graph.nodes` directly
-  and `package_modules` iterates the `module_nodes` tuple -- both drop
-  the `Path.is_relative_to` filter over the merged cross-package
-  `graph`, and `package_modules` also drops the `type == "module"`
-  scan. The analyzer wires these through automatically; custom
-  callers that construct `PluginContext` directly must pass both.
+  contribution graph) and `module_nodes` (its module-typed entries).
+  `package_nodes` and `package_modules` source from these directly,
+  dropping the `Path.is_relative_to` filter and `type == "module"`
+  scan they used to run on the merged cross-package `graph`. The
+  analyzer wires both through automatically; custom callers that
+  construct `PluginContext` directly must pass them.
+- `PackageView.modules()` now reads `PackageContribution.module_nodes`
+  instead of refiltering the contribution graph.
 
 ## [0.9.3] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,17 @@ two versions.
 ## [Unreleased]
 
 ### Changed
-- `PluginContext` accepts an optional `package_graph` constructor
-  argument; when set, `package_nodes` / `package_modules` seed their
-  caches directly from the per-package contribution graph instead of
-  filtering the merged cross-package graph by `Path.is_relative_to`.
-  The analyzer wires `PackageContribution.package_graph` through
-  automatically during `_compose_contribution`, so plugins inside
-  `finalize` skip the O(N_total) walk that previously dominated the
-  first `package_nodes` call in each pass (~235× faster on the
-  dead-cst self-analysis: 9.2 ms → 39 µs). Behavior is unchanged for
-  tests and custom pipelines that construct `PluginContext` without
-  the hint -- the filter path still works.
+- `PluginContext` now requires a `package_graph` argument: the
+  pre-merge per-package contribution graph. `package_nodes` /
+  `package_modules` source their snapshot from it directly, replacing
+  the previous `Path.is_relative_to` filter over the merged
+  cross-package `graph` -- an O(N_total) walk that dominated the first
+  plugin call in each finalize pass (~235× faster on the dead-cst
+  self-analysis: 9.2 ms → 39 µs). The analyzer wires
+  `PackageContribution.package_graph` through automatically. **Custom
+  callers that construct `PluginContext` directly (in tests or
+  out-of-tree pipelines) must pass `package_graph=`** -- for tests with
+  a single graph, `package_graph=graph` reuses the existing input.
 
 ## [0.9.3] - 2026-05-12
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -159,18 +159,16 @@ Folded down from earlier tiers as they landed:
 
 - **v0.9.4**: ``PluginContext`` now requires ``package_graph`` (the
   per-package contribution graph) and ``module_nodes`` (its
-  module-typed entries, precomputed in ``_apply_payload`` from the
-  ``next(...)`` it already does per file). ``package_nodes`` snapshots
-  ``package_graph.nodes`` and ``package_modules`` reads ``module_nodes``
-  directly, replacing two filter passes -- ``Path.is_relative_to`` over
-  the merged cross-package ``graph`` (dominated the first call in every
-  finalize pass: ~9 ms → ~40 µs on the dead-cst self-analysis) and
-  ``type == "module"`` over the contribution graph (~50 µs → ~4 µs).
-  Plugin behavior is unchanged; the helpers expose the same node sets
-  they always did. Custom callers that construct ``PluginContext``
-  directly (tests, out-of-tree pipelines) must pass both fields -- a
-  hard break rather than an optional shim, matching the pre-1.0 API
-  churn budget.
+  module-typed entries). ``package_nodes`` snapshots
+  ``package_graph.nodes`` and ``package_modules`` iterates
+  ``module_nodes`` directly, replacing two filter passes that ran on
+  the merged cross-package ``graph`` every finalize pass:
+  ``Path.is_relative_to`` (~9 ms → ~40 µs on the dead-cst
+  self-analysis) and ``type == "module"`` (~50 µs → ~4 µs). The
+  analyzer wires both through automatically; custom callers that
+  construct ``PluginContext`` directly must pass them -- a hard break
+  rather than an optional shim, matching the pre-1.0 API churn budget.
+  ``PackageView.modules()`` also picks up the precomputed list.
 - **v0.9.3**: ``ServerConfigPlugin`` (``dead_cst.contrib.server_config``,
   registered as the ``server_config`` builtin) marks Gunicorn / Hypercorn
   config files (``gunicorn.conf.py``, ``gunicorn_conf.py``,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -157,6 +157,17 @@ demand.
 
 Folded down from earlier tiers as they landed:
 
+- **v0.9.4**: ``PluginContext`` now requires a ``package_graph`` field
+  (the per-package contribution graph, passed by the analyzer);
+  ``package_nodes`` and ``package_modules`` snapshot from it directly
+  instead of filtering the merged cross-package ``graph`` by
+  ``Path.is_relative_to``. The filter was an O(N_total) walk that
+  dominated the first ``package_nodes`` call in every finalize pass
+  (~9 ms → ~40 µs on the dead-cst self-analysis). Plugin behavior is
+  unchanged; the helpers expose the same node sets they always did.
+  Custom callers that construct ``PluginContext`` directly (tests,
+  out-of-tree pipelines) must pass ``package_graph=`` -- a hard break
+  rather than an optional shim, matching the pre-1.0 API churn budget.
 - **v0.9.3**: ``ServerConfigPlugin`` (``dead_cst.contrib.server_config``,
   registered as the ``server_config`` builtin) marks Gunicorn / Hypercorn
   config files (``gunicorn.conf.py``, ``gunicorn_conf.py``,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -157,17 +157,20 @@ demand.
 
 Folded down from earlier tiers as they landed:
 
-- **v0.9.4**: ``PluginContext`` now requires a ``package_graph`` field
-  (the per-package contribution graph, passed by the analyzer);
-  ``package_nodes`` and ``package_modules`` snapshot from it directly
-  instead of filtering the merged cross-package ``graph`` by
-  ``Path.is_relative_to``. The filter was an O(N_total) walk that
-  dominated the first ``package_nodes`` call in every finalize pass
-  (~9 ms → ~40 µs on the dead-cst self-analysis). Plugin behavior is
-  unchanged; the helpers expose the same node sets they always did.
-  Custom callers that construct ``PluginContext`` directly (tests,
-  out-of-tree pipelines) must pass ``package_graph=`` -- a hard break
-  rather than an optional shim, matching the pre-1.0 API churn budget.
+- **v0.9.4**: ``PluginContext`` now requires ``package_graph`` (the
+  per-package contribution graph) and ``module_nodes`` (its
+  module-typed entries, precomputed in ``_apply_payload`` from the
+  ``next(...)`` it already does per file). ``package_nodes`` snapshots
+  ``package_graph.nodes`` and ``package_modules`` reads ``module_nodes``
+  directly, replacing two filter passes -- ``Path.is_relative_to`` over
+  the merged cross-package ``graph`` (dominated the first call in every
+  finalize pass: ~9 ms → ~40 µs on the dead-cst self-analysis) and
+  ``type == "module"`` over the contribution graph (~50 µs → ~4 µs).
+  Plugin behavior is unchanged; the helpers expose the same node sets
+  they always did. Custom callers that construct ``PluginContext``
+  directly (tests, out-of-tree pipelines) must pass both fields -- a
+  hard break rather than an optional shim, matching the pre-1.0 API
+  churn budget.
 - **v0.9.3**: ``ServerConfigPlugin`` (``dead_cst.contrib.server_config``,
   registered as the ``server_config`` builtin) marks Gunicorn / Hypercorn
   config files (``gunicorn.conf.py``, ``gunicorn_conf.py``,

--- a/dead_cst/_refresh.py
+++ b/dead_cst/_refresh.py
@@ -105,6 +105,7 @@ class PackageContribution:
     export_trie: SymbolTrie
     package_graph: nx.MultiDiGraph
     import_edges: frozenset[tuple[SymbolNode, Import, EdgeFlags]]
+    module_nodes: tuple[SymbolNode, ...]
 
 
 def enumerate_files(
@@ -335,6 +336,7 @@ def build_contribution(
     import_edges: set[tuple[SymbolNode, Import, EdgeFlags]] = set()
     package_graph: nx.MultiDiGraph = nx.MultiDiGraph()
     package_graph.graph["dead_suites"] = {}
+    module_nodes: list[SymbolNode] = []
     shadowed = shadowed_paths(package_files.files)
     for file in package_files.files:
         payload = package_files.hits.get(file)
@@ -347,14 +349,16 @@ def build_contribution(
         if payload is None:
             continue
         file_exported = not exported or _under_any(file, list(exported))
-        _apply_payload(
-            payload,
-            current_trie=current_trie,
-            export_trie=export_trie,
-            file_exported=file_exported,
-            add_to_trie=file not in shadowed,
-            symbol_graph=package_graph,
-            import_edges=import_edges,
+        module_nodes.append(
+            _apply_payload(
+                payload,
+                current_trie=current_trie,
+                export_trie=export_trie,
+                file_exported=file_exported,
+                add_to_trie=file not in shadowed,
+                symbol_graph=package_graph,
+                import_edges=import_edges,
+            )
         )
     current_trie.add_module_hierarchy_edges(package_graph)
     return PackageContribution(
@@ -363,6 +367,7 @@ def build_contribution(
         export_trie=export_trie,
         package_graph=package_graph,
         import_edges=frozenset(import_edges),
+        module_nodes=tuple(module_nodes),
     )
 
 
@@ -582,7 +587,7 @@ def _apply_payload(
     add_to_trie: bool,
     symbol_graph: nx.MultiDiGraph,
     import_edges: set[tuple[SymbolNode, Import, EdgeFlags]],
-) -> None:
+) -> SymbolNode:
     """Emit ``payload`` into the in-progress per-package structures.
 
     Drives all node routing off ``SymbolNode.flags`` and ``type``:
@@ -668,6 +673,8 @@ def _apply_payload(
 
     if payload.dead_suites:
         symbol_graph.graph["dead_suites"][module.path] = payload.dead_suites
+
+    return module
 
 
 def _merge_payloads(*payloads: VisitorPayload) -> VisitorPayload:

--- a/dead_cst/analyze.py
+++ b/dead_cst/analyze.py
@@ -128,6 +128,7 @@ def _compose_contribution(
             symbol_lookup=symbol_lookup,
             package=contrib.package,
             project_root=project_root,
+            package_graph=contrib.package_graph,
         )
         for plugin in plugins:
             if not isinstance(plugin, EdgePlugin):

--- a/dead_cst/analyze.py
+++ b/dead_cst/analyze.py
@@ -949,6 +949,7 @@ class PackageView:
             symbol_lookup=self._analysis._build_symbol_lookup(self._package.path, scope=scope),
             package=self._package,
             project_root=self._analysis.project_root,
+            package_graph=self._analysis._contributions[self._package.path].package_graph,
         )
         return ctx.importers(target)
 

--- a/dead_cst/analyze.py
+++ b/dead_cst/analyze.py
@@ -129,6 +129,7 @@ def _compose_contribution(
             package=contrib.package,
             project_root=project_root,
             package_graph=contrib.package_graph,
+            module_nodes=contrib.module_nodes,
         )
         for plugin in plugins:
             if not isinstance(plugin, EdgePlugin):
@@ -944,12 +945,14 @@ class PackageView:
         what populates the predecessors used here.
         """
         scope = self._analysis._interesting_set(self._package.path)
+        contrib = self._analysis._contributions[self._package.path]
         ctx = PluginContext(
             graph=self._analysis.materialize_closure(self._package.path),
             symbol_lookup=self._analysis._build_symbol_lookup(self._package.path, scope=scope),
             package=self._package,
             project_root=self._analysis.project_root,
-            package_graph=self._analysis._contributions[self._package.path].package_graph,
+            package_graph=contrib.package_graph,
+            module_nodes=contrib.module_nodes,
         )
         return ctx.importers(target)
 

--- a/dead_cst/analyze.py
+++ b/dead_cst/analyze.py
@@ -916,9 +916,7 @@ class PackageView:
         Local-only: refreshes this package if needed but never
         touches deps or consumers.
         """
-        for n in self._contribution().package_graph.nodes:
-            if n.type == "module":
-                yield n
+        yield from self._contribution().module_nodes
 
     def declarations(self, name: str | None = None) -> Iterator[SymbolNode]:
         """Top-level decls in this package.

--- a/dead_cst/plugins/_core.py
+++ b/dead_cst/plugins/_core.py
@@ -88,6 +88,15 @@ class PluginContext:
     symbol_lookup: SymbolTrie
     package: Package
     project_root: Path
+    # Optional pre-merge per-package contribution graph. When supplied,
+    # ``package_modules`` / ``package_nodes`` seed their caches directly
+    # from its node set instead of filtering the merged cross-package
+    # ``graph`` by ``Path.is_relative_to`` -- an O(N_total) walk that
+    # dominates the first plugin call in each finalize pass. The analyzer
+    # passes ``PackageContribution.package_graph`` here; external callers
+    # (tests, custom pipelines) can leave it unset and the helpers fall
+    # back to the filter path.
+    package_graph: nx.MultiDiGraph | None = None
     _modules: dict[Path, cst.Module | None] = field(default_factory=dict, repr=False)
     # Lazy ``fqname -> SymbolNode`` index over synthetic nodes (built on
     # first ``importers`` call).  Plugins that add their own synthetic
@@ -99,7 +108,8 @@ class PluginContext:
     # Plugins may add nodes during their pass (entrypoint synthetics,
     # etc.) but those are never re-iterated by these helpers; we
     # snapshot once at first call to keep iteration cheap when ``graph``
-    # accumulates nodes across packages.
+    # accumulates nodes across packages. When ``package_graph`` is set,
+    # the snapshot is taken from it directly, sidestepping the filter.
     _package_modules_cache: list[tuple[Path, SymbolNode]] | None = field(
         default=None, init=False, repr=False
     )
@@ -153,12 +163,17 @@ class PluginContext:
     def package_modules(self) -> Iterator[tuple[Path, SymbolNode]]:
         """Yield ``(path, module_node)`` for every module under :attr:`package`."""
         if self._package_modules_cache is None:
-            package_path = self.package.path
-            self._package_modules_cache = [
-                (node.path, node)
-                for node in self.graph.nodes
-                if node.type == "module" and node.path.is_relative_to(package_path)
-            ]
+            if self.package_graph is not None:
+                self._package_modules_cache = [
+                    (node.path, node) for node in self.package_graph.nodes if node.type == "module"
+                ]
+            else:
+                package_path = self.package.path
+                self._package_modules_cache = [
+                    (node.path, node)
+                    for node in self.graph.nodes
+                    if node.type == "module" and node.path.is_relative_to(package_path)
+                ]
         return iter(self._package_modules_cache)
 
     def package_nodes(self) -> Iterator[SymbolNode]:
@@ -170,10 +185,13 @@ class PluginContext:
         belonging to sibling packages.
         """
         if self._package_nodes_cache is None:
-            package_path = self.package.path
-            self._package_nodes_cache = [
-                node for node in self.graph.nodes if node.path.is_relative_to(package_path)
-            ]
+            if self.package_graph is not None:
+                self._package_nodes_cache = list(self.package_graph.nodes)
+            else:
+                package_path = self.package.path
+                self._package_nodes_cache = [
+                    node for node in self.graph.nodes if node.path.is_relative_to(package_path)
+                ]
         return iter(self._package_nodes_cache)
 
     def importers(self, target: str) -> set[Path]:

--- a/dead_cst/plugins/_core.py
+++ b/dead_cst/plugins/_core.py
@@ -88,15 +88,13 @@ class PluginContext:
     symbol_lookup: SymbolTrie
     package: Package
     project_root: Path
-    # Optional pre-merge per-package contribution graph. When supplied,
-    # ``package_modules`` / ``package_nodes`` seed their caches directly
-    # from its node set instead of filtering the merged cross-package
-    # ``graph`` by ``Path.is_relative_to`` -- an O(N_total) walk that
-    # dominates the first plugin call in each finalize pass. The analyzer
-    # passes ``PackageContribution.package_graph`` here; external callers
-    # (tests, custom pipelines) can leave it unset and the helpers fall
-    # back to the filter path.
-    package_graph: nx.MultiDiGraph | None = None
+    # Per-package contribution graph: every node whose path is under
+    # ``package.path``, before the cross-package merge. ``package_nodes``
+    # / ``package_modules`` source from this directly so they don't pay
+    # an O(N_total) ``Path.is_relative_to`` scan over the merged
+    # ``graph`` on the first call. The analyzer passes
+    # ``PackageContribution.package_graph``.
+    package_graph: nx.MultiDiGraph
     _modules: dict[Path, cst.Module | None] = field(default_factory=dict, repr=False)
     # Lazy ``fqname -> SymbolNode`` index over synthetic nodes (built on
     # first ``importers`` call).  Plugins that add their own synthetic
@@ -108,8 +106,7 @@ class PluginContext:
     # Plugins may add nodes during their pass (entrypoint synthetics,
     # etc.) but those are never re-iterated by these helpers; we
     # snapshot once at first call to keep iteration cheap when ``graph``
-    # accumulates nodes across packages. When ``package_graph`` is set,
-    # the snapshot is taken from it directly, sidestepping the filter.
+    # accumulates nodes across packages.
     _package_modules_cache: list[tuple[Path, SymbolNode]] | None = field(
         default=None, init=False, repr=False
     )
@@ -163,21 +160,13 @@ class PluginContext:
     def package_modules(self) -> Iterator[tuple[Path, SymbolNode]]:
         """Yield ``(path, module_node)`` for every module under :attr:`package`."""
         if self._package_modules_cache is None:
-            if self.package_graph is not None:
-                self._package_modules_cache = [
-                    (node.path, node) for node in self.package_graph.nodes if node.type == "module"
-                ]
-            else:
-                package_path = self.package.path
-                self._package_modules_cache = [
-                    (node.path, node)
-                    for node in self.graph.nodes
-                    if node.type == "module" and node.path.is_relative_to(package_path)
-                ]
+            self._package_modules_cache = [
+                (node.path, node) for node in self.package_graph.nodes if node.type == "module"
+            ]
         return iter(self._package_modules_cache)
 
     def package_nodes(self) -> Iterator[SymbolNode]:
-        """Yield every graph node whose path is under :attr:`package`.
+        """Yield every graph node under :attr:`package`.
 
         ``graph`` accumulates nodes across packages; plugins that need
         to iterate "everything in this package" should use this instead
@@ -185,13 +174,7 @@ class PluginContext:
         belonging to sibling packages.
         """
         if self._package_nodes_cache is None:
-            if self.package_graph is not None:
-                self._package_nodes_cache = list(self.package_graph.nodes)
-            else:
-                package_path = self.package.path
-                self._package_nodes_cache = [
-                    node for node in self.graph.nodes if node.path.is_relative_to(package_path)
-                ]
+            self._package_nodes_cache = list(self.package_graph.nodes)
         return iter(self._package_nodes_cache)
 
     def importers(self, target: str) -> set[Path]:

--- a/dead_cst/plugins/_core.py
+++ b/dead_cst/plugins/_core.py
@@ -86,6 +86,7 @@ class PluginContext:
 
     graph: nx.DiGraph
     package_graph: nx.MultiDiGraph
+    module_nodes: tuple[SymbolNode, ...]
     symbol_lookup: SymbolTrie
     package: Package
     project_root: Path
@@ -96,14 +97,8 @@ class PluginContext:
     # is fine in practice -- ``importers`` is for prefiltering against
     # the analyzer's already-resolved dep markers.
     _synthetic_index: dict[str, SymbolNode] | None = field(default=None, init=False, repr=False)
-    # Cached materialization of ``package_modules`` / ``package_nodes``.
-    # Plugins may add nodes during their pass (entrypoint synthetics,
-    # etc.) but those are never re-iterated by these helpers; we
-    # snapshot once at first call to keep iteration cheap when ``graph``
-    # accumulates nodes across packages.
-    _package_modules_cache: list[tuple[Path, SymbolNode]] | None = field(
-        default=None, init=False, repr=False
-    )
+    # Snapshot of ``package_graph.nodes`` taken on first call so plugins
+    # that add nodes during their pass see a stable iteration target.
     _package_nodes_cache: list[SymbolNode] | None = field(default=None, init=False, repr=False)
 
     def find_module(self, fqname: str) -> SymbolNode | None:
@@ -153,11 +148,7 @@ class PluginContext:
 
     def package_modules(self) -> Iterator[tuple[Path, SymbolNode]]:
         """Yield ``(path, module_node)`` for every module under :attr:`package`."""
-        if self._package_modules_cache is None:
-            self._package_modules_cache = [
-                (node.path, node) for node in self.package_graph.nodes if node.type == "module"
-            ]
-        return iter(self._package_modules_cache)
+        return ((n.path, n) for n in self.module_nodes)
 
     def package_nodes(self) -> Iterator[SymbolNode]:
         """Yield every graph node under :attr:`package`.

--- a/dead_cst/plugins/_core.py
+++ b/dead_cst/plugins/_core.py
@@ -85,16 +85,10 @@ class PluginContext:
     """
 
     graph: nx.DiGraph
+    package_graph: nx.MultiDiGraph
     symbol_lookup: SymbolTrie
     package: Package
     project_root: Path
-    # Per-package contribution graph: every node whose path is under
-    # ``package.path``, before the cross-package merge. ``package_nodes``
-    # / ``package_modules`` source from this directly so they don't pay
-    # an O(N_total) ``Path.is_relative_to`` scan over the merged
-    # ``graph`` on the first call. The analyzer passes
-    # ``PackageContribution.package_graph``.
-    package_graph: nx.MultiDiGraph
     _modules: dict[Path, cst.Module | None] = field(default_factory=dict, repr=False)
     # Lazy ``fqname -> SymbolNode`` index over synthetic nodes (built on
     # first ``importers`` call).  Plugins that add their own synthetic

--- a/scripts/profile_build_contribution.py
+++ b/scripts/profile_build_contribution.py
@@ -139,23 +139,18 @@ def main() -> None:
 
 
 def _profile_package_nodes(contrib: PackageContribution, project_root: Path) -> None:
-    """Benchmark :meth:`PluginContext.package_nodes`.
+    """Benchmark :meth:`PluginContext.package_nodes` on both paths.
 
     Single-package workload: ``contrib.package_graph`` *is* the composed
-    graph, so the ``is_relative_to`` filter is a worst-case "every node
-    matches" scan. A multi-package workspace gets a slightly cheaper
-    filter per package but the same per-call cost class -- this run
-    bounds it.
+    graph, so the legacy ``is_relative_to`` filter is a worst-case "every
+    node matches" scan. The seeded path (``package_graph=...`` passed to
+    :class:`PluginContext`) sidesteps the filter entirely.
     """
     graph = contrib.package_graph
     n_total = graph.number_of_nodes()
     print(f"\npackage_nodes: composed graph has {n_total} node(s)")
 
-    # Cold-call benchmark: rebuild a fresh ``PluginContext`` each
-    # iteration so the cache doesn't short-circuit the walk. This is
-    # the real per-finalize cost (``_compose_contribution`` constructs
-    # a new context per package).
-    def _make_ctx() -> PluginContext:
+    def _make_filter_ctx() -> PluginContext:
         return PluginContext(
             graph=graph,
             symbol_lookup=contrib.current_trie,
@@ -163,39 +158,45 @@ def _profile_package_nodes(contrib: PackageContribution, project_root: Path) -> 
             project_root=project_root,
         )
 
-    _make_ctx()  # warm import paths
+    def _make_seeded_ctx() -> PluginContext:
+        return PluginContext(
+            graph=graph,
+            symbol_lookup=contrib.current_trie,
+            package=contrib.package,
+            project_root=project_root,
+            package_graph=contrib.package_graph,
+        )
 
-    t0 = time.perf_counter()
-    matched = 0
-    for _ in range(REPEATS):
-        matched = sum(1 for _ in _make_ctx().package_nodes())
-    cold_wall = time.perf_counter() - t0
-    cold_per_call = cold_wall / REPEATS * 1000
-    print(
-        f"  cold:  {cold_per_call:7.2f} ms per call "
-        f"({matched}/{n_total} nodes matched, {REPEATS} iters)"
-    )
+    for label, make_ctx in (("filter", _make_filter_ctx), ("seeded", _make_seeded_ctx)):
+        make_ctx()  # warm import paths
+        t0 = time.perf_counter()
+        matched = 0
+        for _ in range(REPEATS):
+            matched = sum(1 for _ in make_ctx().package_nodes())
+        cold_wall = time.perf_counter() - t0
+        cold_per_call_us = cold_wall / REPEATS * 1e6
+        print(
+            f"  {label:6s} cold:  {cold_per_call_us:8.1f} us per call "
+            f"({matched}/{n_total} nodes matched)"
+        )
 
-    # Warm-call benchmark: same context across calls. Each plugin after
-    # the first in a finalize pass hits this path because ``package_nodes``
-    # memoizes on the ``PluginContext``.
-    warm_ctx = _make_ctx()
-    list(warm_ctx.package_nodes())  # populate cache
-    iters = 10000
-    t0 = time.perf_counter()
-    for _ in range(iters):
-        for _ in warm_ctx.package_nodes():
-            pass
-    warm_per_call_us = (time.perf_counter() - t0) / iters * 1e6
-    print(f"  warm:  {warm_per_call_us:7.2f} us per call ({iters} iters, cached)")
+        warm_ctx = make_ctx()
+        list(warm_ctx.package_nodes())
+        iters = 10000
+        t0 = time.perf_counter()
+        for _ in range(iters):
+            for _ in warm_ctx.package_nodes():
+                pass
+        warm_per_call_us = (time.perf_counter() - t0) / iters * 1e6
+        print(f"  {label:6s} warm:  {warm_per_call_us:8.2f} us per call (cached)")
 
     profiler = cProfile.Profile()
     profiler.enable()
     for _ in range(REPEATS):
-        sum(1 for _ in _make_ctx().package_nodes())
+        sum(1 for _ in _make_seeded_ctx().package_nodes())
     profiler.disable()
 
-    print("\npackage_nodes cold-call top 15 by tottime:")
+    print("\npackage_nodes seeded cold-call top 15 by tottime:")
     pstats.Stats(profiler).sort_stats("tottime").print_stats(15)
 
 

--- a/scripts/profile_build_contribution.py
+++ b/scripts/profile_build_contribution.py
@@ -1,0 +1,129 @@
+"""Standalone benchmark + cProfile for ``_refresh.build_contribution``.
+
+Times the per-package apply pass -- the loop that stitches every cached
+:class:`VisitorPayload` into a per-package graph + trie -- over the
+``dead_cst/`` source tree. The visitor pass is run once up front to
+produce the payloads, then :func:`build_contribution` is called in a
+hot loop with everything already in ``PackageFiles.hits`` so the
+measurement isolates apply-pass cost from libcst parse work.
+
+Run from the repo root:
+
+    uv run python scripts/profile_build_contribution.py
+"""
+
+from __future__ import annotations
+
+import cProfile
+import pstats
+import time
+from pathlib import Path
+
+from dead_cst._fqn import FixedFullyQualifiedNameProvider
+from dead_cst._refresh import (
+    PackageFiles,
+    StaleFile,
+    build_contribution,
+    process_stale_files,
+)
+from dead_cst.branches import DefaultUnreachableRegionDetector
+from dead_cst.cache import GraphCache, compute_fingerprint, default_cache_path
+from dead_cst.resolvers._core import Package
+from dead_cst.resolvers._exports import exported_roots
+
+REPEATS = 50
+
+
+def main() -> None:
+    project_root = Path(".").resolve()
+    target_dir = project_root / "dead_cst"
+    assert target_dir.is_dir(), f"expected {target_dir} to exist"
+
+    detector = DefaultUnreachableRegionDetector()
+    fingerprint = compute_fingerprint(plugins=(), unreachable_detector=detector)
+
+    package = Package(
+        path=project_root,
+        name=project_root.name,
+        exported=tuple(exported_roots(project_root) or ()),
+        deps=(),
+    )
+
+    # Walk only ``dead_cst/`` to avoid the venv / examples / tests trees
+    # that an ``rglob`` from ``project_root`` would otherwise pull in.
+    files = tuple(sorted(p for p in target_dir.rglob("*.py") if p.is_file()))
+    print(f"build_contribution over {len(files)} file(s) under {target_dir.name}/")
+
+    with GraphCache(default_cache_path(project_root)) as cache:
+        # Visitor pass (one-time): produce a payload for every file.
+        hits: dict[Path, object] = {}
+        miss_files: list[Path] = []
+        for f in files:
+            payload = cache.get(f, fingerprint)
+            if payload is None:
+                miss_files.append(f)
+            else:
+                hits[f] = payload
+
+        if miss_files:
+            fqn_cache = FixedFullyQualifiedNameProvider.gen_cache(
+                project_root, [str(f) for f in miss_files], timeout=30
+            )
+            tasks = [
+                StaleFile(
+                    file=f,
+                    package=package,
+                    fqn_entry=fqn_cache[str(f)],
+                    project_root=project_root,
+                )
+                for f in miss_files
+            ]
+            t0 = time.perf_counter()
+            miss_payloads = process_stale_files(
+                tasks=tasks,
+                detector=detector,
+                plugins=(),
+                cache=cache,
+                fingerprint=fingerprint,
+                workers=None,
+            )
+            print(
+                f"  visitor warmup: {(time.perf_counter() - t0) * 1000:.0f} ms over {len(tasks)} miss(es)"
+            )
+            hits.update(miss_payloads)
+
+        pf = PackageFiles(
+            package=package,
+            files=files,
+            hits=hits,  # type: ignore[arg-type]
+            miss_files=(),
+        )
+
+    # Warmup call before timing.
+    build_contribution(package, pf, {})
+
+    t0 = time.perf_counter()
+    for _ in range(REPEATS):
+        build_contribution(package, pf, {})
+    wall = time.perf_counter() - t0
+    per_call = wall / REPEATS * 1000
+    per_file = per_call / len(files)
+    print(f"  wall:     {wall * 1000:7.1f} ms over {REPEATS} calls")
+    print(f"  per-call: {per_call:7.2f} ms")
+    print(f"  per-file: {per_file:7.3f} ms")
+
+    profiler = cProfile.Profile()
+    profiler.enable()
+    for _ in range(REPEATS):
+        build_contribution(package, pf, {})
+    profiler.disable()
+
+    print("\nTop 25 functions by cumulative time:")
+    pstats.Stats(profiler).sort_stats("cumulative").print_stats(25)
+
+    print("\nTop 25 functions by internal (tottime):")
+    pstats.Stats(profiler).sort_stats("tottime").print_stats(25)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_build_contribution.py
+++ b/scripts/profile_build_contribution.py
@@ -139,26 +139,17 @@ def main() -> None:
 
 
 def _profile_package_nodes(contrib: PackageContribution, project_root: Path) -> None:
-    """Benchmark :meth:`PluginContext.package_nodes` on both paths.
+    """Benchmark :meth:`PluginContext.package_nodes`.
 
-    Single-package workload: ``contrib.package_graph`` *is* the composed
-    graph, so the legacy ``is_relative_to`` filter is a worst-case "every
-    node matches" scan. The seeded path (``package_graph=...`` passed to
-    :class:`PluginContext`) sidesteps the filter entirely.
+    Cold = fresh :class:`PluginContext` per iteration (the per-finalize
+    cost; ``_compose_contribution`` builds a new context per package).
+    Warm = same context, subsequent calls hit the snapshot cache.
     """
     graph = contrib.package_graph
     n_total = graph.number_of_nodes()
-    print(f"\npackage_nodes: composed graph has {n_total} node(s)")
+    print(f"\npackage_nodes: package graph has {n_total} node(s)")
 
-    def _make_filter_ctx() -> PluginContext:
-        return PluginContext(
-            graph=graph,
-            symbol_lookup=contrib.current_trie,
-            package=contrib.package,
-            project_root=project_root,
-        )
-
-    def _make_seeded_ctx() -> PluginContext:
+    def _make_ctx() -> PluginContext:
         return PluginContext(
             graph=graph,
             symbol_lookup=contrib.current_trie,
@@ -167,36 +158,32 @@ def _profile_package_nodes(contrib: PackageContribution, project_root: Path) -> 
             package_graph=contrib.package_graph,
         )
 
-    for label, make_ctx in (("filter", _make_filter_ctx), ("seeded", _make_seeded_ctx)):
-        make_ctx()  # warm import paths
-        t0 = time.perf_counter()
-        matched = 0
-        for _ in range(REPEATS):
-            matched = sum(1 for _ in make_ctx().package_nodes())
-        cold_wall = time.perf_counter() - t0
-        cold_per_call_us = cold_wall / REPEATS * 1e6
-        print(
-            f"  {label:6s} cold:  {cold_per_call_us:8.1f} us per call "
-            f"({matched}/{n_total} nodes matched)"
-        )
+    _make_ctx()  # warm import paths
 
-        warm_ctx = make_ctx()
-        list(warm_ctx.package_nodes())
-        iters = 10000
-        t0 = time.perf_counter()
-        for _ in range(iters):
-            for _ in warm_ctx.package_nodes():
-                pass
-        warm_per_call_us = (time.perf_counter() - t0) / iters * 1e6
-        print(f"  {label:6s} warm:  {warm_per_call_us:8.2f} us per call (cached)")
+    t0 = time.perf_counter()
+    matched = 0
+    for _ in range(REPEATS):
+        matched = sum(1 for _ in _make_ctx().package_nodes())
+    cold_per_call_us = (time.perf_counter() - t0) / REPEATS * 1e6
+    print(f"  cold:  {cold_per_call_us:8.1f} us per call ({matched} nodes)")
+
+    warm_ctx = _make_ctx()
+    list(warm_ctx.package_nodes())
+    iters = 10000
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        for _ in warm_ctx.package_nodes():
+            pass
+    warm_per_call_us = (time.perf_counter() - t0) / iters * 1e6
+    print(f"  warm:  {warm_per_call_us:8.2f} us per call (cached)")
 
     profiler = cProfile.Profile()
     profiler.enable()
     for _ in range(REPEATS):
-        sum(1 for _ in _make_seeded_ctx().package_nodes())
+        sum(1 for _ in _make_ctx().package_nodes())
     profiler.disable()
 
-    print("\npackage_nodes seeded cold-call top 15 by tottime:")
+    print("\npackage_nodes cold-call top 15 by tottime:")
     pstats.Stats(profiler).sort_stats("tottime").print_stats(15)
 
 

--- a/scripts/profile_build_contribution.py
+++ b/scripts/profile_build_contribution.py
@@ -1,20 +1,4 @@
-"""Standalone benchmark + cProfile for ``_refresh.build_contribution``
-and ``PluginContext.package_nodes``.
-
-Times the per-package apply pass -- the loop that stitches every cached
-:class:`VisitorPayload` into a per-package graph + trie -- over the
-``dead_cst/`` source tree. The visitor pass is run once up front to
-produce the payloads, then :func:`build_contribution` is called in a
-hot loop with everything already in ``PackageFiles.hits`` so the
-measurement isolates apply-pass cost from libcst parse work.
-
-A second section measures :meth:`PluginContext.package_nodes`, the
-helper plugins use during :meth:`EdgePlugin.finalize` to iterate
-"every node in this package". It scans the composed cross-package
-graph and filters by ``node.path.is_relative_to(package_path)``;
-plugins like ``ExplicitEntrypointPlugin``, ``MockPatchPlugin``, and
-the framework plugins (FastAPI / Flask / discord.py) call it once
-per finalize pass.
+"""Benchmark + cProfile for ``build_contribution`` and ``package_nodes``.
 
 Run from the repo root:
 
@@ -28,16 +12,16 @@ import pstats
 import time
 from pathlib import Path
 
-from dead_cst._fqn import FixedFullyQualifiedNameProvider
 from dead_cst._refresh import (
     PackageContribution,
     PackageFiles,
-    StaleFile,
     build_contribution,
+    build_stale_tasks,
     process_stale_files,
 )
 from dead_cst.branches import DefaultUnreachableRegionDetector
 from dead_cst.cache import GraphCache, compute_fingerprint, default_cache_path
+from dead_cst.graph import VisitorPayload
 from dead_cst.plugins._core import PluginContext
 from dead_cst.resolvers._core import Package
 from dead_cst.resolvers._exports import exported_roots
@@ -47,6 +31,11 @@ REPEATS = 50
 
 def main() -> None:
     project_root = Path(".").resolve()
+    # Walk ``dead_cst/`` only; an ``Analysis`` rooted at ``project_root``
+    # would rglob ``.venv`` / tests / examples too, but libcst's FQN
+    # provider only handles relative imports correctly when the package
+    # root is the project root (``from ..resolvers`` in ``dead_cst/contrib/``
+    # would escape a ``dead_cst``-rooted package).
     target_dir = project_root / "dead_cst"
     assert target_dir.is_dir(), f"expected {target_dir} to exist"
 
@@ -60,14 +49,11 @@ def main() -> None:
         deps=(),
     )
 
-    # Walk only ``dead_cst/`` to avoid the venv / examples / tests trees
-    # that an ``rglob`` from ``project_root`` would otherwise pull in.
     files = tuple(sorted(p for p in target_dir.rglob("*.py") if p.is_file()))
     print(f"build_contribution over {len(files)} file(s) under {target_dir.name}/")
 
     with GraphCache(default_cache_path(project_root)) as cache:
-        # Visitor pass (one-time): produce a payload for every file.
-        hits: dict[Path, object] = {}
+        hits: dict[Path, VisitorPayload] = {}
         miss_files: list[Path] = []
         for f in files:
             payload = cache.get(f, fingerprint)
@@ -76,19 +62,9 @@ def main() -> None:
             else:
                 hits[f] = payload
 
+        pf = PackageFiles(package=package, files=files, hits=hits, miss_files=tuple(miss_files))
         if miss_files:
-            fqn_cache = FixedFullyQualifiedNameProvider.gen_cache(
-                project_root, [str(f) for f in miss_files], timeout=30
-            )
-            tasks = [
-                StaleFile(
-                    file=f,
-                    package=package,
-                    fqn_entry=fqn_cache[str(f)],
-                    project_root=project_root,
-                )
-                for f in miss_files
-            ]
+            tasks = build_stale_tasks({package.path: pf}, project_root)
             t0 = time.perf_counter()
             miss_payloads = process_stale_files(
                 tasks=tasks,
@@ -98,19 +74,10 @@ def main() -> None:
                 fingerprint=fingerprint,
                 workers=None,
             )
-            print(
-                f"  visitor warmup: {(time.perf_counter() - t0) * 1000:.0f} ms over {len(tasks)} miss(es)"
-            )
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            print(f"  visitor warmup: {elapsed_ms:.0f} ms over {len(tasks)} miss(es)")
             hits.update(miss_payloads)
 
-        pf = PackageFiles(
-            package=package,
-            files=files,
-            hits=hits,  # type: ignore[arg-type]
-            miss_files=(),
-        )
-
-    # Warmup call before timing.
     contrib = build_contribution(package, pf, {})
 
     t0 = time.perf_counter()
@@ -139,12 +106,7 @@ def main() -> None:
 
 
 def _profile_package_nodes(contrib: PackageContribution, project_root: Path) -> None:
-    """Benchmark :meth:`PluginContext.package_nodes`.
-
-    Cold = fresh :class:`PluginContext` per iteration (the per-finalize
-    cost; ``_compose_contribution`` builds a new context per package).
-    Warm = same context, subsequent calls hit the snapshot cache.
-    """
+    """Benchmark :meth:`PluginContext.package_nodes`."""
     graph = contrib.package_graph
     n_total = graph.number_of_nodes()
     print(f"\npackage_nodes: package graph has {n_total} node(s)")
@@ -158,7 +120,7 @@ def _profile_package_nodes(contrib: PackageContribution, project_root: Path) -> 
             package_graph=contrib.package_graph,
         )
 
-    _make_ctx()  # warm import paths
+    _make_ctx()
 
     t0 = time.perf_counter()
     matched = 0

--- a/scripts/profile_build_contribution.py
+++ b/scripts/profile_build_contribution.py
@@ -1,4 +1,5 @@
-"""Standalone benchmark + cProfile for ``_refresh.build_contribution``.
+"""Standalone benchmark + cProfile for ``_refresh.build_contribution``
+and ``PluginContext.package_nodes``.
 
 Times the per-package apply pass -- the loop that stitches every cached
 :class:`VisitorPayload` into a per-package graph + trie -- over the
@@ -6,6 +7,14 @@ Times the per-package apply pass -- the loop that stitches every cached
 produce the payloads, then :func:`build_contribution` is called in a
 hot loop with everything already in ``PackageFiles.hits`` so the
 measurement isolates apply-pass cost from libcst parse work.
+
+A second section measures :meth:`PluginContext.package_nodes`, the
+helper plugins use during :meth:`EdgePlugin.finalize` to iterate
+"every node in this package". It scans the composed cross-package
+graph and filters by ``node.path.is_relative_to(package_path)``;
+plugins like ``ExplicitEntrypointPlugin``, ``MockPatchPlugin``, and
+the framework plugins (FastAPI / Flask / discord.py) call it once
+per finalize pass.
 
 Run from the repo root:
 
@@ -21,6 +30,7 @@ from pathlib import Path
 
 from dead_cst._fqn import FixedFullyQualifiedNameProvider
 from dead_cst._refresh import (
+    PackageContribution,
     PackageFiles,
     StaleFile,
     build_contribution,
@@ -28,6 +38,7 @@ from dead_cst._refresh import (
 )
 from dead_cst.branches import DefaultUnreachableRegionDetector
 from dead_cst.cache import GraphCache, compute_fingerprint, default_cache_path
+from dead_cst.plugins._core import PluginContext
 from dead_cst.resolvers._core import Package
 from dead_cst.resolvers._exports import exported_roots
 
@@ -100,7 +111,7 @@ def main() -> None:
         )
 
     # Warmup call before timing.
-    build_contribution(package, pf, {})
+    contrib = build_contribution(package, pf, {})
 
     t0 = time.perf_counter()
     for _ in range(REPEATS):
@@ -123,6 +134,69 @@ def main() -> None:
 
     print("\nTop 25 functions by internal (tottime):")
     pstats.Stats(profiler).sort_stats("tottime").print_stats(25)
+
+    _profile_package_nodes(contrib, project_root)
+
+
+def _profile_package_nodes(contrib: PackageContribution, project_root: Path) -> None:
+    """Benchmark :meth:`PluginContext.package_nodes`.
+
+    Single-package workload: ``contrib.package_graph`` *is* the composed
+    graph, so the ``is_relative_to`` filter is a worst-case "every node
+    matches" scan. A multi-package workspace gets a slightly cheaper
+    filter per package but the same per-call cost class -- this run
+    bounds it.
+    """
+    graph = contrib.package_graph
+    n_total = graph.number_of_nodes()
+    print(f"\npackage_nodes: composed graph has {n_total} node(s)")
+
+    # Cold-call benchmark: rebuild a fresh ``PluginContext`` each
+    # iteration so the cache doesn't short-circuit the walk. This is
+    # the real per-finalize cost (``_compose_contribution`` constructs
+    # a new context per package).
+    def _make_ctx() -> PluginContext:
+        return PluginContext(
+            graph=graph,
+            symbol_lookup=contrib.current_trie,
+            package=contrib.package,
+            project_root=project_root,
+        )
+
+    _make_ctx()  # warm import paths
+
+    t0 = time.perf_counter()
+    matched = 0
+    for _ in range(REPEATS):
+        matched = sum(1 for _ in _make_ctx().package_nodes())
+    cold_wall = time.perf_counter() - t0
+    cold_per_call = cold_wall / REPEATS * 1000
+    print(
+        f"  cold:  {cold_per_call:7.2f} ms per call "
+        f"({matched}/{n_total} nodes matched, {REPEATS} iters)"
+    )
+
+    # Warm-call benchmark: same context across calls. Each plugin after
+    # the first in a finalize pass hits this path because ``package_nodes``
+    # memoizes on the ``PluginContext``.
+    warm_ctx = _make_ctx()
+    list(warm_ctx.package_nodes())  # populate cache
+    iters = 10000
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        for _ in warm_ctx.package_nodes():
+            pass
+    warm_per_call_us = (time.perf_counter() - t0) / iters * 1e6
+    print(f"  warm:  {warm_per_call_us:7.2f} us per call ({iters} iters, cached)")
+
+    profiler = cProfile.Profile()
+    profiler.enable()
+    for _ in range(REPEATS):
+        sum(1 for _ in _make_ctx().package_nodes())
+    profiler.disable()
+
+    print("\npackage_nodes cold-call top 15 by tottime:")
+    pstats.Stats(profiler).sort_stats("tottime").print_stats(15)
 
 
 if __name__ == "__main__":

--- a/scripts/profile_build_contribution.py
+++ b/scripts/profile_build_contribution.py
@@ -118,6 +118,7 @@ def _profile_package_nodes(contrib: PackageContribution, project_root: Path) -> 
             package=contrib.package,
             project_root=project_root,
             package_graph=contrib.package_graph,
+            module_nodes=contrib.module_nodes,
         )
 
     _make_ctx()
@@ -147,6 +148,15 @@ def _profile_package_nodes(contrib: PackageContribution, project_root: Path) -> 
 
     print("\npackage_nodes cold-call top 15 by tottime:")
     pstats.Stats(profiler).sort_stats("tottime").print_stats(15)
+
+    n_modules = len(contrib.module_nodes)
+    print(f"\npackage_modules: {n_modules} module(s) of {n_total} node(s)")
+    t0 = time.perf_counter()
+    matched = 0
+    for _ in range(REPEATS):
+        matched = sum(1 for _ in _make_ctx().package_modules())
+    cold_per_call_us = (time.perf_counter() - t0) / REPEATS * 1e6
+    print(f"  cold:  {cold_per_call_us:8.1f} us per call ({matched} modules)")
 
 
 if __name__ == "__main__":

--- a/tests/test_plugins/test_core.py
+++ b/tests/test_plugins/test_core.py
@@ -81,11 +81,14 @@ def _ctx_with_synthetic(fqname: str, base: Path) -> PluginContext:
         position=CodeRange(start=CodePosition(0, 0), end=CodePosition(0, 0)),
     )
     graph.add_node(node)
+    package_graph = nx.MultiDiGraph()
+    package_graph.add_node(node)
     return PluginContext(
         graph=graph,
         symbol_lookup=SymbolTrie(),
         package=Package(path=base, name="pkg"),
         project_root=base,
+        package_graph=package_graph,
     )
 
 
@@ -360,100 +363,52 @@ def test_find_call_assignments_ignores_non_call_rhs():
 # ---------------------------------------------------------------------------
 
 
-def test_plugin_context_package_modules_caches_first_scan(tmp_path):
+def test_plugin_context_package_modules_yields_from_package_graph(tmp_path):
+    """``package_modules`` sources from ``package_graph`` and snapshots once."""
     pkg = Package(path=tmp_path, name="pkg")
     inside = SymbolNode("pkg.a", "module", tmp_path / "a.py", _pos())
-    outside = SymbolNode("other.b", "module", tmp_path.parent / "other.py", _pos())
-    graph = nx.DiGraph()
-    graph.add_node(inside)
-    graph.add_node(outside)
+    fn = SymbolNode("pkg.a.f", "function", tmp_path / "a.py", _pos())
+    package_graph = nx.MultiDiGraph()
+    package_graph.add_node(inside)
+    package_graph.add_node(fn)
 
-    ctx = PluginContext(graph=graph, symbol_lookup=SymbolTrie(), package=pkg, project_root=tmp_path)
+    ctx = PluginContext(
+        graph=nx.DiGraph(),
+        symbol_lookup=SymbolTrie(),
+        package=pkg,
+        project_root=tmp_path,
+        package_graph=package_graph,
+    )
     first = list(ctx.package_modules())
     assert first == [(inside.path, inside)]
 
-    # Adding a module-typed node after the first call must not appear -- the
-    # cache is intentional, so plugins see a stable snapshot.
+    # Nodes added after the first call must not appear -- the cache is
+    # intentional, so plugins see a stable snapshot.
     late = SymbolNode("pkg.late", "module", tmp_path / "late.py", _pos())
-    graph.add_node(late)
-    second = list(ctx.package_modules())
-    assert second == first
+    package_graph.add_node(late)
+    assert list(ctx.package_modules()) == first
 
 
-def test_plugin_context_package_nodes_filters_and_caches(tmp_path):
+def test_plugin_context_package_nodes_yields_from_package_graph(tmp_path):
+    """``package_nodes`` yields the whole ``package_graph`` node set and snapshots once."""
     pkg = Package(path=tmp_path, name="pkg")
-    inside_mod = SymbolNode("pkg", "module", tmp_path / "__init__.py", _pos())
-    inside_fn = SymbolNode("pkg.f", "function", tmp_path / "a.py", _pos())
-    outside = SymbolNode("other.b", "module", tmp_path.parent / "other.py", _pos())
-    graph = nx.DiGraph()
-    for n in (inside_mod, inside_fn, outside):
-        graph.add_node(n)
-
-    ctx = PluginContext(graph=graph, symbol_lookup=SymbolTrie(), package=pkg, project_root=tmp_path)
-    first = sorted(ctx.package_nodes(), key=lambda n: n.fqname)
-    assert first == [inside_mod, inside_fn]
-
-    # Cached: nodes added after the first scan don't appear, even when their
-    # path is under ``package.path``.
-    late = SymbolNode("pkg.late", "function", tmp_path / "late.py", _pos())
-    graph.add_node(late)
-    second = sorted(ctx.package_nodes(), key=lambda n: n.fqname)
-    assert second == first
-
-
-def test_plugin_context_package_nodes_seeded_from_package_graph(tmp_path):
-    """Seeded path: ``package_graph`` is the source, no filter walk."""
-    pkg = Package(path=tmp_path, name="pkg")
-    inside_mod = SymbolNode("pkg", "module", tmp_path / "__init__.py", _pos())
-    inside_fn = SymbolNode("pkg.f", "function", tmp_path / "a.py", _pos())
-    outside = SymbolNode("other.b", "module", tmp_path.parent / "other.py", _pos())
-
+    mod = SymbolNode("pkg", "module", tmp_path / "__init__.py", _pos())
+    fn = SymbolNode("pkg.f", "function", tmp_path / "a.py", _pos())
     package_graph = nx.MultiDiGraph()
-    package_graph.add_node(inside_mod)
-    package_graph.add_node(inside_fn)
-
-    merged = nx.DiGraph()
-    merged.add_node(inside_mod)
-    merged.add_node(inside_fn)
-    merged.add_node(outside)
+    package_graph.add_node(mod)
+    package_graph.add_node(fn)
 
     ctx = PluginContext(
-        graph=merged,
+        graph=nx.DiGraph(),
         symbol_lookup=SymbolTrie(),
         package=pkg,
         project_root=tmp_path,
         package_graph=package_graph,
     )
-    assert sorted(ctx.package_nodes(), key=lambda n: n.fqname) == [inside_mod, inside_fn]
-    assert sorted(ctx.package_modules(), key=lambda kv: kv[1].fqname) == [
-        (inside_mod.path, inside_mod)
-    ]
+    first = sorted(ctx.package_nodes(), key=lambda n: n.fqname)
+    assert first == [mod, fn]
 
-
-def test_plugin_context_package_graph_seeding_matches_filter(tmp_path):
-    """Seeded and filter paths agree on the same input."""
-    pkg = Package(path=tmp_path, name="pkg")
-    inside_mod = SymbolNode("pkg", "module", tmp_path / "__init__.py", _pos())
-    inside_fn = SymbolNode("pkg.f", "function", tmp_path / "a.py", _pos())
-    outside = SymbolNode("other.b", "module", tmp_path.parent / "other.py", _pos())
-
-    merged = nx.DiGraph()
-    for n in (inside_mod, inside_fn, outside):
-        merged.add_node(n)
-
-    package_graph = nx.MultiDiGraph()
-    package_graph.add_node(inside_mod)
-    package_graph.add_node(inside_fn)
-
-    filter_ctx = PluginContext(
-        graph=merged, symbol_lookup=SymbolTrie(), package=pkg, project_root=tmp_path
-    )
-    seeded_ctx = PluginContext(
-        graph=merged,
-        symbol_lookup=SymbolTrie(),
-        package=pkg,
-        project_root=tmp_path,
-        package_graph=package_graph,
-    )
-    assert set(filter_ctx.package_nodes()) == set(seeded_ctx.package_nodes())
-    assert set(filter_ctx.package_modules()) == set(seeded_ctx.package_modules())
+    # Cached: nodes added after the first scan don't appear.
+    late = SymbolNode("pkg.late", "function", tmp_path / "late.py", _pos())
+    package_graph.add_node(late)
+    assert sorted(ctx.package_nodes(), key=lambda n: n.fqname) == first

--- a/tests/test_plugins/test_core.py
+++ b/tests/test_plugins/test_core.py
@@ -89,6 +89,7 @@ def _ctx_with_synthetic(fqname: str, base: Path) -> PluginContext:
         package=Package(path=base, name="pkg"),
         project_root=base,
         package_graph=package_graph,
+        module_nodes=(),
     )
 
 
@@ -364,29 +365,19 @@ def test_find_call_assignments_ignores_non_call_rhs():
 
 
 def test_plugin_context_package_modules_yields_modules_only(tmp_path):
-    """``package_modules`` yields module-typed nodes and snapshots once."""
+    """``package_modules`` yields the precomputed module-node tuple."""
     pkg = Package(path=tmp_path, name="pkg")
-    inside = SymbolNode("pkg.a", "module", tmp_path / "a.py", _pos())
-    fn = SymbolNode("pkg.a.f", "function", tmp_path / "a.py", _pos())
-    package_graph = nx.MultiDiGraph()
-    package_graph.add_node(inside)
-    package_graph.add_node(fn)
+    mod = SymbolNode("pkg.a", "module", tmp_path / "a.py", _pos())
 
     ctx = PluginContext(
         graph=nx.DiGraph(),
         symbol_lookup=SymbolTrie(),
         package=pkg,
         project_root=tmp_path,
-        package_graph=package_graph,
+        package_graph=nx.MultiDiGraph(),
+        module_nodes=(mod,),
     )
-    first = list(ctx.package_modules())
-    assert first == [(inside.path, inside)]
-
-    # Nodes added after the first call must not appear -- the cache is
-    # intentional, so plugins see a stable snapshot.
-    late = SymbolNode("pkg.late", "module", tmp_path / "late.py", _pos())
-    package_graph.add_node(late)
-    assert list(ctx.package_modules()) == first
+    assert list(ctx.package_modules()) == [(mod.path, mod)]
 
 
 def test_plugin_context_package_nodes_snapshots_first_scan(tmp_path):
@@ -404,6 +395,7 @@ def test_plugin_context_package_nodes_snapshots_first_scan(tmp_path):
         package=pkg,
         project_root=tmp_path,
         package_graph=package_graph,
+        module_nodes=(mod,),
     )
     first = sorted(ctx.package_nodes(), key=lambda n: n.fqname)
     assert first == [mod, fn]

--- a/tests/test_plugins/test_core.py
+++ b/tests/test_plugins/test_core.py
@@ -363,8 +363,8 @@ def test_find_call_assignments_ignores_non_call_rhs():
 # ---------------------------------------------------------------------------
 
 
-def test_plugin_context_package_modules_yields_from_package_graph(tmp_path):
-    """``package_modules`` sources from ``package_graph`` and snapshots once."""
+def test_plugin_context_package_modules_yields_modules_only(tmp_path):
+    """``package_modules`` yields module-typed nodes and snapshots once."""
     pkg = Package(path=tmp_path, name="pkg")
     inside = SymbolNode("pkg.a", "module", tmp_path / "a.py", _pos())
     fn = SymbolNode("pkg.a.f", "function", tmp_path / "a.py", _pos())
@@ -389,8 +389,8 @@ def test_plugin_context_package_modules_yields_from_package_graph(tmp_path):
     assert list(ctx.package_modules()) == first
 
 
-def test_plugin_context_package_nodes_yields_from_package_graph(tmp_path):
-    """``package_nodes`` yields the whole ``package_graph`` node set and snapshots once."""
+def test_plugin_context_package_nodes_snapshots_first_scan(tmp_path):
+    """``package_nodes`` yields every node and snapshots once."""
     pkg = Package(path=tmp_path, name="pkg")
     mod = SymbolNode("pkg", "module", tmp_path / "__init__.py", _pos())
     fn = SymbolNode("pkg.f", "function", tmp_path / "a.py", _pos())

--- a/tests/test_plugins/test_core.py
+++ b/tests/test_plugins/test_core.py
@@ -399,3 +399,61 @@ def test_plugin_context_package_nodes_filters_and_caches(tmp_path):
     graph.add_node(late)
     second = sorted(ctx.package_nodes(), key=lambda n: n.fqname)
     assert second == first
+
+
+def test_plugin_context_package_nodes_seeded_from_package_graph(tmp_path):
+    """Seeded path: ``package_graph`` is the source, no filter walk."""
+    pkg = Package(path=tmp_path, name="pkg")
+    inside_mod = SymbolNode("pkg", "module", tmp_path / "__init__.py", _pos())
+    inside_fn = SymbolNode("pkg.f", "function", tmp_path / "a.py", _pos())
+    outside = SymbolNode("other.b", "module", tmp_path.parent / "other.py", _pos())
+
+    package_graph = nx.MultiDiGraph()
+    package_graph.add_node(inside_mod)
+    package_graph.add_node(inside_fn)
+
+    merged = nx.DiGraph()
+    merged.add_node(inside_mod)
+    merged.add_node(inside_fn)
+    merged.add_node(outside)
+
+    ctx = PluginContext(
+        graph=merged,
+        symbol_lookup=SymbolTrie(),
+        package=pkg,
+        project_root=tmp_path,
+        package_graph=package_graph,
+    )
+    assert sorted(ctx.package_nodes(), key=lambda n: n.fqname) == [inside_mod, inside_fn]
+    assert sorted(ctx.package_modules(), key=lambda kv: kv[1].fqname) == [
+        (inside_mod.path, inside_mod)
+    ]
+
+
+def test_plugin_context_package_graph_seeding_matches_filter(tmp_path):
+    """Seeded and filter paths agree on the same input."""
+    pkg = Package(path=tmp_path, name="pkg")
+    inside_mod = SymbolNode("pkg", "module", tmp_path / "__init__.py", _pos())
+    inside_fn = SymbolNode("pkg.f", "function", tmp_path / "a.py", _pos())
+    outside = SymbolNode("other.b", "module", tmp_path.parent / "other.py", _pos())
+
+    merged = nx.DiGraph()
+    for n in (inside_mod, inside_fn, outside):
+        merged.add_node(n)
+
+    package_graph = nx.MultiDiGraph()
+    package_graph.add_node(inside_mod)
+    package_graph.add_node(inside_fn)
+
+    filter_ctx = PluginContext(
+        graph=merged, symbol_lookup=SymbolTrie(), package=pkg, project_root=tmp_path
+    )
+    seeded_ctx = PluginContext(
+        graph=merged,
+        symbol_lookup=SymbolTrie(),
+        package=pkg,
+        project_root=tmp_path,
+        package_graph=package_graph,
+    )
+    assert set(filter_ctx.package_nodes()) == set(seeded_ctx.package_nodes())
+    assert set(filter_ctx.package_modules()) == set(seeded_ctx.package_modules())

--- a/tests/test_plugins/test_file_cache.py
+++ b/tests/test_plugins/test_file_cache.py
@@ -22,6 +22,7 @@ def _ctx(tmp_path):
         package=Package(path=tmp_path, name="pkg"),
         project_root=tmp_path,
         package_graph=nx.MultiDiGraph(),
+        module_nodes=(),
     )
 
 

--- a/tests/test_plugins/test_file_cache.py
+++ b/tests/test_plugins/test_file_cache.py
@@ -21,6 +21,7 @@ def _ctx(tmp_path):
         symbol_lookup=SymbolTrie(),
         package=Package(path=tmp_path, name="pkg"),
         project_root=tmp_path,
+        package_graph=nx.MultiDiGraph(),
     )
 
 


### PR DESCRIPTION
## Summary

Cuts two filter passes out of the plugin finalize phase by surfacing precomputed views from the per-package contribution onto `PluginContext`.

- **`package_nodes`** (~9.2 ms → ~40 µs per cold call, ~**235×**): `PluginContext` now requires a `package_graph: nx.MultiDiGraph` field. The helper iterates it directly instead of filtering the merged cross-package `graph` by `Path.is_relative_to(package.path)` — an O(N_total) walk dominated by ~3-4 `Path` allocations per node in `pathlib`'s `parents` iteration.
- **`package_modules`** (~50 µs → ~4.4 µs per cold call, ~**11×**): `PluginContext` now requires a `module_nodes: tuple[SymbolNode, ...]` field. `_apply_payload` was already extracting the module node via `next(...)` per file; the return value is now collected onto `PackageContribution.module_nodes`. The helper becomes a generator over the precomputed tuple, dropping the `type == "module"` scan and the `_package_modules_cache` memo that used to amortize it.
- **`PackageView.modules()`** was doing the same `type == "module"` filter on `PackageContribution.package_graph.nodes`. It now reads `PackageContribution.module_nodes` directly — same query, same speedup, one source of truth.
- The analyzer wires both fields through automatically from `_compose_contribution` and `PackageView.importers_of`.

**Breaking**: callers that construct `PluginContext` directly (tests, out-of-tree pipelines) must pass `package_graph=` and `module_nodes=`. For single-graph tests, `package_graph=graph` reuses the existing input; `module_nodes=()` works when the test doesn't exercise `package_modules`.

Tagged as v0.9.4 in `CHANGELOG.md` and `ROADMAP.md`'s "Recently shipped" (next to the v0.9.2 `_descendant_ids` cache, the closest prior pure-perf entry).

Adds `scripts/profile_build_contribution.py` — a standalone bench/cProfile for `build_contribution`, `package_nodes`, and `package_modules`, matching the style of `scripts/bench_find_regions.py`. This is the script that surfaced both hotspots.

## Test plan

- [x] `uv run pytest` — 897 passed (2 new tests in `tests/test_plugins/test_core.py` pinning the precomputed-snapshot semantics)
- [x] `uv run prek run --all-files` — ruff + ty clean
- [x] `uv run python scripts/profile_build_contribution.py` — confirms ~9.2 ms → 40 µs (`package_nodes`) and ~50 µs → 4.4 µs (`package_modules`), with `is_relative_to` and the `type == "module"` filter absent from the cold-path profiles

https://claude.ai/code/session_01VCCsDLVkFLCYtsWpRgPnoQ