### PR TITLE
prototype: emit edges from every reaching def + align Function/Class positions

### DIFF
--- a/crates/dead-cst-ty-native/src/lib.rs
+++ b/crates/dead-cst-ty-native/src/lib.rs
@@ -1005,7 +1005,28 @@ fn ingest_decls(
         let local_name = symbol.name().as_str().to_string();
 
         let target_range = kind.target_range(&parsed);
-        let (sl, sc, el, ec) = position(&line_index, &source, target_range);
+        let (mut sl, mut sc, el, ec) = position(&line_index, &source, target_range);
+
+        // For Function / Class / TypeAlias, ty's `target_range` is the
+        // bound *name* (e.g. `f` in `def f(): ...`). The libcst
+        // pipeline reports the position of the introducing keyword
+        // (`def` / `class` / `type`) — which is the first non-space
+        // character on the same line as the name (decorators sit on
+        // earlier lines and don't count). Align to libcst by snapping
+        // the start column to the line's indent.
+        if matches!(
+            kind,
+            DefinitionKind::Function(_) | DefinitionKind::Class(_) | DefinitionKind::TypeAlias(_)
+        ) {
+            let name_start = line_index.line_column(target_range.start(), &source);
+            let line_text = &source[line_index.line_range(name_start.line, &source)];
+            let indent = line_text
+                .bytes()
+                .take_while(|b| matches!(*b, b' ' | b'\t'))
+                .count();
+            sl = name_start.line.get();
+            sc = indent;
+        }
 
         let import_spec = if node_kind == "import" {
             Some(import_payload_for(kind, db, file, &parsed))
@@ -1821,8 +1842,11 @@ impl<'a, 'db> RefCollector<'a, 'db> {
         None
     }
 
-    /// Walk the use's scope chain looking for the reaching definition
-    /// of `name`. Returns `None` when no binding is found.
+    /// Walk the use's scope chain looking for the reaching definitions
+    /// of `name`. Returns one entry per reaching def — typically a
+    /// single binding, but `if`/`else` or `try`/`except` branches that
+    /// both bind the name leave multiple defs live at end-of-scope and
+    /// every one gets edges (Principle 3).
     ///
     /// Walks outward through visible scopes until we find one that
     /// *binds* `name` (not merely lists it in its place table — a free
@@ -1830,7 +1854,7 @@ impl<'a, 'db> RefCollector<'a, 'db> {
     /// that case we want to keep walking up to the actual definer).
     /// The first binding scope wins; ty's flow-sensitive
     /// `end_of_scope_symbol_bindings` filters within that scope to the
-    /// reaching def (Principle 3).
+    /// reaching defs.
     ///
     /// Resolutions split on whether the binding has a graph node:
     /// module-scope decls and import aliases give `Alias(idx)`;
@@ -1841,26 +1865,20 @@ impl<'a, 'db> RefCollector<'a, 'db> {
     /// Deliberately does NOT use `definitions_for_name`: that walks
     /// past `from X import y` to the upstream definition in `X`,
     /// flattening the local alias edge Principle 2 requires.
-    fn find_local_binding(&self, name: &ExprName) -> Option<Resolution> {
+    fn find_local_bindings(&self, name: &ExprName) -> Vec<Resolution> {
         let db = self.model.db();
         let index = semantic_index(db, self.file);
-        let file_scope = self.model.scope(name.into())?;
+        let Some(file_scope) = self.model.scope(name.into()) else {
+            return Vec::new();
+        };
         for (scope_id, _scope) in index.visible_ancestor_scopes(file_scope) {
             let place_table = index.place_table(scope_id);
             let Some(symbol_id) = place_table.symbol_id(name.id.as_str()) else {
                 continue;
             };
             let use_def_map = index.use_def_map(scope_id);
-            // The first scope that *binds* this name wins, even if the
-            // binding has no graph node (function parameter, loop
-            // target, except-as, walrus inside a comprehension, …) —
-            // outer scopes are shadowed by this one. Free-variable
-            // references show up in `place_table` without producing
-            // any bindings, and for those we fall through to outer
-            // scopes (handled by `place_table.symbol_id` returning
-            // `Some` but the bindings iterator yielding nothing).
             let mut saw_binding = false;
-            let mut result: Option<Resolution> = None;
+            let mut results: Vec<Resolution> = Vec::new();
             for binding in use_def_map.end_of_scope_symbol_bindings(symbol_id) {
                 let Some(def) = binding.binding.definition() else {
                     continue;
@@ -1869,9 +1887,6 @@ impl<'a, 'db> RefCollector<'a, 'db> {
                     continue;
                 }
                 saw_binding = true;
-                if result.is_some() {
-                    continue;
-                }
                 let kind = def.kind(db);
                 let place_id = def.place(db);
                 let key = (
@@ -1880,7 +1895,7 @@ impl<'a, 'db> RefCollector<'a, 'db> {
                     range_key(kind.target_range(self.parsed)),
                 );
                 if let Some(&idx) = self.global_index.get(&key) {
-                    result = Some(Resolution::Alias(idx));
+                    results.push(Resolution::Alias(idx));
                     continue;
                 }
                 if kind.is_import() {
@@ -1889,14 +1904,14 @@ impl<'a, 'db> RefCollector<'a, 'db> {
                     };
                     let bound_name = sym.name().as_str().to_string();
                     let spec = import_payload_for(kind, db, self.file, self.parsed);
-                    result = Some(Resolution::NestedImport { spec, bound_name });
+                    results.push(Resolution::NestedImport { spec, bound_name });
                 }
             }
             if saw_binding {
-                return result;
+                return results;
             }
         }
-        None
+        Vec::new()
     }
 
     /// Emit edges implied by a use of `name`.
@@ -1909,7 +1924,9 @@ impl<'a, 'db> RefCollector<'a, 'db> {
     /// invariant), then parallel upstream reachability edges from
     /// `alias_imports[idx]` if the binding is an import. For nested
     /// imports there's no alias node — go straight to the parallel
-    /// edges, using the spec ty handed us.
+    /// edges, using the spec ty handed us. When ty reports multiple
+    /// reaching defs (if/else branches, try/except, …), we emit for
+    /// each one.
     fn emit_name_use(&mut self, name: &ExprName, extra_chain: &[&str]) {
         // `Name`s in non-`Load` context are binding sites, not uses:
         // the `x` in `for x in data`, `with y as x`, `except E as x`,
@@ -1920,17 +1937,18 @@ impl<'a, 'db> RefCollector<'a, 'db> {
         if !matches!(name.ctx, ruff_python_ast::ExprContext::Load) {
             return;
         }
-        match self.find_local_binding(name) {
-            Some(Resolution::Alias(alias_idx)) => {
-                self.emit_edge(alias_idx);
-                if let Some(spec) = self.alias_imports.get(&alias_idx).cloned() {
-                    self.emit_upstream(&spec, name.id.as_str(), extra_chain);
+        for resolution in self.find_local_bindings(name) {
+            match resolution {
+                Resolution::Alias(alias_idx) => {
+                    self.emit_edge(alias_idx);
+                    if let Some(spec) = self.alias_imports.get(&alias_idx).cloned() {
+                        self.emit_upstream(&spec, name.id.as_str(), extra_chain);
+                    }
+                }
+                Resolution::NestedImport { spec, bound_name } => {
+                    self.emit_upstream(&spec, &bound_name, extra_chain);
                 }
             }
-            Some(Resolution::NestedImport { spec, bound_name }) => {
-                self.emit_upstream(&spec, &bound_name, extra_chain);
-            }
-            None => {}
         }
     }
 
@@ -2232,6 +2250,17 @@ impl<'ast, 'db> Visitor<'ast> for RefCollector<'_, 'db> {
                 }
                 _ => {}
             }
+        } else if stmt_creates_top_level_definition(stmt) {
+            // At module-level walks (or per-def walks of value
+            // expressions, where Stmt nodes wouldn't appear anyway),
+            // nested top-level-definition statements have already been
+            // processed by the per-def pass with their own owner.
+            // Skipping them here prevents double-attribution when a
+            // compound statement (`if` / `for` / `try` / `with` /
+            // `match`) at module scope contains a definition in its
+            // body — e.g. `if True: f = g` would otherwise emit
+            // `mod -> g` *and* the proper `mod.f -> g`.
+            return;
         }
         walk_stmt(self, stmt);
     }


### PR DESCRIPTION
> **Base: `rust_proto`** (not `main`). Diff is the single commit on this branch — `rust_proto` already contains all prior native-crate work (#136 – #146). Compare against `rust_proto` to see just this change.

## Summary

Closes most of the shadowing / redeclaration bucket from the earlier audit. Three small, related changes that together unlock 12 newly-passing tests.

## Changes

### `find_local_binding` → `find_local_bindings` returns `Vec<Resolution>`

ty's `end_of_scope_symbol_bindings` correctly returns *multiple* defs when control flow leaves more than one binding live (try/except bodies, runtime-conditional if/else, etc.). Previously we'd collapse those to the first match; now we emit one edge per reaching def. For linear shadowing (`def f; def f`), ty still hands us just the surviving binding, so that case stays right.

This is the Principle 3 plumbing the earlier audit called for.

### Function/Class/TypeAlias positions snap to the line's indent

ty's `target_range` is the bound *name* (e.g. `f` in `def f(): ...`, col 4). The libcst pipeline reports the position of the introducing keyword (`def` / `class` / `type`), which is the first non-space character on the same line — col 0 for top-level decls, col 4 for ones nested inside an `if` / `else` branch. Align by reading the indent of the name's line from the source. The intern `NodeKey` keeps the new positions, but the `global_index` lookup key still uses `target_range`, so cross-references continue to work.

### `visit_stmt` skips nested top-level defs when not in a function/class body

`if True: f = g` at module scope creates an Assignment definition that the per-def pass already processes (owner = `mod.f@…`). The module-level non-definition pass walks the `If` statement and would otherwise recurse into the `Assign`, emitting a duplicate `mod -> g` edge from the wrong owner. Filtering out top-level-def stmt kinds when `nested_context` is false fixes this without affecting nested-statement walks inside a function body (local assigns inside a function still get walked normally).

## Test impact

| Suite | Before | After |
|---|---|---|
| `test_redeclarations` `--backend=rust` | 0 / 8 | **5 / 8** |
| `test_shadowed_declarations` `--backend=rust` | 0 / 7 | **7 / 7** |
| Full `--backend=rust` | 888 / 990 | **900 / 990** *(+12)* |
| Full `--backend=libcst` | unchanged (one pre-existing failure in `test_init_subclass_plugin_wires_transitive_subclasses` predates this PR) | unchanged |

## Remaining `test_redeclarations` failures (3)

- **`reassignment-creates-two-nodes`** — `a = 1; a = a + 1`. The RHS read needs the *prior* binding (a@1), but `end_of_scope_symbol_bindings` returns only the latest (a@2). The flow-sensitive `bindings_at_use(use_id)` would return the right answer, but its `use_id` lookup API is `pub(crate)` inside `ty_python_core` — not externally accessible.
- **`conditional-rebind-to-alias`** (`if True: f = g`) and **`if-else-function-redefinition`** (`if True: … else: …`) — ty constant-folds `if True:` and reports only the always-taken branch's binding as reaching end-of-scope; the tests expect both branches to be live regardless of the literal condition.

These three are real limitations of working against ty's public surface — not something we can paper over without either patching ty or reimplementing per-use flow analysis ourselves.

## Test plan
- [x] `uv run pytest tests/test_declarations.py -k "redeclarations or shadowed_declarations" --backend=rust` — 12 / 15 passing
- [x] `uv run pytest --backend=libcst` — 989 passed (1 pre-existing failure)
- [x] `uv run pytest --backend=rust` — 900 passed, 90 failed *(was 888 / 102)*
- [x] `cargo clippy --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

https://claude.ai/code/session_01R6GWpvWCUUNeYzJToopc9C

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6GWpvWCUUNeYzJToopc9C)_