### PR TITLE
prototype: fix `parse_noqa_tail` panic on multi-byte comment prefixes

### DIFF
--- a/crates/dead-cst-ty-native/src/lib.rs
+++ b/crates/dead-cst-ty-native/src/lib.rs
@@ -2840,3 +2840,43 @@ fn dead_cst_ty_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ProjectContext>()?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_noqa_tail_multibyte_prefix_does_not_panic() {
+        // Regression: byte-slicing `trimmed[..4]` panicked when the
+        // comment started with a multi-byte UTF-8 char (e.g. the
+        // 3-byte `─` box-drawing char in section banners).
+        assert_eq!(parse_noqa_tail("── Top-level model (dataclass) ──"), None,);
+        assert_eq!(parse_noqa_tail("─"), None);
+        assert_eq!(parse_noqa_tail("héllo"), None);
+        assert_eq!(parse_noqa_tail("🙂🙂"), None);
+    }
+
+    #[test]
+    fn parse_noqa_tail_short_content_returns_none() {
+        assert_eq!(parse_noqa_tail(""), None);
+        assert_eq!(parse_noqa_tail("no"), None);
+        assert_eq!(parse_noqa_tail("noq"), None);
+    }
+
+    #[test]
+    fn parse_noqa_tail_recognizes_bare_directive() {
+        assert_eq!(parse_noqa_tail(" noqa"), Some(NoqaKind::Bare));
+        assert_eq!(parse_noqa_tail("NOQA"), Some(NoqaKind::Bare));
+        assert_eq!(parse_noqa_tail("noqa: "), Some(NoqaKind::Bare));
+    }
+
+    #[test]
+    fn parse_noqa_tail_recognizes_f401() {
+        assert_eq!(parse_noqa_tail("noqa: F401"), Some(NoqaKind::F401Present));
+        assert_eq!(
+            parse_noqa_tail("noqa: E501, F401"),
+            Some(NoqaKind::F401Present),
+        );
+        assert_eq!(parse_noqa_tail("noqa: E501"), Some(NoqaKind::OtherOnly));
+    }
+}

--- a/crates/dead-cst-ty-native/src/lib.rs
+++ b/crates/dead-cst-ty-native/src/lib.rs
@@ -2708,7 +2708,11 @@ impl NoqaKind {
 /// optional whitespace.
 fn parse_noqa_tail(content: &str) -> Option<NoqaKind> {
     let trimmed = content.trim_start();
-    if trimmed.len() < 4 || !trimmed[..4].eq_ignore_ascii_case("noqa") {
+    // `str::get` short-circuits when byte 4 isn't a char boundary —
+    // e.g. a comment that starts with the 3-byte `─` box-drawing char
+    // (common in section banners). Direct slicing would panic.
+    let prefix = trimmed.get(..4)?;
+    if !prefix.eq_ignore_ascii_case("noqa") {
         return None;
     }
     let after_noqa = &trimmed[4..];


### PR DESCRIPTION
> **Base: `rust_proto`** (not `main`). Two commits: the fix + a regression test.

## Summary

While profiling `Project.build()` against the flux0 workspace (`uv run python scripts/profile_backends.py --targets flux0_workspace`), the rust path panicked:

```
thread '<unnamed>' panicked at src/lib.rs:2711:37:
byte index 4 is not a char boundary; it is inside '─' (bytes 3..6) of
`── Top-level model (dataclass) persisted per frame ────────────────────────────`
```

`parse_noqa_tail` (added in #150) was doing `trimmed[..4].eq_ignore_ascii_case("noqa")` — a **byte slice**. Any comment that starts with a multi-byte UTF-8 character lands byte 4 inside that character and panics. The `─` box-drawing char (3 bytes) is common Python practice for section banners; flux0's `packages/server/src/flux0_server/api/models/agents.py` has several.

## Fix

Switch to `trimmed.get(..4)?`. Returns `None` on a non-char-boundary slice — the same fall-through as content shorter than 4 bytes — instead of panicking. The function's behavior for ASCII inputs is unchanged.

```rust
- if trimmed.len() < 4 || !trimmed[..4].eq_ignore_ascii_case("noqa") {
-     return None;
- }
- let after_noqa = &trimmed[4..];
+ let prefix = trimmed.get(..4)?;
+ if !prefix.eq_ignore_ascii_case("noqa") {
+     return None;
+ }
+ let after_noqa = &trimmed[4..];
```

## Tests

First cargo unit tests in this crate (`#[cfg(test)] mod tests` at the bottom of `lib.rs`). Future Rust-only logic can extend the module without standing up its own harness. Cases:

- **Regression**: `── Top-level model ──`, `─`, `héllo`, `🙂🙂` → `None` (used to panic)
- **Short**: `""`, `"no"`, `"noq"` → `None`
- **Bare**: `" noqa"`, `"NOQA"`, `"noqa: "` → `NoqaKind::Bare`
- **F401**: `"noqa: F401"`, `"noqa: E501, F401"` → `F401Present`; `"noqa: E501"` → `OtherOnly`

## Test plan
- [x] `cargo test --release` from `crates/dead-cst-ty-native/` — 4 passed; 0 failed
- [x] `uv run python scripts/profile_backends.py --repeats 3 --targets flux0_workspace` no longer panics; warm rust path: **27 ms** for 100 files / 1959 nodes / 8627 edges (vs libcst warm at 3.45 s — 128×)
- [x] `uv run pytest tests/prototype --deselect tests/prototype/test_plugin_protocol.py::test_init_subclass_plugin_wires_transitive_subclasses` — 27 passed (the one deselect is a pre-existing failure on `rust_proto`, unrelated)

https://claude.ai/code/session_013bbfv7aTfShcRvuAQr9HCt

---
_Generated by [Claude Code](https://claude.ai/code/session_013bbfv7aTfShcRvuAQr9HCt)_