### PR TITLE
tests: pin libcst's nested-/class-/method-body import behavior

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -138,6 +138,110 @@ STAR_REEXPORT_EDGES = frozenset(
             id="nested-cst.ImportFrom",
         ),
         pytest.param(
+            # Nested import with no use of the bound name still
+            # creates a dep on the upstream module — the import
+            # statement itself is a side effect attributed to the
+            # enclosing decl.
+            "def a():\n    import p.functions\n",
+            {
+                "p.x.a -> p.functions",
+                "p.x.a -> p.x",
+            },
+            id="nested-cst.Import-no-use",
+        ),
+        pytest.param(
+            # `from X import Y` with no use still emits both the
+            # parent module and the upstream decl edges, just like
+            # the module-scope ImportFrom alias does.
+            "def a():\n    from p.functions import f\n",
+            {
+                "p.x.a -> p.functions",
+                "p.x.a -> p.functions.f",
+                "p.x.a -> p.x",
+            },
+            id="nested-cst.ImportFrom-no-use",
+        ),
+        pytest.param(
+            # Bare-`import p` then dotted access through it inside
+            # the function body. The chain `.functions.f` walks
+            # submodule then decl from the bound name `p`.
+            "def a():\n    import p\n    p.functions.f()\n",
+            {
+                "p.x.a -> p",
+                "p.x.a -> p.functions",
+                "p.x.a -> p.functions.f",
+                "p.x.a -> p.x",
+            },
+            id="nested-cst.Import-bare-then-dotted",
+        ),
+        pytest.param(
+            # Nested import shadows a module-scope import of the
+            # same root name. Inside `a` the use resolves to the
+            # nested binding; outside it the module-scope alias
+            # still points at its own upstream.
+            "import p.functions\ndef a():\n    import p.classes\n    p.classes.C()\n",
+            {
+                "p.x.a -> p.classes",
+                "p.x.a -> p.classes.C",
+                "p.x.a -> p.x",
+                "p.x.p -> p.functions",
+                "p.x.p -> p.x",
+            },
+            id="nested-cst.Import-shadows-module-scope",
+        ),
+        pytest.param(
+            # Import in a class body. The class is the owner;
+            # the chain walks normally.
+            "class A:\n    import p.functions\n    p.functions.f()\n",
+            {
+                "p.x.A -> p.functions",
+                "p.x.A -> p.functions.f",
+                "p.x.A -> p.x",
+            },
+            id="class-body-cst.Import",
+        ),
+        pytest.param(
+            "class A:\n    from p.functions import f\n    f()\n",
+            {
+                "p.x.A -> p.functions",
+                "p.x.A -> p.functions.f",
+                "p.x.A -> p.x",
+            },
+            id="class-body-cst.ImportFrom",
+        ),
+        pytest.param(
+            # Imports inside method bodies attribute to the
+            # enclosing class — methods are not separate top-level
+            # nodes, per the project's "nested defs are folded
+            # into the enclosing top-level decl" convention.
+            "class A:\n    def m(self):\n        import p.functions\n        p.functions.f()\n",
+            {
+                "p.x.A -> p.functions",
+                "p.x.A -> p.functions.f",
+                "p.x.A -> p.x",
+            },
+            id="method-body-cst.Import",
+        ),
+        pytest.param(
+            # `try: import X as A; except: import Y as A` — both
+            # branches reach end-of-scope with `A` bound, so a use
+            # of `A` (or the import statements alone) attributes
+            # edges to *both* upstreams (Principle 3 — every
+            # reaching def gets edges).
+            "def a():\n"
+            "    try:\n"
+            "        import p.functions as src\n"
+            "    except ImportError:\n"
+            "        import p.classes as src\n"
+            "    src\n",
+            {
+                "p.x.a -> p.classes",
+                "p.x.a -> p.functions",
+                "p.x.a -> p.x",
+            },
+            id="nested-try-except-cst.Import",
+        ),
+        pytest.param(
             "from .functions import f\ndef a(): f()",
             {
                 "p.x.a -> p.functions",


### PR DESCRIPTION
> **Base: `rust_proto`** (not `main`). Diff is the single commit on this branch — `rust_proto` already contains the native crate, the `--backend=rust` fixture, and the Principle 2 refinement from #141. Compare against `rust_proto` to see just the test additions.

## Summary

Pins libcst's behavior for nested-/class-body imports as ten parametrize cases in `test_imports.py`, so the rust backend has a concrete target to implement against. All ten pass under `--backend=libcst` and fail under `--backend=rust` today — that's the gap measurement.

## Three rules these cases pin

1. **No alias node.** Nested imports never mint a `kind="import"` graph node. Edges flow directly from the enclosing top-level decl to whatever upstream the import resolved to.
2. **Owner is the deepest enclosing top-level decl.** `def a()` → `a`. Method inside `class A` → `A` (not the method). Class body → the class.
3. **The import statement itself is a dep, not just uses of the bound name.** `def a(): import p.functions` (no use of `p`) still emits `a → p.functions`.

## Cases added

| Case id | Shape | Edges (beyond parent-module) |
|---|---|---|
| `nested-cst.Import-no-use` | `def a(): import p.functions` | `a → p.functions` |
| `nested-cst.ImportFrom-no-use` | `def a(): from p.functions import f` | `a → p.functions`, `a → p.functions.f` |
| `nested-cst.Import-bare-then-dotted` | `def a(): import p; p.functions.f()` | `a → p`, `a → p.functions`, `a → p.functions.f` |
| `nested-cst.Import-shadows-module-scope` | `import p.functions` (mod) + `def a(): import p.classes; p.classes.C()` | nested wins inside `a`; module-scope alias keeps its own out-edges |
| `class-body-cst.Import` | `class A: import p.functions; p.functions.f()` | `A → p.functions`, `A → p.functions.f` |
| `class-body-cst.ImportFrom` | `class A: from p.functions import f; f()` | `A → p.functions`, `A → p.functions.f` |
| `method-body-cst.Import` | `class A: def m(self): import p.functions; p.functions.f()` | `A → p.functions`, `A → p.functions.f` *(method folds into class)* |
| `nested-try-except-cst.Import` | `def a(): try: import p.functions as src; except: import p.classes as src; src` | both upstreams (Principle 3) |

Plus the two existing failing cases (`nested-cst.Import`, `nested-cst.ImportFrom`) that were already in the suite.

## Test plan
- [x] `uv run pytest tests/test_imports.py -k "nested or class-body or method-body or try-except" --backend=libcst` — 10 passed
- [x] `uv run pytest tests/test_imports.py -k "nested or class-body or method-body or try-except" --backend=rust` — 10 failed
- [ ] Implementation lands in a follow-up commit on this branch.

https://claude.ai/code/session_01R6GWpvWCUUNeYzJToopc9C