### PR TITLE
refactor: swap to rustworkx; consolidate edge dedup in SymbolGraph

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,7 +49,7 @@ or before touching the visitor.
 │                                                              │
 │   each EdgePlugin.finalize(ctx) -> Iterable[GraphOp]         │
 └────────────────────────────┬─────────────────────────────────┘
-                             │ MultiDiGraph
+                             │ SymbolGraph (rustworkx-backed)
                              ▼
                 ┌────────────┴────────────┐
                 ▼                         ▼
@@ -378,6 +378,22 @@ entirely.
 
 ## Graph model invariants
 
+* The graph is `dead_cst.graph.SymbolGraph`, a thin wrapper around
+  `rustworkx.PyDiGraph(multigraph=True)` that owns the
+  `SymbolNode -> int` index map and exposes a `networkx`-shaped surface
+  (`successors`, `predecessors`, `subgraph`, `out_edges`,
+  `nodes(data=True)`, `edges(data=True)`, the `graph` attribute, etc.)
+  so call sites read naturally. Per-node attributes (`entrypoint`,
+  `testcase`) live in a side table on the wrapper rather than on the
+  rustworkx payload, so `successors` / `predecessors` return the bare
+  `SymbolNode` directly.
+* `SymbolGraph` enforces an edge-uniqueness invariant: no two edges
+  share the same `(src, dst, attrs)`. Duplicate inserts are silently
+  dropped. Metadata-distinct parallel edges (one `DEAD_BRANCH` + one
+  `NONE`) are preserved so strict-mode reachability filters on attrs
+  correctly. Callers (visitor apply, plugin op application, cross-file
+  edge stitching) all rely on this and carry no shadow dedup state of
+  their own.
 * One node per top-level declaration plus one synthetic module node per
   file. Nested defs (inner functions, methods, nested classes) are
   deliberately not given their own nodes — refs from inside them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,15 @@ two versions.
   `networkx.MultiDiGraph`; out-of-tree code that constructed graphs
   manually has to swap `nx.MultiDiGraph()` for `SymbolGraph()`. The
   per-file `VisitorPayload` cache shape is unchanged, so no
-  invalidation is required. `networkx` is no longer a runtime
-  dependency (kept in the dev group for test fixtures that exercise
-  external-dist resolution against a recognizable third-party name).
+  invalidation is required. `networkx` is dropped entirely.
+- Edges are now deduplicated by `(src, dst, flags)` at apply / stitch
+  time. Repeated same-suite references (`f(); f(); f()`) used to land
+  as parallel edges with identical attrs; they collapse to a single
+  edge now. Metadata-distinct edges between the same pair (e.g. one
+  `DEAD_BRANCH` + one `NONE`) are still kept separate so strict-mode
+  reachability filters correctly. Reachability behavior is unchanged
+  (BFS already used a `visited` set); the win is memory + iteration
+  cost on hot files.
 - `DispatchAppPlugin` (in `dead_cst.plugins.decl_shapes`) is now the
   shared base for `FlaskPlugin`, `FastAPIPlugin`, and `CeleryPlugin` in
   addition to `TyperPlugin` / `CycloptsPlugin`. The base learned an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ two versions.
 ## [Unreleased]
 
 ### Changed
+- **BREAKING.** The graph backend swapped from `networkx` to
+  `rustworkx`. A new `dead_cst.graph.SymbolGraph` wrapper owns a
+  `rustworkx.PyDiGraph(multigraph=True)` plus the `SymbolNode -> int`
+  index map; it exposes the `networkx`-style surface the analyzer
+  relied on (`successors`, `predecessors`, `subgraph`, `out_edges`,
+  `nodes(data=True)`, `edges(data=True, keys=True)`, `update`,
+  `add_edges_from`, the `graph` attribute for graph-level metadata)
+  so call sites read naturally. `Analysis.graph`,
+  `PackageView.graph`, `GraphView.graph`, and `PluginContext.graph` /
+  `package_graph` now all return / accept `SymbolGraph` rather than
+  `networkx.MultiDiGraph`; out-of-tree code that constructed graphs
+  manually has to swap `nx.MultiDiGraph()` for `SymbolGraph()`. The
+  per-file `VisitorPayload` cache shape is unchanged, so no
+  invalidation is required. `networkx` is no longer a runtime
+  dependency (kept in the dev group for test fixtures that exercise
+  external-dist resolution against a recognizable third-party name).
 - `DispatchAppPlugin` (in `dead_cst.plugins.decl_shapes`) is now the
   shared base for `FlaskPlugin`, `FastAPIPlugin`, and `CeleryPlugin` in
   addition to `TyperPlugin` / `CycloptsPlugin`. The base learned an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,14 +24,17 @@ two versions.
   manually has to swap `nx.MultiDiGraph()` for `SymbolGraph()`. The
   per-file `VisitorPayload` cache shape is unchanged, so no
   invalidation is required. `networkx` is dropped entirely.
-- Edges are now deduplicated by `(src, dst, flags)` at apply / stitch
-  time. Repeated same-suite references (`f(); f(); f()`) used to land
-  as parallel edges with identical attrs; they collapse to a single
-  edge now. Metadata-distinct edges between the same pair (e.g. one
-  `DEAD_BRANCH` + one `NONE`) are still kept separate so strict-mode
-  reachability filters correctly. Reachability behavior is unchanged
-  (BFS already used a `visited` set); the win is memory + iteration
-  cost on hot files.
+- `SymbolGraph` now enforces an edge-uniqueness invariant: no two
+  edges share the same `(src, dst, attrs)`. Duplicate inserts are
+  silently dropped. This consolidates dedup logic that previously
+  lived in three different call sites (the visitor's repeated
+  same-suite refs in `_apply_payload`, plugin fan-outs in
+  `apply_ops`, the cross-file fan-out in `resolve_edges._emit`); all
+  three now rely on the wrapper. Metadata-distinct edges between the
+  same pair (one `DEAD_BRANCH` + one `NONE`) are still preserved so
+  strict-mode reachability filters correctly. Reachability behavior
+  is unchanged (BFS uses a `visited` set); the win is fewer parallel
+  edges on hot files plus one source of truth for the invariant.
 - `DispatchAppPlugin` (in `dead_cst.plugins.decl_shapes`) is now the
   shared base for `FlaskPlugin`, `FastAPIPlugin`, and `CeleryPlugin` in
   addition to `TyperPlugin` / `CycloptsPlugin`. The base learned an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,9 @@ A `PostToolUse` hook in `.claude/settings.json` automatically runs `ruff format`
 
 ## Architecture
 
