### PR TITLE
prototype: emit edges from `__all__` to its listed names

### DIFF
--- a/crates/dead-cst-ty-native/src/lib.rs
+++ b/crates/dead-cst-ty-native/src/lib.rs
@@ -989,11 +989,22 @@ fn walk_owned(kind: &DefinitionKind<'_>, parsed: &ParsedModuleRef, v: &mut RefCo
             }
             v.nested_context = false;
         }
-        DefinitionKind::Assignment(a) => v.visit_expr(a.value(parsed)),
+        DefinitionKind::Assignment(a) => {
+            let value = a.value(parsed);
+            if target_is_dunder_all(a.target(parsed)) {
+                emit_dunder_all_edges(v, value);
+            } else {
+                v.visit_expr(value);
+            }
+        }
         DefinitionKind::AnnotatedAssignment(a) => {
             v.visit_expr(a.annotation(parsed));
             if let Some(val) = a.value(parsed) {
-                v.visit_expr(val);
+                if target_is_dunder_all(a.target(parsed)) {
+                    emit_dunder_all_edges(v, val);
+                } else {
+                    v.visit_expr(val);
+                }
             }
         }
         DefinitionKind::For(for_stmt) => v.visit_expr(for_stmt.iterable(parsed)),
@@ -1001,6 +1012,44 @@ fn walk_owned(kind: &DefinitionKind<'_>, parsed: &ParsedModuleRef, v: &mut RefCo
         DefinitionKind::NamedExpression(named) => v.visit_expr(named.node(parsed).value.as_ref()),
         DefinitionKind::TypeAlias(alias) => v.visit_expr(alias.node(parsed).value.as_ref()),
         _ => {}
+    }
+}
+
+/// True iff `target` is the bare `Name("__all__")` LHS of an
+/// assignment (`__all__ = ...` or `__all__: list[str] = ...`).
+///
+/// Subscript / attribute / tuple-unpack targets (e.g.
+/// `__all__[0] = "f"`, `mod.__all__ = [...]`) are excluded — those
+/// don't redefine the binding in a way the libcst pipeline picks up,
+/// and treating them as `__all__` would emit edges from unrelated
+/// nodes.
+fn target_is_dunder_all(target: &Expr) -> bool {
+    matches!(target, Expr::Name(n) if n.id.as_str() == "__all__")
+}
+
+/// Walk the value of an `__all__` assignment and emit one edge from
+/// the owner (the `__all__` variable node) to each module-scope
+/// binding whose name appears in the list/tuple.
+///
+/// Only string-literal elements are followed; computed entries (e.g.
+/// `__all__ = [*BASE, "extra"]`, `__all__ = list(...)`) are silently
+/// skipped — matching the libcst pipeline, which folds `__all__` only
+/// when it's assigned a list or tuple of string literals. Names that
+/// don't resolve in the file's global scope are skipped without a
+/// warning (`__all__ = ["missing"]` is a runtime error at import
+/// time, not a static dep).
+fn emit_dunder_all_edges(v: &mut RefCollector<'_, '_>, value: &Expr) {
+    let elements = match value {
+        Expr::List(l) => &l.elts,
+        Expr::Tuple(t) => &t.elts,
+        _ => return,
+    };
+    for elem in elements {
+        if let Expr::StringLiteral(s) = elem {
+            if let Some(idx) = v.lookup_module_scope_name(s.value.to_str()) {
+                v.emit_edge(idx);
+            }
+        }
     }
 }
 
