### PR TITLE
prototype: walk decl headers and fix scope-shadowing

### DIFF
--- a/crates/dead-cst-ty-native/src/lib.rs
+++ b/crates/dead-cst-ty-native/src/lib.rs
@@ -502,13 +502,16 @@ fn decl_kind_str(kind: &DefinitionKind<'_>) -> Option<&'static str> {
         DefinitionKind::Function(_) => "function",
         DefinitionKind::Class(_) => "class",
         DefinitionKind::TypeAlias(_) => "type_alias",
+        // Walrus's bound name (PEP 572) leaks to the enclosing scope
+        // — at module level that's a top-level decl. The other
+        // binding-statement targets (`for`, `with ... as`, `except as`,
+        // structural-`match` captures) are local loop / context /
+        // pattern bindings that the libcst pipeline does *not* model
+        // as top-level nodes; skip them so we don't mint phantom
+        // module-scope decls.
         DefinitionKind::Assignment(_)
         | DefinitionKind::AnnotatedAssignment(_)
-        | DefinitionKind::NamedExpression(_)
-        | DefinitionKind::For(_)
-        | DefinitionKind::WithItem(_)
-        | DefinitionKind::ExceptHandler(_)
-        | DefinitionKind::MatchPattern(_) => "variable",
+        | DefinitionKind::NamedExpression(_) => "variable",
         _ => return None,
     })
 }