-`dead-cst` builds a symbol-level reachability graph of a Python codebase using [libcst](https://github.com/Instagram/LibCST) and [networkx](https://networkx.org/), walks from configured entrypoints, and reports (or removes) anything unreachable. The flow is staged so each stage has one job; understanding the staging is the key to navigating the code.
+`dead-cst` builds a symbol-level reachability graph of a Python codebase using [libcst](https://github.com/Instagram/LibCST) and [rustworkx](https://www.rustworkx.org/), walks from configured entrypoints, and reports (or removes) anything unreachable. The flow is staged so each stage has one job; understanding the staging is the key to navigating the code.
+
+The graph is wrapped in `dead_cst.graph.SymbolGraph`, a thin shim around `rustworkx.PyDiGraph(multigraph=True)` that owns the `SymbolNode -> int` index map and exposes a `networkx`-shaped surface (`successors`, `predecessors`, `subgraph`, `out_edges`, `nodes(data=True)`, `edges(data=True, keys=True)`, `update`, `add_edges_from`, the `graph` attribute for graph-level metadata like `dead_suites`). Domain code addresses nodes by `SymbolNode` identity; the integer index is an implementation detail. Per-node attributes (`entrypoint`, `testcase`) live in a side table on the wrapper rather than on the rustworkx payload, so the payload stays a bare `SymbolNode` and `successors` / `predecessors` return the domain object directly.
 
 ### The unified `Cacheable` contract
 
@@ -64,8 +66,8 @@ Three moving pieces — `SymbolVisitor` itself plus two of the three extension p
 
 The supported surface is whatever is re-exported from a module named without a leading `_`. The top-level `dead_cst/__init__.py` re-exports the highlights (`Analysis`, `PackageView`, `Cacheable`, the graph data types). Deeper symbols live in focused public submodules:
 
-- `dead_cst.graph` — `SymbolNode`, `Import`, `NodeFlags`, `EdgeFlags`, `VisitorPayload` (the data classes the analyzer emits and consumes).
-- `dead_cst.analyze` — `Analysis` and `PackageView`, the lazy entry-point classes; plus `GraphView`, the read-only reachability surface returned by `Analysis.preview` (and useful directly to wrap any externally-built `nx.MultiDiGraph`).
+- `dead_cst.graph` — `SymbolNode`, `Import`, `NodeFlags`, `EdgeFlags`, `VisitorPayload` (the data classes the analyzer emits and consumes), and `SymbolGraph` (the rustworkx-backed graph wrapper).
+- `dead_cst.analyze` — `Analysis` and `PackageView`, the lazy entry-point classes; plus `GraphView`, the read-only reachability surface returned by `Analysis.preview` (and useful directly to wrap any externally-built `SymbolGraph`).
 - `dead_cst.codemod` — the LibCST source rewriter.
 - `dead_cst.cache` — `GraphCache`, `compute_fingerprint`, schema/dirname constants.
 - `dead_cst.branches` — `UnreachableRegionDetector`, `DefaultUnreachableRegionDetector`, `TruthinessResolver` (with `evaluate` for truthiness and `resolve_constant` for the underlying literal value), `Const` / `ConstValue` (the wrapper that distinguishes a proved-`None` literal from "unknown"), plus the truthiness helpers (`evaluate_truthiness`, `unreachable_suites`, `unreachable_bodies`) a from-scratch detector needs.

--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ print(sum(1 for _ in pkg.modules()), "modules")
 pkg.remove_dead_code()  # codemod, scoped to this package
 ```
 
-For non-destructive review, `dead_cst.codemod.generate_patch(G, root)` returns the same removal as a `git apply`-compatible unified diff. Selection is driven entirely by `G.nodes`, so you can pass any subgraph slice — e.g. one [strongly-connected component](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.components.strongly_connected_components.html) at a time — to review a large codebase as a series of focused patches.
+For non-destructive review, `dead_cst.codemod.generate_patch(G, root)` returns the same removal as a `git apply`-compatible unified diff. Selection is driven entirely by `G.nodes`, so you can pass any subgraph slice — e.g. one strongly-connected component at a time — to review a large codebase as a series of focused patches.
 
-`Analysis(...).materialize_all()` returns the full `networkx.MultiDiGraph` if you need raw access; `analysis.package(path).graph()` returns the closure-scoped subgraph for one package.
+`Analysis(...).materialize_all()` returns the full `dead_cst.graph.SymbolGraph` (a thin wrapper around `rustworkx.PyDiGraph(multigraph=True)` exposing a `networkx`-shaped surface) if you need raw access; `analysis.package(path).graph()` returns the closure-scoped subgraph for one package.
 
 Edge plugins and the unreachable-region detector share a single `Cacheable` protocol (`name: str`, `version: int`). The core `SymbolVisitor` carries the same pair, so visitor-level changes get an explicit knob too. The visitor / plugin / detector triple feeds the per-file cache fingerprint — bumping any of those `version`s invalidates stale payloads automatically. Path resolvers do **not** implement `Cacheable`: their output flows through the (uncached) edge-stitching pass, so swapping or upgrading a resolver re-stitches edges without invalidating cached payloads (and there is no version to bump). The package `__version__` is intentionally *not* in the fingerprint: every component whose output can shift between releases owns a dedicated `version`, and folding in `__version__` would let unbumped components ride for free on a release bump.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -303,11 +303,12 @@ Folded down from earlier tiers as they landed:
 - **v0.9.0**: ``SymbolNode`` and ``Import`` pre-compute their hash in
   ``__post_init__`` and store it in a private ``_hash`` slot, so
   ``__hash__`` is a single attribute read. Cuts edge-stitching time on
-  large multi-package workspaces where ``resolve_edges._emit`` re-hashes
-  the same ``(src, dst, flags)`` tuples into its dedup set, and pays off
-  again every time a ``SymbolNode`` is hashed by networkx (graph
-  insertion, BFS traversal). ``SCHEMA_VERSION`` bumped to 3 so cache
-  rows pickled before the slot existed are invalidated on first use.
+  large multi-package workspaces where ``resolve_edges`` re-hashes the
+  same ``(src, dst, flags)`` tuples through ``SymbolGraph``'s
+  edge-uniqueness set (since v0.10 the dedup invariant lives on the
+  graph wrapper itself; previously the resolver carried its own
+  ``_emit`` dedup set). ``SCHEMA_VERSION`` bumped to 3 so cache rows
+  pickled before the slot existed are invalidated on first use.
 - **v0.9.0**: Edge stitching no longer emits a spurious "Failed to
   resolve import module: <name>" warning for stdlib imports
   (``import datetime``, ``from pathlib import Path``); the orphaned

--- a/dead_cst/_edges.py
+++ b/dead_cst/_edges.py
@@ -150,7 +150,6 @@ def resolve_edges(
     if search_paths is None:
         search_paths = []
 
-    emitted: set[tuple[SymbolNode, SymbolNode, EdgeFlags]] = set()
     synthetic_memo: dict[str, SymbolNode] = {}
     external_memo: dict[tuple[str, bool], SymbolNode | None] = {}
     # ``id(SymbolTrie)`` is safe as a key here: each trie node is held
@@ -175,14 +174,11 @@ def resolve_edges(
         external_memo[key] = node
         return node
 
-    def _emit(
-        src: SymbolNode, dst: SymbolNode, flags: EdgeFlags
-    ) -> Generator[tuple[SymbolNode, SymbolNode, EdgeFlags], None, None]:
-        key = (src, dst, flags)
-        if key in emitted:
-            return
-        emitted.add(key)
-        yield key
+    # No explicit dedup: ``SymbolGraph.add_edges_from`` (the only
+    # consumer of this generator) enforces the edge-uniqueness invariant
+    # on insertion. The walk algorithm can re-discover the same target
+    # via several ``Import`` shapes that canonicalize to the same trie
+    # state; those duplicates flow into the graph and collapse there.
 
     def _walk(start_node: SymbolTrie, parts: tuple[str, ...]) -> tuple[SymbolNode, ...]:
         cache_key = (id(start_node), parts)
@@ -258,7 +254,7 @@ def resolve_edges(
         ``Import`` is frozen with an eager ``__hash__``, so equal
         spellings across files (the visitor builds fresh objects per
         file) collapse to one cache entry. The result is pre-deduped
-        so the per-src ``_emit`` loop stays short.
+        so the per-src yield loop stays short.
         """
         cached = target_memo.get(raw)
         if cached is not None:
@@ -284,7 +280,7 @@ def resolve_edges(
 
     for src, raw, flags in import_edges:
         for dst_node in _resolve_targets(raw):
-            yield from _emit(src, dst_node, flags)
+            yield (src, dst_node, flags)
 
 
 # Keep these re-exports stable for callers that historically reached

--- a/dead_cst/_refresh.py
+++ b/dead_cst/_refresh.py
@@ -31,7 +31,6 @@ from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
 import libcst as cst
-import networkx as nx
 from libcst.helpers.module import ModuleNameAndPackage
 from libcst.metadata import CodeRange, MetadataWrapper
 
@@ -41,7 +40,15 @@ from ._progress import progress
 from ._visitor import SymbolVisitor
 from .branches import UnreachableRegionDetector
 from .cache import GraphCache
-from .graph import EdgeFlags, Import, NodeFlags, SymbolNode, SymbolTrie, VisitorPayload
+from .graph import (
+    EdgeFlags,
+    Import,
+    NodeFlags,
+    SymbolGraph,
+    SymbolNode,
+    SymbolTrie,
+    VisitorPayload,
+)
 from .plugins import EdgePlugin, ObserveContext
 from .plugins._core import (
     SYNTHETIC_POSITION,
@@ -104,7 +111,7 @@ class PackageContribution:
     package: Package
     current_trie: SymbolTrie
     export_trie: SymbolTrie
-    package_graph: nx.MultiDiGraph
+    package_graph: SymbolGraph
     import_edges: frozenset[tuple[SymbolNode, Import, EdgeFlags]]
     module_nodes: tuple[SymbolNode, ...]
 
@@ -341,7 +348,7 @@ def build_contribution(
     Hits come straight from :class:`PackageFiles`; the rest are looked
     up in the global ``miss_payloads`` map produced by
     :func:`process_stale_files`. The package-local
-    :class:`nx.MultiDiGraph` is what makes scope-bounded materialization
+    :class:`SymbolGraph` is what makes scope-bounded materialization
     cheap: composing it into the full graph or a closure graph doesn't
     redo per-file apply work. Empty :attr:`Package.exported` means
     "no restriction" (every file in the package is exported to consumers).
@@ -356,7 +363,7 @@ def build_contribution(
     export_trie = SymbolTrie()
     exported = package.exported
     import_edges: set[tuple[SymbolNode, Import, EdgeFlags]] = set()
-    package_graph: nx.MultiDiGraph = nx.MultiDiGraph()
+    package_graph: SymbolGraph = SymbolGraph()
     package_graph.graph["dead_suites"] = {}
     module_nodes: list[SymbolNode] = []
     shadowed = shadowed_paths(package_files.files)
@@ -628,7 +635,7 @@ def _apply_payload(
     export_trie: SymbolTrie,
     file_exported: bool,
     add_to_trie: bool,
-    symbol_graph: nx.MultiDiGraph,
+    symbol_graph: SymbolGraph,
     import_edges: set[tuple[SymbolNode, Import, EdgeFlags]],
 ) -> SymbolNode:
     """Emit ``payload`` into the in-progress per-package structures.

--- a/dead_cst/_refresh.py
+++ b/dead_cst/_refresh.py
@@ -695,6 +695,18 @@ def _apply_payload(
         def flag_for(pos: CodeRange) -> EdgeFlags:
             return EdgeFlags.NONE
 
+    # Dedup edges produced by this file. Repeated references inside a
+    # single suite (``f(); f(); f()``) record one ``payload.edges`` entry
+    # per access; after ``flag_for(pos)`` collapse, they would otherwise
+    # land as parallel edges with identical ``(src, dst, flags)``. The
+    # ``decl -> module`` edge is structurally unique per decl so the
+    # ``(n, module, NONE)`` insertion is safe to dedup against the same
+    # set without changing behavior. Per-file scope is sufficient because
+    # ``src`` / ``dst`` SymbolNodes are file-scoped (different files emit
+    # distinct nodes), so no two files in a package can produce the same
+    # triple.
+    seen_edges: set[tuple[SymbolNode, SymbolNode, EdgeFlags]] = set()
+
     for n in payload.nodes:
         symbol_graph.add_node(n)
         if n.flags & NodeFlags.ENTRYPOINT:
@@ -704,7 +716,10 @@ def _apply_payload(
         if n.type == "synthetic":
             continue
         if n.type != "module":
-            symbol_graph.add_edge(n, module, flags=EdgeFlags.NONE)
+            key = (n, module, EdgeFlags.NONE)
+            if key not in seen_edges:
+                seen_edges.add(key)
+                symbol_graph.add_edge(n, module, flags=EdgeFlags.NONE)
         # ``OVERLOAD`` and ``SHADOWED`` exclude a single decl from the
         # cross-module lookup trie; ``add_to_trie=False`` is the
         # file-level equivalent for a ``.py`` whose sibling package
@@ -718,7 +733,11 @@ def _apply_payload(
                 export_trie.add_declaration(n)
 
     for src, dst, pos in payload.edges:
-        symbol_graph.add_edge(src, dst, flags=flag_for(pos))
+        flags = flag_for(pos)
+        key = (src, dst, flags)
+        if key not in seen_edges:
+            seen_edges.add(key)
+            symbol_graph.add_edge(src, dst, flags=flags)
 
     for src, imp, pos in payload.imports:
         import_edges.add((src, imp, flag_for(pos)))

--- a/dead_cst/_refresh.py
+++ b/dead_cst/_refresh.py
@@ -695,18 +695,6 @@ def _apply_payload(
         def flag_for(pos: CodeRange) -> EdgeFlags:
             return EdgeFlags.NONE
 
-    # Dedup edges produced by this file. Repeated references inside a
-    # single suite (``f(); f(); f()``) record one ``payload.edges`` entry
-    # per access; after ``flag_for(pos)`` collapse, they would otherwise
-    # land as parallel edges with identical ``(src, dst, flags)``. The
-    # ``decl -> module`` edge is structurally unique per decl so the
-    # ``(n, module, NONE)`` insertion is safe to dedup against the same
-    # set without changing behavior. Per-file scope is sufficient because
-    # ``src`` / ``dst`` SymbolNodes are file-scoped (different files emit
-    # distinct nodes), so no two files in a package can produce the same
-    # triple.
-    seen_edges: set[tuple[SymbolNode, SymbolNode, EdgeFlags]] = set()
-
     for n in payload.nodes:
         symbol_graph.add_node(n)
         if n.flags & NodeFlags.ENTRYPOINT:
@@ -716,10 +704,7 @@ def _apply_payload(
         if n.type == "synthetic":
             continue
         if n.type != "module":
-            key = (n, module, EdgeFlags.NONE)
-            if key not in seen_edges:
-                seen_edges.add(key)
-                symbol_graph.add_edge(n, module, flags=EdgeFlags.NONE)
+            symbol_graph.add_edge(n, module, flags=EdgeFlags.NONE)
         # ``OVERLOAD`` and ``SHADOWED`` exclude a single decl from the
         # cross-module lookup trie; ``add_to_trie=False`` is the
         # file-level equivalent for a ``.py`` whose sibling package
@@ -732,12 +717,12 @@ def _apply_payload(
             if file_exported:
                 export_trie.add_declaration(n)
 
+    # Repeated same-suite references (``f(); f(); f()``) emit one
+    # ``payload.edges`` entry per access; after ``flag_for(pos)`` the
+    # triples are identical. SymbolGraph's edge-uniqueness invariant
+    # collapses them to a single edge.
     for src, dst, pos in payload.edges:
-        flags = flag_for(pos)
-        key = (src, dst, flags)
-        if key not in seen_edges:
-            seen_edges.add(key)
-            symbol_graph.add_edge(src, dst, flags=flags)
+        symbol_graph.add_edge(src, dst, flags=flag_for(pos))
 
     for src, imp, pos in payload.imports:
         import_edges.add((src, imp, flag_for(pos)))

--- a/dead_cst/analyze.py
+++ b/dead_cst/analyze.py
@@ -7,8 +7,6 @@ from functools import cached_property
 from pathlib import Path
 from typing import Iterable, Iterator, Mapping, Sequence
 
-import networkx as nx
-
 from ._edges import resolve_edges
 from ._refresh import (
     PackageContribution,
@@ -23,7 +21,7 @@ from .branches import (
     UnreachableRegionDetector,
 )
 from .cache import GraphCache, compute_fingerprint
-from .graph import EdgeFlags, NodeFlags, SymbolNode, SymbolTrie, VisitorPayload
+from .graph import EdgeFlags, NodeFlags, SymbolGraph, SymbolNode, SymbolTrie, VisitorPayload
 from .plugins import (
     EdgePlugin,
     PluginContext,
@@ -85,7 +83,7 @@ def _rebind_sys_path(search_paths: tuple[Path, ...], baseline: list[str]) -> Non
 def _compose_contribution(
     contrib: PackageContribution,
     *,
-    target_graph: nx.MultiDiGraph,
+    target_graph: SymbolGraph,
     symbol_lookup: SymbolTrie,
     plugins: Sequence[EdgePlugin],
     project_root: Path,
@@ -142,7 +140,7 @@ def _compose_contribution(
 
 
 def _find_reachable(
-    graph: nx.MultiDiGraph, exclude_flags: NodeFlags = NodeFlags.NONE
+    graph: SymbolGraph, exclude_flags: NodeFlags = NodeFlags.NONE
 ) -> set[SymbolNode]:
     """BFS forward from every node tagged as an entrypoint by a plugin.
 
@@ -177,7 +175,7 @@ def _find_reachable(
     return visited
 
 
-def _find_reachable_strict(graph: nx.MultiDiGraph) -> set[SymbolNode]:
+def _find_reachable_strict(graph: SymbolGraph) -> set[SymbolNode]:
     """Like :func:`_find_reachable` but skips ``DEAD_BRANCH``-flagged edges."""
     visited: set[SymbolNode] = set()
     stack = [n for n, attrs in graph.nodes(data=True) if attrs.get("entrypoint")]
@@ -193,7 +191,7 @@ def _find_reachable_strict(graph: nx.MultiDiGraph) -> set[SymbolNode]:
     return visited
 
 
-def _find_kept_alive_by_dead_branches(graph: nx.MultiDiGraph) -> set[SymbolNode]:
+def _find_kept_alive_by_dead_branches(graph: SymbolGraph) -> set[SymbolNode]:
     """Symbols kept alive only via at least one ``DEAD_BRANCH`` edge.
 
     ``_find_reachable(graph) -`` strict-mode BFS that skips every edge
@@ -206,7 +204,7 @@ def _find_kept_alive_by_dead_branches(graph: nx.MultiDiGraph) -> set[SymbolNode]
     return _find_reachable(graph) - _find_reachable_strict(graph)
 
 
-def _find_kept_alive_by_flags_only(graph: nx.MultiDiGraph, flags: NodeFlags) -> set[SymbolNode]:
+def _find_kept_alive_by_flags_only(graph: SymbolGraph, flags: NodeFlags) -> set[SymbolNode]:
     """Symbols reachable only from entrypoints carrying any of ``flags``.
 
     ``_find_reachable(graph) - _find_reachable(graph, flags)``; the
@@ -217,7 +215,7 @@ def _find_kept_alive_by_flags_only(graph: nx.MultiDiGraph, flags: NodeFlags) -> 
     return _find_reachable(graph) - _find_reachable(graph, flags)
 
 
-def _count_nodes(graph: nx.MultiDiGraph, prefix: Path | None) -> dict[str, int]:
+def _count_nodes(graph: SymbolGraph, prefix: Path | None) -> dict[str, int]:
     """Count nodes in ``graph`` by ``SymbolNode.type``, optionally restricted by path.
 
     If ``prefix`` is given, only nodes whose ``path`` is under ``prefix``
@@ -233,7 +231,7 @@ def _count_nodes(graph: nx.MultiDiGraph, prefix: Path | None) -> dict[str, int]:
 
 
 def _count_nodes_by_prefix(
-    graph: nx.MultiDiGraph, prefixes: Sequence[Path]
+    graph: SymbolGraph, prefixes: Sequence[Path]
 ) -> dict[Path, dict[str, int]]:
     """One-pass equivalent of :func:`_count_nodes` for many prefixes.
 
@@ -373,8 +371,8 @@ class Analysis:
         # the touched packages; absent for packages that were never
         # refreshed.
         self._payloads: dict[Path, VisitorPayload] = {}
-        self._closure_graphs: dict[Path, nx.MultiDiGraph] = {}
-        self._full_graph: nx.MultiDiGraph | None = None
+        self._closure_graphs: dict[Path, SymbolGraph] = {}
+        self._full_graph: SymbolGraph | None = None
         # Memoize closure-walk results -- the package graph is
         # immutable post-construction.
         self._reverse_closures: dict[Path, frozenset[Path]] = {}
@@ -519,7 +517,7 @@ class Analysis:
         for package in self.packages:
             yield PackageView(self, package)
 
-    def materialize_all(self) -> nx.MultiDiGraph:
+    def materialize_all(self) -> SymbolGraph:
         """Build the full graph (every package, cross-package resolution, plugins).
 
         Memoized: the second call returns the same graph object.
@@ -532,7 +530,7 @@ class Analysis:
             self._full_graph = self._materialize(scope=None)
         return self._full_graph
 
-    def materialize_closure(self, package: Path) -> nx.MultiDiGraph:
+    def materialize_closure(self, package: Path) -> SymbolGraph:
         """Build a graph containing every contribution in ``_interesting_set(package)``.
 
         The result is the smallest graph that gives correct
@@ -610,14 +608,14 @@ class Analysis:
     def materialize_with(
         self,
         payloads: Mapping[Path, VisitorPayload],
-    ) -> nx.MultiDiGraph:
+    ) -> SymbolGraph:
         """Materialize a fresh graph with ``payloads`` spliced in for their files.
 
         The non-mutating overlay path: rebuilds only the affected
         packages' contributions (with the substitute payloads
         replacing the originals), leaves every other package's
         contribution untouched, then re-runs the cross-package
-        composition into a new :class:`networkx.MultiDiGraph`.
+        composition into a new :class:`SymbolGraph`.
 
         Pairs with :meth:`preview_payloads` for "what-if" graph
         surgery. The original :meth:`materialize_all` /
@@ -711,7 +709,7 @@ class Analysis:
         *,
         scope: frozenset[Path] | None,
         contributions_override: Mapping[Path, PackageContribution] | None = None,
-    ) -> nx.MultiDiGraph:
+    ) -> SymbolGraph:
         """Compose every refreshed package in ``scope`` into a fresh graph.
 
         ``scope=None`` composes every package. Caller is responsible
@@ -728,7 +726,7 @@ class Analysis:
         """
         from ._progress import progress
 
-        g: nx.MultiDiGraph = nx.MultiDiGraph()
+        g: SymbolGraph = SymbolGraph()
         g.graph["dead_suites"] = {}
         baseline = list(sys.path)
         last_search_paths: tuple[Path, ...] | None = None
@@ -954,7 +952,7 @@ class PackageView:
         )
         return ctx.importers(target)
 
-    def graph(self) -> nx.MultiDiGraph:
+    def graph(self) -> SymbolGraph:
         """Materialize and return the closure-scoped graph for this package.
 
         See :meth:`Analysis.materialize_closure`. The graph is shared
@@ -1059,12 +1057,12 @@ class GraphView:
 
     __slots__ = ("_graph",)
 
-    def __init__(self, graph: nx.MultiDiGraph) -> None:
+    def __init__(self, graph: SymbolGraph) -> None:
         self._graph = graph
 
     @property
-    def graph(self) -> nx.MultiDiGraph:
-        """The underlying :class:`networkx.MultiDiGraph`."""
+    def graph(self) -> SymbolGraph:
+        """The underlying :class:`SymbolGraph`."""
         return self._graph
 
     def reachable(self) -> set[SymbolNode]:

--- a/dead_cst/analyze.py
+++ b/dead_cst/analyze.py
@@ -104,7 +104,7 @@ def _compose_contribution(
     first-party in the trie.
     """
     target_graph.update(
-        edges=contrib.package_graph.edges(data=True, keys=True),
+        edges=contrib.package_graph.edges(data=True),
         nodes=contrib.package_graph.nodes(data=True),
     )
     target_graph.graph.setdefault("dead_suites", {}).update(

--- a/dead_cst/cli.py
+++ b/dead_cst/cli.py
@@ -11,7 +11,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Annotated, Iterator, Sequence
 
-import networkx as nx
 import typer
 from libcst.metadata import CodeRange
 
@@ -22,7 +21,7 @@ from .cache import (
     default_cache_path,
 )
 from .codemod import generate_patch
-from .graph import SymbolNode
+from .graph import SymbolGraph, SymbolNode
 from .plugins import (
     EXTERNAL_PREFIXES,
     EdgePlugin,
@@ -226,8 +225,8 @@ def analyze(
 
 
 def _output_text(
-    graph: nx.MultiDiGraph,
-    unreachable: nx.MultiDiGraph,
+    graph: SymbolGraph,
+    unreachable: SymbolGraph,
     root: Path,
     package_paths: Sequence[Path],
 ) -> None:
@@ -267,7 +266,7 @@ def _output_text(
             typer.echo(f"  {rel}:{start.line}:{start.column}-{end.line}:{end.column}")
 
 
-def _dead_real(unreachable: nx.MultiDiGraph) -> list[SymbolNode]:
+def _dead_real(unreachable: SymbolGraph) -> list[SymbolNode]:
     """Return real (non-synthetic) dead nodes from ``unreachable``.
 
     Synthetic nodes -- entrypoint sentinels, external-dist markers,
@@ -278,7 +277,7 @@ def _dead_real(unreachable: nx.MultiDiGraph) -> list[SymbolNode]:
 
 
 def _dead_suite_locations(
-    graph: nx.MultiDiGraph, package_paths: Sequence[Path]
+    graph: SymbolGraph, package_paths: Sequence[Path]
 ) -> list[tuple[Path, CodeRange]]:
     """Flatten ``graph.graph["dead_suites"]`` into a sorted ``(path, pos)`` list.
 
@@ -298,8 +297,8 @@ def _dead_suite_locations(
 
 
 def _output_json(
-    graph: nx.MultiDiGraph,
-    unreachable: nx.MultiDiGraph,
+    graph: SymbolGraph,
+    unreachable: SymbolGraph,
     root: Path,
     package_paths: Sequence[Path],
 ) -> None:

--- a/dead_cst/codemod.py
+++ b/dead_cst/codemod.py
@@ -4,13 +4,12 @@ import difflib
 from pathlib import Path
 
 import libcst as cst
-import networkx as nx
 from libcst.codemod import CodemodContext
 from libcst.codemod.visitors import RemoveImportsVisitor
 from libcst.metadata import CodeRange, FullRepoManager, PositionProvider, QualifiedNameSource
 
 from ._fqn import FixedFullyQualifiedNameProvider
-from .graph import NodeFlags, SymbolNode
+from .graph import NodeFlags, SymbolGraph, SymbolNode
 
 
 class RemoveDeadSymbols(cst.CSTTransformer):
@@ -88,7 +87,7 @@ def _import_remove_args(node: SymbolNode) -> tuple[str, str | None, str | None]:
     return module, obj, asname
 
 
-def _select_files(G: nx.Graph, base: Path) -> tuple[dict[Path, list[SymbolNode]], list[Path]]:
+def _select_files(G: SymbolGraph, base: Path) -> tuple[dict[Path, list[SymbolNode]], list[Path]]:
     """Group ``G``'s nodes under ``base`` into files-to-rewrite vs. files-to-delete.
 
     Used by both :func:`remove_code` and :func:`generate_patch`. Symbols
@@ -145,7 +144,7 @@ def _rewrite_one(wrapper, nodes: list[SymbolNode]) -> tuple[str, str]:
     return original, result.code
 
 
-def remove_code(G: nx.Graph, package_path: Path) -> None:
+def remove_code(G: SymbolGraph, package_path: Path) -> None:
     """Delete every symbol in ``G`` from the source files under ``package_path``.
 
     Modules are removed by unlinking the file. Functions, classes, and
@@ -184,7 +183,7 @@ def remove_code(G: nx.Graph, package_path: Path) -> None:
             path.write_text(new)
 
 
-def generate_patch(G: nx.Graph, root: Path) -> str:
+def generate_patch(G: SymbolGraph, root: Path) -> str:
     """Return a ``git apply``-compatible unified diff that removes ``G``'s nodes.
 
     Same selection logic as :func:`remove_code` -- group dead nodes by

--- a/dead_cst/graph.py
+++ b/dead_cst/graph.py
@@ -430,39 +430,15 @@ class SymbolGraph:
     Backed by :class:`rustworkx.PyDiGraph` with ``multigraph=True``;
     nodes are :class:`SymbolNode` instances, edges carry an attribute
     dict (typically ``{"flags": EdgeFlags}``). The wrapper owns the
-    ``SymbolNode -> int`` index map so callers continue to address
-    nodes by their domain identity while rustworkx operates on
-    integer indices internally.
+    ``SymbolNode -> int`` index map so callers address nodes by their
+    domain identity while rustworkx operates on integer indices
+    internally. Per-node attributes (``entrypoint``, ``testcase``)
+    live in a side table rather than on the rustworkx payload.
 
-    Exposes the ``networkx``-style surface the analyzer relies on
-    (``successors``, ``predecessors``, ``subgraph``, ``out_edges``,
-    ``nodes(data=True)``, ``edges(data=True, keys=True)``, the
-    ``graph`` attribute for graph-level metadata, etc.) so call sites
-    read naturally. Two methods deserve note:
-
-    * :meth:`subgraph` returns a fresh :class:`SymbolGraph` (rather
-      than a view) containing the induced subgraph; cheap to build
-      because the wrapper is thin.
-    * :meth:`update` merges nodes + edges from another graph -- the
-      composition primitive used to fold per-package graphs into the
-      full / closure graph.
-
-    Node attributes (``entrypoint``, ``testcase``) live in a side
-    table rather than on the rustworkx payload, so the payload stays
-    a bare :class:`SymbolNode` (which keeps ``successors`` /
-    ``predecessors`` returning the domain object directly).
-
-    **Edge uniqueness invariant.** The graph never carries two edges
-    that share the same ``(src, dst, attrs)`` -- duplicate inserts are
-    silently dropped. Multiple callers used to deduplicate before
-    insertion (the visitor's repeated same-suite refs, plugin
-    fan-outs that rediscover the same target, the cross-file
-    :func:`resolve_edges` algorithm's natural fan-out); the wrapper now
-    owns that invariant so call sites don't carry parallel ``seen``
-    sets. The multigraph base is retained so metadata-distinct edges
-    (one ``DEAD_BRANCH``, one ``NONE``) between the same pair stay
-    separate -- strict-mode reachability filters on attrs, so
-    collapsing those would lose fidelity.
+    Duplicate ``(src, dst, attrs)`` inserts are silently dropped.
+    Metadata-distinct parallel edges (e.g. one ``DEAD_BRANCH`` plus
+    one ``NONE``) are preserved -- strict-mode reachability filters
+    on attrs, so collapsing those would lose fidelity.
     """
 
     __slots__ = ("_g", "_idx", "_node_attrs", "_edge_keys", "graph")
@@ -471,12 +447,9 @@ class SymbolGraph:
         self._g: rx.PyDiGraph = rx.PyDiGraph(multigraph=True)
         self._idx: dict[SymbolNode, int] = {}
         self._node_attrs: dict[int, dict[str, Any]] = {}
-        # ``(src_idx, dst_idx, frozen_attrs)`` triples already in the
-        # graph. Consulted on every edge insertion to enforce the
-        # uniqueness invariant; see the class docstring.
         self._edge_keys: set[tuple[int, int, tuple]] = set()
-        # ``graph`` is the networkx convention for graph-level
-        # attributes (``g.graph["dead_suites"]`` etc.). We mirror it.
+        # ``graph`` mirrors networkx's graph-level attribute dict
+        # (``g.graph["dead_suites"]``).
         self.graph: dict[str, Any] = {}
 
     @property
@@ -499,12 +472,15 @@ class SymbolGraph:
     def _freeze_attrs(attrs: dict[str, Any]) -> tuple:
         """Hashable key for an edge's attrs dict (order-independent).
 
-        Empty / single-entry attrs are the common case -- our edges
-        carry at most ``{"flags": EdgeFlags.X}``. Sorting on the empty
-        / 1-element path costs nothing and keeps the rule generic.
+        Fast-paths the empty and single-key cases -- our edges carry
+        at most ``{"flags": EdgeFlags.X}``, so ``sorted`` is wasted
+        work in the dominant path.
         """
-        if not attrs:
+        size = len(attrs)
+        if size == 0:
             return ()
+        if size == 1:
+            return next(iter(attrs.items()))
         return tuple(sorted(attrs.items()))
 
     def _insert_edge(self, src_idx: int, dst_idx: int, payload: dict[str, Any]) -> bool:
@@ -520,7 +496,9 @@ class SymbolGraph:
     def add_edge(self, src: SymbolNode, dst: SymbolNode, **attrs: Any) -> None:
         s = self.add_node(src)
         d = self.add_node(dst)
-        self._insert_edge(s, d, dict(attrs))
+        # ``attrs`` is a fresh dict produced by Python's kwarg
+        # collection; pass it through as the rustworkx edge payload.
+        self._insert_edge(s, d, attrs)
 
     def add_edges_from(
         self, edges: Iterable[tuple[SymbolNode, SymbolNode, dict[str, Any]]]
@@ -593,42 +571,46 @@ class SymbolGraph:
     def subgraph(self, nodes: Iterable[SymbolNode]) -> SymbolGraph:
         """Induced subgraph over ``nodes``: includes every edge whose
         endpoints both survive the filter. Returns a fresh
-        :class:`SymbolGraph`; not a view."""
+        :class:`SymbolGraph`; not a view.
+
+        Source-graph edges are already deduped under the uniqueness
+        invariant, so the rebuild populates ``_edge_keys`` directly
+        without re-probing it on every edge.
+        """
+        old_indices: list[int] = []
+        for n in nodes:
+            idx = self._idx.get(n)
+            if idx is not None:
+                old_indices.append(idx)
         sub = SymbolGraph()
         sub.graph = dict(self.graph)
-        selected: list[tuple[SymbolNode, int]] = []
-        for n in nodes:
-            old_idx = self._idx.get(n)
-            if old_idx is None:
-                continue
-            new_idx = sub.add_node(n)
+        sub._g = self._g.subgraph(old_indices)
+        # rustworkx's ``subgraph`` renumbers; rebuild the side tables
+        # by walking the new graph.
+        for new_idx in sub._g.node_indices():
+            node = sub._g[new_idx]
+            sub._idx[node] = new_idx
+            old_idx = self._idx[node]
             attrs = self._node_attrs.get(old_idx)
             if attrs:
                 sub._node_attrs[new_idx] = dict(attrs)
-            selected.append((n, old_idx))
-        for n, old_idx in selected:
-            new_src = sub._idx[n]
-            for _u_idx, v_idx, payload in self._g.out_edges(old_idx):
-                dst = self._g[v_idx]
-                new_dst = sub._idx.get(dst)
-                if new_dst is not None:
-                    sub._insert_edge(new_src, new_dst, payload)
+        for u, v, payload in sub._g.weighted_edge_list():
+            sub._edge_keys.add((u, v, SymbolGraph._freeze_attrs(payload)))
         return sub
 
     def update(
         self,
         *,
-        edges: Iterable[tuple] | None = None,
+        edges: Iterable[tuple[SymbolNode, SymbolNode, dict[str, Any]]] | None = None,
         nodes: Iterable[tuple[SymbolNode, dict[str, Any]]] | None = None,
     ) -> None:
         """Merge ``nodes`` and ``edges`` from another graph into this one.
 
-        ``nodes`` is an iterable of ``(node, attrs_dict)`` (the shape
-        :meth:`nodes` returns under ``data=True``). ``edges`` may be
-        ``(u, v, attrs)`` triples or ``(u, v, key, attrs)`` 4-tuples
-        (the shape :meth:`edges` returns under ``keys=True, data=True``;
-        the key is discarded because it has no meaning in the target
-        graph)."""
+        ``nodes`` yields ``(node, attrs_dict)`` (the shape returned by
+        :meth:`nodes` under ``data=True``); ``edges`` yields
+        ``(u, v, attrs)`` (the shape returned by :meth:`edges` under
+        ``data=True``).
+        """
         if nodes is not None:
             for n, attrs in nodes:
                 idx = self.add_node(n)
@@ -636,14 +618,10 @@ class SymbolGraph:
                     bucket = self._node_attrs.setdefault(idx, {})
                     bucket.update(attrs)
         if edges is not None:
-            for entry in edges:
-                if len(entry) == 4:
-                    u, v, _key, payload = entry
-                else:
-                    u, v, payload = entry
+            for u, v, payload in edges:
                 s = self.add_node(u)
                 d = self.add_node(v)
-                self._insert_edge(s, d, payload if isinstance(payload, dict) else {})
+                self._insert_edge(s, d, payload)
 
 
 # ``SymbolTrie`` is intentionally absent from ``__all__`` -- it's an

--- a/dead_cst/graph.py
+++ b/dead_cst/graph.py
@@ -451,14 +451,30 @@ class SymbolGraph:
     table rather than on the rustworkx payload, so the payload stays
     a bare :class:`SymbolNode` (which keeps ``successors`` /
     ``predecessors`` returning the domain object directly).
+
+    **Edge uniqueness invariant.** The graph never carries two edges
+    that share the same ``(src, dst, attrs)`` -- duplicate inserts are
+    silently dropped. Multiple callers used to deduplicate before
+    insertion (the visitor's repeated same-suite refs, plugin
+    fan-outs that rediscover the same target, the cross-file
+    :func:`resolve_edges` algorithm's natural fan-out); the wrapper now
+    owns that invariant so call sites don't carry parallel ``seen``
+    sets. The multigraph base is retained so metadata-distinct edges
+    (one ``DEAD_BRANCH``, one ``NONE``) between the same pair stay
+    separate -- strict-mode reachability filters on attrs, so
+    collapsing those would lose fidelity.
     """
 
-    __slots__ = ("_g", "_idx", "_node_attrs", "graph")
+    __slots__ = ("_g", "_idx", "_node_attrs", "_edge_keys", "graph")
 
     def __init__(self) -> None:
         self._g: rx.PyDiGraph = rx.PyDiGraph(multigraph=True)
         self._idx: dict[SymbolNode, int] = {}
         self._node_attrs: dict[int, dict[str, Any]] = {}
+        # ``(src_idx, dst_idx, frozen_attrs)`` triples already in the
+        # graph. Consulted on every edge insertion to enforce the
+        # uniqueness invariant; see the class docstring.
+        self._edge_keys: set[tuple[int, int, tuple]] = set()
         # ``graph`` is the networkx convention for graph-level
         # attributes (``g.graph["dead_suites"]`` etc.). We mirror it.
         self.graph: dict[str, Any] = {}
@@ -479,10 +495,32 @@ class SymbolGraph:
             self._idx[node] = idx
         return idx
 
+    @staticmethod
+    def _freeze_attrs(attrs: dict[str, Any]) -> tuple:
+        """Hashable key for an edge's attrs dict (order-independent).
+
+        Empty / single-entry attrs are the common case -- our edges
+        carry at most ``{"flags": EdgeFlags.X}``. Sorting on the empty
+        / 1-element path costs nothing and keeps the rule generic.
+        """
+        if not attrs:
+            return ()
+        return tuple(sorted(attrs.items()))
+
+    def _insert_edge(self, src_idx: int, dst_idx: int, payload: dict[str, Any]) -> bool:
+        """Insert one edge under the uniqueness invariant. Returns True
+        if a new edge was added, False if it was a duplicate."""
+        key = (src_idx, dst_idx, self._freeze_attrs(payload))
+        if key in self._edge_keys:
+            return False
+        self._edge_keys.add(key)
+        self._g.add_edge(src_idx, dst_idx, payload)
+        return True
+
     def add_edge(self, src: SymbolNode, dst: SymbolNode, **attrs: Any) -> None:
         s = self.add_node(src)
         d = self.add_node(dst)
-        self._g.add_edge(s, d, dict(attrs))
+        self._insert_edge(s, d, dict(attrs))
 
     def add_edges_from(
         self, edges: Iterable[tuple[SymbolNode, SymbolNode, dict[str, Any]]]
@@ -491,7 +529,7 @@ class SymbolGraph:
         for src, dst, payload in edges:
             s = self.add_node(src)
             d = self.add_node(dst)
-            self._g.add_edge(s, d, payload)
+            self._insert_edge(s, d, payload)
 
     def has_edge(self, src: SymbolNode, dst: SymbolNode) -> bool:
         s = self._idx.get(src)
@@ -501,8 +539,23 @@ class SymbolGraph:
         return self._g.has_edge(s, d)
 
     def remove_edge(self, src: SymbolNode, dst: SymbolNode) -> None:
-        """Remove a single edge ``src -> dst``. Matches ``MultiDiGraph.remove_edge``."""
-        self._g.remove_edge(self._idx[src], self._idx[dst])
+        """Remove a single edge ``src -> dst``. Matches ``MultiDiGraph.remove_edge``.
+
+        rustworkx's ``remove_edge(s, d)`` drops one of the parallel
+        edges (impl-defined choice when several share the endpoints).
+        We mirror that choice into ``_edge_keys`` by diffing the
+        ``(s, d)`` payload set across the removal -- the missing entry
+        is the one rustworkx just removed. Edge removal is a cold path
+        (no in-tree plugin emits ``RemoveEdge`` today), so the small
+        scan over parallel edges at the pair is fine.
+        """
+        s = self._idx[src]
+        d = self._idx[dst]
+        pre = {self._freeze_attrs(p) for _u, v_idx, p in self._g.out_edges(s) if v_idx == d}
+        self._g.remove_edge(s, d)
+        post = {self._freeze_attrs(p) for _u, v_idx, p in self._g.out_edges(s) if v_idx == d}
+        for removed in pre - post:
+            self._edge_keys.discard((s, d, removed))
 
     def successors(self, node: SymbolNode) -> Iterator[SymbolNode]:
         idx = self._idx.get(node)
@@ -559,7 +612,7 @@ class SymbolGraph:
                 dst = self._g[v_idx]
                 new_dst = sub._idx.get(dst)
                 if new_dst is not None:
-                    sub._g.add_edge(new_src, new_dst, payload)
+                    sub._insert_edge(new_src, new_dst, payload)
         return sub
 
     def update(
@@ -590,7 +643,7 @@ class SymbolGraph:
                     u, v, payload = entry
                 s = self.add_node(u)
                 d = self.add_node(v)
-                self._g.add_edge(s, d, payload if isinstance(payload, dict) else {})
+                self._insert_edge(s, d, payload if isinstance(payload, dict) else {})
 
 
 # ``SymbolTrie`` is intentionally absent from ``__all__`` -- it's an

--- a/dead_cst/graph.py
+++ b/dead_cst/graph.py
@@ -16,11 +16,12 @@ from __future__ import annotations
 
 import enum
 import logging
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
-import networkx as nx
+import rustworkx as rx
 from libcst.metadata import CodeRange
 
 logger = logging.getLogger(__name__)
@@ -307,7 +308,7 @@ class SymbolTrie:
                 return None
         return node
 
-    def add_module_hierarchy_edges(self, symbol_graph: nx.DiGraph) -> None:
+    def add_module_hierarchy_edges(self, symbol_graph: SymbolGraph) -> None:
         """
         Walk the trie and add edges from each submodule to its parent module.
 
@@ -340,6 +341,258 @@ class SymbolTrie:
         _walk_and_add_edges(self, None)
 
 
+class _NodesView:
+    """View over :class:`SymbolGraph`'s nodes.
+
+    Iterable (yields :class:`SymbolNode`), indexable
+    (``view[node]`` returns the node's mutable attribute dict, creating
+    it on first access), callable (``view(data=True)`` yields
+    ``(node, attrs)`` pairs). Mirrors ``networkx``'s ``NodeView`` for
+    the patterns the analyzer relies on.
+    """
+
+    __slots__ = ("_graph",)
+
+    def __init__(self, graph: SymbolGraph) -> None:
+        self._graph = graph
+
+    def __iter__(self) -> Iterator[SymbolNode]:
+        g = self._graph._g
+        for idx in g.node_indices():
+            yield g[idx]
+
+    def __len__(self) -> int:
+        return self._graph._g.num_nodes()
+
+    def __contains__(self, node: object) -> bool:
+        return node in self._graph._idx
+
+    def __getitem__(self, node: SymbolNode) -> dict[str, Any]:
+        idx = self._graph._idx[node]
+        attrs = self._graph._node_attrs.get(idx)
+        if attrs is None:
+            attrs = {}
+            self._graph._node_attrs[idx] = attrs
+        return attrs
+
+    def __call__(self, *, data: bool = False) -> Iterator[Any]:
+        g = self._graph._g
+        node_attrs = self._graph._node_attrs
+        if data:
+            for idx in g.node_indices():
+                yield g[idx], node_attrs.get(idx, _EMPTY_ATTRS)
+        else:
+            for idx in g.node_indices():
+                yield g[idx]
+
+
+class _EdgesView:
+    """View over :class:`SymbolGraph`'s edges.
+
+    Callable: ``view()`` / ``view(data=True)`` / ``view(keys=True)`` /
+    ``view(data=True, keys=True)`` yield 2-, 3-, 3-, or 4-tuples
+    respectively, one entry per edge instance (parallel edges are not
+    deduped, matching ``networkx.MultiDiGraph``).
+    """
+
+    __slots__ = ("_graph",)
+
+    def __init__(self, graph: SymbolGraph) -> None:
+        self._graph = graph
+
+    def __call__(self, *, data: bool = False, keys: bool = False) -> Iterator[Any]:
+        g = self._graph._g
+        if data and keys:
+            for edge_idx, (u_idx, v_idx, payload) in g.edge_index_map().items():
+                yield g[u_idx], g[v_idx], edge_idx, payload
+        elif data:
+            for u_idx, v_idx, payload in g.weighted_edge_list():
+                yield g[u_idx], g[v_idx], payload
+        elif keys:
+            for edge_idx, (u_idx, v_idx, _payload) in g.edge_index_map().items():
+                yield g[u_idx], g[v_idx], edge_idx
+        else:
+            for u_idx, v_idx in g.edge_list():
+                yield g[u_idx], g[v_idx]
+
+
+# Shared sentinel for ``nodes(data=True)`` on un-attributed nodes. The
+# default dict has to be read-only at the call site -- callers either
+# query ``.get("entrypoint")`` (safe) or use ``nodes[node]["..."] = ...``
+# which routes through :meth:`_NodesView.__getitem__` and materializes
+# a fresh dict.
+_EMPTY_ATTRS: dict[str, Any] = {}
+
+
+class SymbolGraph:
+    """The analyzer's directed multigraph of symbol references.
+
+    Backed by :class:`rustworkx.PyDiGraph` with ``multigraph=True``;
+    nodes are :class:`SymbolNode` instances, edges carry an attribute
+    dict (typically ``{"flags": EdgeFlags}``). The wrapper owns the
+    ``SymbolNode -> int`` index map so callers continue to address
+    nodes by their domain identity while rustworkx operates on
+    integer indices internally.
+
+    Exposes the ``networkx``-style surface the analyzer relies on
+    (``successors``, ``predecessors``, ``subgraph``, ``out_edges``,
+    ``nodes(data=True)``, ``edges(data=True, keys=True)``, the
+    ``graph`` attribute for graph-level metadata, etc.) so call sites
+    read naturally. Two methods deserve note:
+
+    * :meth:`subgraph` returns a fresh :class:`SymbolGraph` (rather
+      than a view) containing the induced subgraph; cheap to build
+      because the wrapper is thin.
+    * :meth:`update` merges nodes + edges from another graph -- the
+      composition primitive used to fold per-package graphs into the
+      full / closure graph.
+
+    Node attributes (``entrypoint``, ``testcase``) live in a side
+    table rather than on the rustworkx payload, so the payload stays
+    a bare :class:`SymbolNode` (which keeps ``successors`` /
+    ``predecessors`` returning the domain object directly).
+    """
+
+    __slots__ = ("_g", "_idx", "_node_attrs", "graph")
+
+    def __init__(self) -> None:
+        self._g: rx.PyDiGraph = rx.PyDiGraph(multigraph=True)
+        self._idx: dict[SymbolNode, int] = {}
+        self._node_attrs: dict[int, dict[str, Any]] = {}
+        # ``graph`` is the networkx convention for graph-level
+        # attributes (``g.graph["dead_suites"]`` etc.). We mirror it.
+        self.graph: dict[str, Any] = {}
+
+    @property
+    def nodes(self) -> _NodesView:
+        return _NodesView(self)
+
+    @property
+    def edges(self) -> _EdgesView:
+        return _EdgesView(self)
+
+    def add_node(self, node: SymbolNode) -> int:
+        """Idempotent: returns the existing index if ``node`` is already in the graph."""
+        idx = self._idx.get(node)
+        if idx is None:
+            idx = self._g.add_node(node)
+            self._idx[node] = idx
+        return idx
+
+    def add_edge(self, src: SymbolNode, dst: SymbolNode, **attrs: Any) -> None:
+        s = self.add_node(src)
+        d = self.add_node(dst)
+        self._g.add_edge(s, d, dict(attrs))
+
+    def add_edges_from(
+        self, edges: Iterable[tuple[SymbolNode, SymbolNode, dict[str, Any]]]
+    ) -> None:
+        """Bulk-add ``(src, dst, attrs)`` triples. ``attrs`` is the edge payload dict."""
+        for src, dst, payload in edges:
+            s = self.add_node(src)
+            d = self.add_node(dst)
+            self._g.add_edge(s, d, payload)
+
+    def has_edge(self, src: SymbolNode, dst: SymbolNode) -> bool:
+        s = self._idx.get(src)
+        d = self._idx.get(dst)
+        if s is None or d is None:
+            return False
+        return self._g.has_edge(s, d)
+
+    def remove_edge(self, src: SymbolNode, dst: SymbolNode) -> None:
+        """Remove a single edge ``src -> dst``. Matches ``MultiDiGraph.remove_edge``."""
+        self._g.remove_edge(self._idx[src], self._idx[dst])
+
+    def successors(self, node: SymbolNode) -> Iterator[SymbolNode]:
+        idx = self._idx.get(node)
+        if idx is None:
+            return iter(())
+        return iter(self._g.successors(idx))
+
+    def predecessors(self, node: SymbolNode) -> Iterator[SymbolNode]:
+        idx = self._idx.get(node)
+        if idx is None:
+            return iter(())
+        return iter(self._g.predecessors(idx))
+
+    def out_edges(self, node: SymbolNode, *, data: bool = False) -> Iterator[Any]:
+        idx = self._idx.get(node)
+        if idx is None:
+            return
+        g = self._g
+        if data:
+            for u_idx, v_idx, payload in g.out_edges(idx):
+                yield g[u_idx], g[v_idx], payload
+        else:
+            for u_idx, v_idx, _payload in g.out_edges(idx):
+                yield g[u_idx], g[v_idx]
+
+    def in_degree(self, node: SymbolNode) -> int:
+        idx = self._idx.get(node)
+        if idx is None:
+            return 0
+        return self._g.in_degree(idx)
+
+    def number_of_nodes(self) -> int:
+        return self._g.num_nodes()
+
+    def subgraph(self, nodes: Iterable[SymbolNode]) -> SymbolGraph:
+        """Induced subgraph over ``nodes``: includes every edge whose
+        endpoints both survive the filter. Returns a fresh
+        :class:`SymbolGraph`; not a view."""
+        sub = SymbolGraph()
+        sub.graph = dict(self.graph)
+        selected: list[tuple[SymbolNode, int]] = []
+        for n in nodes:
+            old_idx = self._idx.get(n)
+            if old_idx is None:
+                continue
+            new_idx = sub.add_node(n)
+            attrs = self._node_attrs.get(old_idx)
+            if attrs:
+                sub._node_attrs[new_idx] = dict(attrs)
+            selected.append((n, old_idx))
+        for n, old_idx in selected:
+            new_src = sub._idx[n]
+            for _u_idx, v_idx, payload in self._g.out_edges(old_idx):
+                dst = self._g[v_idx]
+                new_dst = sub._idx.get(dst)
+                if new_dst is not None:
+                    sub._g.add_edge(new_src, new_dst, payload)
+        return sub
+
+    def update(
+        self,
+        *,
+        edges: Iterable[tuple] | None = None,
+        nodes: Iterable[tuple[SymbolNode, dict[str, Any]]] | None = None,
+    ) -> None:
+        """Merge ``nodes`` and ``edges`` from another graph into this one.
+
+        ``nodes`` is an iterable of ``(node, attrs_dict)`` (the shape
+        :meth:`nodes` returns under ``data=True``). ``edges`` may be
+        ``(u, v, attrs)`` triples or ``(u, v, key, attrs)`` 4-tuples
+        (the shape :meth:`edges` returns under ``keys=True, data=True``;
+        the key is discarded because it has no meaning in the target
+        graph)."""
+        if nodes is not None:
+            for n, attrs in nodes:
+                idx = self.add_node(n)
+                if attrs:
+                    bucket = self._node_attrs.setdefault(idx, {})
+                    bucket.update(attrs)
+        if edges is not None:
+            for entry in edges:
+                if len(entry) == 4:
+                    u, v, _key, payload = entry
+                else:
+                    u, v, payload = entry
+                s = self.add_node(u)
+                d = self.add_node(v)
+                self._g.add_edge(s, d, payload if isinstance(payload, dict) else {})
+
+
 # ``SymbolTrie`` is intentionally absent from ``__all__`` -- it's an
 # internal data structure shared between the visitor, edge stitcher, and
 # plugin context, but not part of the public surface.
@@ -347,6 +600,7 @@ __all__ = [
     "EdgeFlags",
     "Import",
     "NodeFlags",
+    "SymbolGraph",
     "SymbolNode",
     "VisitorPayload",
 ]

--- a/dead_cst/plugins/_core.py
+++ b/dead_cst/plugins/_core.py
@@ -359,6 +359,12 @@ class EdgePlugin(Cacheable, Protocol):
 
 
 def apply_ops(graph: SymbolGraph, ops: Iterable[GraphOp]) -> None:
+    # Plugins that fan out across the graph (subclass-closure walks,
+    # factory-chain traversals) can rediscover the same target node via
+    # multiple paths and emit ``AddEdge(src, dst)`` for the same pair
+    # more than once. The natural attrs payload here is empty
+    # (plugin-emitted edges carry no flags), so a single ``has_edge``
+    # check is enough to collapse the duplicates.
     for op in ops:
         match op:
             case AddNode(node, entrypoint, testcase):
@@ -368,7 +374,8 @@ def apply_ops(graph: SymbolGraph, ops: Iterable[GraphOp]) -> None:
                 if testcase:
                     graph.nodes[node]["testcase"] = True
             case AddEdge(src, dst):
-                graph.add_edge(src, dst)
+                if not graph.has_edge(src, dst):
+                    graph.add_edge(src, dst)
             case RemoveEdge(src, dst):
                 if graph.has_edge(src, dst):
                     graph.remove_edge(src, dst)

--- a/dead_cst/plugins/_core.py
+++ b/dead_cst/plugins/_core.py
@@ -31,11 +31,10 @@ from typing import (
 )
 
 import libcst as cst
-import networkx as nx
 from libcst.metadata import CodePosition, CodeRange
 
 from .._cacheable import Cacheable
-from ..graph import NodeFlags, SymbolNode, SymbolTrie
+from ..graph import NodeFlags, SymbolGraph, SymbolNode, SymbolTrie
 
 if TYPE_CHECKING:
     from ..graph import VisitorPayload
@@ -84,8 +83,8 @@ class PluginContext:
     the same analysis return the cached result.
     """
 
-    graph: nx.DiGraph
-    package_graph: nx.MultiDiGraph
+    graph: SymbolGraph
+    package_graph: SymbolGraph
     module_nodes: tuple[SymbolNode, ...]
     symbol_lookup: SymbolTrie
     package: Package
@@ -359,7 +358,7 @@ class EdgePlugin(Cacheable, Protocol):
     def finalize(self, ctx: PluginContext) -> Iterable[GraphOp]: ...
 
 
-def apply_ops(graph: nx.DiGraph, ops: Iterable[GraphOp]) -> None:
+def apply_ops(graph: SymbolGraph, ops: Iterable[GraphOp]) -> None:
     for op in ops:
         match op:
             case AddNode(node, entrypoint, testcase):
@@ -711,7 +710,7 @@ def collect_module_imports(
 
 
 def walk_to_instance_kind(
-    graph: nx.DiGraph,
+    graph: SymbolGraph,
     start: SymbolNode,
     terminal: SymbolNode,
     module_name: str,

--- a/dead_cst/plugins/_core.py
+++ b/dead_cst/plugins/_core.py
@@ -362,9 +362,8 @@ def apply_ops(graph: SymbolGraph, ops: Iterable[GraphOp]) -> None:
     # Plugins that fan out across the graph (subclass-closure walks,
     # factory-chain traversals) can rediscover the same target node via
     # multiple paths and emit ``AddEdge(src, dst)`` for the same pair
-    # more than once. The natural attrs payload here is empty
-    # (plugin-emitted edges carry no flags), so a single ``has_edge``
-    # check is enough to collapse the duplicates.
+    # more than once; ``SymbolGraph.add_edge`` enforces the
+    # edge-uniqueness invariant so duplicates are dropped silently.
     for op in ops:
         match op:
             case AddNode(node, entrypoint, testcase):
@@ -374,8 +373,7 @@ def apply_ops(graph: SymbolGraph, ops: Iterable[GraphOp]) -> None:
                 if testcase:
                     graph.nodes[node]["testcase"] = True
             case AddEdge(src, dst):
-                if not graph.has_edge(src, dst):
-                    graph.add_edge(src, dst)
+                graph.add_edge(src, dst)
             case RemoveEdge(src, dst):
                 if graph.has_edge(src, dst):
                     graph.remove_edge(src, dst)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,11 +70,6 @@ dev = [
     "fastapi>=0.110",
     "fastmcp>=2.0",
     "flask>=3.0",
-    # ``networkx`` is no longer a runtime dep but a handful of resolver /
-    # external-dist tests fixture-import it as a recognizable third-party
-    # name (it has to be importable for the analyzer to classify it as
-    # ``[external dist] networkx`` rather than ``[unresolved]``).
-    "networkx>=3.0",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "libcst>=1.8.6",
-    "networkx>=3.5",
+    "rustworkx>=0.15",
     "tqdm>=4.66",
     "typer>=0.12",
 ]
@@ -70,6 +70,11 @@ dev = [
     "fastapi>=0.110",
     "fastmcp>=2.0",
     "flask>=3.0",
+    # ``networkx`` is no longer a runtime dep but a handful of resolver /
+    # external-dist tests fixture-import it as a recognizable third-party
+    # name (it has to be importable for the analyzer to classify it as
+    # ``[external dist] networkx`` rather than ``[unresolved]``).
+    "networkx>=3.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,10 @@ import json
 import logging
 import textwrap
 
-import networkx as nx
 import pytest
 
 from dead_cst import Analysis, EdgeFlags
+from dead_cst.graph import SymbolGraph
 from dead_cst.resolvers import ManualResolver
 
 
@@ -56,7 +56,7 @@ def make_analysis(tmp_path):
 
 @pytest.fixture
 def build_decl_graph(tmp_path, make_analysis):
-    def _make_graph(files: dict[str, str]) -> nx.MultiDiGraph:
+    def _make_graph(files: dict[str, str]) -> SymbolGraph:
         for filename, content in files.items():
             full_path = tmp_path / filename
             full_path.parent.mkdir(parents=True, exist_ok=True)
@@ -109,7 +109,7 @@ def _is_dead_branch(attrs) -> bool:
 
 @pytest.fixture
 def assert_edges():
-    def _check(graph: nx.MultiDiGraph, expected_edges: set[str]):
+    def _check(graph: SymbolGraph, expected_edges: set[str]):
         """Compare graph edges to expected 'a -> b' strings.
 
         Iterates the full edge set, including ``DEAD_BRANCH``-flagged
@@ -145,7 +145,7 @@ def assert_positional_edges():
         start = sym.position.start
         return f"{sym.fqname}@{start.line}:{start.column}"
 
-    def _check(graph: nx.MultiDiGraph, expected_edges: set[str]):
+    def _check(graph: SymbolGraph, expected_edges: set[str]):
         actual_edges = {f"{_fmt(src)} -> {_fmt(dst)}" for src, dst in graph.edges(keys=False)}
         assert actual_edges == expected_edges
 
@@ -162,7 +162,7 @@ def assert_dead_branch_edges():
     attribution is a payload-level concern, not a per-edge one).
     """
 
-    def _check(graph: nx.MultiDiGraph, expected_edges: set[str]):
+    def _check(graph: SymbolGraph, expected_edges: set[str]):
         actual = {
             f"{src.fqname} -> {dst.fqname}"
             for src, dst, attrs in graph.edges(data=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -242,7 +242,9 @@ def test_is_dunder_all(fqname, type_, expected):
 @pytest.mark.parametrize(
     "fqname, type_, expected",
     [
-        pytest.param(f"{EXTERNAL_DIST_PREFIX}networkx", "synthetic", True, id="external-synthetic"),
+        pytest.param(
+            f"{EXTERNAL_DIST_PREFIX}rustworkx", "synthetic", True, id="external-synthetic"
+        ),
         pytest.param(f"{EXPLICIT_PREFIX}foo", "synthetic", False, id="entrypoint-synthetic"),
         pytest.param("pkg.foo", "function", False, id="real-function"),
     ],
@@ -526,17 +528,17 @@ def test_dependencies_no_third_party(runner, project):
 
 
 def test_dependencies_third_party_listed(runner, project):
-    root = project({"mod.py": "import networkx\n_x = networkx\n"})
+    root = project({"mod.py": "import rustworkx\n_x = rustworkx\n"})
     result = runner.invoke(app, ["dependencies", str(root)])
     assert result.exit_code == 0
-    assert "[external dist] networkx" in result.stdout
+    assert "[external dist] rustworkx" in result.stdout
 
 
 def test_dependencies_json_output_groups_by_base(runner, project):
-    root = project({"mod.py": "import networkx\n_x = networkx\n"})
+    root = project({"mod.py": "import rustworkx\n_x = rustworkx\n"})
     result = runner.invoke(app, ["dependencies", str(root), "--format", "json"])
     assert result.exit_code == 0
-    assert json.loads(result.stdout) == {str(root.resolve()): ["[external dist] networkx"]}
+    assert json.loads(result.stdout) == {str(root.resolve()): ["[external dist] rustworkx"]}
 
 
 def test_dependencies_json_output_empty_when_no_deps(runner, project):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -270,12 +270,12 @@ def test_dead_real_filters_synthetic_nodes():
     """Synthetic nodes (entrypoint sentinels, external markers) are
     excluded from the dead-symbol report so we don't surface them
     alongside user-visible declarations."""
-    import networkx as nx
+    from dead_cst.graph import SymbolGraph
 
     real = SymbolNode("pkg.f", "function", Path("/a.py"), _pos())
     entrypoint_synth = SymbolNode(f"{EXPLICIT_PREFIX}pkg.f", "synthetic", Path("/a.py"), _pos())
 
-    g = nx.MultiDiGraph()
+    g = SymbolGraph()
     for n in (real, entrypoint_synth):
         g.add_node(n)
 
@@ -283,9 +283,9 @@ def test_dead_real_filters_synthetic_nodes():
 
 
 def test_dead_real_empty_graph_returns_empty_list():
-    import networkx as nx
+    from dead_cst.graph import SymbolGraph
 
-    assert _dead_real(nx.MultiDiGraph()) == []
+    assert _dead_real(SymbolGraph()) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_codemod.py
+++ b/tests/test_codemod.py
@@ -99,7 +99,7 @@ def build_unreachable_graph(tmp_path, make_analysis):
             if node.fqname in entrypoints:
                 graph.nodes[node]["entrypoint"] = True
         reachable = find_reachable(graph)
-        return graph.subgraph([n for n in graph.nodes if n not in reachable]).copy()
+        return graph.subgraph([n for n in graph.nodes if n not in reachable])
 
     return _build
 
@@ -809,9 +809,7 @@ def test_generate_patch_per_subgraph_slice_isolates_decls(build_unreachable_grap
         },
         {"mod.used"},
     )
-    one_only = unreachable.subgraph(
-        [n for n in unreachable.nodes if n.fqname == "mod.dead_one"]
-    ).copy()
+    one_only = unreachable.subgraph([n for n in unreachable.nodes if n.fqname == "mod.dead_one"])
     patch = generate_patch(one_only, tmp_path)
 
     assert "-def dead_one():" in patch

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -515,23 +515,23 @@ def test_third_party_import_creates_synthetic_node(build_decl_graph):
     graph = build_decl_graph(
         {
             "p/__init__.py": "",
-            "p/uses_nx.py": "import networkx as nx\ndef build(): return nx.DiGraph()",
+            "p/uses_rx.py": "import rustworkx as rx\ndef build(): return rx.PyDiGraph()",
         }
     )
-    nx_nodes = {
+    rx_nodes = {
         n
         for n in graph.nodes
         if n.type == "synthetic"
         and n.fqname.startswith(EXTERNAL_PREFIXES)
-        and "networkx" in n.fqname
+        and "rustworkx" in n.fqname
     }
-    assert nx_nodes, (
-        "expected an external-dep synthetic node for networkx, got "
+    assert rx_nodes, (
+        "expected an external-dep synthetic node for rustworkx, got "
         f"{[n.fqname for n in graph.nodes if n.type == 'synthetic']}"
     )
 
-    edge_srcs = {src.fqname for src, dst in graph.edges(keys=False) if dst in nx_nodes}
-    assert {"p.uses_nx.nx", "p.uses_nx.build"} <= edge_srcs
+    edge_srcs = {src.fqname for src, dst in graph.edges(keys=False) if dst in rx_nodes}
+    assert {"p.uses_rx.rx", "p.uses_rx.build"} <= edge_srcs
 
 
 def test_stdlib_imports_are_silent(build_decl_graph, caplog):

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import logging
 
-import networkx as nx
-
 from dead_cst.analyze import _find_reachable as find_reachable
 from dead_cst.codemod import generate_patch
 from dead_cst.graph import NodeFlags
@@ -81,7 +79,6 @@ def test_codemod_skips_notebook_nodes(write_notebook, make_analysis):
     analysis = make_analysis()
     graph = analysis.materialize_all()
     nb_nodes = [n for n in graph.nodes if n.flags & NodeFlags.NOTEBOOK]
-    sub = nx.MultiDiGraph()
-    sub.add_nodes_from(nb_nodes)
+    sub = graph.subgraph(nb_nodes)
     patch = generate_patch(sub, analysis.project_root)
     assert patch == ""

--- a/tests/test_overloads_and_pyi.py
+++ b/tests/test_overloads_and_pyi.py
@@ -107,7 +107,7 @@ def test_dead_overloads_are_removed_with_impl(tmp_path, make_analysis):
         if node.fqname == "mod.keep":
             graph.nodes[node]["entrypoint"] = True
     reachable = find_reachable(graph)
-    unreachable = graph.subgraph([n for n in graph.nodes if n not in reachable]).copy()
+    unreachable = graph.subgraph([n for n in graph.nodes if n not in reachable])
     remove_code(unreachable, tmp_path)
 
     rewritten = (tmp_path / "mod.py").read_text()
@@ -135,7 +135,7 @@ def test_live_overloads_survive_codemod(tmp_path, make_analysis):
     a = make_analysis(plugins=[ExplicitEntrypointPlugin(specs=["mod.f"])])
     graph = a.materialize_all()
     reachable = find_reachable(graph)
-    unreachable = graph.subgraph([n for n in graph.nodes if n not in reachable]).copy()
+    unreachable = graph.subgraph([n for n in graph.nodes if n not in reachable])
     remove_code(unreachable, tmp_path)
 
     rewritten = (tmp_path / "mod.py").read_text()

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -196,7 +196,7 @@ def test_apply_flags_dead_branch_edges(make_analysis, write_files):
     # MultiDiGraph: parallel edges between the same pair are kept
     # separate. Both live and dead-branch refs to ``helper`` produce
     # edges from the module; the flag distinguishes them.
-    edges = list(graph.edges(module, data=True))
+    edges = list(graph.out_edges(module, data=True))
     flags_seen = {attrs.get("flags", EdgeFlags.NONE) for _, dst, attrs in edges if dst == helper}
     assert EdgeFlags.NONE in flags_seen
     assert EdgeFlags.DEAD_BRANCH in flags_seen

--- a/tests/test_plugins/test_core.py
+++ b/tests/test_plugins/test_core.py
@@ -7,11 +7,11 @@ from __future__ import annotations
 from pathlib import Path
 
 import libcst as cst
-import networkx as nx
 import pytest
 from libcst.metadata import CodePosition, CodeRange
 
 from dead_cst.analyze import _find_reachable as find_reachable
+from dead_cst.graph import SymbolGraph, SymbolNode, SymbolTrie
 from dead_cst.plugins import MainBlockPlugin, ProjectScriptsPlugin
 from dead_cst.plugins._core import (
     AddEdge,
@@ -27,7 +27,6 @@ from dead_cst.plugins._core import (
     matched_attr_call,
     single_target_assignment,
 )
-from dead_cst.graph import SymbolNode, SymbolTrie
 from dead_cst.resolvers import Package
 
 
@@ -73,7 +72,7 @@ def test_unknown_plugin_raises():
 
 def _ctx_with_synthetic(fqname: str, base: Path) -> PluginContext:
     """Build a minimal PluginContext containing a single synthetic node."""
-    graph = nx.DiGraph()
+    graph = SymbolGraph()
     node = SymbolNode(
         fqname=fqname,
         type="synthetic",
@@ -81,7 +80,7 @@ def _ctx_with_synthetic(fqname: str, base: Path) -> PluginContext:
         position=CodeRange(start=CodePosition(0, 0), end=CodePosition(0, 0)),
     )
     graph.add_node(node)
-    package_graph = nx.MultiDiGraph()
+    package_graph = SymbolGraph()
     package_graph.add_node(node)
     return PluginContext(
         graph=graph,
@@ -370,11 +369,11 @@ def test_plugin_context_package_modules_yields_modules_only(tmp_path):
     mod = SymbolNode("pkg.a", "module", tmp_path / "a.py", _pos())
 
     ctx = PluginContext(
-        graph=nx.DiGraph(),
+        graph=SymbolGraph(),
         symbol_lookup=SymbolTrie(),
         package=pkg,
         project_root=tmp_path,
-        package_graph=nx.MultiDiGraph(),
+        package_graph=SymbolGraph(),
         module_nodes=(mod,),
     )
     assert list(ctx.package_modules()) == [(mod.path, mod)]
@@ -385,12 +384,12 @@ def test_plugin_context_package_nodes_snapshots_first_scan(tmp_path):
     pkg = Package(path=tmp_path, name="pkg")
     mod = SymbolNode("pkg", "module", tmp_path / "__init__.py", _pos())
     fn = SymbolNode("pkg.f", "function", tmp_path / "a.py", _pos())
-    package_graph = nx.MultiDiGraph()
+    package_graph = SymbolGraph()
     package_graph.add_node(mod)
     package_graph.add_node(fn)
 
     ctx = PluginContext(
-        graph=nx.DiGraph(),
+        graph=SymbolGraph(),
         symbol_lookup=SymbolTrie(),
         package=pkg,
         project_root=tmp_path,

--- a/tests/test_plugins/test_file_cache.py
+++ b/tests/test_plugins/test_file_cache.py
@@ -8,20 +8,19 @@ from pathlib import Path
 from typing import Iterable
 
 import libcst as cst
-import networkx as nx
 
-from dead_cst.graph import SymbolTrie
+from dead_cst.graph import SymbolGraph, SymbolTrie
 from dead_cst.plugins import GraphOp, ObserveContext, PluginContext
 from dead_cst.resolvers import Package
 
 
 def _ctx(tmp_path):
     return PluginContext(
-        graph=nx.DiGraph(),
+        graph=SymbolGraph(),
         symbol_lookup=SymbolTrie(),
         package=Package(path=tmp_path, name="pkg"),
         project_root=tmp_path,
-        package_graph=nx.MultiDiGraph(),
+        package_graph=SymbolGraph(),
         module_nodes=(),
     )
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -59,6 +59,7 @@ EXPECTED_PUBLIC_API: dict[str, list[str]] = {
         "EdgeFlags",
         "Import",
         "NodeFlags",
+        "SymbolGraph",
         "SymbolNode",
         "VisitorPayload",
     ],

--- a/tests/test_unreachable_branches.py
+++ b/tests/test_unreachable_branches.py
@@ -18,15 +18,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import networkx as nx
-
 from dead_cst.analyze import (
     _find_kept_alive_by_dead_branches as find_kept_alive_by_dead_branches,
     _find_reachable as find_reachable,
 )
+from dead_cst.graph import SymbolGraph
 
 
-def _dead_suite_positions(graph: nx.MultiDiGraph, file: Path) -> tuple:
+def _dead_suite_positions(graph: SymbolGraph, file: Path) -> tuple:
     return graph.graph.get("dead_suites", {}).get(file, ())
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -505,7 +505,6 @@ dev = [
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "flask" },
-    { name = "networkx" },
     { name = "prek" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -528,7 +527,6 @@ dev = [
     { name = "fastapi", specifier = ">=0.110" },
     { name = "fastmcp", specifier = ">=2.0" },
     { name = "flask", specifier = ">=3.0" },
-    { name = "networkx", specifier = ">=3.0" },
     { name = "prek", specifier = ">=0.3.11" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -1091,15 +1089,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
-]
-
-[[package]]
-name = "networkx"
-version = "3.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/8d/776adee7bbf76365fdd7f2552710282c79a4ead5d2a46408c9043a2b70ba/networkx-3.5-py3-none-any.whl", hash = "sha256:0030d386a9a06dee3565298b4a734b68589749a544acbb6c412dc9e2489ec6ec", size = 2034406, upload-time = "2025-05-29T11:35:04.961Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ name = "dead-cst"
 source = { editable = "." }
 dependencies = [
     { name = "libcst" },
-    { name = "networkx" },
+    { name = "rustworkx" },
     { name = "tqdm" },
     { name = "typer" },
 ]
@@ -505,6 +505,7 @@ dev = [
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "flask" },
+    { name = "networkx" },
     { name = "prek" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -516,7 +517,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "libcst", specifier = ">=1.8.6" },
-    { name = "networkx", specifier = ">=3.5" },
+    { name = "rustworkx", specifier = ">=0.15" },
     { name = "tqdm", specifier = ">=4.66" },
     { name = "typer", specifier = ">=0.12" },
 ]
@@ -527,6 +528,7 @@ dev = [
     { name = "fastapi", specifier = ">=0.110" },
     { name = "fastmcp", specifier = ">=2.0" },
     { name = "flask", specifier = ">=3.0" },
+    { name = "networkx", specifier = ">=3.0" },
     { name = "prek", specifier = ">=0.3.11" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -1098,6 +1100,85 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/8d/776adee7bbf76365fdd7f2552710282c79a4ead5d2a46408c9043a2b70ba/networkx-3.5-py3-none-any.whl", hash = "sha256:0030d386a9a06dee3565298b4a734b68589749a544acbb6c412dc9e2489ec6ec", size = 2034406, upload-time = "2025-05-29T11:35:04.961Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/c6/4218570d8c8ecc9704b5157a3348e486e84ef4be0ed3e38218ab473c83d2/numpy-2.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f983334aea213c99992053ede6168500e5f086ce74fbc4acc3f2b00f5762e9db", size = 16976799, upload-time = "2026-03-29T13:18:15.438Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/92/b4d922c4a5f5dab9ed44e6153908a5c665b71acf183a83b93b690996e39b/numpy-2.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:72944b19f2324114e9dc86a159787333b77874143efcf89a5167ef83cfee8af0", size = 14971552, upload-time = "2026-03-29T13:18:18.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/dc/df98c095978fa6ee7b9a9387d1d58cbb3d232d0e69ad169a4ce784bde4fd/numpy-2.4.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:86b6f55f5a352b48d7fbfd2dbc3d5b780b2d79f4d3c121f33eb6efb22e9a2015", size = 5476566, upload-time = "2026-03-29T13:18:21.532Z" },
+    { url = "https://files.pythonhosted.org/packages/28/34/b3fdcec6e725409223dd27356bdf5a3c2cc2282e428218ecc9cb7acc9763/numpy-2.4.4-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:ba1f4fc670ed79f876f70082eff4f9583c15fb9a4b89d6188412de4d18ae2f40", size = 6806482, upload-time = "2026-03-29T13:18:23.634Z" },
+    { url = "https://files.pythonhosted.org/packages/68/62/63417c13aa35d57bee1337c67446761dc25ea6543130cf868eace6e8157b/numpy-2.4.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a87ec22c87be071b6bdbd27920b129b94f2fc964358ce38f3822635a3e2e03d", size = 15973376, upload-time = "2026-03-29T13:18:26.677Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c5/9fcb7e0e69cef59cf10c746b84f7d58b08bc66a6b7d459783c5a4f6101a6/numpy-2.4.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df3775294accfdd75f32c74ae39fcba920c9a378a2fc18a12b6820aa8c1fb502", size = 16925137, upload-time = "2026-03-29T13:18:30.14Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/43/80020edacb3f84b9efdd1591120a4296462c23fd8db0dde1666f6ef66f13/numpy-2.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0d4e437e295f18ec29bc79daf55e8a47a9113df44d66f702f02a293d93a2d6dd", size = 17329414, upload-time = "2026-03-29T13:18:33.733Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/06/af0658593b18a5f73532d377188b964f239eb0894e664a6c12f484472f97/numpy-2.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6aa3236c78803afbcb255045fbef97a9e25a1f6c9888357d205ddc42f4d6eba5", size = 18658397, upload-time = "2026-03-29T13:18:37.511Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ce/13a09ed65f5d0ce5c7dd0669250374c6e379910f97af2c08c57b0608eee4/numpy-2.4.4-cp311-cp311-win32.whl", hash = "sha256:30caa73029a225b2d40d9fae193e008e24b2026b7ee1a867b7ee8d96ca1a448e", size = 6239499, upload-time = "2026-03-29T13:18:40.372Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/63/05d193dbb4b5eec1eca73822d80da98b511f8328ad4ae3ca4caf0f4db91d/numpy-2.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:6bbe4eb67390b0a0265a2c25458f6b90a409d5d069f1041e6aff1e27e3d9a79e", size = 12614257, upload-time = "2026-03-29T13:18:42.95Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c5/8168052f080c26fa984c413305012be54741c9d0d74abd7fbeeccae3889f/numpy-2.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:fcfe2045fd2e8f3cb0ce9d4ba6dba6333b8fa05bb8a4939c908cd43322d14c7e", size = 10486775, upload-time = "2026-03-29T13:18:45.835Z" },
+    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
+    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
+    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/33/8fae8f964a4f63ed528264ddf25d2b683d0b663e3cba26961eb838a7c1bd/numpy-2.4.4-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:58c8b5929fcb8287cbd6f0a3fae19c6e03a5c48402ae792962ac465224a629a4", size = 16854491, upload-time = "2026-03-29T13:21:38.03Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d0/1aabee441380b981cf8cdda3ae7a46aa827d1b5a8cce84d14598bc94d6d9/numpy-2.4.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:eea7ac5d2dce4189771cedb559c738a71512768210dc4e4753b107a2048b3d0e", size = 14895830, upload-time = "2026-03-29T13:21:41.509Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b8/aafb0d1065416894fccf4df6b49ef22b8db045187949545bced89c034b8e/numpy-2.4.4-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:51fc224f7ca4d92656d5a5eb315f12eb5fe2c97a66249aa7b5f562528a3be38c", size = 5400927, upload-time = "2026-03-29T13:21:44.747Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/77/063baa20b08b431038c7f9ff5435540c7b7265c78cf56012a483019ca72d/numpy-2.4.4-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:28a650663f7314afc3e6ec620f44f333c386aad9f6fc472030865dc0ebb26ee3", size = 6715557, upload-time = "2026-03-29T13:21:47.406Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a8/379542d45a14f149444c5c4c4e7714707239ce9cc1de8c2803958889da14/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19710a9ca9992d7174e9c52f643d4272dcd1558c5f7af7f6f8190f633bd651a7", size = 15804253, upload-time = "2026-03-29T13:21:50.753Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/c8/f0a45426d6d21e7ea3310a15cf90c43a14d9232c31a837702dba437f3373/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b2aec6af35c113b05695ebb5749a787acd63cafc83086a05771d1e1cd1e555f", size = 16753552, upload-time = "2026-03-29T13:21:54.344Z" },
+    { url = "https://files.pythonhosted.org/packages/04/74/f4c001f4714c3ad9ce037e18cf2b9c64871a84951eaa0baf683a9ca9301c/numpy-2.4.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f2cf083b324a467e1ab358c105f6cad5ea950f50524668a80c486ff1db24e119", size = 12509075, upload-time = "2026-03-29T13:21:57.644Z" },
 ]
 
 [[package]]
@@ -1791,6 +1872,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/58/ac864a75067dcbd3b95be5ab4eb2b601d7fbc3d3d736a27e391a4f92a5c1/ruff-0.15.1-py3-none-win32.whl", hash = "sha256:660975d9cb49b5d5278b12b03bb9951d554543a90b74ed5d366b20e2c57c2098", size = 10462555, upload-time = "2026-02-12T23:09:29.899Z" },
     { url = "https://files.pythonhosted.org/packages/e0/5e/d4ccc8a27ecdb78116feac4935dfc39d1304536f4296168f91ed3ec00cd2/ruff-0.15.1-py3-none-win_amd64.whl", hash = "sha256:c820fef9dd5d4172a6570e5721704a96c6679b80cf7be41659ed439653f62336", size = 11599956, upload-time = "2026-02-12T23:09:01.157Z" },
     { url = "https://files.pythonhosted.org/packages/2a/07/5bda6a85b220c64c65686bc85bd0bbb23b29c62b3a9f9433fa55f17cda93/ruff-0.15.1-py3-none-win_arm64.whl", hash = "sha256:5ff7d5f0f88567850f45081fac8f4ec212be8d0b963e385c3f7d0d2eb4899416", size = 10874604, upload-time = "2026-02-12T23:09:05.515Z" },
+]
+
+[[package]]
+name = "rustworkx"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/b0/66d96f02120f79eeed86b5c5be04029b6821155f31ed4907a4e9f1460671/rustworkx-0.17.1.tar.gz", hash = "sha256:59ea01b4e603daffa4e8827316c1641eef18ae9032f0b1b14aa0181687e3108e", size = 399407, upload-time = "2025-09-15T16:29:46.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/24/8972ed631fa05fdec05a7bb7f1fc0f8e78ee761ab37e8a93d1ed396ba060/rustworkx-0.17.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c08fb8db041db052da404839b064ebfb47dcce04ba9a3e2eb79d0c65ab011da4", size = 2257491, upload-time = "2025-08-13T01:43:31.466Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ae/7b6bbae5e0487ee42072dc6a46edf5db9731a0701ed648db22121fb7490c/rustworkx-0.17.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:4ef8e327dadf6500edd76fedb83f6d888b9266c58bcdbffd5a40c33835c9dd26", size = 2040175, upload-time = "2025-08-13T01:43:33.762Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ea/c17fb9428c8f0dcc605596f9561627a5b9ef629d356204ee5088cfcf52c6/rustworkx-0.17.1-cp39-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b809e0aa2927c68574b196f993233e269980918101b0dd235289c4f3ddb2115", size = 2324771, upload-time = "2025-08-13T01:43:35.553Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/40/ec8b3b8b0f8c0b768690c454b8dcc2781b4f2c767f9f1215539c7909e35b/rustworkx-0.17.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c7e82c46a92fb0fd478b7372e15ca524c287485fdecaed37b8bb68f4df2720f2", size = 2068584, upload-time = "2025-08-13T01:43:37.261Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/22/713b900d320d06ce8677e71bba0ec5df0037f1d83270bff5db3b271c10d7/rustworkx-0.17.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:42170075d8a7319e89ff63062c2f1d1116ced37b6f044f3bf36d10b60a107aa4", size = 2380949, upload-time = "2025-08-13T01:52:17.435Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4b/54be84b3b41a19caf0718a2b6bb280dde98c8626c809c969f16aad17458f/rustworkx-0.17.1-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65cba97fa95470239e2d65eb4db1613f78e4396af9f790ff771b0e5476bfd887", size = 2562069, upload-time = "2025-08-13T02:09:27.222Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5b/281bb21d091ab4e36cf377088366d55d0875fa2347b3189c580ec62b44c7/rustworkx-0.17.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:246cc252053f89e36209535b9c58755960197e6ae08d48d3973760141c62ac95", size = 2221186, upload-time = "2025-08-13T01:43:38.598Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2d/30a941a21b81e9db50c4c3ef8a64c5ee1c8eea3a90506ca0326ce39d021f/rustworkx-0.17.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c10d25e9f0e87d6a273d1ea390b636b4fb3fede2094bf0cb3fe565d696a91b48", size = 2123510, upload-time = "2025-08-13T01:43:40.288Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ef/c9199e4b6336ee5a9f1979c11b5779c5cf9ab6f8386e0b9a96c8ffba7009/rustworkx-0.17.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:48784a673cf8d04f3cd246fa6b53fd1ccc4d83304503463bd561c153517bccc1", size = 2302783, upload-time = "2025-08-13T01:43:42.073Z" },
+    { url = "https://files.pythonhosted.org/packages/30/3d/a49ab633e99fca4ccbb9c9f4bd41904186c175ebc25c530435529f71c480/rustworkx-0.17.1-cp39-abi3-win32.whl", hash = "sha256:5dbc567833ff0a8ad4580a4fe4bde92c186d36b4c45fca755fb1792e4fafe9b5", size = 1931541, upload-time = "2025-08-13T01:43:43.415Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ec/cee878c1879b91ab8dc7d564535d011307839a2fea79d2a650413edf53be/rustworkx-0.17.1-cp39-abi3-win_amd64.whl", hash = "sha256:d0a48fb62adabd549f9f02927c3a159b51bf654c7388a12fc16d45452d5703ea", size = 2055049, upload-time = "2025-08-13T01:43:44.926Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Graph backend swapped from `networkx` to `rustworkx`.** A new `dead_cst.graph.SymbolGraph` wraps `rustworkx.PyDiGraph(multigraph=True)` and owns the `SymbolNode -> int` index map. The wrapper exposes a `networkx`-shaped surface (`successors`, `predecessors`, `subgraph`, `out_edges`, `nodes(data=True)`, `edges(data=True)`, `update`, `add_edges_from`, the `graph` attribute) so call sites read naturally. Per-node attributes (`entrypoint`, `testcase`) live in a side table on the wrapper rather than on the rustworkx payload, so `successors` / `predecessors` return the bare `SymbolNode` directly.

- **BREAKING:** `Analysis.graph`, `PackageView.graph`, `GraphView.graph`, and `PluginContext.graph` / `package_graph` now return / accept `SymbolGraph` rather than `networkx.MultiDiGraph`. Out-of-tree callers that constructed graphs manually have to swap `nx.MultiDiGraph()` for `SymbolGraph()`. The per-file `VisitorPayload` cache shape is unchanged.

- **`networkx` is dropped entirely** (runtime and dev). Test fixtures that imported `networkx` as a recognizable third-party for external-dist resolution checks now import `rustworkx` (guaranteed installed).

- **Edge uniqueness invariant consolidated into `SymbolGraph`.** Duplicate `(src, dst, attrs)` inserts are silently dropped. Three former dedup sites collapsed: the visitor's per-file `seen_edges` (`_apply_payload`), the plugin fan-out's `has_edge` short-circuit (`apply_ops`), and the cross-file resolver's `emitted` set (`resolve_edges._emit` — function removed). Metadata-distinct edges between the same pair (one `DEAD_BRANCH` + one `NONE`) are preserved so strict-mode reachability filters on attrs correctly.

- **Perf polish from code review:** compose path passes `edges(data=True)` instead of `edges(data=True, keys=True)` (the slow `edge_index_map()` path is ~4x slower than `weighted_edge_list()` and the key was discarded anyway); `subgraph` uses native `rx.PyDiGraph.subgraph` + bulk-populates the side tables (source-graph edges are already unique, so re-paying dedup is wasted); `add_edge` no longer copies the kwargs dict; `_freeze_attrs` fast-paths the empty/single-key case.

- **Docs:** `README.md`, `CLAUDE.md`, `ARCHITECTURE.md` updated to describe `SymbolGraph` and the edge-uniqueness invariant. `CHANGELOG.md` `[Unreleased]` has entries for the backend swap and the dedup consolidation. `ROADMAP.md`'s v0.9.0 "Recently shipped" entry corrected to reference the current dedup site instead of the removed `resolve_edges._emit`.

## Test plan

- [x] `uv run pytest` — 948 passed, 10 deselected (e2e)
- [x] `uv run prek run --all-files` — ruff + format + ty all pass
- [x] Public-API snapshot (`tests/test_public_api.py`) updated to include `SymbolGraph` in `dead_cst.graph.__all__`
- [x] Dedup verified end-to-end: `f(); f(); f()` collapses 5 → 3 edges; `(a→b, NONE)` and `(a→b, DEAD_BRANCH)` coexist as two parallel edges; `remove_edge` keeps `_edge_keys` consistent with rustworkx's impl-defined parallel-edge choice via pre/post payload diff.