@@ -1074,6 +1123,40 @@ impl<'a, 'db> RefCollector<'a, 'db> {
         if dst != self.owner {
             self.edges.insert((self.owner, dst));
         }
+    }
+
+    /// Look up a name in the current file's global scope and return
+    /// its end-of-scope live binding's graph node.
+    ///
+    /// Used by the `__all__` walk: each string literal listed there
+    /// should resolve to a top-level decl (or import alias) bound in
+    /// the same file. Names that don't resolve are silently skipped —
+    /// `__all__ = ["missing"]` is a runtime error at import time but
+    /// doesn't influence static dep tracking.
+    fn lookup_module_scope_name(&self, name: &str) -> Option<usize> {
+        let db = self.model.db();
+        let index = semantic_index(db, self.file);
+        let global = FileScopeId::global();
+        let place_table = index.place_table(global);
+        let symbol_id = place_table.symbol_id(name)?;
+        let use_def_map = index.use_def_map(global);
+        for binding in use_def_map.end_of_scope_symbol_bindings(symbol_id) {
+            let Some(def) = binding.binding.definition() else {
+                continue;
+            };
+            if def.file(db) != self.file {
+                continue;
+            }
+            let key = (
+                self.file,
+                def.place(db),
+                range_key(def.kind(db).target_range(self.parsed)),
+            );
+            if let Some(&idx) = self.global_index.get(&key) {
+                return Some(idx);
+            }
+        }
+        None
     }
 
     /// Walk the use's scope chain looking for the reaching definition


### PR DESCRIPTION
> **Base: `rust_proto`** (not `main`). Diff is the single commit on this branch — `rust_proto` already contains the native crate, the `--backend=rust` fixture, the Principle 2 refinement (#141), the pinned nested-import test cases (#142), and the nested-import implementation (#143). Compare against `rust_proto` to see just this change.

## Summary

`__all__ = ["f", "g"]` (or the tuple / annotated-assignment forms) should attribute the variable's value to each name it lists, so deleting `p.x.f` also drops `p.x.__all__ → p.x.f` and reachability sees the dependency. Currently the rust backend emits the `__all__` variable node with no edges to the listed names.

## Implementation

In `walk_owned`:

- **`Assignment` / `AnnotatedAssignment` branches** check whether the target is the bare `Name("__all__")`. If so, dispatch to `emit_dunder_all_edges` instead of walking the value as a normal expression (which would emit nothing — string literals carry no Name references).
- **`emit_dunder_all_edges`** walks the value when it's a `List` or `Tuple` literal, picks out string-literal elements, and looks each one up in the file's module scope via a new `RefCollector::lookup_module_scope_name` helper (ty's place table for global scope + `end_of_scope_symbol_bindings` to pick the live decl). Hits emit one edge from the owner (the `__all__` variable node) to the resolved node. Misses (e.g. `__all__ = ["missing"]`) silently skip — matches the existing `dunder-all-unknown-name-is-ignored` case.
- **Targets we deliberately exclude**: subscript / attribute / tuple-unpack (`__all__[0] = "f"`, `mod.__all__ = [...]`). These don't redefine the binding in a way libcst picks up, and treating them as `__all__` would emit edges from unrelated nodes.
- **Computed RHS** (`__all__ = [*BASE, "extra"]`, `__all__ = list(...)`) falls through to the no-op branch — same pessimism the libcst pipeline applies.

## Test impact

| Suite | Before | After |
|---|---|---|
| `tests/test_imports.py::test_dunder_all_edges` `--backend=rust` | 1 / 5 | **5 / 5** |
| Full `--backend=rust` | 844 / 977 | **848 / 977** |
| Full `--backend=libcst` | 977 / 977 | **977 / 977** |

All four previously-failing `__all__` cases now pass. No regressions.

Remaining import buckets (independent of this change): dynamic imports (`__import__` / `importlib.import_module`), star-reexport flag / shadowing / codemod opt-out, re-export alias preservation through `__init__.py`, and synthetic external-/unresolved-node attribution.

## Test plan
- [x] `uv run pytest tests/test_imports.py::test_dunder_all_edges --backend=rust` — 5 passed
- [x] `uv run pytest --backend=libcst` — 977 passed
- [x] `uv run pytest --backend=rust` — 848 passed, 129 failed (was 844 / 133)
- [x] `cargo clippy --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

https://claude.ai/code/session_01R6GWpvWCUUNeYzJToopc9C

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6GWpvWCUUNeYzJToopc9C)_