### PR TITLE
prototype: dynamic imports emit one DYN-flagged edge per literal symbol

### DIFF
--- a/crates/dead-cst-ty-native/src/lib.rs
+++ b/crates/dead-cst-ty-native/src/lib.rs
@@ -3883,26 +3883,7 @@ impl<'a, 'db> RefCollector<'a, 'db> {
                 let file_pkg = file_package_name(db, self.file);
                 let pkg = explicit_package.or(file_pkg.as_deref());
                 match resolve_dynamic_target(kind, &name, explicit_level, pkg) {
-                    Ok(target) => {
-                        if let Some(module_name) = ModuleName::new(&target) {
-                            self.emit_nested_star(&module_name);
-                            // Literal fromlist entries that themselves
-                            // resolve as submodules of the target get
-                            // fanned out too — they correspond to a
-                            // child `from target.entry import *`.
-                            for entry in &fromlist {
-                                if entry.is_empty() {
-                                    continue;
-                                }
-                                let sub = format!("{target}.{entry}");
-                                if let Some(sub_mn) = ModuleName::new(&sub) {
-                                    if module_name_resolves(&sub, self.file, db) {
-                                        self.emit_nested_star(&sub_mn);
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    Ok(target) => self.emit_dynamic_edges(&target, &fromlist),
                     Err(message) => emit_visitor_warning(py, &message),
                 }
                 true
@@ -3912,6 +3893,78 @@ impl<'a, 'db> RefCollector<'a, 'db> {
                 true
             }
             DynamicParseResult::NotApplicable => false,
+        }
+    }
+
+    /// Emit `owner → target` (and `owner → target.entry` for each
+    /// fromlist entry that resolves) for a dynamic import, each
+    /// tagged with `EDGE_FLAG_DYNAMIC_IMPORT`. The visitor stays
+    /// minimal: one edge per literal symbol the call mentioned. A
+    /// contrib plugin can read the flag and fan out further.
+    fn emit_dynamic_edges(&mut self, target: &str, fromlist: &[&str]) {
+        let db = self.model.db();
+        let saved = self.current_flags;
+        self.current_flags |= EDGE_FLAG_DYNAMIC_IMPORT;
+
+        // Edge to the literal name's module — but only when there's
+        // no fromlist, since with a fromlist the base module is just
+        // a stepping stone to the named entries.
+        if fromlist.is_empty() {
+            self.emit_resolved_module(target);
+        } else {
+            // With a non-empty fromlist Python still loads the base
+            // module (`__import__('p', fromlist=[…])` returns `p`),
+            // so emit the base edge and then resolve each entry as
+            // either a submodule or a global-scope decl in that
+            // module.
+            self.emit_resolved_module(target);
+            for entry in fromlist {
+                if entry.is_empty() {
+                    continue;
+                }
+                let candidate = format!("{target}.{entry}");
+                if module_name_resolves(&candidate, self.file, db) {
+                    self.emit_resolved_module(&candidate);
+                    continue;
+                }
+                let target_file = ModuleName::new(target)
+                    .and_then(|n| resolve_module(db, self.file, &n))
+                    .and_then(|m| m.file(db));
+                if let Some(target_file) = target_file {
+                    if let Some(&decl_idx) =
+                        self.live_decls.get(&(target_file, (*entry).to_string()))
+                    {
+                        self.emit_edge(decl_idx);
+                    }
+                }
+                // Entries that don't resolve as either submodule or
+                // decl are dropped silently — the libcst pipeline
+                // does the same.
+            }
+        }
+
+        self.current_flags = saved;
+    }
+
+    fn emit_resolved_module(&mut self, dotted: &str) {
+        let db = self.model.db();
+        let Some(mn) = ModuleName::new(dotted) else {
+            return;
+        };
+        let Some(module) = resolve_module(db, self.file, &mn) else {
+            return;
+        };
+        if module
+            .search_path(db)
+            .is_some_and(|sp| sp.is_standard_library())
+        {
+            return;
+        }
+        let Some(target_file) = module.file(db) else {
+            return;
+        };
+        if let Some(&idx) = self.module_nodes.get(&target_file) {
+            self.emit_edge(idx);
         }
     }
 }
@@ -4328,6 +4381,13 @@ const NODE_FLAGS_NOQA_PIN: u32 = NODE_FLAG_ENTRYPOINT | NODE_FLAG_NOQA;
 /// first non-`NONE` bit, value `1`. Stamped on every edge produced
 /// by a use site that lives inside a statically-dead region.
 const EDGE_FLAG_DEAD_BRANCH: u32 = 1;
+
+/// `EdgeFlags::DYNAMIC_IMPORT = enum.auto()` in `dead_cst.graph` —
+/// second non-`NONE` bit, value `2`. Stamped on each edge emitted
+/// from a runtime-import call (`__import__('X')` /
+/// `importlib.import_module('X')`) to keep the visitor's resolution
+/// minimal — plugins can read the flag and choose to fan out.
+const EDGE_FLAG_DYNAMIC_IMPORT: u32 = 2;
 
 // ---------------------------------------------------------------------------
 // Dead-region detection

--- a/dead_cst/graph.py
+++ b/dead_cst/graph.py
@@ -105,10 +105,19 @@ class EdgeFlags(enum.IntFlag):
     liveness through the enclosing decl, is preserved. The opt-in
     :func:`dead_cst.find_kept_alive_by_dead_branches` returns the
     "blast radius" of removing every dead suite by skipping these edges.
+
+    ``DYNAMIC_IMPORT`` flags an edge emitted from a runtime-import
+    call (``__import__('X')`` / ``importlib.import_module('X')``).
+    Visitor behavior is minimal — one edge per *explicit symbol* the
+    call mentions, no fan-out to upstream decls — so reachability
+    captures only what the literal call expresses. A contrib plugin
+    can extend the graph by reading the flag and fanning each
+    flagged module-edge out to its exports.
     """
 
     NONE = 0
     DEAD_BRANCH = enum.auto()
+    DYNAMIC_IMPORT = enum.auto()
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,3 +213,18 @@ def assert_dead_branch_edges():
         assert actual == expected_edges
 
     return _check
+
+
+@pytest.fixture
+def assert_dynamic_import_edges():
+    """Assert on edges flagged ``EdgeFlags.DYNAMIC_IMPORT`` as ``"src.fqname -> dst.fqname"``."""
+
+    def _check(graph: SymbolGraph, expected_edges: set[str]):
+        actual = {
+            f"{graph.node(u).fqname} -> {graph.node(v).fqname}"
+            for u, v, payload in graph.raw.weighted_edge_list()
+            if payload & EdgeFlags.DYNAMIC_IMPORT
+        }
+        assert actual == expected_edges
+
+    return _check

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -392,103 +392,163 @@ STAR_REEXPORT_EDGES = frozenset(
             },
             id="star-import-fans-out-to-all-decls",
         ),
+        # ------------------------------------------------------------------
+        # Dynamic imports (`__import__` / `importlib.import_module`).
+        #
+        # libcst minted per-name synthetic aliases that fanned out to
+        # every export of the target module. The rust backend leans on
+        # ty: one edge per *explicit symbol* the call mentions, tagged
+        # with `EdgeFlags.DYNAMIC_IMPORT` so a contrib plugin can fan
+        # out further if a project wants the old semantic.
+        # ------------------------------------------------------------------
         pytest.param(
             "__import__('p.functions')",
-            STAR_REEXPORT_EDGES
-            | {
-                "p.x -> p.functions",
-                "p.x -> p.functions.f",
-                "p.x -> p.functions.g",
+            {
+                "libcst": STAR_REEXPORT_EDGES
+                | {
+                    "p.x -> p.functions",
+                    "p.x -> p.functions.f",
+                    "p.x -> p.functions.g",
+                },
+                "rust": {"p.x -> p.functions"},
             },
             id="dunder-import-call-fans-out-like-star",
         ),
         pytest.param(
             "def a(): getattr(__import__('p.functions'), 'f')()",
             {
-                "p.x.a -> p.functions",
-                "p.x.a -> p.functions.f",
-                "p.x.a -> p.functions.g",
-                "p.x.a -> p.x",
+                "libcst": {
+                    "p.x.a -> p.functions",
+                    "p.x.a -> p.functions.f",
+                    "p.x.a -> p.functions.g",
+                    "p.x.a -> p.x",
+                },
+                "rust": {
+                    "p.x.a -> p.functions",
+                    "p.x.a -> p.x",
+                },
             },
             id="dunder-import-call-inside-function-attributes-to-enclosing-decl",
         ),
         pytest.param(
             "import importlib\nimportlib.import_module('p.functions')",
-            STAR_REEXPORT_EDGES
-            | {
-                "p.x -> p.functions",
-                "p.x -> p.functions.f",
-                "p.x -> p.functions.g",
-                "p.x -> p.x.importlib",
-                "p.x.importlib -> p.x",
+            {
+                "libcst": STAR_REEXPORT_EDGES
+                | {
+                    "p.x -> p.functions",
+                    "p.x -> p.functions.f",
+                    "p.x -> p.functions.g",
+                    "p.x -> p.x.importlib",
+                    "p.x.importlib -> p.x",
+                },
+                "rust": {
+                    "p.x -> p.functions",
+                    "p.x -> p.x.importlib",
+                    "p.x.importlib -> p.x",
+                },
             },
             id="importlib-import-module-fans-out-like-star",
         ),
         pytest.param(
             "import importlib\ndef a(): importlib.import_module('p.functions')",
             {
-                "p.x.a -> p.functions",
-                "p.x.a -> p.functions.f",
-                "p.x.a -> p.functions.g",
-                "p.x.a -> p.x",
-                "p.x.a -> p.x.importlib",
-                "p.x.importlib -> p.x",
+                "libcst": {
+                    "p.x.a -> p.functions",
+                    "p.x.a -> p.functions.f",
+                    "p.x.a -> p.functions.g",
+                    "p.x.a -> p.x",
+                    "p.x.a -> p.x.importlib",
+                    "p.x.importlib -> p.x",
+                },
+                "rust": {
+                    "p.x.a -> p.functions",
+                    "p.x.a -> p.x",
+                    "p.x.a -> p.x.importlib",
+                    "p.x.importlib -> p.x",
+                },
             },
             id="importlib-import-module-inside-function",
         ),
         pytest.param(
             "import importlib\nimportlib.import_module('.functions', 'p')",
-            STAR_REEXPORT_EDGES
-            | {
-                "p.x -> p.functions",
-                "p.x -> p.functions.f",
-                "p.x -> p.functions.g",
-                "p.x -> p.x.importlib",
-                "p.x.importlib -> p.x",
+            {
+                "libcst": STAR_REEXPORT_EDGES
+                | {
+                    "p.x -> p.functions",
+                    "p.x -> p.functions.f",
+                    "p.x -> p.functions.g",
+                    "p.x -> p.x.importlib",
+                    "p.x.importlib -> p.x",
+                },
+                "rust": {
+                    "p.x -> p.functions",
+                    "p.x -> p.x.importlib",
+                    "p.x.importlib -> p.x",
+                },
             },
             id="importlib-import-module-relative-positional-package",
         ),
         pytest.param(
             "import importlib\nimportlib.import_module('.functions', package='p')",
-            STAR_REEXPORT_EDGES
-            | {
-                "p.x -> p.functions",
-                "p.x -> p.functions.f",
-                "p.x -> p.functions.g",
-                "p.x -> p.x.importlib",
-                "p.x.importlib -> p.x",
+            {
+                "libcst": STAR_REEXPORT_EDGES
+                | {
+                    "p.x -> p.functions",
+                    "p.x -> p.functions.f",
+                    "p.x -> p.functions.g",
+                    "p.x -> p.x.importlib",
+                    "p.x.importlib -> p.x",
+                },
+                "rust": {
+                    "p.x -> p.functions",
+                    "p.x -> p.x.importlib",
+                    "p.x.importlib -> p.x",
+                },
             },
             id="importlib-import-module-relative-keyword-package",
         ),
         pytest.param(
             "import importlib\nimportlib.import_module('.functions')",
-            STAR_REEXPORT_EDGES
-            | {
-                "p.x -> p.functions",
-                "p.x -> p.functions.f",
-                "p.x -> p.functions.g",
-                "p.x -> p.x.importlib",
-                "p.x.importlib -> p.x",
+            {
+                "libcst": STAR_REEXPORT_EDGES
+                | {
+                    "p.x -> p.functions",
+                    "p.x -> p.functions.f",
+                    "p.x -> p.functions.g",
+                    "p.x -> p.x.importlib",
+                    "p.x.importlib -> p.x",
+                },
+                "rust": {
+                    "p.x -> p.functions",
+                    "p.x -> p.x.importlib",
+                    "p.x.importlib -> p.x",
+                },
             },
             id="importlib-import-module-relative-uses-enclosing-package",
         ),
         pytest.param(
             "__import__('functions', globals(), locals(), [], 1)",
-            STAR_REEXPORT_EDGES
-            | {
-                "p.x -> p.functions",
-                "p.x -> p.functions.f",
-                "p.x -> p.functions.g",
+            {
+                "libcst": STAR_REEXPORT_EDGES
+                | {
+                    "p.x -> p.functions",
+                    "p.x -> p.functions.f",
+                    "p.x -> p.functions.g",
+                },
+                "rust": {"p.x -> p.functions"},
             },
             id="dunder-import-positional-level-resolves-relative",
         ),
         pytest.param(
             "__import__('functions', level=1)",
-            STAR_REEXPORT_EDGES
-            | {
-                "p.x -> p.functions",
-                "p.x -> p.functions.f",
-                "p.x -> p.functions.g",
+            {
+                "libcst": STAR_REEXPORT_EDGES
+                | {
+                    "p.x -> p.functions",
+                    "p.x -> p.functions.f",
+                    "p.x -> p.functions.g",
+                },
+                "rust": {"p.x -> p.functions"},
             },
             id="dunder-import-keyword-level-resolves-relative",
         ),
@@ -608,40 +668,58 @@ def test_dynamic_import_non_literal_warns(build_decl_graph, visitor_warnings):
         pytest.param("__import__('p', fromlist=['functions'])", id="fromlist-keyword"),
     ],
 )
-def test_dunder_import_fromlist_resolves_submodules(build_decl_graph, assert_edges, src):
-    """Literal ``fromlist`` entries that resolve as submodules are fanned out too."""
+def test_dunder_import_fromlist_resolves_submodules(build_decl_graph, assert_edges, backend, src):
+    """Literal ``fromlist`` entries that resolve as submodules get edges too.
+
+    libcst's per-name fan-out emitted ``mod → upstream.export`` for every
+    name the upstream module exposed (via the synthetic star-reexport
+    aliases). The rust backend emits one edge per explicit symbol the
+    call mentions: the base module plus each literal fromlist entry that
+    resolves as a submodule, all tagged ``EdgeFlags.DYNAMIC_IMPORT``.
+    """
     graph = build_decl_graph({**IMPORT_TEST_FILES, "p/x.py": src})
-    assert_edges(
-        graph,
-        IMPORT_BASE_EDGES
-        | STAR_REEXPORT_EDGES
-        | {
+    if backend == "rust":
+        extras = {
+            "p.x -> p",
+            "p.x -> p.functions",
+        }
+    else:
+        extras = STAR_REEXPORT_EDGES | {
             "p.x -> p.functions",
             "p.x -> p.functions.f",
             "p.x -> p.functions.g",
-        },
-    )
+        }
+    assert_edges(graph, IMPORT_BASE_EDGES | extras)
 
 
 def test_dunder_import_fromlist_attribute_entries_silent(
-    build_decl_graph, assert_edges, visitor_warnings
+    build_decl_graph, assert_edges, visitor_warnings, backend
 ):
-    """Fromlist entries that are not submodules don't warn (already covered by name fan-out)."""
+    """Fromlist entries that are not submodules don't warn.
+
+    libcst still emitted module-level export edges (via per-name aliases);
+    the rust backend looks each entry up as a global-scope decl in the
+    base module and emits an edge if found, otherwise drops silently.
+    """
     graph = build_decl_graph(
         {**IMPORT_TEST_FILES, "p/x.py": "__import__('p.functions', fromlist=['f', ''])"}
     )
 
     assert visitor_warnings() == []
-    assert_edges(
-        graph,
-        IMPORT_BASE_EDGES
-        | STAR_REEXPORT_EDGES
-        | {
+    if backend == "rust":
+        # `f` resolves as a decl in p.functions → edge to p.functions.f;
+        # the empty-string entry is silently skipped. No fan-out to g.
+        extras = {
+            "p.x -> p.functions",
+            "p.x -> p.functions.f",
+        }
+    else:
+        extras = STAR_REEXPORT_EDGES | {
             "p.x -> p.functions",
             "p.x -> p.functions.f",
             "p.x -> p.functions.g",
-        },
-    )
+        }
+    assert_edges(graph, IMPORT_BASE_EDGES | extras)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
> **Base: `rust_proto`** (not `main`). Diff is the single commit on this branch — `rust_proto` already contains all prior native-crate work. Compare against `rust_proto` to see just this change.

## Summary

Phase 2 of the import-shape pivot (Phase 1 was star imports → #161). The libcst pipeline minted per-name synthetic aliases for `__import__('X')` / `importlib.import_module('X')` and fanned out to every export of the target module. The rust backend leans on ty: **one edge per *explicit symbol* the call mentions**, tagged with `EdgeFlags::DYNAMIC_IMPORT`. A contrib plugin can later read the flag and choose to fan out further for projects that want the old semantic.

## What gets emitted

Per the design discussion in the prior thread:

| Call | Edges (all DYN-tagged) |
|---|---|
| `__import__('p.functions')` | `owner → p.functions` |
| `__import__('p', fromlist=['functions'])` *(submodule)* | `owner → p`, `owner → p.functions` |
| `__import__('p.functions', fromlist=['f'])` *(decl)* | `owner → p.functions`, `owner → p.functions.f` |
| `__import__('p', fromlist=['unresolvable_thing'])` | `owner → p` |
| `__import__('functions', level=1)` *(in p/x.py)* | `owner → p.functions` |
| `importlib.import_module('p.functions')` | `owner → p.functions` |
| `importlib.import_module('.functions', 'p')` | `owner → p.functions` |
| `importlib.import_module(name)` *(non-literal)* | nothing (warning) |

Stdlib targets stay suppressed (the typeshed stub doesn't surface).

## Implementation

- New `emit_dynamic_edges` on `RefCollector` replaces the old `emit_nested_star` dispatch in `try_emit_dynamic_import`. Sets `current_flags |= EDGE_FLAG_DYNAMIC_IMPORT` for the duration, emits one edge per literal symbol, then restores.
- New `emit_resolved_module` helper folds the "resolve name → module → mint module node → emit edge" sequence with stdlib filtering.
- `EdgeFlags::DYNAMIC_IMPORT` added to `dead_cst.graph` (`auto()`, value `2`). Mirror constant on the Rust side.
- New `assert_dynamic_import_edges` fixture parallels `assert_dead_branch_edges` for tests that want to assert on the flag.

## Test divergence

Same `{"libcst": ..., "rust": ...}` dict pattern PR #161 introduced. The 9 affected `test_imports` parametrize cases declare both expected sets; `test_dunder_import_fromlist_resolves_submodules` (2 cases) and `test_dunder_import_fromlist_attribute_entries_silent` branch inline on `backend`. Libcst pipeline keeps the per-name fan-out (its tests assert on `STAR_REEXPORT_EDGES` + per-export edges); rust gets the minimal-edge shape.

## Test impact

| Suite | Before | After |
|---|---|---|
| `tests/test_imports.py` dynamic / fromlist `--backend=rust` | 0 / 12 | **12 / 12** |
| Full `--backend=rust` | 929 / 964 | **952 / 977** *(+23)* |
| Full `--backend=libcst` | 990 / 990 | **990 / 990** |

The +23 covers the 12 dynamic-import tests directly addressed plus 11 tests that previously skipped (parametrize entries unreachable until `backend` participated as a fixture parameter — same wiring as #161 introduced).

## Test plan
- [x] `uv run pytest tests/test_imports.py -k "dunder or importlib or dynamic" --backend=rust` — 24 / 24
- [x] `uv run pytest --backend=libcst` — 990 passed
- [x] `uv run pytest --backend=rust` — 952 passed, 25 failed *(was 929 / 35)*
- [x] `cargo clippy --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Follow-up

Contrib plugin that reads `EdgeFlags::DYNAMIC_IMPORT` and fans each flagged module-edge out to its non-underscore exports — gives projects that want the libcst semantic back an opt-in path without baking it into the visitor.

https://claude.ai/code/session_01R6GWpvWCUUNeYzJToopc9C

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6GWpvWCUUNeYzJToopc9C)_