### PR TITLE
refactor: lift factory-pattern handling into DispatchAppPlugin

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -294,17 +294,25 @@ siblings of `plugins/__init__.py` (`MainBlockPlugin`,
 `ProjectScriptsPlugin`, `ExplicitEntrypointPlugin`,
 `ModuleDundersPlugin`, `InitSubclassPlugin`). Third-party-aware
 plugins live under `dead_cst/contrib/` and are re-exported from
-`dead_cst.plugins`. `FastAPIPlugin` is the full-featured reference for
-two-phase plugins; `ClickPlugin` for the `DecoratedDeclPlugin`
-subclass shape; `TyperPlugin` / `CycloptsPlugin` for the
-`DispatchAppPlugin` shape.
+`dead_cst.plugins`. `CeleryPlugin` is the full-featured reference for
+two-phase plugins (factory-aware `DispatchAppPlugin` plus a per-file
+`@shared_task` channel spliced in via an `observe()` override);
+`FlaskPlugin` / `FastAPIPlugin` for the factory-aware
+`DispatchAppPlugin` shape; `TyperPlugin` / `CycloptsPlugin` for the
+pure-dispatch `DispatchAppPlugin` shape; `ClickPlugin` for the
+`DecoratedDeclPlugin` subclass shape.
 
 For the common dynamic-import idioms, three abstract bases ship as
 scaffolding (`plugins/decl_shapes.py`):
 
 * `DecoratedDeclPlugin` — "decorated decls in files matching a search path."
 * `LiteralListPlugin` — "read `<owner>.<var> = ['fqn', ...]` and revive each entry."
-* `DispatchAppPlugin` — "wire `@<instance>.<reg>(...)` handlers to a CLI app."
+* `DispatchAppPlugin` — "wire `@<instance>.<reg>(...)` handlers to an app instance."
+  Pure-dispatch by default (Typer / Cyclopts: `X = App(); @X.command(...)`); opt into
+  factory-aware mode (Flask / FastAPI / Celery) by setting `instance_kinds: Mapping[str, bool]`
+  to emit `<{name}-app>` / `<{name}-pending>` / `<{name}-factory>` synthetics and run a
+  cross-package finalize walk that classifies factory chains (`X = create_app()`) and
+  promotes auto-entrypoint kinds.
 
 ### 7. Reachability — `Analysis.reachable` / `PackageView.reachable`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ two versions.
 
 ## [Unreleased]
 
+### Changed
+- `DispatchAppPlugin` (in `dead_cst.plugins.decl_shapes`) is now the
+  shared base for `FlaskPlugin`, `FastAPIPlugin`, and `CeleryPlugin` in
+  addition to `TyperPlugin` / `CycloptsPlugin`. The base learned an
+  opt-in factory-aware mode driven by a new
+  `instance_kinds: Mapping[str, bool]` field: when set, the plugin
+  emits `<{name}-app>:` / `<{name}-pending>:` / `<{name}-factory>:`
+  synthetics and runs a per-package finalize pass that walks pending
+  variables forward to a discriminating import node or factory marker
+  before promoting the matching kinds to entrypoints. When
+  `instance_kinds` is empty (Typer / Cyclopts) the plugin behaves as
+  before: pure observe, no entrypoint promotion. Flask / FastAPI /
+  Celery now consist almost entirely of their handler / kind config,
+  with Celery's `@shared_task` channel as its only override. No
+  user-visible behavior change.
+
 ### Added
 - Jupyter notebook (`.ipynb`) support. Every `.ipynb` file under a
   package root is ingested by concatenating its code cells into a

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ For project-specific dynamic-import patterns, three abstract bases ship as scaff
 |---|---|
 | `DecoratedDeclPlugin` | "Find decorated decls in files matching a search path." Subclass with `package_prefix`, `decorator_module`, `decorator_names`, `constructor_names`. Pure observe-time. |
 | `LiteralListPlugin` | "Read `<owner>.<var> = ['fqn', ...]` and treat each entry as alive." Subclass with `owner_fqname`, `variable_name`. observe parses and caches; finalize only does graph lookups. |
