### PR TITLE
prototype: match CPython's `_handle_fromlist` order in `resolve_from_imported`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,21 @@ two versions.
   this contract is upheld regardless of how ``refresh`` is invoked.
 
 ### Changed
+- Rust backend: ``resolve_from_imported`` now matches CPython's
+  ``_handle_fromlist`` semantics — namespace lookup first, submodule
+  fallback only when nothing's bound. Previously the submodule was
+  tried first, which gave the wrong answer for ``from p import q``
+  when ``p/__init__.py`` bound ``q`` (e.g. ``q = 42``) *and* a
+  ``p/q.py`` file also existed; CPython binds ``q`` to the int and
+  the submodule never runs, but the old order linked the consumer to
+  the submodule and would have kept dead code in ``p/q.py`` alive.
+  No test in the suite exercises that exact shape today, so the
+  pytest delta is zero failures either way; the change is for
+  correctness on real-world ``__init__.py`` aliasing patterns. Perf
+  is a wash — the work shifts between Phase 2 and Phase 3 but Salsa
+  caching keeps the total cost identical (≈ ±5 ms on flux0 workspace
+  cold, inside measurement noise).
+
 - ``tests/prototype/_bridge.materialize`` (and the inlined copy in
   ``scripts/profile_backends.py``) interns ``pathlib.Path`` objects per
   build and reuses the ``NodeFlags(0)`` / ``EdgeFlags(0)`` singletons

