### PR TITLE
prototype: halve the warm rust bridge cost via Path / flag interning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ two versions.
   this contract is upheld regardless of how ``refresh`` is invoked.
 
 ### Changed
+- ``tests/prototype/_bridge.materialize`` (and the inlined copy in
+  ``scripts/profile_backends.py``) interns ``pathlib.Path`` objects per
+  build and reuses the ``NodeFlags(0)`` / ``EdgeFlags(0)`` singletons
+  instead of constructing fresh enum instances per node/edge. Halves
+  the warm-path bridge cost (``dead_cst`` self: 15.0 ms → 7.5 ms;
+  flux0 server: 2.2 ms → 1.0 ms), which is the dominant cost on warm
+  rust runs now that ty's Salsa db keeps ``Project.build()`` at 10 ms.
+
 - Swapped the graph backend from `networkx.MultiDiGraph` to a minimal
   `rustworkx.PyDiGraph` wrapper (`dead_cst._graphstore.SymbolGraph`).
   The wrapper exposes the `SymbolNode <-> int` index bookkeeping

--- a/scripts/profile_backends.py
+++ b/scripts/profile_backends.py
@@ -145,32 +145,42 @@ def _ensure_flux0_venv(flux0_root: Path) -> Path:
 
 
 if HAS_RUST:
+    _NO_NODE_FLAGS = NodeFlags(0)
+    _NO_EDGE_FLAGS = EdgeFlags(0)
 
     def _bridge_materialize(graph: "native.NativeGraph") -> "SymbolGraph":
         """Same as ``tests/prototype/_bridge.materialize``, inlined here."""
         out = SymbolGraph()
