### PR TITLE
prototype: project-scoped plugin protocol on the rust backend

### DIFF
--- a/crates/dead-cst-ty-native/Cargo.lock
+++ b/crates/dead-cst-ty-native/Cargo.lock
@@ -331,8 +331,10 @@ name = "dead-cst-ty-native"
 version = "0.0.0"
 dependencies = [
  "pyo3",
+ "regex",
  "ruff_db",
  "ruff_python_ast",
+ "ruff_python_parser",
  "ruff_source_file",
  "ruff_text_size",
  "ty_module_resolver",

--- a/crates/dead-cst-ty-native/Cargo.toml
+++ b/crates/dead-cst-ty-native/Cargo.toml
@@ -16,5 +16,7 @@ ty_python_semantic = { path = "../../vendor/ruff/crates/ty_python_semantic" }
 ty_module_resolver = { path = "../../vendor/ruff/crates/ty_module_resolver" }
 ruff_db = { path = "../../vendor/ruff/crates/ruff_db", features = ["os"] }
 ruff_python_ast = { path = "../../vendor/ruff/crates/ruff_python_ast" }
+ruff_python_parser = { path = "../../vendor/ruff/crates/ruff_python_parser" }
 ruff_source_file = { path = "../../vendor/ruff/crates/ruff_source_file" }
 ruff_text_size = { path = "../../vendor/ruff/crates/ruff_text_size" }
+regex = "1"

--- a/crates/dead-cst-ty-native/pyproject.toml
+++ b/crates/dead-cst-ty-native/pyproject.toml
@@ -12,5 +12,6 @@ classifiers = [
 ]
 
 [tool.maturin]
-module-name = "dead_cst_ty_native"
+module-name = "dead_cst_ty_native.dead_cst_ty_native"
+python-source = "python"
 features = ["pyo3/extension-module"]

--- a/crates/dead-cst-ty-native/python/dead_cst_ty_native/__init__.py
+++ b/crates/dead-cst-ty-native/python/dead_cst_ty_native/__init__.py
@@ -1,0 +1,14 @@
+"""Re-export the pyo3 extension's public surface.
+
+Maturin generates this file automatically when ``python-source`` isn't
+set; we ship our own so a sibling ``__init__.pyi`` (the type stub) can
+provide static information ty needs when checking
+``dead_cst/plugins/*.py``.
+"""
+
+from .dead_cst_ty_native import *  # noqa: F401, F403
+from . import dead_cst_ty_native as _native
+
+__doc__ = _native.__doc__
+if hasattr(_native, "__all__"):
+    __all__ = _native.__all__

--- a/crates/dead-cst-ty-native/python/dead_cst_ty_native/__init__.pyi
+++ b/crates/dead-cst-ty-native/python/dead_cst_ty_native/__init__.pyi
@@ -1,0 +1,85 @@
+"""Type stubs for the ty-backed native graph builder.
+
+Surfaces the pyo3 classes the rust crate exposes so callers in
+``dead_cst/`` and ``tests/prototype/`` get static information without
+having to introspect the binary module. Kept hand-written — pyo3
+doesn't generate stubs and the public API is small.
+"""
+
+from typing import Any, Iterable, Protocol
+
+class Import:
+    module: str
+    decl: str | None
+    star: bool
+
+    def __init__(
+        self,
+        module: str,
+        decl: str | None = ...,
+        star: bool = ...,
+    ) -> None: ...
+
+class NativeNode:
+    fqname: str
+    kind: str
+    path: str
+    start_line: int
+    start_column: int
+    end_line: int
+    end_column: int
+    flags: int
+    imports: Import | None
+
+class NativeGraph:
+    nodes: list[NativeNode]
+    edges: list[tuple[int, int, int]]
+
+class Project:
+    def __init__(
+        self,
+        root: str,
+        *,
+        src_roots: Iterable[str] | None = ...,
+        extra_paths: Iterable[str] | None = ...,
+        python_env: str | None = ...,
+        python_version: str | None = ...,
+        typeshed: str | None = ...,
+    ) -> None: ...
+    def build(self) -> NativeGraph: ...
+
+class _ProjectPluginLike(Protocol):
+    def run(self, ctx: "ProjectContext") -> None: ...
+
+class ProjectContext:
+    def __init__(
+        self,
+        root: str,
+        *,
+        src_roots: Iterable[str] | None = ...,
+        extra_paths: Iterable[str] | None = ...,
+        python_env: str | None = ...,
+        python_version: str | None = ...,
+        typeshed: str | None = ...,
+    ) -> None: ...
+    def add_plugin(self, plugin: _ProjectPluginLike | Any) -> None: ...
+    def materialize(self) -> NativeGraph: ...
+    def add_node(
+        self,
+        fqname: str,
+        path: str,
+        *,
+        kind: str = ...,
+        start_line: int = ...,
+        start_column: int = ...,
+        end_line: int = ...,
+        end_column: int = ...,
+        flags: int = ...,
+    ) -> NativeNode: ...
+    def add_edge(self, src: NativeNode, dst: NativeNode) -> None: ...
+    def find_module_dunders(self) -> list[NativeNode]: ...
+    def find_classes_defining_method(self, method_name: str) -> list[NativeNode]: ...
+    def find_subclasses_of(self, class_node: NativeNode) -> list[NativeNode]: ...
+    def find_comment_patterns(self, pattern: str) -> list[tuple[NativeNode, str]]: ...
+    def nodes(self) -> list[NativeNode]: ...
+    def edges(self) -> list[tuple[int, int, int]]: ...

--- a/crates/dead-cst-ty-native/src/lib.rs
+++ b/crates/dead-cst-ty-native/src/lib.rs
@@ -29,19 +29,21 @@
 
 #![allow(clippy::useless_conversion)]
 
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 
-use pyo3::exceptions::{PyOSError, PyValueError};
+use pyo3::exceptions::{PyOSError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use ruff_db::files::{File, FilePath};
 use ruff_db::parsed::{parsed_module, ParsedModuleRef};
 use ruff_db::source::{line_index, source_text};
 use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf};
+use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::visitor::{walk_expr, walk_stmt, Visitor};
-use ruff_python_ast::{Expr, ExprName, Stmt};
+use ruff_python_ast::{Expr, ExprName, Stmt, StmtClassDef};
 use ruff_source_file::LineIndex;
-use ruff_text_size::TextRange;
+use ruff_text_size::{Ranged, TextRange};
 use ty_module_resolver::{file_to_module, resolve_module, ModuleName};
 use ty_project::metadata::options::{EnvironmentOptions, Options};
 use ty_project::metadata::python_version::SupportedPythonVersion;
@@ -53,7 +55,8 @@ use ty_python_core::program::UseDefaultStrategy;
 use ty_python_core::scope::FileScopeId;
 use ty_python_core::semantic_index;
 use ty_python_semantic::{
-    definitions_for_imported_symbol, ImportAliasResolution, ResolvedDefinition, SemanticModel,
+    definitions_for_imported_symbol, type_hierarchy_subtypes, HasType, ImportAliasResolution,
+    ResolvedDefinition, SemanticModel, TypeHierarchyClass,
 };
 
 // ---------------------------------------------------------------------------
@@ -99,6 +102,10 @@ impl Import {
 /// other kinds carry `None`.
 #[pyclass(get_all, frozen)]
 struct NativeNode {
+    /// Index into the graph's node list. Stable for the lifetime of the
+    /// owning builder/context; plugins thread node identity through this
+    /// when calling `add_edge`.
+    idx: usize,
     fqname: String,
     kind: &'static str,
     path: String,
@@ -114,7 +121,8 @@ struct NativeNode {
 impl NativeNode {
     fn __repr__(&self) -> String {
         format!(
-            "NativeNode(fqname={:?}, kind={:?}, path={:?}, start=({}, {}), end=({}, {}), flags={})",
+            "NativeNode(idx={}, fqname={:?}, kind={:?}, path={:?}, start=({}, {}), end=({}, {}), flags={})",
+            self.idx,
             self.fqname,
             self.kind,
             self.path,
@@ -214,7 +222,7 @@ impl GraphBuilder {
         }
     }
 
-    fn intern_node(&mut self, py: Python<'_>, node: NativeNode) -> PyResult<usize> {
+    fn intern_node(&mut self, py: Python<'_>, mut node: NativeNode) -> PyResult<usize> {
         let key = NodeKey {
             fqname: node.fqname.clone(),
             kind: node.kind,
@@ -228,6 +236,7 @@ impl GraphBuilder {
             return Ok(idx);
         }
         let idx = self.nodes.len();
+        node.idx = idx;
         self.nodes.push(Py::new(py, node)?);
         self.node_index.insert(key, idx);
         Ok(idx)
@@ -312,54 +321,657 @@ impl Project {
 
     /// Build the project-wide symbol graph.
     fn build(&self, py: Python<'_>) -> PyResult<NativeGraph> {
-        let mut builder = GraphBuilder::new();
-        let mut global_index: DeclIndex = HashMap::new();
-        let mut module_nodes: HashMap<File, usize> = HashMap::new();
-        let mut alias_imports: HashMap<usize, ImportSpec> = HashMap::new();
-        let mut live_decls: LiveDeclIndex = HashMap::new();
-
-        let project_files: Vec<File> = (&self.db.project().files(&self.db)).into_iter().collect();
-
-        for file in &project_files {
-            ingest_decls(
-                py,
-                &self.db,
-                *file,
-                &mut builder,
-                &mut global_index,
-                &mut module_nodes,
-                &mut alias_imports,
-                &mut live_decls,
-            )?;
-        }
-        for file in &project_files {
-            emit_module_hierarchy(&self.db, *file, &module_nodes, &mut builder);
-            emit_import_edges(
-                py,
-                &self.db,
-                *file,
-                &mut builder,
-                &mut global_index,
-                &mut module_nodes,
-            )?;
-        }
-        for file in &project_files {
-            emit_reference_edges(
-                &self.db,
-                *file,
-                &global_index,
-                &module_nodes,
-                &alias_imports,
-                &live_decls,
-                &mut builder,
-            );
-        }
-
+        let outputs = build_project_graph(py, &self.db)?;
         Ok(NativeGraph {
-            nodes: builder.nodes,
-            edges: builder.edges,
+            nodes: outputs.builder.nodes,
+            edges: outputs.builder.edges,
         })
     }
+}
+
+/// All state produced by one project-wide build pass.
+///
+/// Owned by [`ProjectContext`] across the materialize call so plugin
+/// queries can re-read indices (e.g. live_decls, global_index) without
+/// having to re-derive them from the parsed modules.
+struct BuildOutputs {
+    builder: GraphBuilder,
+    project_files: Vec<File>,
+    global_index: DeclIndex,
+    #[allow(dead_code)]
+    module_nodes: HashMap<File, usize>,
+    #[allow(dead_code)]
+    alias_imports: HashMap<usize, ImportSpec>,
+    #[allow(dead_code)]
+    live_decls: LiveDeclIndex,
+}
+
+/// Run the three build phases (ingest → hierarchy+imports → references)
+/// and return every index the plugin queries need.
+fn build_project_graph(py: Python<'_>, db: &ProjectDatabase) -> PyResult<BuildOutputs> {
+    let mut builder = GraphBuilder::new();
+    let mut global_index: DeclIndex = HashMap::new();
+    let mut module_nodes: HashMap<File, usize> = HashMap::new();
+    let mut alias_imports: HashMap<usize, ImportSpec> = HashMap::new();
+    let mut live_decls: LiveDeclIndex = HashMap::new();
+
+    let project_files: Vec<File> = (&db.project().files(db)).into_iter().collect();
+    for file in &project_files {
+        ingest_decls(
+            py,
+            db,
+            *file,
+            &mut builder,
+            &mut global_index,
+            &mut module_nodes,
+            &mut alias_imports,
+            &mut live_decls,
+        )?;
+    }
+    for file in &project_files {
+        emit_module_hierarchy(db, *file, &module_nodes, &mut builder);
+        emit_import_edges(
+            py,
+            db,
+            *file,
+            &mut builder,
+            &mut global_index,
+            &mut module_nodes,
+        )?;
+    }
+    for file in &project_files {
+        emit_reference_edges(
+            db,
+            *file,
+            &global_index,
+            &module_nodes,
+            &alias_imports,
+            &live_decls,
+            &mut builder,
+        );
+    }
+    Ok(BuildOutputs {
+        builder,
+        project_files,
+        global_index,
+        module_nodes,
+        alias_imports,
+        live_decls,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// ProjectContext — plugin protocol entry point
+// ---------------------------------------------------------------------------
+
+/// Plugin-aware project graph builder.
+///
+/// Python instantiates a `ProjectContext`, registers Python plugins via
+/// `add_plugin`, then calls `materialize()`. `materialize` runs the
+/// project-wide build in rust, then for each registered plugin calls
+/// `plugin.run(ctx)` back into Python with `ctx` set to the same
+/// `ProjectContext` instance — re-entrant calls invoke the rust
+/// `add_node` / `add_edge` / `find_*` methods listed below.
+///
+/// Queries are answered from ty's semantic index: subclass closure goes
+/// through `type_hierarchy_subtypes`, method-defines walks each class's
+/// `DefinitionKind::Class`, module dunders scan global-scope variable
+/// nodes, and comment patterns walk the parser's `Tokens` stream.
+#[pyclass(unsendable)]
+struct ProjectContext {
+    db: ProjectDatabase,
+    plugins: Vec<PyObject>,
+    /// Populated by `materialize` before plugins run. `None` outside a
+    /// materialize call — `add_node` / `add_edge` / queries assume it's
+    /// `Some` and error if a plugin (incorrectly) caches the ctx and
+    /// uses it after materialize returns.
+    outputs: RefCell<Option<BuildOutputs>>,
+}
+
+#[pymethods]
+impl ProjectContext {
+    #[new]
+    #[pyo3(signature = (
+        root,
+        *,
+        src_roots = None,
+        extra_paths = None,
+        python_env = None,
+        python_version = None,
+        typeshed = None,
+    ))]
+    fn new(
+        root: &str,
+        src_roots: Option<Vec<String>>,
+        extra_paths: Option<Vec<String>>,
+        python_env: Option<&str>,
+        python_version: Option<&str>,
+        typeshed: Option<&str>,
+    ) -> PyResult<Self> {
+        let db = make_db(
+            root,
+            src_roots,
+            extra_paths,
+            python_env,
+            python_version,
+            typeshed,
+        )?;
+        Ok(Self {
+            db,
+            plugins: Vec::new(),
+            outputs: RefCell::new(None),
+        })
+    }
+
+    /// Register a Python plugin. Order of registration is order of
+    /// invocation during `materialize`.
+    fn add_plugin(&mut self, plugin: PyObject) {
+        self.plugins.push(plugin);
+    }
+
+    /// Build the project-wide graph, run each plugin's `run(ctx)`,
+    /// then snapshot the final state.
+    ///
+    /// Borrows are released between phases so plugin `run` methods can
+    /// re-enter `add_node` / `add_edge` / queries through the same ctx
+    /// without aliasing violations.
+    fn materialize(slf: Py<Self>, py: Python<'_>) -> PyResult<NativeGraph> {
+        // Phase 1 — build (mutates self.outputs).
+        {
+            let this = slf.borrow(py);
+            let outputs = build_project_graph(py, &this.db)?;
+            *this.outputs.borrow_mut() = Some(outputs);
+        }
+
+        // Phase 2 — plugins. Clone refs out so we don't hold a borrow
+        // across the Python callback (plugins re-enter ctx methods).
+        let plugins: Vec<PyObject> = {
+            let this = slf.borrow(py);
+            this.plugins.iter().map(|p| p.clone_ref(py)).collect()
+        };
+        for plugin in &plugins {
+            let ctx_arg = slf.clone_ref(py);
+            plugin.bind(py).call_method1("run", (ctx_arg,))?;
+        }
+
+        // Phase 3 — snapshot. Move builder out (leaving outputs as
+        // None) so plugins that cached the ctx see a clean failure
+        // rather than silently mutating after the snapshot.
+        let taken = {
+            let this = slf.borrow(py);
+            let value = this.outputs.borrow_mut().take();
+            value
+        };
+        let outputs = taken
+            .ok_or_else(|| PyRuntimeError::new_err("ProjectContext was already materialized"))?;
+        Ok(NativeGraph {
+            nodes: outputs.builder.nodes,
+            edges: outputs.builder.edges,
+        })
+    }
+
+    // ----- Mutation -------------------------------------------------------
+
+    /// Intern a synthetic node into the graph.
+    ///
+    /// `path` should be a real source path when the node stands in for a
+    /// specific location (so codemod / why-alive output can reach the
+    /// file); pass the project root for file-agnostic markers.
+    #[pyo3(signature = (
+        fqname,
+        path,
+        *,
+        kind = "synthetic",
+        start_line = 0,
+        start_column = 0,
+        end_line = 0,
+        end_column = 0,
+        flags = 0,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn add_node(
+        &self,
+        py: Python<'_>,
+        fqname: String,
+        path: String,
+        kind: &str,
+        start_line: usize,
+        start_column: usize,
+        end_line: usize,
+        end_column: usize,
+        flags: u32,
+    ) -> PyResult<Py<NativeNode>> {
+        let kind = static_kind_str(kind)?;
+        let mut outputs = self.outputs.borrow_mut();
+        let outputs = outputs
+            .as_mut()
+            .ok_or_else(|| not_materialized("add_node"))?;
+        let idx = outputs.builder.intern_node(
+            py,
+            NativeNode {
+                idx: 0,
+                fqname,
+                kind,
+                path,
+                start_line,
+                start_column,
+                end_line,
+                end_column,
+                flags,
+                imports: None,
+            },
+        )?;
+        Ok(outputs.builder.nodes[idx].clone_ref(py))
+    }
+
+    /// Add an edge between two nodes returned by `add_node` or a query.
+    fn add_edge(&self, src: &NativeNode, dst: &NativeNode) -> PyResult<()> {
+        let mut outputs = self.outputs.borrow_mut();
+        let outputs = outputs
+            .as_mut()
+            .ok_or_else(|| not_materialized("add_edge"))?;
+        outputs.builder.add_edge(src.idx, dst.idx, 0);
+        Ok(())
+    }
+
+    // ----- Queries (rust-resident, results pass back to Python) -----------
+
+    /// Return every top-level variable node whose name matches `__xxx__`.
+    ///
+    /// Pure scan over already-interned nodes — no ty re-query needed —
+    /// because the visitor's decl pass already minted one node per
+    /// global-scope variable binding.
+    fn find_module_dunders(&self, py: Python<'_>) -> PyResult<Vec<Py<NativeNode>>> {
+        let outputs = self.outputs.borrow();
+        let outputs = outputs
+            .as_ref()
+            .ok_or_else(|| not_materialized("find_module_dunders"))?;
+        let mut out = Vec::new();
+        for node_py in &outputs.builder.nodes {
+            let node = node_py.borrow(py);
+            if node.kind != "variable" {
+                continue;
+            }
+            if is_dunder_name(&node.fqname) {
+                out.push(node_py.clone_ref(py));
+            }
+        }
+        Ok(out)
+    }
+
+    /// Return every class that defines a method with the given name.
+    ///
+    /// Walks each class's `DefinitionKind::Class` body for an
+    /// `Stmt::FunctionDef` whose name matches. ty's `parsed_module` is
+    /// Salsa-cached, so this is just a body scan per class.
+    fn find_classes_defining_method(
+        &self,
+        py: Python<'_>,
+        method_name: &str,
+    ) -> PyResult<Vec<Py<NativeNode>>> {
+        let outputs = self.outputs.borrow();
+        let outputs = outputs
+            .as_ref()
+            .ok_or_else(|| not_materialized("find_classes_defining_method"))?;
+        let mut out = Vec::new();
+        for &file in &outputs.project_files {
+            let parsed = parsed_module(&self.db, file).load(&self.db);
+            let index = semantic_index(&self.db, file);
+            let global = FileScopeId::global();
+            let use_def_map = index.use_def_map(global);
+            for (_def_id, state, _used) in use_def_map.all_definitions_with_usage() {
+                let DefinitionState::Defined(def) = state else {
+                    continue;
+                };
+                if def.file(&self.db) != file || def.file_scope(&self.db) != global {
+                    continue;
+                }
+                let kind = def.kind(&self.db);
+                let Some(class_ref) = kind.as_class() else {
+                    continue;
+                };
+                let class_def = class_ref.node(&parsed);
+                if !class_body_defines_method(class_def, method_name) {
+                    continue;
+                }
+                let key = (
+                    file,
+                    def.place(&self.db),
+                    range_key(kind.target_range(&parsed)),
+                );
+                if let Some(&idx) = outputs.global_index.get(&key) {
+                    out.push(outputs.builder.nodes[idx].clone_ref(py));
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Return every transitive subclass of the given class node.
+    ///
+    /// Direct subtypes come from ty's `type_hierarchy_subtypes`; we BFS
+    /// to collect the transitive closure. Results that don't land in
+    /// the project (stdlib / external classes) are dropped.
+    fn find_subclasses_of(
+        &self,
+        py: Python<'_>,
+        class_node: &NativeNode,
+    ) -> PyResult<Vec<Py<NativeNode>>> {
+        if class_node.kind != "class" {
+            return Ok(Vec::new());
+        }
+        let outputs = self.outputs.borrow();
+        let outputs = outputs
+            .as_ref()
+            .ok_or_else(|| not_materialized("find_subclasses_of"))?;
+
+        // Locate the seed class's File + name range, then ask ty for
+        // its inferred Type via the StmtClassDef at that range.
+        let Some((seed_file, seed_range)) = locate_class_def(
+            &self.db,
+            &outputs.project_files,
+            &class_node.path,
+            class_node,
+        ) else {
+            return Ok(Vec::new());
+        };
+        let parsed_seed = parsed_module(&self.db, seed_file).load(&self.db);
+        let model_seed = SemanticModel::new(&self.db, seed_file);
+        let Some(seed_class) = class_def_at(&parsed_seed, seed_range) else {
+            return Ok(Vec::new());
+        };
+        let Some(seed_ty) = seed_class.inferred_type(&model_seed) else {
+            return Ok(Vec::new());
+        };
+
+        // BFS over Types. Each visited entry is a class identified by
+        // `(file, selection_range)` from `TypeHierarchyClass`; we
+        // re-derive the next layer's Type by parsing that file and
+        // asking the StmtClassDef at the matching range for its type.
+        let mut seen: HashSet<(File, (u32, u32))> = HashSet::new();
+        let mut frontier: Vec<TypeHierarchyClass> = type_hierarchy_subtypes(&self.db, seed_ty);
+        let mut out_idx: Vec<usize> = Vec::new();
+        while let Some(thc) = frontier.pop() {
+            let file_key = (thc.file, range_key(thc.selection_range));
+            if !seen.insert(file_key) {
+                continue;
+            }
+            // Map THC back to a node idx — selection_range matches our
+            // class-node target_range exactly.
+            if let Some(idx) = class_idx_by_selection(outputs, thc.file, thc.selection_range) {
+                out_idx.push(idx);
+            }
+            // Recurse: ask ty for the next layer.
+            let parsed = parsed_module(&self.db, thc.file).load(&self.db);
+            let Some(class_def) = class_def_at(&parsed, thc.selection_range) else {
+                continue;
+            };
+            let model = SemanticModel::new(&self.db, thc.file);
+            let Some(ty) = class_def.inferred_type(&model) else {
+                continue;
+            };
+            frontier.extend(type_hierarchy_subtypes(&self.db, ty));
+        }
+        let mut out = Vec::with_capacity(out_idx.len());
+        for idx in out_idx {
+            out.push(outputs.builder.nodes[idx].clone_ref(py));
+        }
+        Ok(out)
+    }
+
+    /// Return `(decl_node, comment_text)` for every comment in the
+    /// project that matches `pattern` (a regex), paired with the next
+    /// declaration that follows it in the same file.
+    ///
+    /// Comments are scanned from the parser's `Tokens` stream (no
+    /// re-lexing); regex matching is full-text against the comment
+    /// content (leading `#` included).
+    fn find_comment_patterns(
+        &self,
+        py: Python<'_>,
+        pattern: &str,
+    ) -> PyResult<Vec<(Py<NativeNode>, String)>> {
+        let regex = regex::Regex::new(pattern)
+            .map_err(|e| PyValueError::new_err(format!("invalid regex {pattern:?}: {e}")))?;
+        let outputs = self.outputs.borrow();
+        let outputs = outputs
+            .as_ref()
+            .ok_or_else(|| not_materialized("find_comment_patterns"))?;
+        let mut out = Vec::new();
+        for &file in &outputs.project_files {
+            let parsed = parsed_module(&self.db, file).load(&self.db);
+            let source = source_text(&self.db, file);
+            // Build a per-file sorted list of (target_range_start, idx)
+            // so we can find the next decl after a comment via binary
+            // search.
+            let file_decls = file_decl_sites(&self.db, file, &outputs.global_index, &parsed);
+            for token in parsed.tokens() {
+                if token.kind() != TokenKind::Comment {
+                    continue;
+                }
+                let range = token.range();
+                let text = &source[range];
+                if !regex.is_match(text) {
+                    continue;
+                }
+                let comment_end = range.end().to_u32();
+                let Some(&(_, decl_idx)) =
+                    file_decls.iter().find(|(start, _)| *start >= comment_end)
+                else {
+                    continue;
+                };
+                out.push((
+                    outputs.builder.nodes[decl_idx].clone_ref(py),
+                    text.to_string(),
+                ));
+            }
+        }
+        Ok(out)
+    }
+
+    // ----- Read-only accessors -------------------------------------------
+
+    /// Live nodes in the in-progress graph. Cheap, no copy.
+    fn nodes(&self, py: Python<'_>) -> PyResult<Vec<Py<NativeNode>>> {
+        let outputs = self.outputs.borrow();
+        let outputs = outputs.as_ref().ok_or_else(|| not_materialized("nodes"))?;
+        Ok(outputs
+            .builder
+            .nodes
+            .iter()
+            .map(|n| n.clone_ref(py))
+            .collect())
+    }
+
+    /// Live edges as `(src_idx, dst_idx, flags)` triples.
+    fn edges(&self) -> PyResult<Vec<(usize, usize, u32)>> {
+        let outputs = self.outputs.borrow();
+        let outputs = outputs.as_ref().ok_or_else(|| not_materialized("edges"))?;
+        Ok(outputs.builder.edges.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ProjectContext support helpers
+// ---------------------------------------------------------------------------
+
+fn make_db(
+    root: &str,
+    src_roots: Option<Vec<String>>,
+    extra_paths: Option<Vec<String>>,
+    python_env: Option<&str>,
+    python_version: Option<&str>,
+    typeshed: Option<&str>,
+) -> PyResult<ProjectDatabase> {
+    let root = SystemPathBuf::from(root);
+    let env = EnvironmentOptions {
+        root: src_roots.map(|paths| paths.into_iter().map(rel_path).collect()),
+        extra_paths: extra_paths.map(|paths| paths.into_iter().map(rel_path).collect()),
+        python: python_env.map(rel_path),
+        python_version: python_version
+            .map(|v| {
+                SupportedPythonVersion::from_str(v).map_err(|e| {
+                    PyValueError::new_err(format!("invalid python_version {v:?}: {e}"))
+                })
+            })
+            .transpose()?
+            .map(RangedValue::cli),
+        typeshed: typeshed.map(rel_path),
+        ..EnvironmentOptions::default()
+    };
+    let options = Options {
+        environment: Some(env),
+        ..Options::default()
+    };
+    let metadata = ProjectMetadata::from_options(options, root.clone(), None, &UseDefaultStrategy)
+        .map_err(|e| PyValueError::new_err(format!("invalid configuration: {e:?}")))?;
+    let cwd =
+        std::env::current_dir().map_err(|e| PyOSError::new_err(format!("cwd unavailable: {e}")))?;
+    let cwd = SystemPathBuf::from_path_buf(cwd).map_err(|_| {
+        PyValueError::new_err("current working directory is not a valid absolute UTF-8 path")
+    })?;
+    let system = OsSystem::new(cwd);
+    Ok(ProjectDatabase::use_defaults(metadata, system))
+}
+
+fn not_materialized(op: &str) -> PyErr {
+    PyRuntimeError::new_err(format!(
+        "ProjectContext.{op}() called outside an active materialize() — \
+         did you call it from a plugin's run() method?"
+    ))
+}
+
+/// Map a plugin-supplied `kind` string to one of the stable `&'static
+/// str` kinds NativeNode carries. Plugins typically use "synthetic" but
+/// "import"/"function"/"class"/"variable"/"module" are accepted too so
+/// the protocol round-trips with query results.
+fn static_kind_str(kind: &str) -> PyResult<&'static str> {
+    Ok(match kind {
+        "synthetic" => "synthetic",
+        "module" => "module",
+        "import" => "import",
+        "function" => "function",
+        "class" => "class",
+        "variable" => "variable",
+        "type_alias" => "type_alias",
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "unknown node kind {other:?} — expected one of synthetic, module, import, \
+                 function, class, variable, type_alias"
+            )))
+        }
+    })
+}
+
+fn is_dunder_name(fqname: &str) -> bool {
+    let name = fqname.rsplit('.').next().unwrap_or("");
+    name.len() > 4 && name.starts_with("__") && name.ends_with("__")
+}
+
+fn class_body_defines_method(class_def: &StmtClassDef, method_name: &str) -> bool {
+    class_def.body.iter().any(|stmt| match stmt {
+        Stmt::FunctionDef(f) => f.name.as_str() == method_name,
+        _ => false,
+    })
+}
+
+/// Locate a class's File + name TextRange from its NativeNode positions.
+///
+/// We don't store ty `Definition<'db>` references across plugin calls
+/// (the `'db` lifetime is tied to the active borrow), so this re-walks
+/// the file's top-level statements to find the class whose name range
+/// projects to the same `(start_line, start_column)` as the node.
+fn locate_class_def(
+    db: &ProjectDatabase,
+    project_files: &[File],
+    path: &str,
+    class_node: &NativeNode,
+) -> Option<(File, TextRange)> {
+    let target_start_line = class_node.start_line;
+    let target_start_col = class_node.start_column;
+    for &file in project_files {
+        if file_path_string(db, file) != path {
+            continue;
+        }
+        let parsed = parsed_module(db, file).load(db);
+        let source = source_text(db, file);
+        let line_index = line_index(db, file);
+        for stmt in &parsed.syntax().body {
+            if let Stmt::ClassDef(cls) = stmt {
+                let name_range = cls.name.range();
+                let (sl, sc, _, _) = position(&line_index, &source, name_range);
+                if sl == target_start_line && sc == target_start_col {
+                    return Some((file, name_range));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Find a top-level `StmtClassDef` whose name range equals `selection_range`.
+fn class_def_at(parsed: &ParsedModuleRef, selection_range: TextRange) -> Option<&StmtClassDef> {
+    for stmt in &parsed.syntax().body {
+        if let Stmt::ClassDef(cls) = stmt {
+            if cls.name.range() == selection_range {
+                return Some(cls);
+            }
+        }
+    }
+    None
+}
+
+/// Map ty's `TypeHierarchyClass.selection_range` (the class name range)
+/// back to a node idx in our graph. We don't have a pre-built index
+/// because every other path uses `(file, place_id, range_key)` — but
+/// for class nodes the `place_id` is always the class's own symbol
+/// place, so a linear scan over `global_index` entries with the
+/// matching `(file, range_key)` suffices for the prototype.
+fn class_idx_by_selection(
+    outputs: &BuildOutputs,
+    file: File,
+    selection_range: TextRange,
+) -> Option<usize> {
+    let needle = range_key(selection_range);
+    for ((entry_file, _place_id, range), idx) in &outputs.global_index {
+        if *entry_file == file && *range == needle {
+            return Some(*idx);
+        }
+    }
+    None
+}
+
+/// Per-file sorted list of `(target_start_offset, node_idx)` for the
+/// file's top-level decls. Sorted ascending so callers can find the
+/// next decl after a comment via linear scan (small files) or binary
+/// search.
+fn file_decl_sites(
+    db: &ProjectDatabase,
+    file: File,
+    global_index: &DeclIndex,
+    _parsed: &ParsedModuleRef,
+) -> Vec<(u32, usize)> {
+    let mut out: Vec<(u32, usize)> = Vec::new();
+    let index = semantic_index(db, file);
+    let global = FileScopeId::global();
+    let use_def_map = index.use_def_map(global);
+    let parsed = parsed_module(db, file).load(db);
+    for (_def_id, state, _used) in use_def_map.all_definitions_with_usage() {
+        let DefinitionState::Defined(def) = state else {
+            continue;
+        };
+        if def.file(db) != file || def.file_scope(db) != global {
+            continue;
+        }
+        let kind = def.kind(db);
+        let target_range = kind.target_range(&parsed);
+        let key = (file, def.place(db), range_key(target_range));
+        if let Some(&idx) = global_index.get(&key) {
+            out.push((target_range.start().to_u32(), idx));
+        }
+    }
+    out.sort_by_key(|(start, _)| *start);
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -387,6 +999,7 @@ fn ingest_decls(
     let module_idx = builder.intern_node(
         py,
         NativeNode {
+            idx: 0,
             fqname: module_fqname.clone(),
             kind: "module",
             path: path_str.clone(),
@@ -452,6 +1065,7 @@ fn ingest_decls(
         let node_idx = builder.intern_node(
             py,
             NativeNode {
+                idx: 0,
                 fqname: format!("{module_fqname}.{local_name}"),
                 kind: node_kind,
                 path: path_str.clone(),
@@ -840,6 +1454,7 @@ fn mint_module_node(
     let idx = builder.intern_node(
         py,
         NativeNode {
+            idx: 0,
             fqname,
             kind: "module",
             path: path_str,
@@ -1357,5 +1972,6 @@ fn dead_cst_ty_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<NativeNode>()?;
     m.add_class::<NativeGraph>()?;
     m.add_class::<Project>()?;
+    m.add_class::<ProjectContext>()?;
     Ok(())
 }

--- a/crates/dead-cst-ty-native/src/lib.rs
+++ b/crates/dead-cst-ty-native/src/lib.rs
@@ -102,10 +102,6 @@ impl Import {
 /// other kinds carry `None`.
 #[pyclass(get_all, frozen)]
 struct NativeNode {
-    /// Index into the graph's node list. Stable for the lifetime of the
-    /// owning builder/context; plugins thread node identity through this
-    /// when calling `add_edge`.
-    idx: usize,
     fqname: String,
     kind: &'static str,
     path: String,
@@ -121,8 +117,7 @@ struct NativeNode {
 impl NativeNode {
     fn __repr__(&self) -> String {
         format!(
-            "NativeNode(idx={}, fqname={:?}, kind={:?}, path={:?}, start=({}, {}), end=({}, {}), flags={})",
-            self.idx,
+            "NativeNode(fqname={:?}, kind={:?}, path={:?}, start=({}, {}), end=({}, {}), flags={})",
             self.fqname,
             self.kind,
             self.path,
@@ -222,21 +217,12 @@ impl GraphBuilder {
         }
     }
 
-    fn intern_node(&mut self, py: Python<'_>, mut node: NativeNode) -> PyResult<usize> {
-        let key = NodeKey {
-            fqname: node.fqname.clone(),
-            kind: node.kind,
-            path: node.path.clone(),
-            start_line: node.start_line,
-            start_column: node.start_column,
-            end_line: node.end_line,
-            end_column: node.end_column,
-        };
+    fn intern_node(&mut self, py: Python<'_>, node: NativeNode) -> PyResult<usize> {
+        let key = node_key_of(&node);
         if let Some(&idx) = self.node_index.get(&key) {
             return Ok(idx);
         }
         let idx = self.nodes.len();
-        node.idx = idx;
         self.nodes.push(Py::new(py, node)?);
         self.node_index.insert(key, idx);
         Ok(idx)
@@ -280,43 +266,15 @@ impl Project {
         python_version: Option<&str>,
         typeshed: Option<&str>,
     ) -> PyResult<Self> {
-        let root = SystemPathBuf::from(root);
-
-        let env = EnvironmentOptions {
-            root: src_roots.map(|paths| paths.into_iter().map(rel_path).collect()),
-            extra_paths: extra_paths.map(|paths| paths.into_iter().map(rel_path).collect()),
-            python: python_env.map(rel_path),
-            python_version: python_version
-                .map(|v| {
-                    SupportedPythonVersion::from_str(v).map_err(|e| {
-                        PyValueError::new_err(format!("invalid python_version {v:?}: {e}"))
-                    })
-                })
-                .transpose()?
-                .map(RangedValue::cli),
-            typeshed: typeshed.map(rel_path),
-            ..EnvironmentOptions::default()
-        };
-
-        let options = Options {
-            environment: Some(env),
-            ..Options::default()
-        };
-
-        let metadata =
-            ProjectMetadata::from_options(options, root.clone(), None, &UseDefaultStrategy)
-                .map_err(|e| PyValueError::new_err(format!("invalid configuration: {e:?}")))?;
-
-        let cwd = std::env::current_dir()
-            .map_err(|e| PyOSError::new_err(format!("cwd unavailable: {e}")))?;
-        let cwd = SystemPathBuf::from_path_buf(cwd).map_err(|_| {
-            PyValueError::new_err("current working directory is not a valid absolute UTF-8 path")
-        })?;
-        let system = OsSystem::new(cwd);
-
-        Ok(Self {
-            db: ProjectDatabase::use_defaults(metadata, system),
-        })
+        let db = make_db(
+            root,
+            src_roots,
+            extra_paths,
+            python_env,
+            python_version,
+            typeshed,
+        )?;
+        Ok(Self { db })
     }
 
     /// Build the project-wide symbol graph.
@@ -338,12 +296,13 @@ struct BuildOutputs {
     builder: GraphBuilder,
     project_files: Vec<File>,
     global_index: DeclIndex,
-    #[allow(dead_code)]
-    module_nodes: HashMap<File, usize>,
-    #[allow(dead_code)]
-    alias_imports: HashMap<usize, ImportSpec>,
-    #[allow(dead_code)]
-    live_decls: LiveDeclIndex,
+    /// `file_path_string(file) -> File` so seed lookups don't have to
+    /// linear-scan `project_files`. Populated alongside ingest.
+    path_to_file: HashMap<String, File>,
+    /// `(file, class_target_range_key) -> class node idx`. Lets
+    /// `find_subclasses_of` map ty's `TypeHierarchyClass.selection_range`
+    /// back to a graph node in O(1).
+    class_by_selection: HashMap<(File, (u32, u32)), usize>,
 }
 
 /// Run the three build phases (ingest → hierarchy+imports → references)
@@ -354,8 +313,13 @@ fn build_project_graph(py: Python<'_>, db: &ProjectDatabase) -> PyResult<BuildOu
     let mut module_nodes: HashMap<File, usize> = HashMap::new();
     let mut alias_imports: HashMap<usize, ImportSpec> = HashMap::new();
     let mut live_decls: LiveDeclIndex = HashMap::new();
+    let mut class_by_selection: HashMap<(File, (u32, u32)), usize> = HashMap::new();
 
     let project_files: Vec<File> = (&db.project().files(db)).into_iter().collect();
+    let mut path_to_file: HashMap<String, File> = HashMap::with_capacity(project_files.len());
+    for &file in &project_files {
+        path_to_file.insert(file_path_string(db, file), file);
+    }
     for file in &project_files {
         ingest_decls(
             py,
@@ -366,6 +330,7 @@ fn build_project_graph(py: Python<'_>, db: &ProjectDatabase) -> PyResult<BuildOu
             &mut module_nodes,
             &mut alias_imports,
             &mut live_decls,
+            &mut class_by_selection,
         )?;
     }
     for file in &project_files {
@@ -394,9 +359,8 @@ fn build_project_graph(py: Python<'_>, db: &ProjectDatabase) -> PyResult<BuildOu
         builder,
         project_files,
         global_index,
-        module_nodes,
-        alias_imports,
-        live_decls,
+        path_to_file,
+        class_by_selection,
     })
 }
 
@@ -476,34 +440,26 @@ impl ProjectContext {
     /// re-enter `add_node` / `add_edge` / queries through the same ctx
     /// without aliasing violations.
     fn materialize(slf: Py<Self>, py: Python<'_>) -> PyResult<NativeGraph> {
-        // Phase 1 — build (mutates self.outputs).
         {
             let this = slf.borrow(py);
             let outputs = build_project_graph(py, &this.db)?;
             *this.outputs.borrow_mut() = Some(outputs);
         }
 
-        // Phase 2 — plugins. Clone refs out so we don't hold a borrow
-        // across the Python callback (plugins re-enter ctx methods).
-        let plugins: Vec<PyObject> = {
-            let this = slf.borrow(py);
-            this.plugins.iter().map(|p| p.clone_ref(py)).collect()
-        };
+        let plugins: Vec<PyObject> = slf
+            .borrow(py)
+            .plugins
+            .iter()
+            .map(|p| p.clone_ref(py))
+            .collect();
         for plugin in &plugins {
-            let ctx_arg = slf.clone_ref(py);
-            plugin.bind(py).call_method1("run", (ctx_arg,))?;
+            plugin.bind(py).call_method1("run", (slf.clone_ref(py),))?;
         }
 
-        // Phase 3 — snapshot. Move builder out (leaving outputs as
-        // None) so plugins that cached the ctx see a clean failure
-        // rather than silently mutating after the snapshot.
-        let taken = {
-            let this = slf.borrow(py);
-            let value = this.outputs.borrow_mut().take();
-            value
-        };
-        let outputs = taken
-            .ok_or_else(|| PyRuntimeError::new_err("ProjectContext was already materialized"))?;
+        let outputs =
+            slf.borrow(py).outputs.borrow_mut().take().ok_or_else(|| {
+                PyRuntimeError::new_err("ProjectContext was already materialized")
+            })?;
         Ok(NativeGraph {
             nodes: outputs.builder.nodes,
             edges: outputs.builder.edges,
@@ -549,7 +505,6 @@ impl ProjectContext {
         let idx = outputs.builder.intern_node(
             py,
             NativeNode {
-                idx: 0,
                 fqname,
                 kind,
                 path,
@@ -565,12 +520,20 @@ impl ProjectContext {
     }
 
     /// Add an edge between two nodes returned by `add_node` or a query.
+    ///
+    /// Identity is content-based: each side is looked up in the
+    /// builder's intern table via its `(fqname, kind, path, position)`
+    /// key, so two `NativeNode` Python references that wrap the same
+    /// logical node resolve to the same edge endpoint. Passing a node
+    /// that was never interned raises `ValueError`.
     fn add_edge(&self, src: &NativeNode, dst: &NativeNode) -> PyResult<()> {
         let mut outputs = self.outputs.borrow_mut();
         let outputs = outputs
             .as_mut()
             .ok_or_else(|| not_materialized("add_edge"))?;
-        outputs.builder.add_edge(src.idx, dst.idx, 0);
+        let src_idx = lookup_idx(&outputs.builder, src, "src")?;
+        let dst_idx = lookup_idx(&outputs.builder, dst, "dst")?;
+        outputs.builder.add_edge(src_idx, dst_idx, 0);
         Ok(())
     }
 
@@ -669,7 +632,7 @@ impl ProjectContext {
         // its inferred Type via the StmtClassDef at that range.
         let Some((seed_file, seed_range)) = locate_class_def(
             &self.db,
-            &outputs.project_files,
+            &outputs.path_to_file,
             &class_node.path,
             class_node,
         ) else {
@@ -696,9 +659,9 @@ impl ProjectContext {
             if !seen.insert(file_key) {
                 continue;
             }
-            // Map THC back to a node idx — selection_range matches our
-            // class-node target_range exactly.
-            if let Some(idx) = class_idx_by_selection(outputs, thc.file, thc.selection_range) {
+            // `selection_range` is the class name range — same key the
+            // class-node was interned under.
+            if let Some(&idx) = outputs.class_by_selection.get(&file_key) {
                 out_idx.push(idx);
             }
             // Recurse: ask ty for the next layer.
@@ -741,10 +704,8 @@ impl ProjectContext {
         for &file in &outputs.project_files {
             let parsed = parsed_module(&self.db, file).load(&self.db);
             let source = source_text(&self.db, file);
-            // Build a per-file sorted list of (target_range_start, idx)
-            // so we can find the next decl after a comment via binary
-            // search.
-            let file_decls = file_decl_sites(&self.db, file, &outputs.global_index, &parsed);
+            // Lazy — files with no matching comments skip the decl scan.
+            let mut file_decls: Option<Vec<(u32, usize)>> = None;
             for token in parsed.tokens() {
                 if token.kind() != TokenKind::Comment {
                     continue;
@@ -754,10 +715,11 @@ impl ProjectContext {
                 if !regex.is_match(text) {
                     continue;
                 }
+                let decls =
+                    file_decls.get_or_insert_with(|| file_decl_sites(file, &outputs.global_index));
                 let comment_end = range.end().to_u32();
-                let Some(&(_, decl_idx)) =
-                    file_decls.iter().find(|(start, _)| *start >= comment_end)
-                else {
+                let i = decls.partition_point(|(start, _)| *start < comment_end);
+                let Some(&(_, decl_idx)) = decls.get(i) else {
                     continue;
                 };
                 out.push((
@@ -841,10 +803,39 @@ fn not_materialized(op: &str) -> PyErr {
     ))
 }
 
+/// Project a `NativeNode` onto the `NodeKey` used for intern-table
+/// identity. Clones the two `String` fields (`fqname`, `path`); the
+/// rest are `Copy`.
+fn node_key_of(node: &NativeNode) -> NodeKey {
+    NodeKey {
+        fqname: node.fqname.clone(),
+        kind: node.kind,
+        path: node.path.clone(),
+        start_line: node.start_line,
+        start_column: node.start_column,
+        end_line: node.end_line,
+        end_column: node.end_column,
+    }
+}
+
+/// Resolve a `NativeNode` reference to its builder-side index for an
+/// edge endpoint. Surfaces a precise `ValueError` (with `side`) when
+/// the node was never interned in this context.
+fn lookup_idx(builder: &GraphBuilder, node: &NativeNode, side: &str) -> PyResult<usize> {
+    builder
+        .node_index
+        .get(&node_key_of(node))
+        .copied()
+        .ok_or_else(|| {
+            PyValueError::new_err(format!(
+                "add_edge: {side} node {:?} is not interned in this ProjectContext",
+                node.fqname
+            ))
+        })
+}
+
 /// Map a plugin-supplied `kind` string to one of the stable `&'static
-/// str` kinds NativeNode carries. Plugins typically use "synthetic" but
-/// "import"/"function"/"class"/"variable"/"module" are accepted too so
-/// the protocol round-trips with query results.
+/// str` kinds NativeNode carries.
 fn static_kind_str(kind: &str) -> PyResult<&'static str> {
     Ok(match kind {
         "synthetic" => "synthetic",
@@ -875,35 +866,34 @@ fn class_body_defines_method(class_def: &StmtClassDef, method_name: &str) -> boo
     })
 }
 
+fn iter_top_level_classes(parsed: &ParsedModuleRef) -> impl Iterator<Item = &StmtClassDef> {
+    parsed.syntax().body.iter().filter_map(|stmt| match stmt {
+        Stmt::ClassDef(cls) => Some(cls),
+        _ => None,
+    })
+}
+
 /// Locate a class's File + name TextRange from its NativeNode positions.
 ///
 /// We don't store ty `Definition<'db>` references across plugin calls
 /// (the `'db` lifetime is tied to the active borrow), so this re-walks
-/// the file's top-level statements to find the class whose name range
+/// the matching file's top-level classes for one whose name range
 /// projects to the same `(start_line, start_column)` as the node.
 fn locate_class_def(
     db: &ProjectDatabase,
-    project_files: &[File],
+    path_to_file: &HashMap<String, File>,
     path: &str,
     class_node: &NativeNode,
 ) -> Option<(File, TextRange)> {
-    let target_start_line = class_node.start_line;
-    let target_start_col = class_node.start_column;
-    for &file in project_files {
-        if file_path_string(db, file) != path {
-            continue;
-        }
-        let parsed = parsed_module(db, file).load(db);
-        let source = source_text(db, file);
-        let line_index = line_index(db, file);
-        for stmt in &parsed.syntax().body {
-            if let Stmt::ClassDef(cls) = stmt {
-                let name_range = cls.name.range();
-                let (sl, sc, _, _) = position(&line_index, &source, name_range);
-                if sl == target_start_line && sc == target_start_col {
-                    return Some((file, name_range));
-                }
-            }
+    let &file = path_to_file.get(path)?;
+    let parsed = parsed_module(db, file).load(db);
+    let source = source_text(db, file);
+    let line_index = line_index(db, file);
+    for cls in iter_top_level_classes(&parsed) {
+        let name_range = cls.name.range();
+        let (sl, sc, _, _) = position(&line_index, &source, name_range);
+        if sl == class_node.start_line && sc == class_node.start_column {
+            return Some((file, name_range));
         }
     }
     None
@@ -911,65 +901,22 @@ fn locate_class_def(
 
 /// Find a top-level `StmtClassDef` whose name range equals `selection_range`.
 fn class_def_at(parsed: &ParsedModuleRef, selection_range: TextRange) -> Option<&StmtClassDef> {
-    for stmt in &parsed.syntax().body {
-        if let Stmt::ClassDef(cls) = stmt {
-            if cls.name.range() == selection_range {
-                return Some(cls);
-            }
-        }
-    }
-    None
-}
-
-/// Map ty's `TypeHierarchyClass.selection_range` (the class name range)
-/// back to a node idx in our graph. We don't have a pre-built index
-/// because every other path uses `(file, place_id, range_key)` — but
-/// for class nodes the `place_id` is always the class's own symbol
-/// place, so a linear scan over `global_index` entries with the
-/// matching `(file, range_key)` suffices for the prototype.
-fn class_idx_by_selection(
-    outputs: &BuildOutputs,
-    file: File,
-    selection_range: TextRange,
-) -> Option<usize> {
-    let needle = range_key(selection_range);
-    for ((entry_file, _place_id, range), idx) in &outputs.global_index {
-        if *entry_file == file && *range == needle {
-            return Some(*idx);
-        }
-    }
-    None
+    iter_top_level_classes(parsed).find(|cls| cls.name.range() == selection_range)
 }
 
 /// Per-file sorted list of `(target_start_offset, node_idx)` for the
-/// file's top-level decls. Sorted ascending so callers can find the
-/// next decl after a comment via linear scan (small files) or binary
-/// search.
-fn file_decl_sites(
-    db: &ProjectDatabase,
-    file: File,
-    global_index: &DeclIndex,
-    _parsed: &ParsedModuleRef,
-) -> Vec<(u32, usize)> {
-    let mut out: Vec<(u32, usize)> = Vec::new();
-    let index = semantic_index(db, file);
-    let global = FileScopeId::global();
-    let use_def_map = index.use_def_map(global);
-    let parsed = parsed_module(db, file).load(db);
-    for (_def_id, state, _used) in use_def_map.all_definitions_with_usage() {
-        let DefinitionState::Defined(def) = state else {
-            continue;
-        };
-        if def.file(db) != file || def.file_scope(db) != global {
-            continue;
-        }
-        let kind = def.kind(db);
-        let target_range = kind.target_range(&parsed);
-        let key = (file, def.place(db), range_key(target_range));
-        if let Some(&idx) = global_index.get(&key) {
-            out.push((target_range.start().to_u32(), idx));
-        }
-    }
+/// file's top-level decls. Sorted ascending so callers can binary-search
+/// for the next decl after a comment.
+///
+/// Reads straight from `global_index` — every key in there already
+/// carries the decl's `(start, end)` range tuple, and `ingest_decls`
+/// populated it from the same `all_definitions_with_usage()` walk.
+fn file_decl_sites(file: File, global_index: &DeclIndex) -> Vec<(u32, usize)> {
+    let mut out: Vec<(u32, usize)> = global_index
+        .iter()
+        .filter(|((f, _, _), _)| *f == file)
+        .map(|((_, _, (start, _)), idx)| (*start, *idx))
+        .collect();
     out.sort_by_key(|(start, _)| *start);
     out
 }
@@ -988,6 +935,7 @@ fn ingest_decls(
     module_nodes: &mut HashMap<File, usize>,
     alias_imports: &mut HashMap<usize, ImportSpec>,
     live_decls: &mut LiveDeclIndex,
+    class_by_selection: &mut HashMap<(File, (u32, u32)), usize>,
 ) -> PyResult<()> {
     let parsed = parsed_module(db, file).load(db);
     let source = source_text(db, file);
@@ -999,7 +947,6 @@ fn ingest_decls(
     let module_idx = builder.intern_node(
         py,
         NativeNode {
-            idx: 0,
             fqname: module_fqname.clone(),
             kind: "module",
             path: path_str.clone(),
@@ -1065,7 +1012,6 @@ fn ingest_decls(
         let node_idx = builder.intern_node(
             py,
             NativeNode {
-                idx: 0,
                 fqname: format!("{module_fqname}.{local_name}"),
                 kind: node_kind,
                 path: path_str.clone(),
@@ -1079,6 +1025,9 @@ fn ingest_decls(
         )?;
         builder.add_edge(node_idx, module_idx, 0);
         global_index.insert((file, place_id, range_key(target_range)), node_idx);
+        if node_kind == "class" {
+            class_by_selection.insert((file, range_key(target_range)), node_idx);
+        }
 
         if let Some(spec) = import_spec {
             alias_imports.insert(node_idx, spec);
@@ -1454,7 +1403,6 @@ fn mint_module_node(
     let idx = builder.intern_node(
         py,
         NativeNode {
-            idx: 0,
             fqname,
             kind: "module",
             path: path_str,

--- a/dead_cst/plugins/init_subclass.py
+++ b/dead_cst/plugins/init_subclass.py
@@ -190,22 +190,6 @@ class InitSubclassPlugin:
                     yield AddEdge(marker, sub)
 
     def run(self, ctx: native.ProjectContext) -> None:
-        """Rust-backend entry point: one query for parents, one per parent
-        for the transitive subclass closure.
-
-        Replaces the two-phase libcst flow (per-file ``observe`` collecting
-        bases + ``finalize`` BFS) with two ty queries:
-        ``find_classes_defining_method("__init_subclass__")`` locates each
-        parent, and ``find_subclasses_of`` returns the transitive closure
-        straight out of ty's ``type_hierarchy_subtypes``.
-
-        The marker keying matches ``observe`` / ``finalize``
-        (``<__init_subclass__>:<parent.fqname>``) so external tooling
-        keying on the prefix sees the same shape regardless of backend.
-        The ``<subclass-of>:`` intermediate buckets the libcst path
-        emits are not needed here -- ty answers the transitive question
-        in one call, so the marker edges directly to each subclass.
-        """
         for parent in ctx.find_classes_defining_method(_INIT_SUBCLASS):
             marker = ctx.add_node(
                 fqname=f"{INIT_SUBCLASS_PREFIX}{parent.fqname}",

--- a/dead_cst/plugins/init_subclass.py
+++ b/dead_cst/plugins/init_subclass.py
@@ -54,6 +54,8 @@ from ._core import (
 )
 
 if TYPE_CHECKING:
+    import dead_cst_ty_native as native
+
     from ..graph import VisitorPayload
 
 _INIT_SUBCLASS = "__init_subclass__"
@@ -186,6 +188,32 @@ class InitSubclassPlugin:
                     if sub in existing_targets[marker]:
                         continue
                     yield AddEdge(marker, sub)
+
+    def run(self, ctx: native.ProjectContext) -> None:
+        """Rust-backend entry point: one query for parents, one per parent
+        for the transitive subclass closure.
+
+        Replaces the two-phase libcst flow (per-file ``observe`` collecting
+        bases + ``finalize`` BFS) with two ty queries:
+        ``find_classes_defining_method("__init_subclass__")`` locates each
+        parent, and ``find_subclasses_of`` returns the transitive closure
+        straight out of ty's ``type_hierarchy_subtypes``.
+
+        The marker keying matches ``observe`` / ``finalize``
+        (``<__init_subclass__>:<parent.fqname>``) so external tooling
+        keying on the prefix sees the same shape regardless of backend.
+        The ``<subclass-of>:`` intermediate buckets the libcst path
+        emits are not needed here -- ty answers the transitive question
+        in one call, so the marker edges directly to each subclass.
+        """
+        for parent in ctx.find_classes_defining_method(_INIT_SUBCLASS):
+            marker = ctx.add_node(
+                fqname=f"{INIT_SUBCLASS_PREFIX}{parent.fqname}",
+                path=parent.path,
+            )
+            ctx.add_edge(parent, marker)
+            for sub in ctx.find_subclasses_of(parent):
+                ctx.add_edge(marker, sub)
 
 
 def _has_init_subclass(class_def: cst.ClassDef) -> bool:

--- a/dead_cst/plugins/module_dunders.py
+++ b/dead_cst/plugins/module_dunders.py
@@ -17,6 +17,8 @@ from ._core import (
 )
 
 if TYPE_CHECKING:
+    import dead_cst_ty_native as native
+
     from ..graph import VisitorPayload
 
 DUNDER_PREFIX = "<dunder>:"
@@ -61,6 +63,23 @@ class ModuleDundersPlugin:
 
     def finalize(self, ctx: PluginContext) -> Iterable[GraphOp]:
         return ()
+
+    def run(self, ctx: native.ProjectContext) -> None:
+        """Rust-backend entry point: same intent, one query call.
+
+        ``__future__`` imports are not surfaced here yet -- the rust
+        crate currently has no `find_future_imports` query, and a
+        single ``find_module_dunders`` covers the more common
+        ``__all__`` / ``__version__`` case. Follow-up: a
+        ``find_imports_of`` query would close the gap.
+        """
+        for dunder in ctx.find_module_dunders():
+            marker = ctx.add_node(
+                fqname=f"{DUNDER_PREFIX}{dunder.fqname}",
+                path=dunder.path,
+                flags=int(NodeFlags.ENTRYPOINT),
+            )
+            ctx.add_edge(marker, dunder)
 
 
 def _is_kept_alive(node: SymbolNode) -> bool:

--- a/dead_cst/plugins/module_dunders.py
+++ b/dead_cst/plugins/module_dunders.py
@@ -65,14 +65,8 @@ class ModuleDundersPlugin:
         return ()
 
     def run(self, ctx: native.ProjectContext) -> None:
-        """Rust-backend entry point: same intent, one query call.
-
-        ``__future__`` imports are not surfaced here yet -- the rust
-        crate currently has no `find_future_imports` query, and a
-        single ``find_module_dunders`` covers the more common
-        ``__all__`` / ``__version__`` case. Follow-up: a
-        ``find_imports_of`` query would close the gap.
-        """
+        # ``__future__`` imports are not surfaced here yet; the rust
+        # crate has no ``find_future_imports`` query today.
         for dunder in ctx.find_module_dunders():
             marker = ctx.add_node(
                 fqname=f"{DUNDER_PREFIX}{dunder.fqname}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,3 +123,10 @@ known-first-party = ["dead_cst"]
 # unresolved-import case the analyzer is meant to detect, so they aren't
 # meaningful targets for ty.
 include = ["dead_cst"]
+
+[tool.ty.environment]
+# The rust extension `dead_cst_ty_native` ships its type stubs from
+# `crates/dead-cst-ty-native/python/`. Point ty at the source layout
+# directly so CI (which never builds the maturin wheel) can still
+# resolve `native.ProjectContext` in plugin annotations.
+extra-paths = ["crates/dead-cst-ty-native/python"]

--- a/tests/prototype/plugin_protocol.py
+++ b/tests/prototype/plugin_protocol.py
@@ -35,6 +35,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterable, Protocol, runtime_checkable
 
+from dead_cst.graph import NodeFlags
+
 if TYPE_CHECKING:
     import dead_cst_ty_native as native
 
@@ -99,6 +101,6 @@ class KeepAliveCommentPlugin:
             marker = ctx.add_node(
                 fqname=f"<keep>:{decl.fqname}",
                 path=decl.path,
-                flags=2,  # NodeFlags.ENTRYPOINT
+                flags=int(NodeFlags.ENTRYPOINT),
             )
             ctx.add_edge(marker, decl)

--- a/tests/prototype/plugin_protocol.py
+++ b/tests/prototype/plugin_protocol.py
@@ -75,51 +75,13 @@ def run_plugins(
 
 
 # ---------------------------------------------------------------------------
-# Example plugins — same intent as the libcst-side builtins, ported to
-# the new shape so the size delta is visible.
+# Example plugin — demonstrates a query (``find_comment_patterns``) with
+# no libcst-side equivalent. The built-in plugins
+# (:class:`dead_cst.plugins.ModuleDundersPlugin`,
+# :class:`dead_cst.plugins.InitSubclassPlugin`, ...) implement ``run``
+# directly so they satisfy this protocol alongside the libcst-side
+# ``observe`` / ``finalize`` contract.
 # ---------------------------------------------------------------------------
-
-
-class ModuleDundersPlugin:
-    """Keep module-level dunder variables alive.
-
-    Same intent as :class:`dead_cst.plugins.ModuleDundersPlugin` but
-    the per-file CST inspection is gone: ``ctx.find_module_dunders``
-    already returns the matching variable nodes from the rust side.
-    """
-
-    name = "module_dunders"
-
-    def run(self, ctx: "native.ProjectContext") -> None:
-        for dunder in ctx.find_module_dunders():
-            marker = ctx.add_node(
-                fqname=f"<dunder>:{dunder.fqname}",
-                path=dunder.path,
-                flags=2,  # NodeFlags.ENTRYPOINT
-            )
-            ctx.add_edge(marker, dunder)
-
-
-class InitSubclassPlugin:
-    """Keep transitive subclasses of ``__init_subclass__``-defining classes alive.
-
-    Replaces the two-phase libcst plugin (observe + finalize) with one
-    query each: ``find_classes_defining_method("__init_subclass__")``
-    locates the parents, then ``find_subclasses_of`` returns the
-    transitive closure straight from ty's `type_hierarchy_subtypes`.
-    """
-
-    name = "init_subclass"
-
-    def run(self, ctx: "native.ProjectContext") -> None:
-        for parent in ctx.find_classes_defining_method("__init_subclass__"):
-            marker = ctx.add_node(
-                fqname=f"<__init_subclass__>:{parent.fqname}",
-                path=parent.path,
-            )
-            ctx.add_edge(parent, marker)
-            for sub in ctx.find_subclasses_of(parent):
-                ctx.add_edge(marker, sub)
 
 
 class KeepAliveCommentPlugin:

--- a/tests/prototype/plugin_protocol.py
+++ b/tests/prototype/plugin_protocol.py
@@ -1,0 +1,142 @@
+"""Prototype plugin protocol for the rust backend.
+
+Demonstrates a new plugin shape distinct from the libcst-side
+:class:`dead_cst.plugins.EdgePlugin`:
+
+* **Once per project**, not per file or per package. The rust crate
+  builds the project-wide graph (`ingest_decls` → `emit_*` phases),
+  then invokes each plugin's :meth:`ProjectPlugin.run` exactly once,
+  passing a `ProjectContext` whose mutation + query methods are
+  implemented in rust against ty's `SemanticIndex` / `parsed_module`.
+
+* The **context is the rust pyclass** (`dead_cst_ty_native.ProjectContext`).
+  Plugins call its methods to mint nodes (`add_node`), wire edges
+  (`add_edge`), and ask structured questions
+  (`find_module_dunders`, `find_classes_defining_method`,
+  `find_subclasses_of`, `find_comment_patterns`). Queries return
+  `NativeNode` Python objects whose `idx` carries the graph identity
+  edges need.
+
+* Configuration mirrors the existing `Project` constructor today
+  (root + optional `src_roots` / `python_env` / `python_version` /
+  `typeshed` / `extra_paths`); the formal multi-package descriptor
+  surface is a follow-up — for the prototype the consumer hands the
+  ctx whatever the resolver produced as keyword args.
+
+Typical flow::
+
+    ctx = ProjectContext(project_root, src_roots=["src"], ...)
+    ctx.add_plugin(ModuleDundersPlugin())
+    ctx.add_plugin(InitSubclassPlugin())
+    graph = ctx.materialize()  # builds, runs plugins, snapshots
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    import dead_cst_ty_native as native
+
+
+@runtime_checkable
+class ProjectPlugin(Protocol):
+    """One project-scoped pass over the rust-built graph.
+
+    Implementations call ``ctx.add_node`` / ``ctx.add_edge`` to extend
+    the graph and ``ctx.find_*`` to query it. Both groups round-trip
+    through rust — queries execute against ty's semantic index;
+    mutations land in the same builder the snapshot reads at the end.
+
+    A plugin's :attr:`name` is informational (used in error messages
+    and for ordering / dedup at the call site). Plugins don't carry a
+    ``version`` because the rust backend has no per-file payload cache
+    to invalidate — ty's Salsa db is the cache.
+    """
+
+    name: str
+
+    def run(self, ctx: "native.ProjectContext") -> None: ...
+
+
+def run_plugins(
+    ctx: "native.ProjectContext", plugins: Iterable[ProjectPlugin]
+) -> "native.NativeGraph":
+    """Register ``plugins`` on ``ctx`` and materialize the final graph.
+
+    Thin convenience over :meth:`ProjectContext.add_plugin` +
+    :meth:`ProjectContext.materialize` — useful when plugins are
+    assembled by the caller (e.g. resolved from entry points) rather
+    than appended one at a time.
+    """
+    for plugin in plugins:
+        ctx.add_plugin(plugin)
+    return ctx.materialize()
+
+
+# ---------------------------------------------------------------------------
+# Example plugins — same intent as the libcst-side builtins, ported to
+# the new shape so the size delta is visible.
+# ---------------------------------------------------------------------------
+
+
+class ModuleDundersPlugin:
+    """Keep module-level dunder variables alive.
+
+    Same intent as :class:`dead_cst.plugins.ModuleDundersPlugin` but
+    the per-file CST inspection is gone: ``ctx.find_module_dunders``
+    already returns the matching variable nodes from the rust side.
+    """
+
+    name = "module_dunders"
+
+    def run(self, ctx: "native.ProjectContext") -> None:
+        for dunder in ctx.find_module_dunders():
+            marker = ctx.add_node(
+                fqname=f"<dunder>:{dunder.fqname}",
+                path=dunder.path,
+                flags=2,  # NodeFlags.ENTRYPOINT
+            )
+            ctx.add_edge(marker, dunder)
+
+
+class InitSubclassPlugin:
+    """Keep transitive subclasses of ``__init_subclass__``-defining classes alive.
+
+    Replaces the two-phase libcst plugin (observe + finalize) with one
+    query each: ``find_classes_defining_method("__init_subclass__")``
+    locates the parents, then ``find_subclasses_of`` returns the
+    transitive closure straight from ty's `type_hierarchy_subtypes`.
+    """
+
+    name = "init_subclass"
+
+    def run(self, ctx: "native.ProjectContext") -> None:
+        for parent in ctx.find_classes_defining_method("__init_subclass__"):
+            marker = ctx.add_node(
+                fqname=f"<__init_subclass__>:{parent.fqname}",
+                path=parent.path,
+            )
+            ctx.add_edge(parent, marker)
+            for sub in ctx.find_subclasses_of(parent):
+                ctx.add_edge(marker, sub)
+
+
+class KeepAliveCommentPlugin:
+    """Keep any decl preceded by ``# dead-cst: keep`` alive.
+
+    Demonstrates the comment-pattern query. ``find_comment_patterns``
+    returns ``(decl_node, comment_text)`` pairs where ``decl_node`` is
+    the next declaration following each matching comment.
+    """
+
+    name = "keep_alive_comment"
+
+    def run(self, ctx: "native.ProjectContext") -> None:
+        for decl, _comment in ctx.find_comment_patterns(r"#\s*dead-cst:\s*keep\b"):
+            marker = ctx.add_node(
+                fqname=f"<keep>:{decl.fqname}",
+                path=decl.path,
+                flags=2,  # NodeFlags.ENTRYPOINT
+            )
+            ctx.add_edge(marker, decl)

--- a/tests/prototype/test_plugin_protocol.py
+++ b/tests/prototype/test_plugin_protocol.py
@@ -208,9 +208,8 @@ def test_find_comment_patterns_skips_unmatched_comments(make_ctx):
 # ---------------------------------------------------------------------------
 
 
-def test_add_node_returns_node_with_idx(make_ctx):
-    """Nodes minted by `add_node` carry a stable idx that `add_edge` consumes."""
-    captured: dict[str, object] = {}
+def test_add_node_and_add_edge_round_trip(make_ctx):
+    """`add_edge` resolves node identity by content (no idx field needed)."""
 
     class MintAndCheck:
         name = "mint_and_check"
@@ -220,10 +219,7 @@ def test_add_node_returns_node_with_idx(make_ctx):
             assert len(decls) == 1
             decl = decls[0]
             synth = ctx.add_node(fqname="<seed>", path=decl.path)
-            assert synth.idx != decl.idx
             ctx.add_edge(synth, decl)
-            captured["synth_idx"] = synth.idx
-            captured["decl_idx"] = decl.idx
 
     ctx = make_ctx({"mod.py": "def f(): pass\n"})
     ctx.add_plugin(MintAndCheck())
@@ -233,6 +229,34 @@ def test_add_node_returns_node_with_idx(make_ctx):
     synth_idx = fqnames.index("<seed>")
     decl_idx = fqnames.index("mod.f")
     assert (synth_idx, decl_idx, 0) in graph.edges
+
+
+def test_add_edge_dedups_by_content(make_ctx):
+    """Two NativeNode refs to the same logical node resolve to one edge."""
+
+    class MintTwice:
+        name = "mint_twice"
+
+        def run(self, ctx: native.ProjectContext) -> None:
+            decl = next(n for n in ctx.nodes() if n.fqname == "mod.f")
+            # Two `add_node` calls with the same key return refs that
+            # alias the same interned node; `add_edge` from either one
+            # produces the same single edge.
+            synth1 = ctx.add_node(fqname="<seed>", path=decl.path)
+            synth2 = ctx.add_node(fqname="<seed>", path=decl.path)
+            ctx.add_edge(synth1, decl)
+            ctx.add_edge(synth2, decl)
+
+    ctx = make_ctx({"mod.py": "def f(): pass\n"})
+    ctx.add_plugin(MintTwice())
+    graph = ctx.materialize()
+    fqnames = [n.fqname for n in graph.nodes]
+    # The synthetic was interned exactly once.
+    assert fqnames.count("<seed>") == 1
+    synth_idx = fqnames.index("<seed>")
+    decl_idx = fqnames.index("mod.f")
+    seed_to_f = [(s, d, f) for (s, d, f) in graph.edges if s == synth_idx and d == decl_idx]
+    assert len(seed_to_f) == 1
 
 
 def test_query_outside_materialize_raises(make_ctx):

--- a/tests/prototype/test_plugin_protocol.py
+++ b/tests/prototype/test_plugin_protocol.py
@@ -1,0 +1,265 @@
+"""Smoke tests for the prototype plugin protocol.
+
+Each test materializes a small project through `ProjectContext`, runs
+one or two plugins, and asserts on the post-plugin edge set. The
+plugin runs entirely through the rust-side context — these tests are
+exercising the four ty-backed queries (`find_module_dunders`,
+`find_classes_defining_method`, `find_subclasses_of`,
+`find_comment_patterns`) plus the `add_node` / `add_edge` mutation
+path and the rust → Python → rust re-entry through `materialize`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+native = pytest.importorskip("dead_cst_ty_native")
+
+from .plugin_protocol import (  # noqa: E402
+    InitSubclassPlugin,
+    KeepAliveCommentPlugin,
+    ModuleDundersPlugin,
+    run_plugins,
+)
+
+
+@pytest.fixture
+def make_ctx(tmp_path: Path):
+    """Write `{relpath: source}` files and return a fresh ProjectContext."""
+
+    def make(files: dict[str, str], **kwargs) -> native.ProjectContext:
+        for relpath, source in files.items():
+            target = tmp_path / relpath
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(source, encoding="utf-8")
+        return native.ProjectContext(str(tmp_path), **kwargs)
+
+    return make
+
+
+def _edges(graph: native.NativeGraph) -> set[str]:
+    return {f"{graph.nodes[s].fqname} -> {graph.nodes[d].fqname}" for s, d, _ in graph.edges}
+
+
+def _fqnames(graph: native.NativeGraph) -> set[str]:
+    return {n.fqname for n in graph.nodes}
+
+
+# ---------------------------------------------------------------------------
+# Materialize round-trips back to Python and re-enters rust
+# ---------------------------------------------------------------------------
+
+
+def test_materialize_with_no_plugins_matches_project_build(make_ctx, tmp_path):
+    """Empty plugin list should produce the same graph as `Project.build`."""
+    files = {"mod.py": "def f(): pass\nclass C: pass\n"}
+    ctx = make_ctx(files)
+    via_ctx = ctx.materialize()
+
+    project = native.Project(str(tmp_path))
+    via_project = project.build()
+
+    assert _fqnames(via_ctx) == _fqnames(via_project)
+    assert _edges(via_ctx) == _edges(via_project)
+
+
+def test_plugin_runs_once_per_project(make_ctx):
+    """A plugin sees a single ctx; counts add up across files."""
+    calls: list[int] = []
+
+    class Counter:
+        name = "counter"
+
+        def run(self, ctx: native.ProjectContext) -> None:
+            calls.append(len(ctx.find_module_dunders()))
+
+    ctx = make_ctx(
+        {
+            "a.py": "__version__ = '1'\n__all__ = ['x']\nx = 1\n",
+            "b.py": "__author__ = 'me'\ny = 2\n",
+        }
+    )
+    ctx.add_plugin(Counter())
+    ctx.materialize()
+    assert calls == [3]
+
+
+# ---------------------------------------------------------------------------
+# find_module_dunders + ModuleDundersPlugin
+# ---------------------------------------------------------------------------
+
+
+def test_module_dunders_plugin_marks_each_dunder(make_ctx):
+    ctx = make_ctx(
+        {
+            "pkg/__init__.py": "",
+            "pkg/mod.py": "__version__ = '1'\n__all__ = ['public']\npublic = 1\n_private = 2\n",
+        }
+    )
+    graph = run_plugins(ctx, [ModuleDundersPlugin()])
+
+    edges = _edges(graph)
+    assert "<dunder>:pkg.mod.__version__ -> pkg.mod.__version__" in edges
+    assert "<dunder>:pkg.mod.__all__ -> pkg.mod.__all__" in edges
+    # The non-dunder name must NOT have been marked.
+    assert "<dunder>:pkg.mod.public -> pkg.mod.public" not in edges
+    assert "<dunder>:pkg.mod._private -> pkg.mod._private" not in edges
+
+
+def test_module_dunders_skips_function_with_dunder_name(make_ctx):
+    """`def __init_subclass__` at module scope is not a variable dunder."""
+    ctx = make_ctx({"mod.py": "def __init__(): pass\n__version__ = '1'\n"})
+    graph = run_plugins(ctx, [ModuleDundersPlugin()])
+    assert "<dunder>:mod.__version__ -> mod.__version__" in _edges(graph)
+    assert "<dunder>:mod.__init__ -> mod.__init__" not in _edges(graph)
+
+
+# ---------------------------------------------------------------------------
+# find_classes_defining_method + find_subclasses_of
+# ---------------------------------------------------------------------------
+
+
+def test_init_subclass_plugin_wires_transitive_subclasses(make_ctx):
+    ctx = make_ctx(
+        {
+            "registry.py": (
+                "class Base:\n"
+                "    def __init_subclass__(cls): pass\n"
+                "class Mid(Base): pass\n"
+                "class Leaf(Mid): pass\n"
+            ),
+        }
+    )
+    graph = run_plugins(ctx, [InitSubclassPlugin()])
+    edges = _edges(graph)
+
+    # Marker is wired to the parent, then to each transitive subclass.
+    assert "registry.Base -> <__init_subclass__>:registry.Base" in edges
+    assert "<__init_subclass__>:registry.Base -> registry.Mid" in edges
+    assert "<__init_subclass__>:registry.Base -> registry.Leaf" in edges
+
+
+def test_init_subclass_plugin_no_marker_when_no_dunder(make_ctx):
+    ctx = make_ctx({"mod.py": "class Base: pass\nclass Sub(Base): pass\n"})
+    graph = run_plugins(ctx, [InitSubclassPlugin()])
+    assert not any(n.fqname.startswith("<__init_subclass__>:") for n in graph.nodes)
+
+
+def test_find_subclasses_of_returns_empty_for_non_class(make_ctx):
+    """Asking for subclasses of a function-kind node yields []."""
+    ctx = make_ctx({"mod.py": "def f(): pass\n"})
+
+    captured: list[list] = []
+
+    class Inspect:
+        name = "inspect"
+
+        def run(self, ctx: native.ProjectContext) -> None:
+            for node in ctx.nodes():
+                if node.fqname == "mod.f":
+                    captured.append(ctx.find_subclasses_of(node))
+
+    ctx.add_plugin(Inspect())
+    ctx.materialize()
+    assert captured == [[]]
+
+
+# ---------------------------------------------------------------------------
+# find_comment_patterns + KeepAliveCommentPlugin
+# ---------------------------------------------------------------------------
+
+
+def test_keep_alive_comment_plugin_attaches_to_following_decl(make_ctx):
+    ctx = make_ctx(
+        {
+            "mod.py": (
+                "# dead-cst: keep\n"
+                "def kept(): pass\n"
+                "\n"
+                "def normal(): pass\n"
+                "\n"
+                "# dead-cst: keep\n"
+                "class AlsoKept: pass\n"
+            ),
+        }
+    )
+    graph = run_plugins(ctx, [KeepAliveCommentPlugin()])
+    edges = _edges(graph)
+    assert "<keep>:mod.kept -> mod.kept" in edges
+    assert "<keep>:mod.AlsoKept -> mod.AlsoKept" in edges
+    # `normal` has no preceding directive.
+    assert "<keep>:mod.normal -> mod.normal" not in edges
+
+
+def test_find_comment_patterns_skips_unmatched_comments(make_ctx):
+    """A regex miss must yield no edges."""
+    ctx = make_ctx(
+        {
+            "mod.py": "# regular comment\ndef f(): pass\n# dead-cst: keep\ndef g(): pass\n",
+        }
+    )
+    graph = run_plugins(ctx, [KeepAliveCommentPlugin()])
+    edges = _edges(graph)
+    assert "<keep>:mod.g -> mod.g" in edges
+    assert "<keep>:mod.f -> mod.f" not in edges
+
+
+# ---------------------------------------------------------------------------
+# add_node / add_edge / re-entry mechanics
+# ---------------------------------------------------------------------------
+
+
+def test_add_node_returns_node_with_idx(make_ctx):
+    """Nodes minted by `add_node` carry a stable idx that `add_edge` consumes."""
+    captured: dict[str, object] = {}
+
+    class MintAndCheck:
+        name = "mint_and_check"
+
+        def run(self, ctx: native.ProjectContext) -> None:
+            decls = [n for n in ctx.nodes() if n.fqname == "mod.f"]
+            assert len(decls) == 1
+            decl = decls[0]
+            synth = ctx.add_node(fqname="<seed>", path=decl.path)
+            assert synth.idx != decl.idx
+            ctx.add_edge(synth, decl)
+            captured["synth_idx"] = synth.idx
+            captured["decl_idx"] = decl.idx
+
+    ctx = make_ctx({"mod.py": "def f(): pass\n"})
+    ctx.add_plugin(MintAndCheck())
+    graph = ctx.materialize()
+    # The minted edge survived to the snapshot.
+    fqnames = [n.fqname for n in graph.nodes]
+    synth_idx = fqnames.index("<seed>")
+    decl_idx = fqnames.index("mod.f")
+    assert (synth_idx, decl_idx, 0) in graph.edges
+
+
+def test_query_outside_materialize_raises(make_ctx):
+    """Calling a query method on an un-materialized context errors clearly."""
+    ctx = make_ctx({"mod.py": "x = 1\n"})
+    with pytest.raises(RuntimeError, match="ProjectContext.find_module_dunders"):
+        ctx.find_module_dunders()
+
+
+def test_materialize_is_idempotent(make_ctx):
+    """Calling materialize twice rebuilds; the same plugin re-runs once per call."""
+    counts: list[int] = []
+
+    class CountAdded:
+        name = "count"
+
+        def run(self, ctx: native.ProjectContext) -> None:
+            ctx.add_node(fqname="<seed>", path="/")
+            counts.append(sum(1 for n in ctx.nodes() if n.fqname == "<seed>"))
+
+    ctx = make_ctx({"mod.py": "x = 1\n"})
+    ctx.add_plugin(CountAdded())
+    g1 = ctx.materialize()
+    g2 = ctx.materialize()
+    # The second run gets a fresh outputs (not the accumulated state).
+    assert counts == [1, 1]
+    assert {n.fqname for n in g1.nodes} == {n.fqname for n in g2.nodes}

--- a/tests/prototype/test_plugin_protocol.py
+++ b/tests/prototype/test_plugin_protocol.py
@@ -17,12 +17,9 @@ import pytest
 
 native = pytest.importorskip("dead_cst_ty_native")
 
-from .plugin_protocol import (  # noqa: E402
-    InitSubclassPlugin,
-    KeepAliveCommentPlugin,
-    ModuleDundersPlugin,
-    run_plugins,
-)
+from dead_cst.plugins import InitSubclassPlugin, ModuleDundersPlugin  # noqa: E402
+
+from .plugin_protocol import KeepAliveCommentPlugin, run_plugins  # noqa: E402
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Adds a new `ProjectContext` pyclass to the ty-backed native crate that lets Python plugins run **once per project** against the rust-built graph. The context's mutate (`add_node`, `add_edge`) and query (`find_module_dunders`, `find_classes_defining_method`, `find_subclasses_of`, `find_comment_patterns`) methods all execute in rust against ty's semantic index; plugins consume the results in Python.

Flow:

```python
ctx = ProjectContext(project_root, src_roots=["src"], ...)
ctx.add_plugin(ModuleDundersPlugin())
ctx.add_plugin(InitSubclassPlugin())
graph = ctx.materialize()   # builds, runs plugins, snapshots
```

`materialize` runs the existing three build phases (`ingest_decls` → hierarchy+imports → references), then for each registered plugin calls `plugin.run(ctx)` back into Python with `slf` so re-entrant calls land in the same rust methods. Borrows drop between phases so plugins can interleave mutates + queries freely.

## What the queries do

Each one is one method on `ProjectContext`, backed by ty:

* `find_module_dunders()` — variable nodes whose simple name matches `__xxx__`. Pure scan over interned global-scope variables.
* `find_classes_defining_method(name)` — walks each class's `DefinitionKind::Class` body for a `Stmt::FunctionDef` with the given name.
* `find_subclasses_of(class)` — seeds ty's `type_hierarchy_subtypes` from the class's inferred `Type`, BFSes the transitive closure, and maps each `TypeHierarchyClass.selection_range` back to a node idx via a pre-built `class_by_selection` index.
* `find_comment_patterns(pattern)` — regex-matches against the parser's `Tokens` stream filtered to `TokenKind::Comment`, pairing each match with the next declaration in the same file via a per-file `(target_start, idx)` list derived from `global_index` and binary-searched.

Node identity is content-based: `add_edge(src, dst)` looks each side up via its `NodeKey` (`fqname` + `kind` + `path` + position), so two `NativeNode` Python references that wrap the same logical node resolve to the same edge endpoint. No `idx` field is exposed.

## Existing plugins satisfy the new protocol

`dead_cst.plugins.ModuleDundersPlugin` and `dead_cst.plugins.InitSubclassPlugin` gain a `run(ctx)` method alongside their existing `observe` / `finalize` pair — same class, same `<dunder>:` / `<__init_subclass__>:` marker prefixes — so external tooling keying on the prefix sees the same shape regardless of backend. No fork.

`KeepAliveCommentPlugin` stays in `tests/prototype/plugin_protocol.py` as the one example without a libcst-side analog (it exercises `find_comment_patterns`).

## Reuse / efficiency notes

After the `/simplify` pass:

* `BuildOutputs` carries two reverse indices populated during `ingest_decls`: `path_to_file` (O(1) seed-file lookup in `locate_class_def`) and `class_by_selection` (O(1) lookup per BFS hit in `find_subclasses_of`).
* `file_decl_sites` reads straight from `global_index` instead of re-walking `all_definitions_with_usage` per file; the comment-pattern loop builds it lazily and binary-searches via `partition_point`.
* `Project::new` delegates to the new shared `make_db` helper.

## Test plan

- [x] 12 new tests in `tests/prototype/test_plugin_protocol.py` covering each query, the mutation path, the rust→Python→rust re-entry, error cases (`not_materialized`), and parity with `Project.build` for empty plugin lists. The two libcst-side plugins drive them through their new `run(ctx)` method.
- [x] Existing 15 prototype tests (`test_native_graph.py`) still pass — `Project.build` path unchanged.
- [x] Full python suite (989 tests) green — no libcst-pipeline regressions.

Build the native extension with `uv run --with maturin maturin develop --manifest-path crates/dead-cst-ty-native/Cargo.toml` to enable the prototype tests (otherwise they `skip` via `pytest.importorskip`).