-| `DispatchAppPlugin` | "Wire `@<instance>.<reg>(...)` handlers to a CLI app instance." Subclass with `app_module`, `constructor_targets`, `registration_decorators`. Powers `TyperPlugin` and `CycloptsPlugin`; reuse for any framework with the `X = App(); @X.command(...)` shape. |
+| `DispatchAppPlugin` | "Wire `@<instance>.<reg>(...)` handlers to an app instance." Subclass with `app_module`, `registration_decorators`, plus either `constructor_targets` (pure-dispatch — powers `TyperPlugin` / `CycloptsPlugin`, app instances stay pass-through) or `instance_kinds: Mapping[str, bool]` (factory-aware — powers `FlaskPlugin` / `FastAPIPlugin` / `CeleryPlugin`; emits `<{name}-app>` / `<{name}-pending>` / `<{name}-factory>` synthetics and runs a per-package finalize walk that classifies factory chains across files and promotes auto-entrypoint kinds). |
 
 All three bases require subclasses to set `name` (a unique identifier for the cache namespace) and `version` (a Unix epoch int — bump it to the current epoch when the subclass's config changes). For example:
 

--- a/dead_cst/contrib/celery.py
+++ b/dead_cst/contrib/celery.py
@@ -1,31 +1,32 @@
 """Plugin: keep Celery task handlers and ``shared_task`` callables alive.
 
 Strategy: mirror :class:`FlaskPlugin` / :class:`FastAPIPlugin` for the
-``app = Celery(...)`` / ``@app.task`` shape, and add a third channel for
-the appless ``@shared_task`` decorator that registers a task into
-Celery's global registry regardless of which app loads it.
+``app = Celery(...)`` / ``@app.task`` shape via the factory-aware
+:class:`DispatchAppPlugin` base, and add a third channel for the
+appless ``@shared_task`` decorator that registers a task into Celery's
+global registry regardless of which app loads it.
 
 1. Direct ``X = Celery(...)`` (named import) and ``X = celery.Celery(...)``
-   (module-prefixed) assignments are classified per-file in
-   :meth:`observe`. The Celery worker process loads the app via
-   ``celery -A package.module:X``, so a Celery instance is always an
-   entrypoint -- matching how :class:`FlaskPlugin` and
-   :class:`FastAPIPlugin` treat their app instances.
+   (module-prefixed) assignments are classified per-file. The Celery
+   worker process loads the app via ``celery -A package.module:X``, so
+   a Celery instance is always an entrypoint -- matching how
+   :class:`FlaskPlugin` and :class:`FastAPIPlugin` treat their app
+   instances.
 2. ``@<X>.task`` and ``@<X>.task(...)`` decorators on top-level functions
    produce ``X -> handler`` edges so the task callable lives as long as
    the owning app does. Variables that are decorated but not directly
-   classified get a :data:`CELERY_PENDING_PREFIX` marker the finalize
-   pass resolves once cross-file edges are stitched -- this covers the
+   classified get a ``<celery-pending>:`` marker the finalize pass
+   resolves once cross-file edges are stitched -- this covers the
    ``X = make_celery()`` factory shape.
 3. Factory functions / classes whose body constructs ``Celery(...)``
-   get a :data:`CELERY_FACTORY_PREFIX` marker so the cross-package walk
-   has a discriminator even when the factory uses
+   get a ``<celery-factory>:`` marker so the cross-package walk has a
+   discriminator even when the factory uses
    ``import celery; celery.Celery()`` and the external-edge classifier
    drops the ``decl='Celery'`` half (see ``fastapi.py`` for the
    rationale -- same mechanism).
 4. Top-level functions decorated ``@shared_task`` / ``@shared_task(...)``
    (with ``shared_task`` imported from ``celery``) are seeded as
-   entrypoints via a per-file :data:`CELERY_SHARED_PREFIX` synthetic.
+   entrypoints via a per-file ``<celery-shared>:`` synthetic.
    ``shared_task`` registers into Celery's global registry and is
    invoked by name by any worker that imports the module, so there is
    no owning ``app`` instance to wire through.
@@ -44,8 +45,8 @@ recognized.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Mapping
 
 import libcst as cst
 from libcst.metadata import CodeRange
@@ -53,45 +54,28 @@ from libcst.metadata import CodeRange
 from ..graph import NodeFlags, SymbolNode
 from ..plugins._core import (
     SYNTHETIC_POSITION,
-    AddEdge,
-    AddNode,
-    GraphOp,
     ObserveContext,
-    PluginContext,
     collect_module_imports,
     decls_by_simple_name,
-    find_call_assignments,
-    find_factory_decls,
-    find_handlers,
     make_payload,
     matched_attr_call,
-    require_resolved_dep,
     synthetic_node,
-    walk_to_instance_kind,
 )
+from ..plugins.decl_shapes import DispatchAppPlugin
 
 if TYPE_CHECKING:
     from ..graph import VisitorPayload
-
-# Attribute names a Celery app uses to register a task callable. Matched
-# as the rightmost attribute of ``@<instance>.<name>(...)``.
-_REGISTRATION_DECORATORS: frozenset[str] = frozenset({"task"})
 
 # Classes from ``celery`` that produce an app instance. Value records
 # whether the instance should be seeded as an entrypoint -- always
 # ``True`` for Celery: the worker process loads ``module:app`` by import
 # path, so every constructed app is reachable from the framework side.
-_INSTANCE_KINDS: dict[str, bool] = {"Celery": True}
+_INSTANCE_KINDS: Mapping[str, bool] = {"Celery": True}
 
 # Module-level decorator names from ``celery`` that register an appless
 # task into the global registry.
 _SHARED_TASK_NAMES: frozenset[str] = frozenset({"shared_task"})
 
-CELERY_APP_PREFIX = "<celery-app>:"
-CELERY_PENDING_PREFIX = "<celery-pending>:"
-# Cross-package factory discriminator -- see ``fastapi.py`` for the
-# rationale. Format: ``<celery-factory>:Celery:<owner.fqname>``.
-CELERY_FACTORY_PREFIX = "<celery-factory>:"
 # Per-file synthetic that anchors every ``@shared_task`` decorated
 # top-level function in the file. ``shared_task`` is appless: it
 # registers into Celery's global registry, so there's no owning
@@ -100,123 +84,59 @@ CELERY_SHARED_PREFIX = "<celery-shared>:"
 
 
 @dataclass
-class CeleryPlugin:
+class CeleryPlugin(DispatchAppPlugin):
     """Mark Celery apps as entrypoints and wire task handlers through them.
 
-    Two-phase shape mirrors :class:`FlaskPlugin`:
-
-    * :meth:`observe` (per-file) classifies direct ``X = Celery(...)``
-      assignments and emits ``X -> handler`` edges for every
-      ``@<X>.task(...)`` decorator. Direct hits get a
-      :data:`CELERY_APP_PREFIX` synthetic entrypoint pointed at the
-      variable. Variables that have handlers but no direct kind get a
-      :data:`CELERY_PENDING_PREFIX` marker synthetic linked to the
-      variable, deferred to :meth:`finalize`. Top-level decls whose
-      body constructs a Celery instance get a
-      :data:`CELERY_FACTORY_PREFIX` marker that survives cross-package
-      walks. Top-level functions decorated ``@shared_task`` /
-      ``@shared_task(...)`` (with ``shared_task`` imported from
-      ``celery``) are seeded via a single :data:`CELERY_SHARED_PREFIX`
-      synthetic per file.
-    * :meth:`finalize` (per-package) walks each pending marker forward
-      through the graph and promotes any Celery factory chain to an
-      entrypoint via :func:`walk_to_instance_kind` (with
-      :data:`CELERY_FACTORY_PREFIX` so factory markers count as
-      discriminators).
+    Configures the factory-aware :class:`DispatchAppPlugin` shape for
+    Celery and overrides :meth:`observe` to add the appless
+    ``@shared_task`` channel (a per-file ``<celery-shared>:`` synthetic
+    that points at every top-level function decorated with
+    ``shared_task`` imported from ``celery``).
     """
 
     name: str = "celery"
     version: int = 1779000000
+    app_module: str = "celery"
+    registration_decorators: frozenset[str] = frozenset({"task"})
+    instance_kinds: Mapping[str, bool] = field(default_factory=lambda: dict(_INSTANCE_KINDS))
 
-    def observe(self, ctx: ObserveContext) -> VisitorPayload | None:
-        celery_app_imports = collect_module_imports(ctx.module, "celery", _INSTANCE_KINDS)
+    def observe(self, ctx: ObserveContext) -> "VisitorPayload | None":
+        base = super().observe(ctx)
+        shared = self._shared_task_payload(ctx)
+        if shared is None:
+            return base
+        if base is None:
+            return shared
+        return make_payload(
+            nodes=tuple(base.nodes) + tuple(shared.nodes),
+            edges=tuple(base.edges) + tuple(shared.edges),
+        )
+
+    def _shared_task_payload(self, ctx: ObserveContext) -> "VisitorPayload | None":
+        """Wire ``@shared_task`` decorated top-level functions to a per-file synthetic."""
         celery_shared_imports = collect_module_imports(ctx.module, "celery", _SHARED_TASK_NAMES)
-        direct = find_call_assignments(ctx.module, celery_app_imports, _INSTANCE_KINDS)
-        decorated = find_handlers(ctx.module, None, _REGISTRATION_DECORATORS)
-        factory_kinds = find_factory_decls(ctx.module, celery_app_imports, _INSTANCE_KINDS)
         shared_task_names = _find_shared_task_handlers(ctx.module, celery_shared_imports)
-        if not direct and not decorated and not factory_kinds and not shared_task_names:
+        if not shared_task_names:
             return None
 
         decls_by_name = decls_by_simple_name(ctx.payload.nodes)
-        nodes: list[SymbolNode] = []
-        edges: list[tuple[SymbolNode, SymbolNode, CodeRange]] = []
-
-        for var_name in direct.keys() | decorated.keys():
-            var_decls = decls_by_name.get(var_name, [])
-            kind = direct.get(var_name)
-            for var_decl in var_decls:
-                if kind is None:
-                    pending = synthetic_node(f"{CELERY_PENDING_PREFIX}{var_decl.fqname}", ctx.path)
-                    nodes.append(pending)
-                    edges.append((pending, var_decl, SYNTHETIC_POSITION))
-                elif _INSTANCE_KINDS[kind]:
-                    seed = synthetic_node(
-                        f"{CELERY_APP_PREFIX}{var_decl.fqname}",
-                        ctx.path,
-                        flags=NodeFlags.ENTRYPOINT,
-                    )
-                    nodes.append(seed)
-                    edges.append((seed, var_decl, SYNTHETIC_POSITION))
-
-                for handler_name in decorated.get(var_name, ()):
-                    for handler_decl in decls_by_name.get(handler_name, []):
-                        edges.append((var_decl, handler_decl, SYNTHETIC_POSITION))
-
-        # Factory markers: see fastapi.py for the rationale.
-        for decl_name, kinds in factory_kinds.items():
-            for decl in decls_by_name.get(decl_name, []):
-                for kind in kinds:
-                    marker = synthetic_node(
-                        f"{CELERY_FACTORY_PREFIX}{kind}:{decl.fqname}", ctx.path
-                    )
-                    nodes.append(marker)
-                    edges.append((decl, marker, SYNTHETIC_POSITION))
-
-        # ``@shared_task`` decorated functions: one entrypoint synthetic
-        # per file, with an edge to each appless task callable.
-        if shared_task_names:
-            shared_targets: list[SymbolNode] = []
-            for name in shared_task_names:
-                for decl in decls_by_name.get(name, []):
-                    if decl.type == "function":
-                        shared_targets.append(decl)
-            if shared_targets:
-                shared_seed = synthetic_node(
-                    f"{CELERY_SHARED_PREFIX}{ctx.path.name}",
-                    ctx.path,
-                    flags=NodeFlags.ENTRYPOINT,
-                )
-                nodes.append(shared_seed)
-                for target in shared_targets:
-                    edges.append((shared_seed, target, SYNTHETIC_POSITION))
-
-        if not nodes and not edges:
+        shared_targets: list[SymbolNode] = []
+        for name in shared_task_names:
+            for decl in decls_by_name.get(name, []):
+                if decl.type == "function":
+                    shared_targets.append(decl)
+        if not shared_targets:
             return None
-        return make_payload(nodes=nodes, edges=edges)
 
-    def finalize(self, ctx: PluginContext) -> Iterable[GraphOp]:
-        celery_node = require_resolved_dep(ctx, "celery")
-        if celery_node is None:
-            return
-
-        for synth in list(ctx.package_nodes()):
-            if synth.type != "synthetic" or not synth.fqname.startswith(CELERY_PENDING_PREFIX):
-                continue
-            for var in list(ctx.graph.successors(synth)):
-                kind = walk_to_instance_kind(
-                    ctx.graph,
-                    var,
-                    celery_node,
-                    "celery",
-                    _INSTANCE_KINDS,
-                    factory_marker_prefix=CELERY_FACTORY_PREFIX,
-                )
-                if kind is None or not _INSTANCE_KINDS[kind]:
-                    continue
-                seed = synthetic_node(f"{CELERY_APP_PREFIX}{var.fqname}", var.path)
-                yield AddNode(seed, entrypoint=True)
-                yield AddEdge(seed, var)
+        shared_seed = synthetic_node(
+            f"{CELERY_SHARED_PREFIX}{ctx.path.name}",
+            ctx.path,
+            flags=NodeFlags.ENTRYPOINT,
+        )
+        edges: list[tuple[SymbolNode, SymbolNode, CodeRange]] = [
+            (shared_seed, target, SYNTHETIC_POSITION) for target in shared_targets
+        ]
+        return make_payload(nodes=[shared_seed], edges=edges)
 
 
 def _find_shared_task_handlers(module: cst.Module, imports: dict[str, str]) -> list[str]:

--- a/dead_cst/contrib/fastapi.py
+++ b/dead_cst/contrib/fastapi.py
@@ -5,22 +5,21 @@ top-level variable that the analyzer has already linked back to the
 ``fastapi`` import -- whether the assignment is the literal
 ``X = FastAPI()``, the aliased ``X = F()`` after ``from fastapi import
 FastAPI as F``, or the factory form ``X = create_app()`` whose body
-returns ``FastAPI(...)``. The plugin reuses those reference edges:
+returns ``FastAPI(...)``. The plugin reuses those reference edges via
+the factory-aware :class:`DispatchAppPlugin` base:
 
 1. Direct shape (``X = FastAPI(...)`` / ``X = APIRouter(...)``,
-   ``X = fastapi.FastAPI(...)``, etc.) is recognized syntactically via
-   ``find_call_assignments`` -- this is unambiguous, so it gives the
-   kind directly even for ``import fastapi`` forms where the graph
-   alone can't distinguish the two classes. Resolution happens in
-   :meth:`observe`.
+   ``X = fastapi.FastAPI(...)``, etc.) is recognized syntactically.
+   This is unambiguous, so it gives the kind directly even for
+   ``import fastapi`` forms where the graph alone can't distinguish
+   the two classes.
 2. Indirect shape (any variable decorated by ``@X.<route_verb>(...)``)
-   is detected via the route-decorator scan. Per-file ``observe``
-   emits a ``<fastapi-pending>:<X.fqname>`` marker plus the
-   ``X -> handler`` edges; the per-package ``finalize`` pass walks the
-   graph forward from each pending marker and promotes
-   ``FastAPI`` instances to entrypoints.
+   produces a ``<fastapi-pending>:<X.fqname>`` marker plus the
+   ``X -> handler`` edges. The per-package finalize pass walks the
+   graph forward from each pending marker and promotes ``FastAPI``
+   instances to entrypoints.
 3. Factory functions / classes whose body constructs a FastAPI /
-   APIRouter instance are tagged at ``observe`` time with a
+   APIRouter instance are tagged with a
    ``<fastapi-factory>:<kind>:<decl.fqname>`` marker. This lets a
    cross-package consumer's pending-variable walk hit a discriminator
    even when the factory uses the ``import fastapi; fastapi.FastAPI()``
@@ -32,31 +31,10 @@ returns ``FastAPI(...)``. The plugin reuses those reference edges:
 
 from __future__ import annotations
 
-from libcst.metadata import CodeRange
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterable
+from dataclasses import dataclass, field
+from typing import Mapping
 
-from ..graph import NodeFlags, SymbolNode
-from ..plugins._core import (
-    SYNTHETIC_POSITION,
-    AddEdge,
-    AddNode,
-    GraphOp,
-    ObserveContext,
-    PluginContext,
-    collect_module_imports,
-    decls_by_simple_name,
-    find_call_assignments,
-    find_factory_decls,
-    find_handlers,
-    make_payload,
-    require_resolved_dep,
-    synthetic_node,
-    walk_to_instance_kind,
-)
-
-if TYPE_CHECKING:
-    from ..graph import VisitorPayload
+from ..plugins.decl_shapes import DispatchAppPlugin
 
 # Attribute names FastAPI / APIRouter use to register a callable. Matched as
 # the rightmost attribute of ``@<instance>.<name>(...)``.
@@ -81,142 +59,47 @@ _REGISTRATION_DECORATORS: frozenset[str] = frozenset(
 
 # Classes whose instances we treat specially. Value records whether the
 # instance should be seeded as an entrypoint.
-_INSTANCE_KINDS: dict[str, bool] = {
+_INSTANCE_KINDS: Mapping[str, bool] = {
     "FastAPI": True,  # uvicorn loads ``module:app`` -- always an entrypoint
     "APIRouter": False,  # only alive if reached via ``include_router``
 }
 
-FASTAPI_APP_PREFIX = "<fastapi-app>:"
-FASTAPI_PENDING_PREFIX = "<fastapi-pending>:"
-# Synthetic emitted from ``observe`` for any top-level function / class whose
-# body constructs a ``FastAPI()`` / ``APIRouter()`` instance. Lets
-# :meth:`FastAPIPlugin.finalize` classify cross-package factory chains where
-# the framework class is reached via ``import fastapi; fastapi.FastAPI()`` --
-# the attribute-form access lands as a bare ``[external dist] fastapi`` edge
-# (the resolver drops ``decl='FastAPI'`` for external classifications), so the
-# graph alone can't distinguish FastAPI from APIRouter on the downstream walk.
-# Format: ``<fastapi-factory>:<FastAPI|APIRouter>:<owner.fqname>``.
-FASTAPI_FACTORY_PREFIX = "<fastapi-factory>:"
-
 
 @dataclass
-class FastAPIPlugin:
+class FastAPIPlugin(DispatchAppPlugin):
     """Mark FastAPI apps as entrypoints and wire route handlers through them.
 
-    For each module the plugin observes:
+    Concrete configuration of the factory-aware
+    :class:`DispatchAppPlugin` shape:
 
-    1. Direct ``X = FastAPI(...)`` / ``X = APIRouter(...)`` assignments
-       via ``find_call_assignments``. This is the unambiguous path and
-       handles module-prefixed forms like
-       ``import fastapi; X = fastapi.FastAPI()`` that pure graph
-       reachability cannot distinguish (the variable's edge goes
-       straight to the ``fastapi`` synthetic with no intermediate
-       ``FastAPI`` vs ``APIRouter`` import to discriminate). Direct
-       FastAPI hits get a :data:`FASTAPI_APP_PREFIX` synthetic
-       entrypoint plus an edge pointing at the variable; routers do
-       not.
-    2. ``@<X>.<verb>(...)`` decorators via ``find_handlers``. Each
-       ``X -> handler`` edge is emitted unconditionally; whether ``X``
-       is reachable depends on the next step.
-    3. Variables decorated but not directly classified get a
-       :data:`FASTAPI_PENDING_PREFIX` marker synthetic with an edge
-       to the variable. The :meth:`finalize` pass picks these up.
-    4. Top-level decls whose body constructs a FastAPI / APIRouter
-       instance get a :data:`FASTAPI_FACTORY_PREFIX` marker. This
-       discriminator survives cross-package walks where the external
-       edge would otherwise lose ``decl='FastAPI'`` info.
-
-    Finalize walks forward from each pending variable until it hits
-    a discriminator (a ``from fastapi import FastAPI``-style import
-    node or a factory marker), classifies the variable, and -- for
-    ``FastAPI`` instances -- emits a ``<fastapi-app>:`` synthetic
-    entrypoint plus an edge to the variable. Routers and unclassified
-    variables stay as-is, so an ``APIRouter`` that nothing
-    ``include_router``s remains dead.
+    * Direct ``X = FastAPI(...)`` / ``X = APIRouter(...)`` assignments
+      handle module-prefixed forms like
+      ``import fastapi; X = fastapi.FastAPI()`` that pure graph
+      reachability cannot distinguish (the variable's edge goes
+      straight to the ``fastapi`` synthetic with no intermediate
+      ``FastAPI`` vs ``APIRouter`` import to discriminate). Direct
+      FastAPI hits get a ``<fastapi-app>:`` synthetic entrypoint plus
+      an edge pointing at the variable; routers do not.
+    * ``@<X>.<verb>(...)`` decorators produce ``X -> handler`` edges
+      unconditionally; whether ``X`` is reachable depends on
+      classification.
+    * Variables decorated but not directly classified get a
+      ``<fastapi-pending>:`` marker. Finalize walks forward from each
+      pending variable until it hits a discriminator (a
+      ``from fastapi import FastAPI``-style import node or a factory
+      marker), classifies the variable, and -- for ``FastAPI``
+      instances -- emits a ``<fastapi-app>:`` synthetic entrypoint plus
+      an edge to the variable. Routers and unclassified variables stay
+      as-is, so an ``APIRouter`` that nothing ``include_router``s
+      remains dead.
+    * Top-level decls whose body constructs a FastAPI / APIRouter
+      instance get a ``<fastapi-factory>:`` marker. This discriminator
+      survives cross-package walks where the external edge would
+      otherwise lose ``decl='FastAPI'`` info.
     """
 
     name: str = "fastapi"
     version: int = 1778973600
-
-    def observe(self, ctx: ObserveContext) -> VisitorPayload | None:
-        fastapi_imports = collect_module_imports(ctx.module, "fastapi", _INSTANCE_KINDS)
-        direct = find_call_assignments(ctx.module, fastapi_imports, _INSTANCE_KINDS)
-        decorated = find_handlers(ctx.module, None, _REGISTRATION_DECORATORS)
-        # Top-level decls whose body constructs a FastAPI / APIRouter instance.
-        # ``fastapi_imports`` doubles as the binding map for ``matched_attr_call``
-        # so both ``FastAPI()`` (named import) and ``fastapi.FastAPI()`` (module
-        # import) are recognized.
-        factory_kinds = find_factory_decls(ctx.module, fastapi_imports, _INSTANCE_KINDS)
-        if not direct and not decorated and not factory_kinds:
-            return None
-
-        decls_by_name = decls_by_simple_name(ctx.payload.nodes)
-        nodes: list[SymbolNode] = []
-        edges: list[tuple[SymbolNode, SymbolNode, CodeRange]] = []
-
-        # Every variable observed (direct or just decorated) gets either
-        # an app entrypoint, a router classification, or a pending marker
-        # for finalize to resolve.
-        for var_name in direct.keys() | decorated.keys():
-            var_decls = decls_by_name.get(var_name, [])
-            kind = direct.get(var_name)
-            for var_decl in var_decls:
-                if kind is None:
-                    pending = synthetic_node(f"{FASTAPI_PENDING_PREFIX}{var_decl.fqname}", ctx.path)
-                    nodes.append(pending)
-                    edges.append((pending, var_decl, SYNTHETIC_POSITION))
-                elif _INSTANCE_KINDS[kind]:
-                    seed = synthetic_node(
-                        f"{FASTAPI_APP_PREFIX}{var_decl.fqname}",
-                        ctx.path,
-                        flags=NodeFlags.ENTRYPOINT,
-                    )
-                    nodes.append(seed)
-                    edges.append((seed, var_decl, SYNTHETIC_POSITION))
-                # APIRouter direct hits get only handler edges below.
-
-                for handler_name in decorated.get(var_name, ()):
-                    for handler_decl in decls_by_name.get(handler_name, []):
-                        edges.append((var_decl, handler_decl, SYNTHETIC_POSITION))
-
-        # Factory markers: decl bodies that build a FastAPI / APIRouter
-        # instance. Anchored to the constructing decl so finalize's forward
-        # walk hits them regardless of which file the consumer lives in.
-        for decl_name, kinds in factory_kinds.items():
-            for decl in decls_by_name.get(decl_name, []):
-                for kind in kinds:
-                    marker = synthetic_node(
-                        f"{FASTAPI_FACTORY_PREFIX}{kind}:{decl.fqname}", ctx.path
-                    )
-                    nodes.append(marker)
-                    edges.append((decl, marker, SYNTHETIC_POSITION))
-
-        if not nodes and not edges:
-            return None
-        return make_payload(nodes=nodes, edges=edges)
-
-    def finalize(self, ctx: PluginContext) -> Iterable[GraphOp]:
-        fastapi_node = require_resolved_dep(ctx, "fastapi")
-        if fastapi_node is None:
-            return
-
-        for synth in list(ctx.package_nodes()):
-            if synth.type != "synthetic" or not synth.fqname.startswith(FASTAPI_PENDING_PREFIX):
-                continue
-            successors = list(ctx.graph.successors(synth))
-            if not successors:
-                continue
-            for var in successors:
-                kind = walk_to_instance_kind(
-                    ctx.graph,
-                    var,
-                    fastapi_node,
-                    "fastapi",
-                    _INSTANCE_KINDS,
-                    factory_marker_prefix=FASTAPI_FACTORY_PREFIX,
-                )
-                if kind is None or not _INSTANCE_KINDS[kind]:
-                    continue
-                seed = synthetic_node(f"{FASTAPI_APP_PREFIX}{var.fqname}", var.path)
-                yield AddNode(seed, entrypoint=True)
-                yield AddEdge(seed, var)
+    app_module: str = "fastapi"
+    registration_decorators: frozenset[str] = _REGISTRATION_DECORATORS
+    instance_kinds: Mapping[str, bool] = field(default_factory=lambda: dict(_INSTANCE_KINDS))

--- a/dead_cst/contrib/flask.py
+++ b/dead_cst/contrib/flask.py
@@ -2,12 +2,13 @@
 
 Mirrors :class:`FastAPIPlugin`: direct ``X = Flask(...)`` /
 ``X = Blueprint(...)`` assignments are classified per-file in
-:meth:`observe`, while factory-style apps (``X = create_app()``) are
-deferred to :meth:`finalize` via ``<flask-pending>:`` markers that the
-graph walk resolves once cross-file edges are in place. Factory
-functions / classes whose body constructs a Flask / Blueprint instance
-also get a ``<flask-factory>:<kind>:<owner.fqname>`` marker so the
-cross-package walk has a discriminator even when the factory uses the
+:meth:`DispatchAppPlugin.observe`, while factory-style apps
+(``X = create_app()``) are deferred to :meth:`DispatchAppPlugin.finalize`
+via ``<flask-pending>:`` markers that the graph walk resolves once
+cross-file edges are in place. Factory functions / classes whose body
+constructs a Flask / Blueprint instance also get a
+``<flask-factory>:<kind>:<owner.fqname>`` marker so the cross-package
+walk has a discriminator even when the factory uses the
 ``import flask; flask.Flask()`` attribute form -- in that shape
 :func:`resolve_edges` drops the ``decl='Flask'`` half of the external
 classification and the import-node check alone misses the case.
@@ -15,31 +16,10 @@ classification and the import-node check alone misses the case.
 
 from __future__ import annotations
 
-from libcst.metadata import CodeRange
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterable
+from dataclasses import dataclass, field
+from typing import Mapping
 
-from ..graph import NodeFlags, SymbolNode
-from ..plugins._core import (
-    SYNTHETIC_POSITION,
-    AddEdge,
-    AddNode,
-    GraphOp,
-    ObserveContext,
-    PluginContext,
-    collect_module_imports,
-    decls_by_simple_name,
-    find_call_assignments,
-    find_factory_decls,
-    find_handlers,
-    make_payload,
-    require_resolved_dep,
-    synthetic_node,
-    walk_to_instance_kind,
-)
-
-if TYPE_CHECKING:
-    from ..graph import VisitorPayload
+from ..plugins.decl_shapes import DispatchAppPlugin
 
 # Attribute names Flask / Blueprint use to register a callable. Matched as
 # the rightmost attribute of ``@<instance>.<name>(...)``. Includes the HTTP
@@ -85,115 +65,36 @@ _REGISTRATION_DECORATORS: frozenset[str] = frozenset(
 
 # Classes whose instances we treat specially. Value records whether the
 # instance should be seeded as an entrypoint.
-_INSTANCE_KINDS: dict[str, bool] = {
+_INSTANCE_KINDS: Mapping[str, bool] = {
     "Flask": True,  # WSGI servers load ``module:app`` -- always an entrypoint
     "Blueprint": False,  # only alive if reached via ``register_blueprint``
 }
 
-FLASK_APP_PREFIX = "<flask-app>:"
-FLASK_PENDING_PREFIX = "<flask-pending>:"
-# See ``FASTAPI_FACTORY_PREFIX`` for the rationale. Same shape, same
-# motivation: cross-package factory chains lose the ``decl='Flask'``
-# half of an ``import flask; flask.Flask()`` access through the
-# external-edge classifier, so we anchor a marker on the constructing
-# decl that finalize's walk can recognize regardless of file.
-# Format: ``<flask-factory>:<Flask|Blueprint>:<owner.fqname>``.
-FLASK_FACTORY_PREFIX = "<flask-factory>:"
-
 
 @dataclass
-class FlaskPlugin:
+class FlaskPlugin(DispatchAppPlugin):
     """Mark Flask apps as entrypoints and wire route handlers through them.
 
-    Two-phase shape mirrors :class:`FastAPIPlugin`:
+    Concrete configuration of the factory-aware
+    :class:`DispatchAppPlugin` shape:
 
-    * :meth:`observe` (per-file) classifies direct
-      ``X = Flask(...)`` / ``X = Blueprint(...)`` assignments and emits
-      ``X -> handler`` edges for every ``@<X>.<verb>(...)`` decorator.
-      Direct ``Flask`` hits get a :data:`FLASK_APP_PREFIX` synthetic
-      entrypoint pointed at the variable. Variables that have handlers
-      but no direct kind get a :data:`FLASK_PENDING_PREFIX` marker
-      synthetic linked to the variable, deferred to :meth:`finalize`.
-      Top-level decls whose body constructs a Flask / Blueprint
-      instance get a :data:`FLASK_FACTORY_PREFIX` marker that survives
-      cross-package walks.
-    * :meth:`finalize` (per-package) walks each pending marker forward
-      through the graph, classifies via :func:`walk_to_instance_kind`
-      (with :data:`FLASK_FACTORY_PREFIX` so factory markers count as
-      discriminators), and promotes ``Flask`` factories to entrypoints.
-      Blueprints stay pass-through.
+    * Direct ``X = Flask(...)`` / ``X = Blueprint(...)`` assignments are
+      classified per-file. Direct ``Flask`` hits get a ``<flask-app>:``
+      synthetic entrypoint pointed at the variable.
+    * ``@<X>.<verb>(...)`` decorators emit ``X -> handler`` edges.
+      Variables that have handlers but no direct kind get a
+      ``<flask-pending>:`` marker the cross-package finalize pass
+      resolves, supporting the ``X = create_app()`` factory shape.
+    * Top-level decls whose body constructs a Flask / Blueprint
+      instance get a ``<flask-factory>:<kind>:<owner.fqname>`` marker so
+      the pending walk can classify cross-package factory chains where
+      the framework class is reached via the attribute-form
+      ``flask.Flask()`` and the external-edge classifier drops the
+      ``decl='Flask'`` half.
     """
 
     name: str = "flask"
     version: int = 1778973600
-
-    def observe(self, ctx: ObserveContext) -> VisitorPayload | None:
-        flask_imports = collect_module_imports(ctx.module, "flask", _INSTANCE_KINDS)
-        direct = find_call_assignments(ctx.module, flask_imports, _INSTANCE_KINDS)
-        decorated = find_handlers(ctx.module, None, _REGISTRATION_DECORATORS)
-        # Top-level decls whose body constructs a Flask / Blueprint instance.
-        # Recognizes both ``Flask()`` (named import) and ``flask.Flask()``
-        # (module import) shapes via ``matched_attr_call``.
-        factory_kinds = find_factory_decls(ctx.module, flask_imports, _INSTANCE_KINDS)
-        if not direct and not decorated and not factory_kinds:
-            return None
-
-        decls_by_name = decls_by_simple_name(ctx.payload.nodes)
-        nodes: list[SymbolNode] = []
-        edges: list[tuple[SymbolNode, SymbolNode, CodeRange]] = []
-
-        for var_name in direct.keys() | decorated.keys():
-            var_decls = decls_by_name.get(var_name, [])
-            kind = direct.get(var_name)
-            for var_decl in var_decls:
-                if kind is None:
-                    pending = synthetic_node(f"{FLASK_PENDING_PREFIX}{var_decl.fqname}", ctx.path)
-                    nodes.append(pending)
-                    edges.append((pending, var_decl, SYNTHETIC_POSITION))
-                elif _INSTANCE_KINDS[kind]:
-                    seed = synthetic_node(
-                        f"{FLASK_APP_PREFIX}{var_decl.fqname}",
-                        ctx.path,
-                        flags=NodeFlags.ENTRYPOINT,
-                    )
-                    nodes.append(seed)
-                    edges.append((seed, var_decl, SYNTHETIC_POSITION))
-
-                for handler_name in decorated.get(var_name, ()):
-                    for handler_decl in decls_by_name.get(handler_name, []):
-                        edges.append((var_decl, handler_decl, SYNTHETIC_POSITION))
-
-        # Factory markers: see fastapi.py for the rationale.
-        for decl_name, kinds in factory_kinds.items():
-            for decl in decls_by_name.get(decl_name, []):
-                for kind in kinds:
-                    marker = synthetic_node(f"{FLASK_FACTORY_PREFIX}{kind}:{decl.fqname}", ctx.path)
-                    nodes.append(marker)
-                    edges.append((decl, marker, SYNTHETIC_POSITION))
-
-        if not nodes and not edges:
-            return None
-        return make_payload(nodes=nodes, edges=edges)
-
-    def finalize(self, ctx: PluginContext) -> Iterable[GraphOp]:
-        flask_node = require_resolved_dep(ctx, "flask")
-        if flask_node is None:
-            return
-
-        for synth in list(ctx.package_nodes()):
-            if synth.type != "synthetic" or not synth.fqname.startswith(FLASK_PENDING_PREFIX):
-                continue
-            for var in list(ctx.graph.successors(synth)):
-                kind = walk_to_instance_kind(
-                    ctx.graph,
-                    var,
-                    flask_node,
-                    "flask",
-                    _INSTANCE_KINDS,
-                    factory_marker_prefix=FLASK_FACTORY_PREFIX,
-                )
-                if kind is None or not _INSTANCE_KINDS[kind]:
-                    continue
-                seed = synthetic_node(f"{FLASK_APP_PREFIX}{var.fqname}", var.path)
-                yield AddNode(seed, entrypoint=True)
-                yield AddEdge(seed, var)
+    app_module: str = "flask"
+    registration_decorators: frozenset[str] = _REGISTRATION_DECORATORS
+    instance_kinds: Mapping[str, bool] = field(default_factory=lambda: dict(_INSTANCE_KINDS))

--- a/dead_cst/plugins/decl_shapes.py
+++ b/dead_cst/plugins/decl_shapes.py
@@ -23,8 +23,8 @@ Both bases use only the public plugin-helpers re-exported from
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterable, cast
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Iterable, Mapping, cast
 
 import libcst as cst
 from libcst.metadata import CodeRange, PositionProvider
@@ -33,19 +33,23 @@ from ..graph import NodeFlags, SymbolNode
 from ._core import (
     SYNTHETIC_POSITION,
     AddEdge,
+    AddNode,
     GraphOp,
     ObserveContext,
     PluginContext,
     collect_module_imports,
     decls_by_simple_name,
     find_call_assignments,
+    find_factory_decls,
     find_handlers,
     make_payload,
     matched_attr_call,
     module_node,
+    require_resolved_dep,
     simple_name,
     single_target_assignment,
     synthetic_node,
+    walk_to_instance_kind,
 )
 
 if TYPE_CHECKING:
@@ -249,18 +253,62 @@ class LiteralListPlugin:
 class DispatchAppPlugin:
     """Wire ``@<instance>.<reg_decorator>(...)`` handlers to their app instance.
 
-    Generic shape behind :class:`~dead_cst.contrib.TyperPlugin` and
-    :class:`~dead_cst.contrib.CycloptsPlugin`: find top-level
-    ``X = <Ctor>(...)`` assignments where ``Ctor`` is one of
-    ``constructor_targets`` imported from ``app_module``, then for every
+    Generic shape behind :class:`~dead_cst.contrib.TyperPlugin`,
+    :class:`~dead_cst.contrib.CycloptsPlugin`,
+    :class:`~dead_cst.contrib.FlaskPlugin`,
+    :class:`~dead_cst.contrib.FastAPIPlugin`, and
+    :class:`~dead_cst.contrib.CeleryPlugin`: find top-level
+    ``X = <Ctor>(...)`` assignments where ``Ctor`` is recognized as an
+    app constructor imported from ``app_module``, then for every
     top-level function decorated ``@X.<name>(...)`` where ``name`` is in
     ``registration_decorators`` emit an edge ``X -> handler``.
 
-    Pure observe: instance detection and decorator scanning are
-    file-local CST passes; the corresponding ``SymbolNode`` decls are
-    looked up in this file's :class:`VisitorPayload`. App instances
-    are not auto-marked as entrypoints; reachability flows through
-    ``[project.scripts]`` or a ``__main__`` block.
+    The plugin has two modes:
+
+    * **Pure dispatch** (``instance_kinds`` empty -- Typer / Cyclopts):
+      only top-level ``X = Ctor(...)`` assignments are tracked, and
+      every ``X -> handler`` edge requires ``X`` to be one of those
+      direct constructions. App instances are *not* auto-marked as
+      entrypoints; reachability flows through ``[project.scripts]`` or
+      a ``__main__`` block. Pure observe-time; :meth:`finalize` is a
+      no-op.
+    * **Factory-aware** (``instance_kinds`` non-empty -- Flask /
+      FastAPI / Celery): each kind in the mapping is recognized as a
+      constructor, and the boolean value tells us whether direct
+      ``X = Kind(...)`` hits should be promoted to entrypoints (e.g.
+      ``Flask=True``, ``Blueprint=False``). Factory functions / classes
+      whose body constructs one of the kinds get a
+      ``<{name}-factory>:<kind>:<owner.fqname>`` marker. Variables
+      decorated by handler decorators but not directly classified get a
+      ``<{name}-pending>:<var.fqname>`` marker that :meth:`finalize`
+      resolves by walking forward through the graph until it hits a
+      classifying import node or factory marker.
+
+    Configuration:
+
+    * ``app_module`` -- dotted module name the constructors are
+      imported from (``"flask"``, ``"fastapi"``, ``"celery"``,
+      ``"typer"``, ...).
+    * ``constructor_targets`` -- legacy field used only when
+      ``instance_kinds`` is empty. Names of constructors to recognize.
+    * ``registration_decorators`` -- attribute names on the instance
+      that register a handler (``"route"`` / ``"get"`` / ``"task"`` /
+      ``"command"`` / ...).
+    * ``instance_kinds`` -- mapping ``{kind_name: auto_entrypoint}``.
+      Setting any entry opts the plugin into factory-aware mode. The
+      auto-entrypoint flag controls whether a direct hit on that kind
+      gets a ``<{name}-app>:`` entrypoint synthetic (the framework's
+      "this is always alive" classification, e.g. WSGI / ASGI / Celery
+      worker autoloads).
+
+    Aliased / module-prefixed forms (``import flask as f`` ->
+    ``f.Flask()``) flow through :func:`collect_module_imports` and
+    :func:`matched_attr_call`, so subclasses don't have to model them.
+
+    Subclasses inject framework-specific behaviour (e.g. Celery's
+    ``@shared_task``) by overriding :meth:`observe` to call
+    ``super().observe(ctx)`` and splice extra nodes / edges into the
+    returned payload.
 
     Abstract base: subclasses must set ``name`` and ``version``. The
     cache fingerprint is ``(name, version)``, so every concrete plugin
@@ -272,33 +320,130 @@ class DispatchAppPlugin:
     app_module: str = ""
     constructor_targets: frozenset[str] = frozenset()
     registration_decorators: frozenset[str] = frozenset()
+    instance_kinds: Mapping[str, bool] = field(default_factory=dict)
+
+    @property
+    def _factory_aware(self) -> bool:
+        return bool(self.instance_kinds)
+
+    @property
+    def _targets(self) -> Mapping[str, bool] | frozenset[str]:
+        # Factory-aware plugins drive recognition off the kinds map;
+        # pure-dispatch plugins keep the legacy flat-set config.
+        return self.instance_kinds if self._factory_aware else self.constructor_targets
+
+    @property
+    def _app_prefix(self) -> str:
+        return f"<{self.name}-app>:"
+
+    @property
+    def _pending_prefix(self) -> str:
+        return f"<{self.name}-pending>:"
+
+    @property
+    def _factory_prefix(self) -> str:
+        return f"<{self.name}-factory>:"
 
     def observe(self, ctx: ObserveContext) -> "VisitorPayload | None":
-        if not (self.app_module and self.constructor_targets and self.registration_decorators):
+        if not (self.app_module and self.registration_decorators):
             return None
-        imports = collect_module_imports(ctx.module, self.app_module, self.constructor_targets)
-        if not imports:
+        targets = self._targets
+        if not targets:
             return None
-        instances = set(find_call_assignments(ctx.module, imports, self.constructor_targets))
-        if not instances:
-            return None
-        handlers = find_handlers(ctx.module, instances, self.registration_decorators)
-        if not handlers:
-            return None
+        imports = collect_module_imports(ctx.module, self.app_module, targets)
+
+        # ``find_call_assignments`` / ``find_factory_decls`` need imports to
+        # recognize the constructors; ``find_handlers`` does not (it scans
+        # ``@<owner>.<attr>`` decorator shapes directly). Factory-aware mode
+        # depends on that: ``app = create_app()`` in a file that imports the
+        # factory (not Flask itself) still needs a pending marker emitted
+        # from the decorator scan alone.
+        direct = find_call_assignments(ctx.module, imports, targets) if imports else {}
+        if self._factory_aware:
+            decorated = find_handlers(ctx.module, None, self.registration_decorators)
+            factory_kinds = find_factory_decls(ctx.module, imports, targets) if imports else {}
+            if not direct and not decorated and not factory_kinds:
+                return None
+        else:
+            # Pure-dispatch: only emit edges for handlers owned by a
+            # direct construction, so the imports gate is meaningful.
+            if not direct:
+                return None
+            decorated = find_handlers(ctx.module, set(direct), self.registration_decorators)
+            factory_kinds = {}
+            if not decorated:
+                return None
 
         decls_by_name = decls_by_simple_name(ctx.payload.nodes)
+        nodes: list[SymbolNode] = []
         edges: list[tuple[SymbolNode, SymbolNode, CodeRange]] = []
-        for var_name, handler_names in handlers.items():
-            for instance_decl in decls_by_name.get(var_name, []):
-                for handler_name in handler_names:
+
+        for var_name in direct.keys() | decorated.keys():
+            var_decls = decls_by_name.get(var_name, [])
+            kind = direct.get(var_name)
+            for var_decl in var_decls:
+                if self._factory_aware:
+                    if kind is None:
+                        pending = synthetic_node(
+                            f"{self._pending_prefix}{var_decl.fqname}", ctx.path
+                        )
+                        nodes.append(pending)
+                        edges.append((pending, var_decl, SYNTHETIC_POSITION))
+                    elif self.instance_kinds[kind]:
+                        seed = synthetic_node(
+                            f"{self._app_prefix}{var_decl.fqname}",
+                            ctx.path,
+                            flags=NodeFlags.ENTRYPOINT,
+                        )
+                        nodes.append(seed)
+                        edges.append((seed, var_decl, SYNTHETIC_POSITION))
+                    # Non-entrypoint direct kinds (e.g. Blueprint / APIRouter)
+                    # get only handler edges below.
+                for handler_name in decorated.get(var_name, ()):
                     for handler_decl in decls_by_name.get(handler_name, []):
-                        edges.append((instance_decl, handler_decl, SYNTHETIC_POSITION))
-        if not edges:
+                        edges.append((var_decl, handler_decl, SYNTHETIC_POSITION))
+
+        # Factory markers: anchored on the constructing decl so finalize's
+        # forward walk hits them regardless of which file the consumer lives
+        # in. Required because ``import <mod>; <mod>.<Cls>()`` flows through
+        # an external-edge that loses ``decl='<Cls>'`` after
+        # :func:`resolve_edges`, so the import-node check alone can't tell
+        # the kinds apart on the downstream walk.
+        for decl_name, kinds in factory_kinds.items():
+            for decl in decls_by_name.get(decl_name, []):
+                for kind in kinds:
+                    marker = synthetic_node(f"{self._factory_prefix}{kind}:{decl.fqname}", ctx.path)
+                    nodes.append(marker)
+                    edges.append((decl, marker, SYNTHETIC_POSITION))
+
+        if not nodes and not edges:
             return None
-        return make_payload(edges=edges)
+        return make_payload(nodes=nodes, edges=edges)
 
     def finalize(self, ctx: PluginContext) -> Iterable[GraphOp]:
-        return ()
+        if not self._factory_aware:
+            return
+        app_node = require_resolved_dep(ctx, self.app_module)
+        if app_node is None:
+            return
+        pending_prefix = self._pending_prefix
+        for synth in list(ctx.package_nodes()):
+            if synth.type != "synthetic" or not synth.fqname.startswith(pending_prefix):
+                continue
+            for var in list(ctx.graph.successors(synth)):
+                kind = walk_to_instance_kind(
+                    ctx.graph,
+                    var,
+                    app_node,
+                    self.app_module,
+                    self.instance_kinds,
+                    factory_marker_prefix=self._factory_prefix,
+                )
+                if kind is None or not self.instance_kinds[kind]:
+                    continue
+                seed = synthetic_node(f"{self._app_prefix}{var.fqname}", var.path)
+                yield AddNode(seed, entrypoint=True)
+                yield AddEdge(seed, var)
 
 
 def _read_string_list_with_positions(

--- a/dead_cst/plugins/decl_shapes.py
+++ b/dead_cst/plugins/decl_shapes.py
@@ -332,17 +332,9 @@ class DispatchAppPlugin:
         # pure-dispatch plugins keep the legacy flat-set config.
         return self.instance_kinds if self._factory_aware else self.constructor_targets
 
-    @property
-    def _app_prefix(self) -> str:
-        return f"<{self.name}-app>:"
-
-    @property
-    def _pending_prefix(self) -> str:
-        return f"<{self.name}-pending>:"
-
-    @property
-    def _factory_prefix(self) -> str:
-        return f"<{self.name}-factory>:"
+    def _prefix(self, kind: str) -> str:
+        """Return the synthetic prefix ``<{name}-{kind}>:`` for ``app`` / ``pending`` / ``factory``."""
+        return f"<{self.name}-{kind}>:"
 
     def observe(self, ctx: ObserveContext) -> "VisitorPayload | None":
         if not (self.app_module and self.registration_decorators):
@@ -378,20 +370,21 @@ class DispatchAppPlugin:
         nodes: list[SymbolNode] = []
         edges: list[tuple[SymbolNode, SymbolNode, CodeRange]] = []
 
+        app_prefix = self._prefix("app")
+        pending_prefix = self._prefix("pending")
+        factory_prefix = self._prefix("factory")
         for var_name in direct.keys() | decorated.keys():
             var_decls = decls_by_name.get(var_name, [])
             kind = direct.get(var_name)
             for var_decl in var_decls:
                 if self._factory_aware:
                     if kind is None:
-                        pending = synthetic_node(
-                            f"{self._pending_prefix}{var_decl.fqname}", ctx.path
-                        )
+                        pending = synthetic_node(f"{pending_prefix}{var_decl.fqname}", ctx.path)
                         nodes.append(pending)
                         edges.append((pending, var_decl, SYNTHETIC_POSITION))
                     elif self.instance_kinds[kind]:
                         seed = synthetic_node(
-                            f"{self._app_prefix}{var_decl.fqname}",
+                            f"{app_prefix}{var_decl.fqname}",
                             ctx.path,
                             flags=NodeFlags.ENTRYPOINT,
                         )
@@ -412,7 +405,7 @@ class DispatchAppPlugin:
         for decl_name, kinds in factory_kinds.items():
             for decl in decls_by_name.get(decl_name, []):
                 for kind in kinds:
-                    marker = synthetic_node(f"{self._factory_prefix}{kind}:{decl.fqname}", ctx.path)
+                    marker = synthetic_node(f"{factory_prefix}{kind}:{decl.fqname}", ctx.path)
                     nodes.append(marker)
                     edges.append((decl, marker, SYNTHETIC_POSITION))
 
@@ -426,7 +419,9 @@ class DispatchAppPlugin:
         app_node = require_resolved_dep(ctx, self.app_module)
         if app_node is None:
             return
-        pending_prefix = self._pending_prefix
+        app_prefix = self._prefix("app")
+        pending_prefix = self._prefix("pending")
+        factory_prefix = self._prefix("factory")
         for synth in list(ctx.package_nodes()):
             if synth.type != "synthetic" or not synth.fqname.startswith(pending_prefix):
                 continue
@@ -437,11 +432,11 @@ class DispatchAppPlugin:
                     app_node,
                     self.app_module,
                     self.instance_kinds,
-                    factory_marker_prefix=self._factory_prefix,
+                    factory_marker_prefix=factory_prefix,
                 )
                 if kind is None or not self.instance_kinds[kind]:
                     continue
-                seed = synthetic_node(f"{self._app_prefix}{var.fqname}", var.path)
+                seed = synthetic_node(f"{app_prefix}{var.fqname}", var.path)
                 yield AddNode(seed, entrypoint=True)
                 yield AddEdge(seed, var)
 


### PR DESCRIPTION
## Summary

Flask / FastAPI / Celery all repeated the same observe + finalize shape: direct constructor recognition, `<name>-pending` markers for handler-only vars, `<name>-factory` markers for factory decls, and a finalize walk that classifies pending vars and promotes auto-entrypoint kinds. The three plugins kept duplicated copies of that machinery (~80 lines each) plus per-plugin prefix constants.

- `DispatchAppPlugin` (the existing scaffold behind Typer / Cyclopts) grows an opt-in factory-aware mode driven by a new `instance_kinds: Mapping[str, bool]` field. When set, the plugin emits `<{name}-app>` / `<{name}-pending>` / `<{name}-factory>` synthetics and runs the cross-package finalize walk. When empty (Typer / Cyclopts) the plugin keeps its pure-observe behaviour and does not auto-promote app instances to entrypoints.
- `FlaskPlugin`, `FastAPIPlugin`, `CeleryPlugin` are now thin subclasses that just configure `app_module`, `registration_decorators`, and `instance_kinds`. Celery keeps an `observe()` override for its appless `@shared_task` channel.
- Three prefix properties (`_app_prefix` / `_pending_prefix` / `_factory_prefix`) collapsed into one `_prefix(kind)` method since they all formatted the same `<{name}-{kind}>:` pattern.
- Docs updated: README's `DispatchAppPlugin` row, ARCHITECTURE's plugin section + scaffolds bullet, CHANGELOG `[Unreleased]` entry under `Changed`.

Net diff: −459 / +319 across the three contrib plugins and `decl_shapes.py`. No user-visible behavior change.

## Test plan

- [x] `uv run pytest` — 933 passed, 10 deselected
- [x] `uv run prek run --all-files` — ruff (lint+format) + ty type-check pass
- [x] Plugin-level suites for the three migrated plugins (`test_flask.py`, `test_fastapi.py`, `test_celery.py`) and the two unchanged ones (`test_typer.py`, `test_cyclopts.py`) — 93 passed

https://claude.ai/code/session_014o9o7Yaw8fe2GQSCV1w3uy