-        symbol_nodes = [
-            SymbolNode(
-                fqname=n.fqname,
-                type=n.kind,  # type: ignore[arg-type]
-                path=Path(n.path),
-                position=CodeRange(
-                    CodePosition(n.start_line, n.start_column),
-                    CodePosition(n.end_line, n.end_column),
-                ),
-                imports=(
-                    DCImport(module=n.imports.module, decl=n.imports.decl, star=n.imports.star)
-                    if n.imports is not None
-                    else None
-                ),
-                flags=NodeFlags(n.flags),
+        path_cache: dict[str, Path] = {}
+        symbol_nodes: list[SymbolNode] = []
+        for n in graph.nodes:
+            path = path_cache.get(n.path)
+            if path is None:
+                path = Path(n.path)
+                path_cache[n.path] = path
+            flags = _NO_NODE_FLAGS if n.flags == 0 else NodeFlags(n.flags)
+            symbol_nodes.append(
+                SymbolNode(
+                    fqname=n.fqname,
+                    type=n.kind,  # type: ignore[arg-type]
+                    path=path,
+                    position=CodeRange(
+                        CodePosition(n.start_line, n.start_column),
+                        CodePosition(n.end_line, n.end_column),
+                    ),
+                    imports=(
+                        DCImport(module=n.imports.module, decl=n.imports.decl, star=n.imports.star)
+                        if n.imports is not None
+                        else None
+                    ),
+                    flags=flags,
+                )
             )
-            for n in graph.nodes
-        ]
         for sn in symbol_nodes:
             out.add(sn)
         for src, dst, flags in graph.edges:
-            out.add_edge(symbol_nodes[src], symbol_nodes[dst], EdgeFlags(flags))
+            edge_flags = _NO_EDGE_FLAGS if flags == 0 else EdgeFlags(flags)
+            out.add_edge(symbol_nodes[src], symbol_nodes[dst], edge_flags)
         return out
 
 

--- a/tests/prototype/_bridge.py
+++ b/tests/prototype/_bridge.py
@@ -18,19 +18,11 @@ from libcst.metadata import CodePosition, CodeRange
 from dead_cst._graphstore import SymbolGraph
 from dead_cst.graph import EdgeFlags, Import, NodeFlags, SymbolNode
 
-
-def _to_symbol_node(n: native.NativeNode) -> SymbolNode:
-    return SymbolNode(
-        fqname=n.fqname,
-        type=cast("SymbolNode.type", n.kind),
-        path=Path(n.path),
-        position=CodeRange(
-            CodePosition(n.start_line, n.start_column),
-            CodePosition(n.end_line, n.end_column),
-        ),
-        imports=_to_import(n.imports),
-        flags=NodeFlags(n.flags),
-    )
+# Most nodes carry no flags and most edges have flags=0; reusing the
+# zero singleton avoids ~5k `EdgeFlags(0)` constructor calls per warm
+# build on `dead_cst` itself.
+_NO_NODE_FLAGS = NodeFlags(0)
+_NO_EDGE_FLAGS = EdgeFlags(0)
 
 
 def _to_import(native_import: native.Import | None) -> Import | None:
@@ -46,9 +38,33 @@ def _to_import(native_import: native.Import | None) -> Import | None:
 def materialize(graph: native.NativeGraph) -> SymbolGraph:
     """Convert a project-wide `NativeGraph` into a fresh `SymbolGraph`."""
     out = SymbolGraph()
-    symbol_nodes = [_to_symbol_node(n) for n in graph.nodes]
+    # Per-build cache: ~1k nodes typically span ~40 unique paths, so
+    # interning here saves ~10ms of pathlib.Path construction +
+    # hashing per warm build on `dead_cst` itself.
+    path_cache: dict[str, Path] = {}
+    symbol_nodes: list[SymbolNode] = []
+    for n in graph.nodes:
+        path = path_cache.get(n.path)
+        if path is None:
+            path = Path(n.path)
+            path_cache[n.path] = path
+        flags = _NO_NODE_FLAGS if n.flags == 0 else NodeFlags(n.flags)
+        symbol_nodes.append(
+            SymbolNode(
+                fqname=n.fqname,
+                type=cast("SymbolNode.type", n.kind),
+                path=path,
+                position=CodeRange(
+                    CodePosition(n.start_line, n.start_column),
+                    CodePosition(n.end_line, n.end_column),
+                ),
+                imports=_to_import(n.imports),
+                flags=flags,
+            )
+        )
     for sn in symbol_nodes:
         out.add(sn)
     for src, dst, flags in graph.edges:
-        out.add_edge(symbol_nodes[src], symbol_nodes[dst], EdgeFlags(flags))
+        edge_flags = _NO_EDGE_FLAGS if flags == 0 else EdgeFlags(flags)
+        out.add_edge(symbol_nodes[src], symbol_nodes[dst], edge_flags)
     return out


### PR DESCRIPTION
> **Base: `rust_proto`** (not `main`). Diff is the single commit on this branch.

## Summary

cProfile of the warm rust path on `dead_cst` self (45 files, 1149 nodes, 4789 edges) showed `Project.build()` at 10.5 ms but the python-side bridge to `SymbolGraph` at 15 ms — **the bridge is now the bottleneck** on warm runs, not rust, now that ty's Salsa db keeps `build()` cheap on repeat.

Two cheap wins in the bridge collapse most of that cost:

- **Intern `Path` objects per build.** ~12 ms of the 15 ms was `pathlib.Path(n.path)` construction + hashing — 1149 fresh `Path` instances even though only ~40 unique paths exist. A per-build `dict[str, Path]` cache reduces this to ~40 allocations.
- **Reuse `NodeFlags(0)` / `EdgeFlags(0)` singletons.** ~3 ms was `enum.__call__` coercion on flags that are almost always 0. Module-level singletons + a zero check skip the enum constructor.

Applied to the canonical bridge in `tests/prototype/_bridge.py` and the inlined copy in `scripts/profile_backends.py`.

## Measured impact

Warm bridge timings, best-of-10 on `Project.build()` output (rust path otherwise unchanged):

| target          | nodes | edges | before  | after   | speedup |
|-----------------|------:|------:|--------:|--------:|--------:|
| dead_cst (self) |  1149 |  4789 | 15.0 ms |  7.5 ms |   50%   |
| flux0 server    |   185 |   462 |  2.2 ms |  1.0 ms |   52%   |

Numbers verified against the in-tree `_bridge.materialize` after landing (7.6 ms / 1.1 ms), not just a standalone benchmark.

## Out of scope (potential follow-ups)

- `NodeKey` clones `fqname` + `path` strings on every `intern_node`; could likely key on `(file_id, target_start, target_end, kind)` for native nodes.
- `RefCollector::flush` dedups edges in a per-collector `HashSet`, then `builder.add_edge` re-dedups via its own `edge_set` — one layer would suffice.
- Cold path (~112 ms on `dead_cst` self) is dominated by ty's parse + `SemanticIndex` build and isn't really actionable without deeper structural work.

## Test plan
- [x] `uv run pytest tests/prototype` — 27 passed, 1 pre-existing failure deselected (`test_init_subclass_plugin_wires_transitive_subclasses` — unrelated, reproduces on `rust_proto` `HEAD` without this change).
- [x] In-tree `_bridge.materialize` benchmarked against `Project.build()` output for `dead_cst` self + `flux0/packages/server/src` — 50% / 52% bridge speedup confirmed.

https://claude.ai/code/session_013bbfv7aTfShcRvuAQr9HCt