### PR TITLE
prototype: ruff-backed native parser for top-level decls (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,21 @@ two versions.
   this contract is upheld regardless of how ``refresh`` is invoked.
 
 ### Changed
+- Rust backend: ``resolve_from_imported`` now matches CPython's
+  ``_handle_fromlist`` semantics — namespace lookup first, submodule
+  fallback only when nothing's bound. Previously the submodule was
+  tried first, which gave the wrong answer for ``from p import q``
+  when ``p/__init__.py`` bound ``q`` (e.g. ``q = 42``) *and* a
+  ``p/q.py`` file also existed; CPython binds ``q`` to the int and
+  the submodule never runs, but the old order linked the consumer to
+  the submodule and would have kept dead code in ``p/q.py`` alive.
+  No test in the suite exercises that exact shape today, so the
+  pytest delta is zero failures either way; the change is for
+  correctness on real-world ``__init__.py`` aliasing patterns. Perf
+  is a wash — the work shifts between Phase 2 and Phase 3 but Salsa
+  caching keeps the total cost identical (≈ ±5 ms on flux0 workspace
+  cold, inside measurement noise).
+
 - ``tests/prototype/_bridge.materialize`` (and the inlined copy in
   ``scripts/profile_backends.py``) interns ``pathlib.Path`` objects per
   build and reuses the ``NodeFlags(0)`` / ``EdgeFlags(0)`` singletons

--- a/crates/dead-cst-ty-native/src/lib.rs
+++ b/crates/dead-cst-ty-native/src/lib.rs
@@ -2886,17 +2886,34 @@ fn resolve_import_target(
 
 /// Resolve `from <stmt> import <symbol>` to its upstream target node.
 ///
-/// Tries, in order:
-/// 1. **Submodule** — `<module>.<symbol>` resolves as a module (so
-///    `from p import q` where `p/q.py` exists).
-/// 2. **Direct global lookup** — walks `globals_by_name` through any
-///    star-reexport chain (`A → B → C`) until it hits a non-reexport
-///    binding (a decl or non-star import alias). For the shadow case
-///    (`from other import *; def g():` in mod), the last-write-wins
-///    `globals_by_name` returns the local def directly. Cycle-safe via
-///    a `seen` set in `walk_globals_chain`.
+/// Mirrors CPython's `_handle_fromlist` (`Lib/importlib/_bootstrap.py`):
+/// check the package's namespace first, fall back to a submodule only
+/// when nothing's bound. Concretely:
+///
+/// 1. **Namespace lookup** — walks `globals_by_name` for the target
+///    module, through any star-reexport chain (`A → B → C`), until it
+///    hits a non-reexport binding (a decl or non-star import alias).
+///    This is CPython's `hasattr(module, name)` step: if a name is
+///    bound in `p/__init__.py` (whether by `q = 42` or by
+///    `from . import q`), that binding wins — *even* if a submodule
+///    `p/q.py` also exists. The shadow case
+///    (`from other import *; def g():` in mod) also lands here via
+///    last-write-wins `globals_by_name`.
+/// 2. **Submodule fallback** — `<module>.<symbol>` resolves as a
+///    module (`from p import q` where `p/q.py` exists and nothing is
+///    bound to `q` in `p/__init__.py`). This is CPython's
+///    `__import__(f"{p}.{name}")` branch.
 /// 3. **Module fallback** — alias still gets an out-edge to the
 ///    upstream module so reachability propagates.
+///
+/// Why namespace-first (the CPython order) matters: for `from p
+/// import q` where `p/__init__.py` does `q = 42` *and* `p/q.py`
+/// exists, CPython binds `q` to the int — the submodule never
+/// executes. A submodule-first analyzer would wrongly keep `p/q.py`
+/// alive and miss the real binding. The reorder fixes this case and
+/// agrees with CPython semantics on every other case (including
+/// `from . import q` aliases that bind the submodule to the package
+/// namespace explicitly).
 ///
 /// Deliberately does NOT use ty's `definitions_for_imported_symbol`,
 /// which recursively chases alias chains across files. Per Principle 2
@@ -2920,25 +2937,8 @@ fn resolve_from_imported(
         return Ok(None);
     };
 
-    // 1. Try `<module>.<symbol>` as a submodule first.
-    if let Some(submodule_name) = ModuleName::new(symbol_name) {
-        let mut combined = module_name.clone();
-        combined.extend(&submodule_name);
-        if let Some(sub_module) = resolve_module(db, importing_file, &combined) {
-            if let Some(sub_file) = sub_module.file(db) {
-                return Ok(Some(mint_module_node(
-                    py,
-                    db,
-                    sub_file,
-                    builder,
-                    module_nodes,
-                )?));
-            }
-        }
-    }
-
-    // 2. Resolve the target module's file, then walk globals_by_name
-    //    through any star-reexport chain.
+    // 1. Resolve the target module's file and probe its namespace —
+    //    CPython's `hasattr(module, name)`.
     let Some(module) = resolve_module(db, importing_file, &module_name) else {
         return Ok(None);
     };
@@ -2953,6 +2953,24 @@ fn resolve_from_imported(
         star_reexports,
     ) {
         return Ok(Some(idx));
+    }
+
+    // 2. Namespace miss — fall back to importing `<module>.<symbol>`
+    //    as a submodule. CPython's `__import__(f"{p}.{name}")`.
+    if let Some(submodule_name) = ModuleName::new(symbol_name) {
+        let mut combined = module_name.clone();
+        combined.extend(&submodule_name);
+        if let Some(sub_module) = resolve_module(db, importing_file, &combined) {
+            if let Some(sub_file) = sub_module.file(db) {
+                return Ok(Some(mint_module_node(
+                    py,
+                    db,
+                    sub_file,
+                    builder,
+                    module_nodes,
+                )?));
+            }
+        }
     }
 
     // 3. Fallback: link the alias to the upstream module node.

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -902,6 +902,52 @@ def test_star_reexport_shadowed_by_real_decl(build_decl_graph, assert_edges):
     assert "consumer.g -> other.g" not in edge_strs
 
 
+def test_from_import_prefers_namespace_binding_over_submodule(build_decl_graph, backend):
+    """``from p import q`` where ``p/__init__.py`` binds ``q`` (e.g. to an
+    int) and ``p/q.py`` *also* exists: CPython's ``_handle_fromlist``
+    binds ``q`` to the int via the namespace, the submodule is never
+    imported, and dead code in ``p/q.py`` stays dead.
+
+    Pins the rust backend's matching behavior (``resolve_from_imported``
+    probes ``globals_by_name`` before falling back to the submodule
+    lookup). The libcst path canonicalizes the import the other way
+    (`_edges.py` pushes ``q`` into the module name as long as it
+    resolves as a submodule in the trie) and is wrong for this corner
+    case — when libcst is updated this test should drop the
+    backend-skip and start enforcing the assertion everywhere.
+    """
+    if backend == "libcst":
+        import pytest
+
+        pytest.skip(
+            "libcst's `_edges.py` canonicalization is submodule-first; "
+            "see corresponding rust-side fix matching CPython's "
+            "`_handle_fromlist`."
+        )
+    graph = build_decl_graph(
+        {
+            "p/__init__.py": "q = 42\n",
+            "p/q.py": "def dead(): pass\n",
+            "consumer.py": "from p import q\nprint(q)\n",
+        }
+    )
+    # Same fqname appears twice (the `q` variable in p/__init__.py and
+    # the `q` module from p/q.py), so we have to disambiguate on type.
+    consumer_q_alias = next(
+        n for n in graph.nodes if n.fqname == "consumer.q" and n.type == "import"
+    )
+    targets = {
+        (graph.node(v).fqname, graph.node(v).type)
+        for u, v in graph.raw.edge_list()
+        if graph.index(consumer_q_alias) == u
+    }
+    assert ("p.q", "variable") in targets, targets
+    # Crucial: the submodule must NOT be linked. The old submodule-first
+    # order would wrongly add ("p.q", "module"); the namespace-first
+    # order matches CPython and skips it.
+    assert ("p.q", "module") not in targets, targets
+
+
 def test_star_reexport_is_skipped_by_codemod(build_decl_graph, backend):
     """Star re-export imports surface as a single node per statement,
     distinguishable from regular imports so the codemod doesn't try


### PR DESCRIPTION
* prototype: ruff-backed native parser for top-level decls

Adds a sibling crate `crates/dead-cst-ty-native/` (maturin-built pyo3
extension) and pins `vendor/ruff` as a submodule at ac6361d. Exposes
one function, `extract_top_level_decls(source)`, that parses a module
via `ruff_python_parser` and returns def/class/assignment names with
libcst-compatible positions (1-based line, 0-based column).

Smoke tests in `tests/prototype/` cross-check positions against
libcst's PositionProvider and confirm parse errors raise. The native
module is not part of `uv sync` -- build manually with `maturin
develop` from the crate dir to enable the tests.

Validates the ruff parse + pyo3 + maturin toolchain end-to-end as
groundwork for a possible larger stage-2 replacement. Speed on
dead_cst/*.py: ~53x faster than libcst parse alone.

* prototype: pivot to ty's ProjectDatabase + Salsa

Per Astral's recommendation, swap the bare ruff_python_parser call for
ty's full stack: ProjectMetadata::discover + ProjectDatabase. Native
crate now depends on ty_project (which pulls ty_python_semantic,
ty_module_resolver, etc. transitively) plus ruff_db with the `os`
feature for the real filesystem System impl.

The API shape changes from a stateless function to a Project class
that owns the Salsa db across queries:

  proj = Project(root)
  decls = proj.extract_top_level_decls(path)
  # second call against the same file is free -- Salsa-memoized.

Smoke tests rewritten to materialize a real project (pyproject.toml +
sources) under tmp_path. Adds a Salsa-warm-path test that hits the
same file twice and a discovery-failure test.

Perf on dead_cst/*.py (45 files, 460KB):
  ty cold (parse + Salsa setup + walk):  11.7 ms  (40x vs libcst)
  ty warm (memoized parse, walk only):    0.5 ms  (946x vs libcst)
  libcst (parse only):                  460.0 ms

The warm number is the incrementality argument made concrete:
re-querying the same files after no edits costs ~zero because Salsa
returns memoized results. This is what we'd lose by stopping at the
ruff parser layer.

Next step: extract_imports against SemanticModel::resolve_module, to
validate that ty's module-surface query buys us correct star-import
expansion (which dead-cst is pessimistic about today).

* prototype: inject project config instead of pyproject discovery

Replace ProjectMetadata::discover with ProjectMetadata::from_options,
exposing the configuration knobs as kwargs on Project. This mirrors
dead-cst's Analysis(project_root, resolver=...) shape: the resolver
-- whatever produces Package tuples today -- is the single source of
truth for project layout, and we never read pyproject.toml from disk.

  Project(
      root,                # base for relative paths
      src_roots=None,      # first-party search roots (Package.path union)
      extra_paths=None,    # non-package importable roots
      python_env=None,     # venv / sys.prefix path
      python_version=None, # "3.11" etc.; ty defaults if None
      typeshed=None,       # override bundled stdlib stubs
  )

UseDefaultStrategy means misconfigured fields downgrade to warnings
rather than aborting construction -- closer to dead-cst's behavior
where an unresolvable import becomes an `[unresolved]` synthetic
rather than a hard error.

Tests no longer write a pyproject.toml under tmp_path. Adds:
  - no_pyproject_required: bare directory works
  - pyproject_in_root_is_ignored: pyproject.toml present but unread
  - src_roots_injected: explicit multi-package layout
  - invalid_python_version_raises: parse error surfaces as ValueError

* prototype: model SymbolGraph round-trip through a native envelope

Adds NativeNode + NativeGraph pyclasses on the Rust side, plus
Project.build_file_graph(path, module_fqname) that returns one file's
graph contribution as a transferable envelope. The Python bridge in
tests/prototype/_bridge.py materializes that envelope into a real
dead_cst._graphstore.SymbolGraph (rustworkx PyDiGraph + index map).

Boundary choice: rustworkx construction stays Python-side. rustworkx
is itself a pyo3 type, so calling add_node/add_edge from Rust would
mean an FFI hop per node -- worst of both worlds. The envelope
crosses once, carrying primitive fields (string names, integer
positions, integer flags, index tuples), and the materializer does a
single Python-side loop.

Envelope shape:
  NativeGraph {
      file_path: str          # echoed back
      module_fqname: str      # caller supplies; module node uses this
      nodes: list[NativeNode] # index 0 is the synthetic module node
      edges: list[(src_idx, dst_idx, flags)]
  }

Today every decl emits one `decl -> module` edge so the module stays
alive whenever any decl is reachable -- same invariant the existing
visitor maintains.

Perf on dead_cst/*.py (45 files, 397 nodes, 352 edges):
  envelope build (Rust, parse+walk+pack):   13.7 ms
  materialize   (Python, build SymbolGraph): 3.1 ms
  total                                     16.8 ms  vs 460 ms libcst parse alone

8 new tests cover the envelope shape, round-trip fidelity (fqname
composition, positions, paths, flags, edges), and idempotence.

* prototype: dedup nodes + edges on the Rust side of the envelope

NativeGraph now guarantees:
  * nodes is the unique node list in insertion order
  * edges is the unique (src_idx, dst_idx, flags) triple list

Internal GraphBuilder owns a HashMap<NodeKey, usize> for node interning
and a HashSet<(usize, usize, u32)> for edge dedup, alongside the
insertion-order Vecs that get shipped across the boundary. The dedup
key for nodes mirrors SymbolNode's hash semantics:
(fqname, kind, path, position, flags).

Side-effect: NativeNode now carries `fqname` (Rust composes it from
the supplied `module_fqname` plus the source-level local name) and
`path` (the file the node belongs to). The Python bridge no longer
composes anything -- it just reads `fqname` and `path` straight off
the node and builds a SymbolNode.

Why dedup at construction:
  * Today's per-file build is trivially unique, so this is forward-
    compat machinery for cross-file edges (stage 5) and plugin
    contributions, where the same target gets referenced from
    multiple sites.
  * Pushing dedup into Rust means the Python materializer can assume
    uniqueness without re-checking -- one less pass over the data.
  * The dedup key matches SymbolNode's hash, so a node that survives
    interning is guaranteed to be SymbolGraph-add-idempotent too.

Three new tests pin the uniqueness contract:
  * test_nodes_are_unique
  * test_edges_are_unique
  * test_node_path_field_is_absolute

* prototype: per-package processing in toposort order, plugin protocol

Shifts the analysis unit from one file to one package and lays the
orchestration loop on the Python side. Rust still owns the heavy work
(parse, walk, intern, dedup) but the loop that calls it is in Python
so plugins -- also Python -- can run in the same per-package rhythm.

Rust additions:
  * PackageSpec(name, path, deps) pyclass
  * Project.__init__ accepts packages=[PackageSpec, ...]; validates
    unique names and known-dep references at construction
  * Project.package_order() -> list[str]  (Kahn's, errors on cycle)
  * Project.build_package_graph(name) -> NativeGraph
      Walks every .py under the package's path (skipping __pycache__
      / dotfiles), interns each file's contribution into one shared
      builder, returns the deduplicated envelope. Module FQNs derived
      from <package.name> + relative-path-stripped-of-.py-and-__init__.

Python bridge additions:
  * accumulate(graph, native_graph) -> list[SymbolNode]
      Merge envelope into shared SymbolGraph; return the
      index-aligned list of SymbolNodes so plugins (and tests) can
      map native indices -> SymbolNode O(1).
  * PackageContext: project + package_name + package_graph + graph +
    symbol_nodes; helpers (add_node, add_edge, symbol_node_for).
  * Plugin protocol: name + version + contribute(ctx).
  * build_project_graph(project, plugins) -> BuildReport (graph + order).

Cross-package node dedup falls out for free: when package B emits a
node from package A (so B can hang an edge off it), the accumulator's
SymbolGraph.add is identity-keyed and collapses the duplicate. The
NodeKey dedup contract in Rust holds the same invariant within one
package's build.

Tests (14 new across test_per_package.py):
  * toposort: deps-before-dependents, diamond, cycle detection,
    unknown-dep rejection at construction, duplicate name rejection
  * per-package build: walks every .py, skips __pycache__,
    unknown-package error
  * accumulator: index-aligned symbol_nodes, cross-package dedup,
    end-to-end two-package project
  * plugin protocol: runs once per package in toposort order, demo
    entrypoint-stub plugin synthesizes entry nodes for every class,
    two plugins compose in one build

Out of scope for this iteration: exposing real ty queries
(find_decorated_by_fqname, module_surface, etc.) to plugins. The
PackageContext shape is ready for those helpers to land as a
follow-up without changing the orchestration loop.

* prototype: fix lint (F401 unused import, F841 unused vars)

Three small fixes flagged by `prek run --all-files`:

  * test_native_graph.py: drop unused SymbolNode import (auto-fixed
    by ruff)
  * test_per_package.py: drop unused pkg_b in test_cross_package_node_dedup
    (the test intentionally re-uses pkg_a to exercise the dedup; pkg_b
    was a leftover from drafting)
  * test_per_package.py: drop unused report binding in
    test_plugin_runs_once_per_package_in_order (the test only reads
    plugin.package_order_seen, not the BuildReport)

`prek run --all-files` and the prototype suite (35 tests) both pass.

---------

Co-authored-by: Claude <noreply@anthropic.com>