### PR TITLE
prototype: emit use-site upstream edges to import-alias decls too

### DIFF
--- a/crates/dead-cst-ty-native/src/lib.rs
+++ b/crates/dead-cst-ty-native/src/lib.rs
@@ -3005,9 +3005,14 @@ fn ingest_decls(
             let key = (file, def.place(db), range_key(kind.target_range(&parsed)));
             if let Some(&idx) = global_index.get(&key) {
                 live.push(idx);
-                if !kind.is_import() {
-                    live_real_decls.push(idx);
-                }
+                // ``live_decls`` mirrors what's reachable as a decl-like
+                // target in the module's namespace — an import alias is
+                // still a decl from the consumer's standpoint, so it
+                // belongs here too. Filtering on ``!kind.is_import()``
+                // would skip ``mod -> lib.f@2:18`` when ``lib.f`` is
+                // ``from a import f`` (Principle 2's parallel-upstream
+                // edge from the use site to the decl in ``lib``).
+                live_real_decls.push(idx);
             }
         }
         let key = (file, name);

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -293,6 +293,7 @@ STAR_REEXPORT_EDGES = frozenset(
             "from p.chain import functions as g\ndef a(): g.f()",
             {
                 "p.x.a -> p.chain",
+                "p.x.a -> p.chain.functions",
                 "p.x.a -> p.x",
                 "p.x.a -> p.x.g",
                 "p.x.g -> p.chain",
@@ -373,6 +374,7 @@ STAR_REEXPORT_EDGES = frozenset(
             "from p.chain import functions\ndef a(): functions.f()",
             {
                 "p.x.a -> p.chain",
+                "p.x.a -> p.chain.functions",
                 "p.x.a -> p.x",
                 "p.x.a -> p.x.functions",
                 "p.x.functions -> p.chain",
@@ -1028,10 +1030,13 @@ def test_cyclic_reexport_terminates_rust(build_decl_graph, assert_edges):
     """Re-export cycle terminates without spinning (rust behavior).
 
     The rust backend resolves each alias once and stops — no
-    reexport-chain self-edges (``A.x -> A.x``), no use-site fan-out
-    through the cycle (``main -> A.x`` / ``main -> B.x``). The cycle
-    itself is still represented (``A.x -> B.x``, ``B.x -> A.x``) so
-    reachability from `main` can still walk it.
+    reexport-chain self-edges (``A.x -> A.x``), no transitive walk
+    through the cycle (no ``main -> B.x``). The cycle itself is still
+    represented (``A.x -> B.x``, ``B.x -> A.x``) so reachability from
+    `main` can still walk it. The use-site does emit the standard
+    Principle 2 parallel-upstream edge to ``A.x`` (the decl in A's
+    namespace that the import resolved to) — same shape as
+    ``main -> A`` for the upstream module.
     """
     graph = build_decl_graph(
         {
@@ -1051,6 +1056,7 @@ def test_cyclic_reexport_terminates_rust(build_decl_graph, assert_edges):
             "B.x -> A.x",
             "B.x -> B",
             "main -> A",
+            "main -> A.x",
             "main -> main.x",
             "main.x -> A",
             "main.x -> A.x",


### PR DESCRIPTION
> **Stacked on #173** (the walrus fix). Diff is the single commit on this branch.

## Summary

For `from lib import f` in `mod` where `lib` has multiple bindings of `f` (try/except, conditional re-import, ...), #170's multi-binding cross-module lookup wires the **consumer alias** to every binding:

```
mod.f@1:16 -> lib.f@2:18    ✓
mod.f@1:16 -> lib.f@4:4     ✓
```

But the **use-site** Principle 2 parallel-upstream-decl edge from `mod` itself only fanned to the non-import branch:

```
mod -> lib.f@4:4        ✓ (the `def f` branch)
mod -> lib.f@2:18       ✗ MISSING (the `from a import f` branch)
```

The asymmetry came from a filter in the `live_decls` post-pass that excluded `DefinitionKind::is_import()` bindings. The original intent was to keep cyclic import-alias chains from emitting use-site edges to upstream aliases, but Principle 2 doesn't care whether the decl-in-the-target-module is an import alias or a real def — both are decls in that module's namespace, and the use-site's parallel upstream-decl edge should reach each.

This PR drops the filter so `live_decls` matches `globals_by_name`'s shape across the board.

## What this fixes

- `mod -> lib.f@2:18` now exists for `try-except-both-branches-exported` (and similar shapes). Parallel-upstream symmetry restored.
- The 3 rust-only `test_imports` cases that documented the old asymmetric shape pick up one extra edge each — expectations updated accordingly.

## What this does NOT fix

The user-confirmed contract is "rust does not chase alias chains transitively":

- `mod -> a.f@1:0` (transitive through `lib.f@2:18 -> a.f@1:0`) — still not emitted.
- `mod.f@1:16 -> a.f@1:0` — same.

These would require recursive chain-walking in `walk_globals_chain` / `emit_upstream`. Out of scope.

## Test impact

| Suite | Before | After |
|---|---|---|
| `--backend=libcst` | 1000 / 0 fail | **1000 / 0 fail** (unchanged) |
| `--backend=rust`   | 1000 / 6 fail  | **1000 / 6 fail** (same count, ~~`try-except-both-branches-exported` strictly closer~~) |

Counts are unchanged but **the shape is now consistent**: every `try-except-both-branches-exported` edge except the 2 transitive `a.f` ones is present, vs the previous gap that mixed structural and transitive misses.

## Rust-only test updates

- `import-chain-via-reexport-rust`: + `p.x.a -> p.chain.functions`
- `reexport-through-package-init-rust`: + `p.x.a -> p.chain.functions`
- `test_cyclic_reexport_terminates_rust`: + `main -> A.x` (and docstring updated to reflect the new shape)

## Test plan
- [x] `cargo build --release` — clean
- [x] `cargo clippy --all-targets --locked --release -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `uv run pytest --backend=libcst` — 1000 passed, 31 skipped
- [x] `uv run pytest --backend=rust` — 1000 passed, 6 failed, 25 skipped (same 6 as #173 base)

https://claude.ai/code/session_01R6GWpvWCUUNeYzJToopc9C

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6GWpvWCUUNeYzJToopc9C)_