### PR TITLE
tests: parametrize build_decl_graph with --backend=libcst|rust

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,37 @@
 import json
 import logging
 import textwrap
+from pathlib import Path
+from typing import cast
 
 import pytest
+from libcst.metadata import CodePosition, CodeRange
 
 from dead_cst import Analysis, EdgeFlags
+from dead_cst._fqn import FixedFullyQualifiedNameProvider
 from dead_cst._graphstore import SymbolGraph
+from dead_cst.graph import NodeFlags, SymbolNode
 from dead_cst.resolvers import ManualResolver
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--backend",
+        action="store",
+        default="libcst",
+        choices=["libcst", "rust"],
+        help=(
+            "Backend the build_decl_graph fixture uses. 'libcst' (default) is the "
+            "production pipeline; 'rust' routes through dead_cst_ty_native to surface "
+            "missing-feature gaps. Tests that exercise Analysis-specific configuration "
+            "(plugins, cache, unreachable_detector) bypass this fixture and stay on libcst."
+        ),
+    )
+
+
+@pytest.fixture(scope="session")
+def backend(request) -> str:
+    return request.config.getoption("--backend")
 
 
 @pytest.fixture
@@ -55,15 +80,80 @@ def make_analysis(tmp_path):
 
 
 @pytest.fixture
-def build_decl_graph(tmp_path, make_analysis):
+def build_decl_graph(tmp_path, make_analysis, backend):
+    """Build a SymbolGraph from inline ``{relpath: source}`` files.
+
+    Dispatches to the configured ``--backend``. ``libcst`` (default) runs
+    today's :class:`Analysis` pipeline; ``rust`` routes through the
+    ``dead_cst_ty_native`` prototype to surface its feature gaps.
+    """
+
     def _make_graph(files: dict[str, str]) -> SymbolGraph:
         for filename, content in files.items():
             full_path = tmp_path / filename
             full_path.parent.mkdir(parents=True, exist_ok=True)
             full_path.write_text(textwrap.dedent(content).strip())
+        if backend == "rust":
+            return _build_rust_graph(tmp_path)
         return make_analysis().materialize_all()
 
     return _make_graph
+
+
+def _build_rust_graph(root: Path) -> SymbolGraph:
+    """Build a SymbolGraph by routing every ``.py`` file under ``root`` through Rust.
+
+    Uses libcst's :class:`FixedFullyQualifiedNameProvider` to derive each
+    file's canonical FQN (matching the libcst pipeline), then asks the
+    Rust prototype for one ``NativeGraph`` per file and accumulates the
+    results into a single :class:`SymbolGraph`. Skips the suite if the
+    native extension hasn't been built.
+
+    Tests that hit this path are expected to fail wherever the Rust
+    backend doesn't yet emit the edges / nodes the libcst visitor would
+    — that is the whole point of the abstraction.
+    """
+    native = pytest.importorskip(
+        "dead_cst_ty_native",
+        reason="Run `maturin develop --manifest-path crates/dead-cst-ty-native/Cargo.toml` "
+        "to build the prototype rust backend.",
+    )
+
+    files = sorted(p for p in root.rglob("*.py") if p.is_file())
+    fqn_cache = FixedFullyQualifiedNameProvider.gen_cache(root, [str(f) for f in files], timeout=5)
+
+    project = native.Project(str(root))
+    graph = SymbolGraph()
+    for f in files:
+        fqn = fqn_cache[str(f)].name
+        native_graph = project.build_file_graph(str(f), fqn)
+        _accumulate_native(graph, native_graph)
+    return graph
+
+
+def _accumulate_native(graph: SymbolGraph, native_graph) -> None:
+    """Merge a ``NativeGraph`` envelope into ``graph``.
+
+    Mirrors ``tests/prototype/_bridge.accumulate``; inlined here so
+    the conftest doesn't have to reach across into the prototype
+    package (no ``tests/__init__.py`` today).
+    """
+    symbol_nodes: list[SymbolNode] = []
+    for n in native_graph.nodes:
+        sn = SymbolNode(
+            fqname=n.fqname,
+            type=cast("SymbolNode.type", n.kind),
+            path=Path(n.path),
+            position=CodeRange(
+                CodePosition(n.start_line, n.start_column),
+                CodePosition(n.end_line, n.end_column),
+            ),
+            flags=NodeFlags(n.flags),
+        )
+        graph.add(sn)
+        symbol_nodes.append(sn)
+    for src, dst, flags in native_graph.edges:
+        graph.add_edge(symbol_nodes[src], symbol_nodes[dst], EdgeFlags(flags))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Adds a `pytest --backend=libcst|rust` flag so the existing inline-source suite
can run on either the production `Analysis` pipeline or the
`dead_cst_ty_native` prototype, without forking the fixtures.

The `build_decl_graph` fixture now dispatches on `--backend`:

- `libcst` (default): unchanged — `make_analysis().materialize_all()`.
- `rust`: enumerate `.py` under `tmp_path`, derive each file's canonical FQN
  via libcst's `FixedFullyQualifiedNameProvider` (so the assertion is on graph
  contents, not on rust's fqname derivation), call
  `native.Project.build_file_graph(path, fqn)` per file, and accumulate the
  envelopes into one `SymbolGraph` (inlined mirror of
  `tests/prototype/_bridge.accumulate`).

Scope (per discussion): only `build_decl_graph` is abstracted. Tests that
construct `Analysis` directly with `plugins=`/`cache=`/`unreachable_detector=`
stay on libcst — they exercise features the rust backend doesn't have at all,
so re-routing them would just add noise.

Skip rule: `pytest.importorskip("dead_cst_ty_native")` — `--backend=rust`
skips if the crate hasn't been built. Build it via
`maturin develop --manifest-path crates/dead-cst-ty-native/Cargo.toml --release`
from inside the project venv.

## Results

```
uv run pytest tests                    988 passed   (zero regression)
uv run pytest tests --backend=rust     782 passed, 206 failed
```

Failures cluster cleanly by feature gap:

| File | Failures | Missing |
|---|---|---|
| `test_declarations.py` | 96 | call / decorator / inheritance / annotation edges, redeclarations, shadowing |
| `test_imports.py` | 48 | import nodes + cross-file edges |
| `test_unreachable_branches.py` | 34 | `EdgeFlags.DEAD_BRANCH` flagging |
| `test_noqa_pinning.py` | 14 | `NOQA` / `ENTRYPOINT` flag handling |
| `test_top_level_only.py` | 7 | nested-def reference attribution |
| `test_limitations.py` | 4 | star-import / `__import__` handling |
| `test_kept_alive_by_noqa.py` | 3 | reachability via NOQA seeds |

This is the prioritization map for closing the rust gap.

## Test plan

- [x] `uv run pytest tests` — 988 passed
- [x] `uv run pytest tests --backend=rust` — 782 passed, 206 failed, all in graph-content assertions (no fixture-side errors)
- [x] `uv run pytest tests/prototype` — 35 passed (existing rust-only suite untouched)
- [x] Spot-checked one rust failure (`function-call-and-module-entry`): diff shows missing `mod -> mod.b` and `mod.b -> mod.a` call edges, exactly the expected gap

https://claude.ai/code/session_01U9eTnsito9tdyXuz21puZw