@@ -976,15 +979,42 @@ fn stmt_creates_top_level_definition(stmt: &Stmt) -> bool {
 fn walk_owned(kind: &DefinitionKind<'_>, parsed: &ParsedModuleRef, v: &mut RefCollector<'_, '_>) {
     match kind {
         DefinitionKind::Function(func) => {
+            let node = func.node(parsed);
+            // Header parts evaluate at the *definition* site (module
+            // scope for top-level defs), not inside the body — leave
+            // `nested_context` false so a stray `import X` in a
+            // decorator expression doesn't get re-attributed as a
+            // body-local nested import.
+            walk_decorators(&node.decorator_list, v);
+            if let Some(type_params) = &node.type_params {
+                walk_type_params(type_params, v);
+            }
+            walk_parameters(&node.parameters, v);
+            if let Some(returns) = &node.returns {
+                v.visit_expr(returns);
+            }
             v.nested_context = true;
-            for s in &func.node(parsed).body {
+            for s in &node.body {
                 v.visit_stmt(s);
             }
             v.nested_context = false;
         }
         DefinitionKind::Class(cls) => {
+            let node = cls.node(parsed);
+            walk_decorators(&node.decorator_list, v);
+            if let Some(type_params) = &node.type_params {
+                walk_type_params(type_params, v);
+            }
+            if let Some(args) = &node.arguments {
+                for base in &args.args {
+                    v.visit_expr(base);
+                }
+                for kw in &args.keywords {
+                    v.visit_expr(&kw.value);
+                }
+            }
             v.nested_context = true;
-            for s in &cls.node(parsed).body {
+            for s in &node.body {
                 v.visit_stmt(s);
             }
             v.nested_context = false;
@@ -1007,11 +1037,80 @@ fn walk_owned(kind: &DefinitionKind<'_>, parsed: &ParsedModuleRef, v: &mut RefCo
                 }
             }
         }
-        DefinitionKind::For(for_stmt) => v.visit_expr(for_stmt.iterable(parsed)),
-        DefinitionKind::WithItem(item) => v.visit_expr(item.context_expr(parsed)),
         DefinitionKind::NamedExpression(named) => v.visit_expr(named.node(parsed).value.as_ref()),
-        DefinitionKind::TypeAlias(alias) => v.visit_expr(alias.node(parsed).value.as_ref()),
+        DefinitionKind::TypeAlias(alias) => {
+            let node = alias.node(parsed);
+            if let Some(type_params) = &node.type_params {
+                walk_type_params(type_params, v);
+            }
+            v.visit_expr(node.value.as_ref());
+        }
+        // For / WithItem / ExceptHandler / MatchPattern bindings are
+        // not modeled as top-level decls (see `decl_kind_str`), so
+        // their definitions never appear in `global_index` and
+        // `walk_owned` never runs for them. Their value-bearing
+        // sub-expressions (loop iterables, context managers, etc.)
+        // are walked instead from the module-level non-definition
+        // pass, where `Stmt::For` / `Stmt::With` / `Stmt::Try` get
+        // their normal `walk_stmt` recursion.
         _ => {}
+    }
+}
+
+fn walk_decorators(decorators: &[ruff_python_ast::Decorator], v: &mut RefCollector<'_, '_>) {
+    for d in decorators {
+        v.visit_expr(&d.expression);
+    }
+}
+
+fn walk_parameters(parameters: &ruff_python_ast::Parameters, v: &mut RefCollector<'_, '_>) {
+    for p in parameters
+        .posonlyargs
+        .iter()
+        .chain(&parameters.args)
+        .chain(&parameters.kwonlyargs)
+    {
+        if let Some(annotation) = &p.parameter.annotation {
+            v.visit_expr(annotation);
+        }
+        if let Some(default) = &p.default {
+            v.visit_expr(default);
+        }
+    }
+    if let Some(vararg) = &parameters.vararg {
+        if let Some(annotation) = &vararg.annotation {
+            v.visit_expr(annotation);
+        }
+    }
+    if let Some(kwarg) = &parameters.kwarg {
+        if let Some(annotation) = &kwarg.annotation {
+            v.visit_expr(annotation);
+        }
+    }
+}
+
+fn walk_type_params(type_params: &ruff_python_ast::TypeParams, v: &mut RefCollector<'_, '_>) {
+    for tp in &type_params.type_params {
+        match tp {
+            ruff_python_ast::TypeParam::TypeVar(t) => {
+                if let Some(bound) = &t.bound {
+                    v.visit_expr(bound);
+                }
+                if let Some(default) = &t.default {
+                    v.visit_expr(default);
+                }
+            }
+            ruff_python_ast::TypeParam::TypeVarTuple(t) => {
+                if let Some(default) = &t.default {
+                    v.visit_expr(default);
+                }
+            }
+            ruff_python_ast::TypeParam::ParamSpec(t) => {
+                if let Some(default) = &t.default {
+                    v.visit_expr(default);
+                }
+            }
+        }
     }
 }
 
@@ -1189,11 +1288,25 @@ impl<'a, 'db> RefCollector<'a, 'db> {
                 continue;
             };
             let use_def_map = index.use_def_map(scope_id);
+            // The first scope that *binds* this name wins, even if the
+            // binding has no graph node (function parameter, loop
+            // target, except-as, walrus inside a comprehension, …) —
+            // outer scopes are shadowed by this one. Free-variable
+            // references show up in `place_table` without producing
+            // any bindings, and for those we fall through to outer
+            // scopes (handled by `place_table.symbol_id` returning
+            // `Some` but the bindings iterator yielding nothing).
+            let mut saw_binding = false;
+            let mut result: Option<Resolution> = None;
             for binding in use_def_map.end_of_scope_symbol_bindings(symbol_id) {
                 let Some(def) = binding.binding.definition() else {
                     continue;
                 };
                 if def.file(db) != self.file {
+                    continue;
+                }
+                saw_binding = true;
+                if result.is_some() {
                     continue;
                 }
                 let kind = def.kind(db);
@@ -1204,23 +1317,20 @@ impl<'a, 'db> RefCollector<'a, 'db> {
                     range_key(kind.target_range(self.parsed)),
                 );
                 if let Some(&idx) = self.global_index.get(&key) {
-                    return Some(Resolution::Alias(idx));
+                    result = Some(Resolution::Alias(idx));
+                    continue;
                 }
-                // Not in global_index — the binding lives in a
-                // non-global scope. Imports are the only non-global
-                // bindings we care about (function parameters / local
-                // assigns / comprehension vars have no upstream to
-                // chase). For each nested import, hand back the spec
-                // and the actual bound name so the caller can emit
-                // parallel upstream edges from the enclosing owner.
                 if kind.is_import() {
                     let PlaceExprRef::Symbol(sym) = place_table.place(place_id) else {
                         continue;
                     };
                     let bound_name = sym.name().as_str().to_string();
                     let spec = import_payload_for(kind, db, self.file, self.parsed);
-                    return Some(Resolution::NestedImport { spec, bound_name });
+                    result = Some(Resolution::NestedImport { spec, bound_name });
                 }
+            }
+            if saw_binding {
+                return result;
             }
         }
         None
@@ -1238,6 +1348,15 @@ impl<'a, 'db> RefCollector<'a, 'db> {
     /// imports there's no alias node — go straight to the parallel
     /// edges, using the spec ty handed us.
     fn emit_name_use(&mut self, name: &ExprName, extra_chain: &[&str]) {
+        // `Name`s in non-`Load` context are binding sites, not uses:
+        // the `x` in `for x in data`, `with y as x`, `except E as x`,
+        // and the LHS of `x = ...` / `del x`. Skipping them keeps the
+        // graph free of spurious target → binding-source edges (and
+        // mirrors the libcst pipeline, which only emits edges for
+        // reads).
+        if !matches!(name.ctx, ruff_python_ast::ExprContext::Load) {
+            return;
+        }
         match self.find_local_binding(name) {
             Some(Resolution::Alias(alias_idx)) => {
                 self.emit_edge(alias_idx);


### PR DESCRIPTION
> **Base: `rust_proto`** (not `main`). Diff is the single commit on this branch — `rust_proto` already contains all prior native-crate work (#136 – #144). Compare against `rust_proto` to see just this change.

## Summary

Closes the biggest single chunk of bucket A (missing expression walks in `walk_owned`) plus bucket B (the scope-shadowing bug in `find_local_binding`) from the earlier audit. Three small mechanical fixes that together unlock 27 newly-passing tests.

## Changes

### `walk_owned` visits decl *header* expressions, not just bodies

Each missing piece below was a `visit_expr` call that wasn't being made against an AST sub-tree the libcst pipeline walks:

- **Function**: decorators, type params (PEP 695), parameter annotations + defaults (positional-only, regular, keyword-only, `*args`, `**kwargs`), return annotation, then body.
- **Class**: decorators, type params, bases, keyword arguments (`metaclass=…`), then body.
- **TypeAlias**: type params before the value expression.

Header parts evaluate at the *definition* site (module scope for top-level decls), not inside the body — `nested_context` stays false for the header walks so a stray `import X` in a decorator expression doesn't get re-attributed as a body-local nested import. The flag flips to true only while walking the body.

### `find_local_binding` stops at the first scope that *binds* the name

Function parameters, loop targets, except-as captures, comprehension targets, etc. all shadow outer-scope bindings. Previously the walk fell through to the next outer scope whenever the inner binding wasn't in `global_index`, so `def dec(f): return f` resolved the inner `f` to the module-level `def f` instead of to the parameter. The new discriminator is "did `end_of_scope_symbol_bindings` yield any binding?" — free-variable references show up in `place_table` with no bindings and still fall through correctly.

### `emit_name_use` skips `Name`s in non-`Load` context

The `x` in `for x in data`, `with y as x`, `except E as x`, the LHS of `x = …`, and `del x` are binding sites, not reads. Skipping them keeps the graph free of spurious target → binding-source edges and matches the libcst pipeline, which only walks loads.

### `decl_kind_str` no longer mints "variable" nodes for For/WithItem/ExceptHandler/MatchPattern

The libcst pipeline doesn't model loop / context / pattern targets as top-level decls — `for x in data:` shouldn't put `mod.x` in the graph. Filtering at `decl_kind_str` keeps them out of `global_index`, so `walk_owned` never dispatches on them; the surrounding `Stmt::For` / `Stmt::With` / `Stmt::Try` still get walked from the module-level non-definition pass with the iterable / context expressions attributed to the module. `NamedExpression` (walrus) still mints a node — PEP 572 leaks its binding to the enclosing scope.

## Test impact

| Suite | Before | After |
|---|---|---|
| `tests/test_declarations.py` `--backend=rust` | 58 / 108 | **84 / 108** *(+26)* |
| `tests/test_top_level_only.py` `--backend=rust` | 5 / 6 | **6 / 6** *(+1)* |
| Full `--backend=rust` | 848 / 977 | **875 / 977** *(+27)* |
| Full `--backend=libcst` | 977 / 977 | **977 / 977** |

## Test plan
- [x] `uv run pytest tests/test_declarations.py --backend=rust` — 84 / 108
- [x] `uv run pytest --backend=libcst` — 977 passed
- [x] `uv run pytest --backend=rust` — 875 passed, 102 failed (was 848 / 129)
- [x] `cargo clippy --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Remaining buckets *(out of scope here)*

Remaining `test_declarations` failures cluster in:
- **Shadowing / redeclaration** (~15) — needs the Principle 3 mechanism (multiple reaching defs, `NodeFlags::SHADOWED`).
- **Pairwise tuple-unpacking** (~2) — `a, b = f(), g()` should map each target to its corresponding RHS element.
- **Walrus inside comprehensions** (~3) — PEP 572 binding leakage.
- **Cross-module branch-bindings exported** (3 in `test_branch_bindings_exported`).

The other 78 failures are in independent buckets: unreachable-branch detection (32), noqa pinning (16), remaining import buckets (26), limitations (4).

https://claude.ai/code/session_01R6GWpvWCUUNeYzJToopc9C

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6GWpvWCUUNeYzJToopc9C)_