### PR TITLE
analyze: replace graph.graph["dead_suites"] with Analysis/PackageView accessors

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -355,6 +355,13 @@ F401 pin" (the visitor stamps `ENTRYPOINT | NOQA` on imports
 preserved by a per-line or file-level ruff/pyflakes directive); OR
 the bits to combine.
 
+For the raw dead-suite positions themselves (the input to the
+`EdgeFlags.DEAD_BRANCH` flagging from stage 3), call
+`Analysis.dead_suites()` for the merged `{file: tuple[CodeRange, ...]}`
+across every package, or `PackageView.dead_suites()` for one
+package's slice. Both read straight off the per-package contribution
+— no graph materialization required.
+
 ### 8. Codemod — `dead_cst/codemod.py`
 
 `remove_code` runs a LibCST `RemoveDeadSymbols` transformer keyed on
@@ -400,8 +407,10 @@ stages happen on demand:
    payloads, so warm per-package queries stay fast.
 
 Per-package queries that don't need the assembled graph
-(`PackageView.declarations` / `PackageView.count_nodes`) skip stage 3
-entirely.
+(`PackageView.declarations` / `PackageView.count_nodes` /
+`PackageView.dead_suites`) skip stage 3 entirely.
+`Analysis.dead_suites()` also stops at stage 2 — it merges the
+per-package contribution maps without composing a graph.
 
 ## Graph model invariants
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ two versions.
   `resolve_edges` and `apply_ops` both take `emitted` as a required
   argument (breaking).
 
+- Dead-suite positions moved off the materialized graph onto the
+  analysis itself: `Analysis.dead_suites()` returns the merged
+  `{file: tuple[CodeRange, ...]}` mapping across every package's
+  contribution, and `PackageView.dead_suites()` returns the per-package
+  slice. The previous `graph.graph["dead_suites"]` attribute is gone.
+  Reads off `_contributions` instead of duplicating onto the graph; the
+  CLI's `dead-cst report` is the only first-party consumer.
+
 - New `NodeFlags.EXPORTED` tags every node from a file under
   `Package.exported`, set via the visitor's `default_flags` mechanism
   (same pattern as `NOTEBOOK`). `Package.exported` now participates in

--- a/dead_cst/analyze.py
+++ b/dead_cst/analyze.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Iterable, Iterator, Mapping, Sequence
 
 import networkx as nx
+from libcst.metadata import CodeRange
 
 from ._edges import resolve_edges
 from ._package import PackageContribution, build_contribution
