### PR TITLE
plugins: rust run(ctx) for UnittestPlugin

### DIFF
--- a/dead_cst/contrib/unittest.py
+++ b/dead_cst/contrib/unittest.py
@@ -55,6 +55,7 @@ from ..plugins.init_subclass import (
 )
 
 if TYPE_CHECKING:
+    import dead_cst_ty_native as native
     from libcst.metadata import CodeRange
 
     from ..graph import VisitorPayload
@@ -211,6 +212,44 @@ class UnittestPlugin:
             yield AddNode(synth)
             for sub in subs:
                 yield AddEdge(synth, sub)
+
+    def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
+        import dead_cst_ty_native as native
+
+        # Gate hook detection on files that import unittest. The class
+        # subclass walk doesn't need this — ty's type hierarchy only
+        # returns real subclasses of stdlib unittest.TestCase, so a
+        # local ``class TestCase: pass`` followed by ``class X(TestCase)``
+        # never shows up (X inherits from the local class, not stdlib's).
+        importer_paths = {n.path for n in ctx.find_imports_of("unittest")}
+
+        decls_by_path: dict[str, list[native.NativeNode]] = {}
+        for base_fqname in _UNITTEST_BASE_FQNAMES:
+            for sub in ctx.find_subclasses(base_fqname, transitive=True):
+                decls_by_path.setdefault(sub.path, []).append(sub)
+
+        # Module-level hooks (setUpModule / tearDownModule / load_tests)
+        # in any file that imports unittest.
+        for node in ctx.nodes():
+            if node.kind != "function":
+                continue
+            if node.path not in importer_paths:
+                continue
+            simple = node.fqname.rsplit(".", 1)[-1]
+            if simple in _MODULE_HOOKS:
+                decls_by_path.setdefault(node.path, []).append(node)
+
+        flags = int(NodeFlags.ENTRYPOINT | NodeFlags.TESTCASE)
+        for path, decls in decls_by_path.items():
+            module = ctx.module_for(path)
+            if module is None:
+                continue
+            yield native.AddNode(
+                fqname=f"{UNITTEST_PREFIX}{module.fqname}",
+                path=path,
+                flags=flags,
+                edges_to=decls,
+            )
 
 
 def _expand_aliases(ctx: PluginContext, seeds: frozenset[str]) -> set[str]:

--- a/tests/test_plugins/test_unittest.py
+++ b/tests/test_plugins/test_unittest.py
@@ -148,10 +148,15 @@ def test_unittest_plugin_skips_files_not_importing_unittest(build_plugin_graph, 
     assert "pkg.things.MyThings" not in reachable_fqnames(graph)
 
 
-def test_unittest_plugin_skips_pure_star_import(build_plugin_graph, reachable_fqnames):
-    # Documented limitation: the resolver doesn't surface stdlib star
-    # imports as graph nodes, so the prefilter can't see them. Users
-    # should ``from unittest import TestCase`` instead.
+def test_unittest_plugin_skips_pure_star_import(build_plugin_graph, reachable_fqnames, backend):
+    # Backend-specific behavior:
+    # * libcst: documented limitation — the visitor doesn't bind
+    #   individual names from a star import, so ``class X(TestCase)``
+    #   after ``from unittest import *`` doesn't resolve. Users should
+    #   ``from unittest import TestCase`` instead.
+    # * rust: ty's type hierarchy follows star imports correctly, so
+    #   the subclass IS picked up. The rust path supersedes the libcst
+    #   limitation.
     graph = build_plugin_graph(
         {
             "pkg/__init__.py": "",
@@ -164,7 +169,11 @@ def test_unittest_plugin_skips_pure_star_import(build_plugin_graph, reachable_fq
         },
         [UnittestPlugin()],
     )
-    assert "pkg.things.MyThings" not in reachable_fqnames(graph)
+    reached = reachable_fqnames(graph)
+    if backend == "rust":
+        assert "pkg.things.MyThings" in reached
+    else:
+        assert "pkg.things.MyThings" not in reached
 
 
 def test_unittest_plugin_loads_via_load_plugin():


### PR DESCRIPTION
> **Base: `rust_proto`** (not `main`). Single commit on top of #158.

## Summary

Closes the 13-test rust-backend skip bucket for `UnittestPlugin`. The `find_subclasses("unittest.TestCase", transitive=True)` query added in #158 (with ty's re-export chain follower) does most of the heavy lifting — it correctly walks through:

* the stdlib re-export chain (`unittest/__init__.pyi` → `unittest.case`);
* project-local mixins (`class ProjectTC(unittest.TestCase); class MyTest(ProjectTC)`);
* re-exports (`pkg.bases.TestCase = unittest.TestCase` → `from pkg.bases import TestCase; class MyTest(TestCase)`);
* aliased imports (`import unittest as ut; class X(ut.TestCase)`, `from unittest import TestCase as TC`).

Plus a separate pass for `setUpModule` / `tearDownModule` / `load_tests` module-level hooks in any file that `import`s `unittest` (`ctx.find_imports_of("unittest")` as the gate). One yielded `AddNode` per module marks the file's surface as alive (`NodeFlags.ENTRYPOINT | NodeFlags.TESTCASE`) with edges to every discovered hook + subclass — same shape as the libcst plugin's finalize.

## Behavior divergence on star imports

`test_unittest_plugin_skips_pure_star_import` documented a libcst limitation: `from unittest import *; class X(TestCase)` doesn't resolve through the libcst-side `_resolve_bases` (the visitor doesn't bind individual names from a star import). **The rust path doesn't have this limitation** — ty's type hierarchy follows star imports correctly, so `X` IS picked up as a subclass.

That's strictly better behavior. The test now branches on the `backend` fixture: libcst asserts the (known) limitation; rust asserts the correct outcome.

## Status after this PR

The rust backend now handles every builtin plugin **except** `DiscordPyPlugin` (13 remaining skips). `DiscordPyPlugin` is harder — bot.command / bot.event with multi-instance + Cog subclass patterns; really wants stage 3's CallRef + `find_calls` primitive. The 4 remaining failures in the rust-backend plugin suite are the same cross-file-factory cases from PR #151.

## Test plan

- [x] `uv run pytest tests/test_plugins/test_unittest.py` — 13/13 (libcst)
- [x] `uv run pytest tests/test_plugins/test_unittest.py --backend=rust` — 13/13 (rust)
- [x] `uv run pytest tests/test_plugins --backend=rust` — 261 passed, 13 skipped (all discordpy), 4 failed (pre-existing cross-file factory)
- [x] `uv run pytest` — full default suite 990/990
- [x] `uv run prek run --all-files` clean

https://claude.ai/code/session_01KZf2rbhxbQjRYGckcRuSCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZf2rbhxbQjRYGckcRuSCE)_