### PR TITLE
plugins: cross-file factory walk in rust DispatchAppPlugin.run

### DIFF
--- a/dead_cst/plugins/decl_shapes.py
+++ b/dead_cst/plugins/decl_shapes.py
@@ -506,6 +506,15 @@ class DispatchAppPlugin:
             simple = var_node.fqname.rsplit(".", 1)[-1]
             direct_by_owner.setdefault((var_node.path, simple), []).append((var_node, kind))
 
+        # Top-level vars keyed by (path, simple_name) so handler-edge
+        # emission and the pending-factory walk both have O(1) lookup.
+        vars_by_file: dict[tuple[str, str], native.NativeNode] = {}
+        for n in ctx.nodes():
+            if n.kind != "variable":
+                continue
+            simple = n.fqname.rsplit(".", 1)[-1]
+            vars_by_file.setdefault((n.path, simple), n)
+
         app_prefix = self._prefix("app")
         factory_prefix = self._prefix("factory")
 
@@ -526,9 +535,63 @@ class DispatchAppPlugin:
                         edges_from=[decl_node],
                     )
 
-        for owner_name, handler_func in handlers:
-            for var_node, _kind in direct_by_owner.get((handler_func.path, owner_name), []):
-                yield native.AddEdge(var_node, handler_func)
+        # Handler edges. Factory-aware plugins (Flask / FastAPI /
+        # FastMCP / Celery) emit edges for every top-level var named as
+        # a decorator owner, regardless of whether the var was directly
+        # constructed — pending vars need the edge so reachability
+        # flows from the entrypoint marker through the var to the
+        # handler once the factory walk classifies them. Pure-dispatch
+        # plugins (Typer / Cyclopts / Click) only wire owners that were
+        # directly classified; that gating is what lets the
+        # ``from typer import *`` limitation hold (the star import
+        # binds ``app`` but ``find_instance_constructions`` doesn't
+        # resolve through star imports, so ``app`` stays unclassified
+        # and its handlers stay dead).
+        if self._factory_aware:
+            for owner_name, handler_func in handlers:
+                var = vars_by_file.get((handler_func.path, owner_name))
+                if var is not None:
+                    yield native.AddEdge(var, handler_func)
+        else:
+            for owner_name, handler_func in handlers:
+                for var_node, _kind in direct_by_owner.get((handler_func.path, owner_name), []):
+                    yield native.AddEdge(var_node, handler_func)
+
+        if self._factory_aware:
+            # Cross-file factory classification: for every decorator-owned
+            # var that wasn't directly constructed as a known kind, walk
+            # forward through the graph until we hit a factory marker
+            # that classifies the var's kind. The forward closure of a
+            # factory-pattern var passes through its assignment RHS to
+            # the factory decl to that decl's body's references to the
+            # framework class — and to the factory marker we emitted on
+            # the factory decl. Same logic as the libcst plugin's
+            # ``walk_to_instance_kind``, but using ``ctx.descendants``
+            # for the BFS so the work is rust-side.
+            classified: set[tuple[str, str]] = set()
+            for owner_name, handler in handlers:
+                key = (handler.path, owner_name)
+                if key in direct_by_owner or key in classified:
+                    continue
+                var = vars_by_file.get(key)
+                if var is None:
+                    continue
+                for desc in ctx.descendants(var):
+                    if desc.kind != "synthetic":
+                        continue
+                    if not desc.fqname.startswith(factory_prefix):
+                        continue
+                    kind = desc.fqname[len(factory_prefix) :].split(":", 1)[0]
+                    if not self.instance_kinds.get(kind):
+                        continue
+                    classified.add(key)
+                    yield native.AddNode(
+                        fqname=f"{app_prefix}{var.fqname}",
+                        path=var.path,
+                        flags=int(NodeFlags.ENTRYPOINT),
+                        edges_to=[var],
+                    )
+                    break
 
 
 def _read_string_list_with_positions(


### PR DESCRIPTION
> **Base: `rust_proto`** (not `main`). Single commit on top of #163.

## Summary

Closes the four cross-file-factory plugin failures from #151 in the rust-backend matrix (Flask / FastAPI / FastMCP / Celery). `tests/test_plugins --backend=rust` is now **278 / 278**.

## Two bugs, both surfaced by the same test pattern

```python
# app/factory.py
from flask import Flask
def create_app() -> Flask:
    return Flask(__name__)

# app/main.py
from app.factory import create_app
app = create_app()                   # ← factory pattern; not direct
@app.route("/items")
def list_items(): pass
```

The libcst-side `DispatchAppPlugin` handles this in two phases: `observe` per-file emits a `<flask-pending>:<var.fqname>` marker for vars that *look* like app instances but aren't directly classified, and `finalize` per-package walks the graph forward from each pending marker (`walk_to_instance_kind`) to find a `<flask-factory>:Kind:` marker emitted on the factory decl. The rust port collapsed both phases into a single `run(ctx)` and missed two pieces:

* **Handler edges weren't emitted for pending owners.** The original loop only iterated `direct_by_owner` keys, so a factory-pattern `app = create_app()` had no `app → list_items` edge — even if we'd classified the var, reachability had nothing to flow through. Fixed by building a `vars_by_file` map up front and emitting handler edges for every top-level var named as a decorator owner.
* **The factory walk wasn't ported.** Even with handler edges in place, the pending var never got an entrypoint marker, so it (and its handlers) stayed dead. Added a forward BFS from each pending var via `ctx.descendants(var)`, looking for the first `<flask-factory>:Kind:` synthetic that classifies the kind as entrypoint-worthy. Same logic as the libcst plugin's `walk_to_instance_kind`, but operating on the rust-resident graph through the existing `descendants` query — no new query primitives needed.

## Pure-dispatch / factory-aware asymmetry

Caught a libcst-side subtlety I'd missed initially: pure-dispatch plugins (Typer / Cyclopts / Click) gate handler edges on direct classification, while factory-aware plugins (Flask / FastAPI / FastMCP / Celery) emit handler edges broadly. The gating is what makes `from typer import *; app = Typer(); @app.command()...` correctly treat `hello` as dead — the star import isn't seen as binding `Typer`, so `app` stays unclassified and the handler edge isn't emitted, so reachability never touches the handler.

Mirrored the asymmetry in the rust port: factory-aware mode emits broadly, pure-dispatch mode preserves the gated behavior. Two tests that I'd initially regressed (`test_typer_plugin_ignores_import_star`, `test_cyclopts_plugin_ignores_import_star`) are back to green.

## Test plan

- [x] `uv run pytest tests/test_plugins --backend=rust` — **278 / 278** (was 274 / 4 failed)
- [x] `uv run pytest` — full default suite 990 / 990
- [x] `uv run pytest --backend=rust` — 960 passed, 31 failed (down from 35; the remaining failures are in `test_imports.py` / `test_declarations.py` / `test_limitations.py`, unrelated to plugins)
- [x] `uv run prek run --all-files` clean

https://claude.ai/code/session_01KZf2rbhxbQjRYGckcRuSCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZf2rbhxbQjRYGckcRuSCE)_