--- a/crates/dead-cst-ty-native/src/lib.rs
+++ b/crates/dead-cst-ty-native/src/lib.rs
@@ -2886,17 +2886,34 @@ fn resolve_import_target(
 
 /// Resolve `from <stmt> import <symbol>` to its upstream target node.
 ///
-/// Tries, in order:
-/// 1. **Submodule** — `<module>.<symbol>` resolves as a module (so
-///    `from p import q` where `p/q.py` exists).
-/// 2. **Direct global lookup** — walks `globals_by_name` through any
-///    star-reexport chain (`A → B → C`) until it hits a non-reexport
-///    binding (a decl or non-star import alias). For the shadow case
-///    (`from other import *; def g():` in mod), the last-write-wins
-///    `globals_by_name` returns the local def directly. Cycle-safe via
-///    a `seen` set in `walk_globals_chain`.
+/// Mirrors CPython's `_handle_fromlist` (`Lib/importlib/_bootstrap.py`):
+/// check the package's namespace first, fall back to a submodule only
+/// when nothing's bound. Concretely:
+///
+/// 1. **Namespace lookup** — walks `globals_by_name` for the target
+///    module, through any star-reexport chain (`A → B → C`), until it
+///    hits a non-reexport binding (a decl or non-star import alias).
+///    This is CPython's `hasattr(module, name)` step: if a name is
+///    bound in `p/__init__.py` (whether by `q = 42` or by
+///    `from . import q`), that binding wins — *even* if a submodule
+///    `p/q.py` also exists. The shadow case
+///    (`from other import *; def g():` in mod) also lands here via
+///    last-write-wins `globals_by_name`.
+/// 2. **Submodule fallback** — `<module>.<symbol>` resolves as a
+///    module (`from p import q` where `p/q.py` exists and nothing is
+///    bound to `q` in `p/__init__.py`). This is CPython's
+///    `__import__(f"{p}.{name}")` branch.
 /// 3. **Module fallback** — alias still gets an out-edge to the
 ///    upstream module so reachability propagates.
+///
+/// Why namespace-first (the CPython order) matters: for `from p
+/// import q` where `p/__init__.py` does `q = 42` *and* `p/q.py`
+/// exists, CPython binds `q` to the int — the submodule never
+/// executes. A submodule-first analyzer would wrongly keep `p/q.py`
+/// alive and miss the real binding. The reorder fixes this case and
+/// agrees with CPython semantics on every other case (including
+/// `from . import q` aliases that bind the submodule to the package
+/// namespace explicitly).
 ///
 /// Deliberately does NOT use ty's `definitions_for_imported_symbol`,
 /// which recursively chases alias chains across files. Per Principle 2
@@ -2920,25 +2937,8 @@ fn resolve_from_imported(
         return Ok(None);
     };
 
-    // 1. Try `<module>.<symbol>` as a submodule first.
-    if let Some(submodule_name) = ModuleName::new(symbol_name) {
-        let mut combined = module_name.clone();
-        combined.extend(&submodule_name);
-        if let Some(sub_module) = resolve_module(db, importing_file, &combined) {
-            if let Some(sub_file) = sub_module.file(db) {
-                return Ok(Some(mint_module_node(
-                    py,
-                    db,
-                    sub_file,
-                    builder,
-                    module_nodes,
-                )?));
-            }
-        }
-    }
-
-    // 2. Resolve the target module's file, then walk globals_by_name
-    //    through any star-reexport chain.
+    // 1. Resolve the target module's file and probe its namespace —
+    //    CPython's `hasattr(module, name)`.
     let Some(module) = resolve_module(db, importing_file, &module_name) else {
         return Ok(None);
     };
@@ -2953,6 +2953,24 @@ fn resolve_from_imported(
         star_reexports,
     ) {
         return Ok(Some(idx));
+    }
+
+    // 2. Namespace miss — fall back to importing `<module>.<symbol>`
+    //    as a submodule. CPython's `__import__(f"{p}.{name}")`.
+    if let Some(submodule_name) = ModuleName::new(symbol_name) {
+        let mut combined = module_name.clone();
+        combined.extend(&submodule_name);
+        if let Some(sub_module) = resolve_module(db, importing_file, &combined) {
+            if let Some(sub_file) = sub_module.file(db) {
+                return Ok(Some(mint_module_node(
+                    py,
+                    db,
+                    sub_file,
+                    builder,
+                    module_nodes,
+                )?));
+            }
+        }
     }
 
     // 3. Fallback: link the alias to the upstream module node.

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -902,6 +902,52 @@ def test_star_reexport_shadowed_by_real_decl(build_decl_graph, assert_edges):
     assert "consumer.g -> other.g" not in edge_strs
 
 
+def test_from_import_prefers_namespace_binding_over_submodule(build_decl_graph, backend):
+    """``from p import q`` where ``p/__init__.py`` binds ``q`` (e.g. to an
+    int) and ``p/q.py`` *also* exists: CPython's ``_handle_fromlist``
+    binds ``q`` to the int via the namespace, the submodule is never
+    imported, and dead code in ``p/q.py`` stays dead.
+
+    Pins the rust backend's matching behavior (``resolve_from_imported``
+    probes ``globals_by_name`` before falling back to the submodule
+    lookup). The libcst path canonicalizes the import the other way
+    (`_edges.py` pushes ``q`` into the module name as long as it
+    resolves as a submodule in the trie) and is wrong for this corner
+    case — when libcst is updated this test should drop the
+    backend-skip and start enforcing the assertion everywhere.
+    """
+    if backend == "libcst":
+        import pytest
+
+        pytest.skip(
+            "libcst's `_edges.py` canonicalization is submodule-first; "
+            "see corresponding rust-side fix matching CPython's "
+            "`_handle_fromlist`."
+        )
+    graph = build_decl_graph(
+        {
+            "p/__init__.py": "q = 42\n",
+            "p/q.py": "def dead(): pass\n",
+            "consumer.py": "from p import q\nprint(q)\n",
+        }
+    )
+    # Same fqname appears twice (the `q` variable in p/__init__.py and
+    # the `q` module from p/q.py), so we have to disambiguate on type.
+    consumer_q_alias = next(
+        n for n in graph.nodes if n.fqname == "consumer.q" and n.type == "import"
+    )
+    targets = {
+        (graph.node(v).fqname, graph.node(v).type)
+        for u, v in graph.raw.edge_list()
+        if graph.index(consumer_q_alias) == u
+    }
+    assert ("p.q", "variable") in targets, targets
+    # Crucial: the submodule must NOT be linked. The old submodule-first
+    # order would wrongly add ("p.q", "module"); the namespace-first
+    # order matches CPython and skips it.
+    assert ("p.q", "module") not in targets, targets
+
+
 def test_star_reexport_is_skipped_by_codemod(build_decl_graph, backend):
     """Star re-export imports surface as a single node per statement,
     distinguishable from regular imports so the codemod doesn't try


### PR DESCRIPTION
> **Base: `rust_proto`** (not `main`). Two commits: the reorder + a regression test.

## Summary

Rust backend's `resolve_from_imported` now matches CPython's `_handle_fromlist` semantics — namespace lookup first, submodule fallback only when nothing's bound. The old submodule-first order gave the wrong answer for this shape:

```python
# p/__init__.py
q = 42
# p/q.py exists with some dead code
# consumer.py
from p import q   # CPython: q = 42 (namespace wins, submodule never imports)
```

CPython's `Lib/importlib/_bootstrap.py::_handle_fromlist` (paraphrased):

```python
for name in fromlist:
    if not hasattr(module, name):                      # ← namespace lookup FIRST
        try:
            __import__(f"{module.__name__}.{name}")    # ← submodule fallback
        except ModuleNotFoundError:
            ...
```

The old order would have linked `consumer.q` directly to `p/q.py` (the module), wrongly keeping its contents alive. The new order goes through `globals_by_name`, finds the `q = 42` binding, and `p/q.py`'s contents correctly fall out of reachability.

## Why this is also CPython-accurate for the common case

The "common case" people worry about is `p/__init__.py` doing `from . import q` (which binds `q` in `p`'s namespace, pointing at the submodule). CPython's discovery path:

1. `from . import q` runs first → imports `p.q` AND binds the name `q` in `p`'s namespace to the module object
2. Later `from p import q` → `hasattr(p, "q")` returns True → returns the module via the namespace, fallback never runs

Our graph after this PR mirrors that path exactly: `consumer.q → p.q_alias → p.q (submodule)`. Two hops, but they're the *actual mechanism* CPython uses — not an approximation. The old "one direct hop" was eliding a real intermediate step.

## Test

`test_from_import_prefers_namespace_binding_over_submodule` pins the `q = 42; p/q.py exists` corner case directly. It **passes on `--backend=rust`** (verifies the new behavior) and **skips on `--backend=libcst`** (the libcst path's `_edges.py` has the same submodule-first canonicalization bug, just out of scope here). The skip message points at the libcst code so a future fix knows to drop the gate and start enforcing everywhere.

## Perf is a wash

I went hunting for this as a perf win initially (Phase 2 was doing ~1149 submodule probes that fail ~99% of the time). It turned out those probes weren't wasted — they were incidentally warming Salsa's cache for Phase 3's `emit_upstream`, which probes the same `(file, X.Y)` pairs once per use site. Reordering shifts the cold work from Phase 2 to Phase 3 rather than eliminating it.

Measured on flux0 workspace cold (5 iters, fresh `Project` per iter):

| variant                    | total cold ms |
|----------------------------|--------------:|
| baseline (origin/rust_proto) |    ~247      |
| with reorder               |        ~250   |

Within measurement noise (±5–10 ms on this host). **This PR lands the reorder for correctness only — not for perf.**

## Test plan
- [x] `cargo test --release` — 4 passed; 0 failed
- [x] `uv run pytest --backend=rust` — 941 passed, 37 failed (same 37 as `rust_proto` baseline, 0 new regressions), 13 skipped
- [x] `uv run pytest` (libcst, default) — 990 passed, 1 skipped (the new test)
- [x] `uv run pytest tests/test_imports.py::test_from_import_prefers_namespace_binding_over_submodule --backend=rust` — passes
- [x] `uv run pytest tests/test_imports.py::test_from_import_prefers_namespace_binding_over_submodule` — skips with clear message
- [x] `uv run pytest tests/prototype` — 28 passed

https://claude.ai/code/session_013bbfv7aTfShcRvuAQr9HCt

---
_Generated by [Claude Code](https://claude.ai/code/session_013bbfv7aTfShcRvuAQr9HCt)_