### PR TITLE
prototype: one node per `from X import *` statement

### DIFF
--- a/crates/dead-cst-ty-native/src/lib.rs
+++ b/crates/dead-cst-ty-native/src/lib.rs
@@ -1864,6 +1864,14 @@ fn ingest_decls(
     let global = FileScopeId::global();
     let place_table = index.place_table(global);
     let use_def_map = index.use_def_map(global);
+    // ty emits one `StarImport` definition per imported name, but
+    // every per-name def from the same `from X import *` statement
+    // shares the `*` token's range — so the `*<src>` local name we
+    // synthesize is identical across all of them. Cache by that
+    // shared range to avoid re-resolving `from_module_string` and
+    // re-allocating the format string N times for a star statement
+    // that brings in N names.
+    let mut star_local_name_cache: HashMap<TextRange, String> = HashMap::new();
 
     for (_def_id, state, _used) in use_def_map.all_definitions_with_usage() {
         let DefinitionState::Defined(def) = state else {
@@ -1909,18 +1917,18 @@ fn ingest_decls(
         // all pointing at this single node — so a downstream
         // `from A import g` still finds the star alias by name and
         // can chase through it to B.
+        let target_range = kind.target_range(&parsed);
         let local_name = match kind {
-            DefinitionKind::StarImport(k) => {
-                let stmt = k.import(&parsed);
-                let src = ModuleName::from_import_statement(db, file, stmt)
-                    .map(|n| n.as_str().to_string())
-                    .unwrap_or_default();
-                format!("*{src}")
-            }
+            DefinitionKind::StarImport(k) => star_local_name_cache
+                .entry(target_range)
+                .or_insert_with(|| {
+                    let src = from_module_string(db, file, k.import(&parsed));
+                    format!("*{src}")
+                })
+                .clone(),
             _ => per_name.clone(),
         };
 
-        let target_range = kind.target_range(&parsed);
         let (mut sl, mut sc, el, ec) = position(&line_index, &source, target_range);
 
         // For Function / Class / TypeAlias, ty's `target_range` is the
@@ -2003,7 +2011,7 @@ fn ingest_decls(
         // would otherwise miss `from A import g` chains that probe
         // for the per-name `"g"`. For non-star imports `per_name`
         // and `local_name` are identical so this is a no-op there.
-        let name_key = (file, per_name.clone());
+        let name_key = (file, per_name);
         if let Some(spec) = import_spec {
             // Star-reexport synthetics need their upstream tracked so
             // Phase 2 can walk a `from A import g` resolution through

--- a/crates/dead-cst-ty-native/src/lib.rs
+++ b/crates/dead-cst-ty-native/src/lib.rs
@@ -1885,7 +1885,40 @@ fn ingest_decls(
         let PlaceExprRef::Symbol(symbol) = place_table.place(place_id) else {
             continue;
         };
-        let local_name = symbol.name().as_str().to_string();
+        // The per-name binding (e.g. `f`, `g`) ty sees. We keep this
+        // for the `globals_by_name` / `star_reexports` maps that
+        // Phase 2's cross-module chain walk uses to chase a
+        // `from A import g` through A's `from B import *`.
+        let per_name = symbol.name().as_str().to_string();
+
+        // `from X import *` — ty produces one `StarImport` definition
+        // per name brought in, but the graph holds *one* node per
+        // statement: the import statement itself is the local thing
+        // that should be kept alive by use sites, and ty's name
+        // resolution still routes each use to its specific upstream.
+        // The libcst per-name synthetic alias was a workaround for
+        // libcst's inability to resolve uses through star imports —
+        // we don't need it here.
+        //
+        // Collapse by giving every per-name `StarImport` from the
+        // same statement a shared `*<source>` local name; combined
+        // with the shared `target_range` (the `*` token), they all
+        // intern to the same `NodeKey` and therefore the same
+        // `node_idx`. The per-name lookup maps (`globals_by_name`,
+        // `star_reexports`) keep using each per-name as their key,
+        // all pointing at this single node — so a downstream
+        // `from A import g` still finds the star alias by name and
+        // can chase through it to B.
+        let local_name = match kind {
+            DefinitionKind::StarImport(k) => {
+                let stmt = k.import(&parsed);
+                let src = ModuleName::from_import_statement(db, file, stmt)
+                    .map(|n| n.as_str().to_string())
+                    .unwrap_or_default();
+                format!("*{src}")
+            }
+            _ => per_name.clone(),
+        };
 
         let target_range = kind.target_range(&parsed);
         let (mut sl, mut sc, el, ec) = position(&line_index, &source, target_range);
@@ -1964,7 +1997,13 @@ fn ingest_decls(
         // and the query callers care about the end-of-scope live binding.
         decl_by_name_range.insert((file, range_key(target_range)), node_idx);
 
-        let name_key = (file, local_name.clone());
+        // Lookup maps key by the *per-name* (the actual bound symbol
+        // each ty `StarImport` corresponds to), not the node's
+        // `local_name` — the star node's collapsed `*<src>` fqname
+        // would otherwise miss `from A import g` chains that probe
+        // for the per-name `"g"`. For non-star imports `per_name`
+        // and `local_name` are identical so this is a no-op there.
+        let name_key = (file, per_name.clone());
         if let Some(spec) = import_spec {
             // Star-reexport synthetics need their upstream tracked so
             // Phase 2 can walk a `from A import g` resolution through
@@ -2175,17 +2214,18 @@ fn emit_import_edges(
                 globals_by_name,
                 star_reexports,
             )?,
-            DefinitionKind::StarImport(k) => resolve_from_imported(
-                py,
-                db,
-                file,
-                k.import(&parsed),
-                place_table.symbol(k.symbol_id()).name().as_str(),
-                builder,
-                module_nodes,
-                globals_by_name,
-                star_reexports,
-            )?,
+            // `from X import *` — no per-name fan-out edge. ty's
+            // `definitions_for_imported_symbol` would resolve each
+            // per-name `StarImport` to its specific upstream decl,
+            // but we collapse the per-name aliases to one node per
+            // statement (see `ingest_decls`) and don't want N edges
+            // pointing at the same alias. The from-style parallel
+            // path below still emits `alias → upstream module` once,
+            // which is exactly what carries reachability under the
+            // new model — uses of star-bound names emit their own
+            // parallel `use → upstream module / upstream decl` edges
+            // via `emit_upstream` and ty's name resolution.
+            DefinitionKind::StarImport(_) => None,
             _ => continue,
         };
         if let Some(target_idx) = target {

--- a/tests/prototype/test_native_graph.py
+++ b/tests/prototype/test_native_graph.py
@@ -145,9 +145,17 @@ def test_aliased_import_binds_asname(project_factory):
     assert "pkg.mod.gee -> pkg.other.g" in _edges(g)
 
 
-def test_star_import_binds_each_exported_name(project_factory):
-    """`from foo import *` mints one *implicit* `kind=import` node per
-    name `foo` exports — Principle 2 applied to star imports."""
+def test_star_import_mints_one_node_per_statement(project_factory):
+    """`from X import *` mints exactly one `kind=import` node per
+    statement (named `<importing_module>.*<source>`), not one per
+    name `X` exports — ty already resolves uses of star-bound names
+    to their specific upstream definitions, so the per-name aliases
+    libcst minted as a workaround aren't needed here. The single
+    star node carries one outgoing edge to the upstream module; uses
+    of star-bound names emit `use → star_node` plus the standard
+    parallel `use → upstream_module` / `use → upstream_decl` edges
+    via Principle 2.
+    """
     proj, _ = project_factory(
         {
             "pkg/__init__.py": "",
@@ -157,16 +165,23 @@ def test_star_import_binds_each_exported_name(project_factory):
     )
     g = proj.build()
     fqs = _fqnames(g)
-    assert "pkg.mod.g" in fqs and "pkg.mod.h" in fqs
-    assert "pkg.mod._private" not in fqs  # underscore-prefixed not star-exported
+    # One star node per statement — the underscored-private decl
+    # didn't matter for node count, and per-name `pkg.mod.g` /
+    # `pkg.mod.h` aliases are gone.
+    assert "pkg.mod.*pkg.other" in fqs
+    assert "pkg.mod.g" not in fqs
+    assert "pkg.mod.h" not in fqs
     edges = _edges(g)
-    assert "pkg.mod.g -> pkg.other.g" in edges
-    assert "pkg.mod.h -> pkg.other.h" in edges
-    assert "pkg.mod.use -> pkg.mod.g" in edges
-    assert "pkg.mod.use -> pkg.mod.h" in edges
+    # Star alias's one outgoing edge: to the upstream module.
+    assert "pkg.mod.*pkg.other -> pkg.other" in edges
+    # Use sites: alias edge through the star + parallel upstream
+    # (ty's resolution finds `g` / `h` in `pkg.other`).
+    assert "pkg.mod.use -> pkg.mod.*pkg.other" in edges
+    assert "pkg.mod.use -> pkg.other.g" in edges
+    assert "pkg.mod.use -> pkg.other.h" in edges
 
 
-def test_star_import_node_is_flagged_as_star(project_factory):
+def test_star_import_node_carries_star_spec(project_factory):
     proj, _ = project_factory(
         {
             "pkg/__init__.py": "",
@@ -175,7 +190,8 @@ def test_star_import_node_is_flagged_as_star(project_factory):
         }
     )
     g = proj.build()
-    [node] = [n for n in g.nodes if n.fqname == "pkg.mod.g"]
+    [node] = [n for n in g.nodes if n.fqname == "pkg.mod.*pkg.other"]
+    assert node.kind == "import"
     assert node.imports is not None
     assert node.imports.star is True
     assert node.imports.module == "pkg.other"

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -364,12 +364,31 @@ STAR_REEXPORT_EDGES = frozenset(
         ),
         pytest.param(
             "from p.functions import *\ndef a(): f()",
-            STAR_REEXPORT_EDGES
-            | {
-                "p.x -> p.functions",
-                "p.x -> p.functions.f",
-                "p.x -> p.functions.g",
-                "p.x.a -> p.x",
+            {
+                # libcst's per-name synthetic aliases — a workaround
+                # for its inability to resolve uses *through* a star
+                # import.
+                "libcst": STAR_REEXPORT_EDGES
+                | {
+                    "p.x -> p.functions",
+                    "p.x -> p.functions.f",
+                    "p.x -> p.functions.g",
+                    "p.x.a -> p.x",
+                },
+                # The rust backend mints one node per `from X import *`
+                # statement (named `<mod>.*<src>`), with a single
+                # outgoing edge to the upstream module. Use sites
+                # route through this node (alias edge) and emit the
+                # standard parallel upstream module/decl edges via
+                # ty's name resolution (Principle 2).
+                "rust": {
+                    "p.x.*p.functions -> p.x",
+                    "p.x.*p.functions -> p.functions",
+                    "p.x.a -> p.x",
+                    "p.x.a -> p.x.*p.functions",
+                    "p.x.a -> p.functions",
+                    "p.x.a -> p.functions.f",
+                },
             },
             id="star-import-fans-out-to-all-decls",
         ),
@@ -475,9 +494,20 @@ STAR_REEXPORT_EDGES = frozenset(
         ),
     ],
 )
-def test_imports(build_decl_graph, assert_edges, src, expected_extra_edges):
+def test_imports(build_decl_graph, assert_edges, backend, src, expected_extra_edges):
+    # A case can declare divergent expectations per backend by passing
+    # a `{"libcst": {...}, "rust": {...}}` dict instead of a single
+    # set — the libcst pipeline minted per-name synthetic aliases for
+    # star imports as a workaround for its inability to resolve uses
+    # through `from X import *`, but the rust backend leans on ty's
+    # name resolution and only mints one node per star statement.
+    extras = (
+        expected_extra_edges[backend]
+        if isinstance(expected_extra_edges, dict)
+        else expected_extra_edges
+    )
     graph = build_decl_graph({**IMPORT_TEST_FILES, "p/x.py": src})
-    assert_edges(graph, IMPORT_BASE_EDGES | expected_extra_edges)
+    assert_edges(graph, IMPORT_BASE_EDGES | extras)
 
 
 @pytest.mark.parametrize(
@@ -872,20 +902,38 @@ def test_star_reexport_shadowed_by_real_decl(build_decl_graph, assert_edges):
     assert "consumer.g -> other.g" not in edge_strs
 
 
-def test_star_reexport_is_skipped_by_codemod(build_decl_graph, tmp_path, assert_edges):
-    """Star re-export synthetics carry ``STAR_REEXPORT`` and stay out of the codemod's hands."""
-    from dead_cst.graph import NodeFlags
+def test_star_reexport_is_skipped_by_codemod(build_decl_graph, backend):
+    """Star re-export imports surface as a single node per statement,
+    distinguishable from regular imports so the codemod doesn't try
+    to drop them as normal `unused import` candidates.
 
+    The libcst pipeline minted per-name synthetic aliases and flagged
+    them with `NodeFlags.STAR_REEXPORT`; the rust backend mints one
+    node per statement named `<mod>.*<src>` with `kind="import"` and
+    an `imports.star=True` payload — the `*` prefix is the marker.
+    """
     graph = build_decl_graph(
         {
             "pkg/__init__.py": "from pkg._internal import *\n",
             "pkg/_internal.py": "def g(): pass\n",
         }
     )
-    reexports = [
-        n for n in graph.nodes if n.fqname == "pkg.g" and n.flags & NodeFlags.STAR_REEXPORT
-    ]
-    assert len(reexports) == 1, [n.fqname for n in graph.nodes if "pkg" in n.fqname]
+    if backend == "rust":
+        # One star node per `from X import *`, named `*<src>`.
+        star_nodes = [
+            n for n in graph.nodes if n.fqname == "pkg.*pkg._internal" and n.type == "import"
+        ]
+        assert len(star_nodes) == 1, [n.fqname for n in graph.nodes if "pkg" in n.fqname]
+        assert star_nodes[0].imports is not None
+        assert star_nodes[0].imports.star is True
+        assert star_nodes[0].imports.module == "pkg._internal"
+    else:
+        from dead_cst.graph import NodeFlags
+
+        reexports = [
+            n for n in graph.nodes if n.fqname == "pkg.g" and n.flags & NodeFlags.STAR_REEXPORT
+        ]
+        assert len(reexports) == 1, [n.fqname for n in graph.nodes if "pkg" in n.fqname]
 
 
 def test_star_reexport_inherits_exported_from_importing_module(tmp_path, make_analysis):


### PR DESCRIPTION
> **Base: `rust_proto`** (not `main`). Diff is the single commit on this branch — `rust_proto` already contains all prior native-crate work. Compare against `rust_proto` to see just this change.

## Summary

The libcst pipeline minted per-name synthetic aliases for `from X import *` — a workaround for its inability to resolve use sites *through* a star import. The rust backend leans on ty's name resolution instead, so we don't need the per-name nodes: **one node per star statement** is enough to keep the import alive, and use sites still attribute to specific upstream decls via the standard parallel-upstream edges (Principle 2).

For `from p.functions import *; def a(): f()` in `p/x.py`, the rust backend now emits:

```
p.x.*p.functions → p.x              ← star alias's parent
p.x.*p.functions → p.functions      ← only outgoing edge
p.x.a            → p.x              ← f's parent
p.x.a            → p.x.*p.functions ← use-site alias edge
p.x.a            → p.functions      ← parallel upstream module (Principle 2)
p.x.a            → p.functions.f    ← parallel upstream decl (ty resolves f)
```

No per-name fan-out from the star alias — ty has already done the resolution at the use site.

## Implementation

- **`ingest_decls`** gives every per-name `DefinitionKind::StarImport` a shared `*<source>` local name (`p.x.*p.functions`). Combined with the shared `target_range` (the `*` token), all per-name defs intern to the same `NodeKey` and therefore the same `node_idx`. The per-name lookup maps (`globals_by_name`, `star_reexports`) still key by the actual symbol name (`f`, `g`, …) — all pointing at the single star node — so Phase 2's chain walk for `from A import g` chasing through A's `from B import *` still works.
- **`emit_import_edges`** returns `None` for `StarImport` instead of calling `resolve_from_imported` — no per-name fan-out edges. The existing from-style parallel emit still adds the one `alias → upstream_module` edge.
- **Use sites** are unchanged: ty resolves `g` to the (deduplicated) star node and emits `use → alias` + parallel upstream via `emit_upstream`.
- **No `STAR_REEXPORT` flag** — the `*` prefix in fqname plus `kind=="import"` + `imports.star=true` is enough to identify these.

## Test divergence

Tests pinning the libcst per-name model now carry per-backend expectations:

- `test_imports` parametrize cases can use `{"libcst": …, "rust": …}` dicts instead of a single set; the test body dispatches on the new `backend` arg.
- `test_star_reexport_is_skipped_by_codemod` branches inline on `backend`.
- Prototype `test_star_import_*` tests in `tests/prototype/test_native_graph.py` are rewritten to assert the new shape directly (they're rust-specific anyway).

## Test impact

| Suite | Before | After |
|---|---|---|
| Full `--backend=rust` | 927 / 964 | **929 / 964** *(+2)* |
| Full `--backend=libcst` | 990 / 990 | **990 / 990** |

Newly passing:
- `test_imports[star-import-fans-out-to-all-decls]`
- `test_star_reexport_is_skipped_by_codemod`

Remaining import failures cluster in independent buckets — dynamic imports needing per-call edges (Phase 2 of this work), alias preservation through `__init__.py` re-exports, synthetic external/unresolved nodes. Out of scope here.

## Test plan
- [x] `uv run pytest tests/test_imports.py tests/prototype/test_native_graph.py --backend=rust` — 60 / 76 *(was 58 / 76)*
- [x] `uv run pytest --backend=libcst` — 990 passed
- [x] `uv run pytest --backend=rust` — 929 passed, 35 failed *(was 927 / 37)*
- [x] `cargo clippy --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

https://claude.ai/code/session_01R6GWpvWCUUNeYzJToopc9C

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6GWpvWCUUNeYzJToopc9C)_