@@ -112,7 +113,6 @@ def _compose_contribution(
     ``MultiDiGraph`` edges.
     """
     target_graph.add_nodes_from(contrib.nodes)
-    target_graph.graph.setdefault("dead_suites", {}).update(contrib.dead_suites)
     for src, dst, flags in contrib.edges:
         if _claim_edge(emitted, src, dst, flags):
             target_graph.add_edge(src, dst, flags=flags)
@@ -578,7 +578,6 @@ class Analysis:
         from ._progress import progress
 
         g: nx.MultiDiGraph = nx.MultiDiGraph()
-        g.graph["dead_suites"] = {}
         baseline = list(sys.path)
         last_search_paths: tuple[Path, ...] | None = None
         target_paths = [p.path for p in self.packages if p.path in included]
@@ -660,6 +659,20 @@ class Analysis:
         :class:`NodeFlags` for the full list.
         """
         return _find_kept_alive_by_flags_only(self.materialize_all(), flags)
+
+    def dead_suites(self) -> Mapping[Path, tuple[CodeRange, ...]]:
+        """Statically-dead suite positions, merged across every package.
+
+        Triggers :meth:`refresh` on first call so the contributions are
+        populated. Each key is the absolute file path; the value is the
+        tuple of dead-suite :class:`CodeRange`s the detector recorded
+        for that file. Files with no dead suites are omitted.
+        """
+        self.refresh()
+        merged: dict[Path, tuple[CodeRange, ...]] = {}
+        for contrib in self._contributions.values():
+            merged.update(contrib.dead_suites)
+        return merged
 
     def count_nodes(self, prefix: Path | None = None) -> dict[str, int]:
         """Count nodes in the full graph by ``SymbolNode.type``.
@@ -815,6 +828,15 @@ class PackageView:
         """
         g = self._analysis.materialize_closure(self._package.path)
         return _find_kept_alive_by_flags_only(g, flags, prefix=self._package.path)
+
+    def dead_suites(self) -> Mapping[Path, tuple[CodeRange, ...]]:
+        """Statically-dead suite positions for files in this package.
+
+        Local-only: reads straight from this package's
+        :class:`PackageContribution` (triggers a refresh of just this
+        package). Files with no dead suites are omitted.
+        """
+        return dict(self._contribution().dead_suites)
 
     def count_nodes(self) -> dict[str, int]:
         """Count nodes contributed by this package, by ``SymbolNode.type``.

--- a/dead_cst/cli.py
+++ b/dead_cst/cli.py
@@ -9,7 +9,7 @@ import re
 import sys
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Iterator, Sequence
+from typing import Annotated, Iterator, Mapping, Sequence
 
 import networkx as nx
 import typer
@@ -216,10 +216,11 @@ def analyze(
     unreachable_graph = graph.subgraph([n for n in graph.nodes if n not in reachable])
 
     package_paths = [p.path for p in analysis.packages]
+    dead_suites = analysis.dead_suites()
     if output_format == OutputFormat.json:
-        _output_json(graph, unreachable_graph, root, package_paths)
+        _output_json(graph, unreachable_graph, root, package_paths, dead_suites)
     else:
-        _output_text(graph, unreachable_graph, root, package_paths)
+        _output_text(graph, unreachable_graph, root, package_paths, dead_suites)
 
     if unreachable_graph.number_of_nodes() > 0:
         raise typer.Exit(1)
@@ -230,6 +231,7 @@ def _output_text(
     unreachable: nx.MultiDiGraph,
     root: Path,
     package_paths: Sequence[Path],
+    dead_suites: Mapping[Path, tuple[CodeRange, ...]],
 ) -> None:
     total_by_path = _count_nodes_by_prefix(graph.nodes, package_paths)
     unreachable_by_path = _count_nodes_by_prefix(unreachable.nodes, package_paths)
@@ -257,7 +259,7 @@ def _output_text(
         for node in sorted(dead_real, key=lambda n: (str(n.path), n.fqname)):
             typer.echo(f"  {node.fqname} ({node.type}) at {_rel_path(node.path, root)}")
 
-    branches = _dead_suite_locations(graph, package_paths)
+    branches = _dead_suite_locations(dead_suites, package_paths)
     if branches:
         typer.echo(f"\nUnreachable branches ({len(branches)}):")
         for path, pos in branches:
@@ -278,17 +280,16 @@ def _dead_real(unreachable: nx.MultiDiGraph) -> list[SymbolNode]:
 
 
 def _dead_suite_locations(
-    graph: nx.MultiDiGraph, package_paths: Sequence[Path]
+    dead_suites: Mapping[Path, tuple[CodeRange, ...]], package_paths: Sequence[Path]
 ) -> list[tuple[Path, CodeRange]]:
-    """Flatten ``graph.graph["dead_suites"]`` into a sorted ``(path, pos)`` list.
+    """Flatten :meth:`Analysis.dead_suites` into a sorted ``(path, pos)`` list.
 
     Restricted to files under one of the analyzed packages' paths so
     the report doesn't surface dead suites in workspace dependencies
     that the user isn't asking about.
     """
-    raw: dict = graph.graph.get("dead_suites", {})
     out: list[tuple[Path, CodeRange]] = []
-    for path, suites in raw.items():
+    for path, suites in dead_suites.items():
         if not any(path.is_relative_to(p) for p in package_paths):
             continue
         for pos in suites:
@@ -302,6 +303,7 @@ def _output_json(
     unreachable: nx.MultiDiGraph,
     root: Path,
     package_paths: Sequence[Path],
+    dead_suites: Mapping[Path, tuple[CodeRange, ...]],
 ) -> None:
     result: dict = {
         "summary": {},
@@ -333,7 +335,7 @@ def _output_json(
             }
         )
 
-    for path, pos in _dead_suite_locations(graph, package_paths):
+    for path, pos in _dead_suite_locations(dead_suites, package_paths):
         result["unreachable_branches"].append(
             {
                 "path": str(_rel_path(path, root)),

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -273,8 +273,8 @@ def test_shadowed_decl_in_graph_keeps_consistent_identity(make_analysis, write_f
     assert flagged_matches == [s]
 
 
-def test_dead_suites_exposed_on_graph(tmp_path, make_analysis, write_files):
-    """``graph.graph['dead_suites']`` lists positions per analyzed file."""
+def test_dead_suites_exposed_on_analysis(tmp_path, make_analysis, write_files):
+    """``Analysis.dead_suites()`` lists positions per analyzed file."""
     write_files(
         {
             "pkg/__init__.py": "",
@@ -284,8 +284,7 @@ def test_dead_suites_exposed_on_graph(tmp_path, make_analysis, write_files):
             """,
         }
     )
-    g = make_analysis().materialize_all()
-    suites = g.graph["dead_suites"]
+    suites = make_analysis().dead_suites()
     file = tmp_path / "pkg" / "a.py"
     assert file in suites
     assert len(suites[file]) == 1

--- a/tests/test_unreachable_branches.py
+++ b/tests/test_unreachable_branches.py
@@ -18,20 +18,19 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import networkx as nx
-
+from dead_cst import Analysis
 from dead_cst.analyze import (
     _find_kept_alive_by_dead_branches as find_kept_alive_by_dead_branches,
     _find_reachable as find_reachable,
 )
 
 
-def _dead_suite_positions(graph: nx.MultiDiGraph, file: Path) -> tuple:
-    return graph.graph.get("dead_suites", {}).get(file, ())
+def _dead_suite_positions(analysis: Analysis, file: Path) -> tuple:
+    return analysis.dead_suites().get(file, ())
 
 
-def test_if_false_records_dead_suite(build_decl_graph, tmp_path):
-    graph = build_decl_graph(
+def test_if_false_records_dead_suite(make_analysis, write_files, tmp_path):
+    write_files(
         {
             "mod.py": """
             def helper(): pass
@@ -40,7 +39,8 @@ def test_if_false_records_dead_suite(build_decl_graph, tmp_path):
             """
         }
     )
-    suites = _dead_suite_positions(graph, tmp_path / "mod.py")
+    analysis = make_analysis()
+    suites = _dead_suite_positions(analysis, tmp_path / "mod.py")
     assert len(suites) == 1
     pos = suites[0]
     # libcst positions an ``IndentedBlock`` at its first statement, not
@@ -50,8 +50,8 @@ def test_if_false_records_dead_suite(build_decl_graph, tmp_path):
     assert pos.start.column == 4
 
 
-def test_if_true_marks_else_as_unreachable(build_decl_graph, tmp_path):
-    graph = build_decl_graph(
+def test_if_true_marks_else_as_unreachable(make_analysis, write_files, tmp_path):
+    write_files(
         {
             "mod.py": """
             def helper(): pass
@@ -62,11 +62,12 @@ def test_if_true_marks_else_as_unreachable(build_decl_graph, tmp_path):
             """
         }
     )
-    assert len(_dead_suite_positions(graph, tmp_path / "mod.py")) == 1
+    analysis = make_analysis()
+    assert len(_dead_suite_positions(analysis, tmp_path / "mod.py")) == 1
 
 
-def test_unknown_condition_records_no_dead_suite(build_decl_graph, tmp_path):
-    graph = build_decl_graph(
+def test_unknown_condition_records_no_dead_suite(make_analysis, write_files, tmp_path):
+    write_files(
         {
             "mod.py": """
             def helper(): pass
@@ -77,7 +78,8 @@ def test_unknown_condition_records_no_dead_suite(build_decl_graph, tmp_path):
             """
         }
     )
-    assert _dead_suite_positions(graph, tmp_path / "mod.py") == ()
+    analysis = make_analysis()
+    assert _dead_suite_positions(analysis, tmp_path / "mod.py") == ()
 
 
 def test_dead_branch_internal_ref_is_flagged(build_decl_graph, assert_dead_branch_edges):
@@ -162,8 +164,8 @@ def test_find_kept_alive_by_dead_branches_returns_strict_diff(build_decl_graph, 
     assert helper in blast
 
 
-def test_nested_dead_suites_record_separate_positions(build_decl_graph, tmp_path):
-    graph = build_decl_graph(
+def test_nested_dead_suites_record_separate_positions(make_analysis, write_files, tmp_path):
+    write_files(
         {
             "mod.py": """
             def a(): pass
@@ -175,7 +177,8 @@ def test_nested_dead_suites_record_separate_positions(build_decl_graph, tmp_path
             """
         }
     )
-    assert len(_dead_suite_positions(graph, tmp_path / "mod.py")) == 2
+    analysis = make_analysis()
+    assert len(_dead_suite_positions(analysis, tmp_path / "mod.py")) == 2
 
 
 def test_nested_dead_suites_flag_both_refs(build_decl_graph, assert_dead_branch_edges):
@@ -326,8 +329,9 @@ def test_default_detector_does_not_flag_named_condition(tmp_path, make_analysis,
             "settings.py": "IS_PROD = True\n",
         }
     )
-    graph = make_analysis().materialize_all()
-    assert _dead_suite_positions(graph, tmp_path / "mod.py") == ()
+    analysis = make_analysis()
+    analysis.materialize_all()
+    assert _dead_suite_positions(analysis, tmp_path / "mod.py") == ()
 
 
 def test_elif_false_in_chain_flags_only_dead_branch(build_decl_graph, assert_dead_branch_edges):


### PR DESCRIPTION
## Summary

The materialized graph used to carry the dead-suite map on its `graph.graph["dead_suites"]` attribute dict; nothing about reachability needed it there (the per-edge `EdgeFlags.DEAD_BRANCH` already encodes the influence on traversal), and `PackageContribution` already had the same data per package. This collapses the duplication and surfaces it through explicit accessors.

- `Analysis.dead_suites() -> Mapping[Path, tuple[CodeRange, ...]]` — merges every package's `PackageContribution.dead_suites` into one mapping. Calls `refresh()` so it works without `materialize_all()`.
- `PackageView.dead_suites() -> Mapping[Path, tuple[CodeRange, ...]]` — this package's slice only, refresh-on-demand. Stops at stage 2 (no graph composition needed), same as `declarations` / `count_nodes`.
- Drops the `graph.graph["dead_suites"]` write in `_materialize` and `_compose_contribution`. The composed `MultiDiGraph` is now strictly nodes + edges + `EdgeFlags.DEAD_BRANCH`.
- CLI `dead-cst report` (text + JSON) routes through `analysis.dead_suites()` instead of reading off the graph; `_dead_suite_locations` now takes the merged mapping.
- ARCHITECTURE.md §7 + the lazy-materialization section call out the new accessors. `CHANGELOG.md [Unreleased]` notes the breaking removal.

## Test plan

- [x] `tests/test_payload.py::test_dead_suites_exposed_on_analysis` renamed + retargeted to `Analysis.dead_suites()`.
- [x] Five tests in `tests/test_unreachable_branches.py` migrated off the old `graph.graph["dead_suites"]` helper onto the new accessor (`_dead_suite_positions(analysis, file)` now takes an `Analysis`).
- [x] CLI text + JSON output paths covered by `tests/test_cli.py` — `Unreachable branches` text section and `unreachable_branches` JSON array both populate correctly.
- [x] Full suite: 944 passed, 10 deselected.
- [x] `prek run --all-files` clean (ruff + ty).

https://claude.ai/code/session_01L75apRQqFj8gfmnkESP5qe