### PR TITLE
graph: split keepalive from ENTRYPOINT; introduce KEEPALIVE_DEFAULT mask

### DIFF
--- a/crates/dead-cst-ty-native/python/dead_cst_ty_native/__init__.pyi
+++ b/crates/dead-cst-ty-native/python/dead_cst_ty_native/__init__.pyi
@@ -45,8 +45,11 @@ class NodeFlags:
     live binding."""
 
     ENTRYPOINT: int
-    """Reachability seed. BFS for "what's live" starts from every node
-    carrying this bit."""
+    """Explicit entrypoint — plugin-emitted seeds, the CLI's ``-e`` flag,
+    ``[project.scripts]`` targets, factory-app synthetics, etc. One of
+    the keepalive bits ORed into ``KEEPALIVE_DEFAULT`` on the Python
+    side, so reachability seeds from ``ENTRYPOINT``-flagged nodes by
+    default."""
 
     OVERLOAD: int
     """``typing.overload`` stub (or any same-name decl anchored to a
@@ -54,22 +57,24 @@ class NodeFlags:
     kept alive by an explicit ``impl -> overload`` edge."""
 
     TESTCASE: int
-    """Tags an entrypoint as test-only (pytest / unittest fixtures and
-    test methods). Layered on top of ``ENTRYPOINT`` so the
-    ``kept_alive_by_flags_only(TESTCASE)`` blast-radius query can ask
-    "what's only alive because of tests"."""
+    """Pytest / unittest test discoveries. One of the keepalive bits in
+    ``KEEPALIVE_DEFAULT``, so tests are alive by default. The
+    ``kept_alive_by_flags_only(TESTCASE)`` blast-radius query isolates
+    "what's only alive because of tests" by computing the diff against
+    ``reachable(seed_flags=KEEPALIVE_DEFAULT & ~TESTCASE)``."""
 
     NOQA: int
-    """Tags an entrypoint as preserved by an explicit user noqa
-    directive (bare ``# noqa``, ``# noqa: F401``, multi-rule
-    ``# noqa: E501, F401``, or the file-level ``# ruff: noqa`` /
-    ``# flake8: noqa``)."""
+    """Import alias preserved by a user noqa directive (bare
+    ``# noqa``, ``# noqa: F401``, multi-rule ``# noqa: E501, F401``, or
+    the file-level ``# ruff: noqa`` / ``# flake8: noqa``). One of the
+    keepalive bits in ``KEEPALIVE_DEFAULT``."""
 
     NOTEBOOK: int
-    """Every node sourced from a Jupyter ``.ipynb`` file. Combined with
-    ``ENTRYPOINT`` because cells run top-to-bottom rather than being
-    imported, and the codemod skips notebook nodes (it can't rewrite
-    the cell JSON envelope)."""
+    """Every node sourced from a Jupyter ``.ipynb`` file. Cells run
+    top-to-bottom rather than being imported, so the bit alone keeps
+    the node alive (no ``ENTRYPOINT`` overlay needed — ``NOTEBOOK`` is
+    in ``KEEPALIVE_DEFAULT``). The codemod also reads the bit to skip
+    notebook nodes (it can't rewrite the cell JSON envelope)."""
 
     EXPORTED: int
     """Every node sourced from a file under the package's ``exported``

--- a/crates/dead-cst-ty-native/src/lib.rs
+++ b/crates/dead-cst-ty-native/src/lib.rs
@@ -5883,12 +5883,17 @@ fn rel_path<P: AsRef<str>>(path: P) -> RelativePathBuf {
 /// Per-source-type default flags for ``.ipynb``: notebook decls are
 /// always alive (cells run top-to-bottom, not imported) and the
 /// codemod must skip them (it can't rewrite the cell JSON envelope).
-const NODE_FLAGS_NOTEBOOK_DEFAULT: u32 = NodeFlags::ENTRYPOINT | NodeFlags::NOTEBOOK;
+/// The `NOTEBOOK` bit alone is enough — the Python-side
+/// `KEEPALIVE_DEFAULT` mask includes `NOTEBOOK`, so reachability seeds
+/// from notebook nodes without needing the `ENTRYPOINT` overlay.
+const NODE_FLAGS_NOTEBOOK_DEFAULT: u32 = NodeFlags::NOTEBOOK;
 
-/// Bits stamped on every import alias pinned by a noqa directive — both
-/// `ENTRYPOINT` (so reachability keeps it alive) and `NOQA` (so the
-/// `kept_alive_by_flags_only(NOQA)` blast-radius query can find it).
-const NODE_FLAGS_NOQA_PIN: u32 = NodeFlags::ENTRYPOINT | NodeFlags::NOQA;
+/// Bits stamped on every import alias pinned by a noqa directive. The
+/// `NOQA` bit alone is enough — the Python-side `KEEPALIVE_DEFAULT`
+/// mask includes `NOQA`, so reachability seeds from noqa-pinned
+/// aliases and the `kept_alive_by_flags_only(NOQA)` blast-radius query
+/// isolates them.
+const NODE_FLAGS_NOQA_PIN: u32 = NodeFlags::NOQA;
 
 /// Internal aliases for the pyclass classattrs used by the call sites
 /// scattered through this file. Read as bare constants rather than
@@ -5918,8 +5923,11 @@ impl NodeFlags {
     /// the live binding.
     #[classattr]
     const SHADOWED: u32 = 1;
-    /// Reachability seed. BFS for "what's live" starts from every node
-    /// carrying this bit.
+    /// Explicit entrypoint — plugin-emitted seeds, the CLI's `-e`
+    /// flag, `[project.scripts]` targets, factory-app synthetics, etc.
+    /// One of the keepalive bits ORed into `KEEPALIVE_DEFAULT` on the
+    /// Python side, so reachability seeds from `ENTRYPOINT`-flagged
+    /// nodes by default.
     #[classattr]
     const ENTRYPOINT: u32 = 2;
     /// `typing.overload` stub (or any same-name decl whose lifetime is
@@ -5927,21 +5935,23 @@ impl NodeFlags {
     /// `SHADOWED`; kept alive by an explicit `impl -> overload` edge.
     #[classattr]
     const OVERLOAD: u32 = 4;
-    /// Tags an entrypoint as test-only (pytest / unittest fixtures and
-    /// test methods). Layered on top of `ENTRYPOINT` so the
-    /// `kept_alive_by_flags_only(TESTCASE)` query can ask "what's only
-    /// alive because of tests".
+    /// Pytest / unittest test discoveries. One of the keepalive bits in
+    /// `KEEPALIVE_DEFAULT`, so tests are alive by default. The
+    /// `kept_alive_by_flags_only(TESTCASE)` blast-radius query isolates
+    /// "what's only alive because of tests" by computing the diff
+    /// against `reachable(seed_flags=KEEPALIVE_DEFAULT & ~TESTCASE)`.
     #[classattr]
     const TESTCASE: u32 = 8;
-    /// Tags an entrypoint as preserved by an explicit user noqa
-    /// directive (bare `# noqa`, `# noqa: F401`, multi-rule
-    /// `# noqa: E501, F401`, or the file-level `# ruff: noqa` /
-    /// `# flake8: noqa`).
+    /// Import alias preserved by a user noqa directive (bare `# noqa`,
+    /// `# noqa: F401`, multi-rule `# noqa: E501, F401`, or the
+    /// file-level `# ruff: noqa` / `# flake8: noqa`). One of the
+    /// keepalive bits in `KEEPALIVE_DEFAULT`.
     #[classattr]
     const NOQA: u32 = 16;
-    /// Every node sourced from a Jupyter `.ipynb` file. Combined with
-    /// `ENTRYPOINT` via `NODE_FLAGS_NOTEBOOK_DEFAULT` because cells run
-    /// top-to-bottom rather than being imported, and the codemod skips
+    /// Every node sourced from a Jupyter `.ipynb` file. Cells run
+    /// top-to-bottom rather than being imported, so the bit alone keeps
+    /// the node alive (no `ENTRYPOINT` overlay needed — `NOTEBOOK` is in
+    /// `KEEPALIVE_DEFAULT`). The codemod also reads the bit to skip
     /// notebook nodes (it can't rewrite the cell JSON envelope).
     #[classattr]
     const NOTEBOOK: u32 = 32;

--- a/dead_cst/analyze.py
+++ b/dead_cst/analyze.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Iterable, Iterator, Mapping, Sequence
 
 from ._graphstore import SymbolGraph
-from .graph import EdgeFlags, NodeFlags, SymbolNode
+from .graph import KEEPALIVE_DEFAULT, EdgeFlags, NodeFlags, SymbolNode
 from .resolvers import Package, PathResolver
 from .resolvers._core import _validate_packages
 
@@ -31,12 +31,16 @@ def _bfs_order(seeds: Iterable[Path], neighbors: Mapping[Path, Sequence[Path]]) 
 _NON_DECL_TYPES: frozenset[str] = frozenset({"module", "synthetic"})
 
 
-def _entrypoint_seeds(graph: SymbolGraph, exclude_flags: NodeFlags = NodeFlags.NONE) -> list[int]:
-    return [
-        graph.index(n)
-        for n in graph.nodes
-        if n.flags & NodeFlags.ENTRYPOINT and not (n.flags & exclude_flags)
-    ]
+def _keepalive_seeds(graph: SymbolGraph, seed_flags: NodeFlags) -> list[int]:
+    """Indices of every node whose flags intersect ``seed_flags``.
+
+    Each bit in ``seed_flags`` is a keepalive criterion -- a node
+    carrying any of them is a reachability seed. Pass
+    :data:`KEEPALIVE_DEFAULT` for the standard behaviour, or a narrower
+    mask to ask focused questions (e.g. ``NodeFlags.ENTRYPOINT`` alone
+    excludes tests / noqa pins / notebooks from the seed set).
+    """
+    return [graph.index(n) for n in graph.nodes if n.flags & seed_flags]
 
 
 def _find_reachable(
@@ -67,26 +71,41 @@ def _find_reachable(
 
 
 def _find_kept_alive_by_dead_branches(
-    graph: SymbolGraph, *, prefix: Path | None = None
+    graph: SymbolGraph,
+    *,
+    seed_flags: NodeFlags = KEEPALIVE_DEFAULT,
+    prefix: Path | None = None,
 ) -> set[SymbolNode]:
-    seeds = _entrypoint_seeds(graph)
+    seeds = _keepalive_seeds(graph, seed_flags)
     return _find_reachable(graph, seeds, prefix=prefix) - _find_reachable(
         graph, seeds, prefix=prefix, skip_dead_branches=True
     )
 
 
 def _find_kept_alive_by_flags_only(
-    graph: SymbolGraph, flags: NodeFlags, *, prefix: Path | None = None
+    graph: SymbolGraph,
+    flags: NodeFlags,
+    *,
+    seed_flags: NodeFlags = KEEPALIVE_DEFAULT,
+    prefix: Path | None = None,
 ) -> set[SymbolNode]:
-    all_seeds = _entrypoint_seeds(graph)
-    kept_seeds = [i for i in all_seeds if not (graph.node(i).flags & flags)]
+    """Diff between ``reachable(seed_flags)`` and
+    ``reachable(seed_flags & ~flags)`` -- the blast radius of dropping
+    every seed whose flags carry any bit in ``flags``."""
+    all_seeds = _keepalive_seeds(graph, seed_flags)
+    kept_seeds = _keepalive_seeds(graph, seed_flags & ~flags)
     return _find_reachable(graph, all_seeds, prefix=prefix) - _find_reachable(
         graph, kept_seeds, prefix=prefix
     )
 
 
-def _iter_dead(graph: SymbolGraph, *, prefix: Path | None = None) -> Iterator[SymbolNode]:
-    reachable = _find_reachable(graph, _entrypoint_seeds(graph))
+def _iter_dead(
+    graph: SymbolGraph,
+    *,
+    seed_flags: NodeFlags = KEEPALIVE_DEFAULT,
+    prefix: Path | None = None,
+) -> Iterator[SymbolNode]:
+    reachable = _find_reachable(graph, _keepalive_seeds(graph, seed_flags))
     for n in graph.nodes:
         if prefix is not None and not n.path.is_relative_to(prefix):
             continue
@@ -224,18 +243,30 @@ class Analysis:
         """
         return self.materialize_all()
 
-    def reachable(self) -> set[SymbolNode]:
+    def reachable(self, *, seed_flags: NodeFlags = KEEPALIVE_DEFAULT) -> set[SymbolNode]:
+        """Set of every decl reachable from any seed in ``seed_flags``.
+
+        ``seed_flags`` defaults to :data:`KEEPALIVE_DEFAULT` (every
+        keepalive bit ORed together). Pass a subset to scope the
+        question -- e.g. ``seed_flags=NodeFlags.ENTRYPOINT`` excludes
+        tests, ``noqa``-pinned imports, and notebooks from the seed set.
+        """
         g = self.materialize_all()
-        return _find_reachable(g, _entrypoint_seeds(g))
+        return _find_reachable(g, _keepalive_seeds(g, seed_flags))
 
-    def dead(self) -> Iterator[SymbolNode]:
-        return _iter_dead(self.materialize_all())
+    def dead(self, *, seed_flags: NodeFlags = KEEPALIVE_DEFAULT) -> Iterator[SymbolNode]:
+        """Yield every decl that no seed in ``seed_flags`` reaches."""
+        return _iter_dead(self.materialize_all(), seed_flags=seed_flags)
 
-    def kept_alive_by_dead_branches(self) -> set[SymbolNode]:
-        return _find_kept_alive_by_dead_branches(self.materialize_all())
+    def kept_alive_by_dead_branches(
+        self, *, seed_flags: NodeFlags = KEEPALIVE_DEFAULT
+    ) -> set[SymbolNode]:
+        return _find_kept_alive_by_dead_branches(self.materialize_all(), seed_flags=seed_flags)
 
-    def kept_alive_by_flags_only(self, flags: NodeFlags) -> set[SymbolNode]:
-        return _find_kept_alive_by_flags_only(self.materialize_all(), flags)
+    def kept_alive_by_flags_only(
+        self, flags: NodeFlags, *, seed_flags: NodeFlags = KEEPALIVE_DEFAULT
+    ) -> set[SymbolNode]:
+        return _find_kept_alive_by_flags_only(self.materialize_all(), flags, seed_flags=seed_flags)
 
     def count_nodes(self, prefix: Path | None = None) -> dict[str, int]:
         return _count_nodes(self.materialize_all().nodes, prefix)
@@ -278,21 +309,34 @@ class PackageView:
     def graph(self) -> SymbolGraph:
         return self._analysis.materialize_all()
 
-    def reachable(self) -> set[SymbolNode]:
+    def reachable(self, *, seed_flags: NodeFlags = KEEPALIVE_DEFAULT) -> set[SymbolNode]:
         g = self._analysis.materialize_all()
-        return _find_reachable(g, _entrypoint_seeds(g), prefix=self._package.path)
+        return _find_reachable(g, _keepalive_seeds(g, seed_flags), prefix=self._package.path)
 
-    def dead(self) -> Iterator[SymbolNode]:
-        return _iter_dead(self._analysis.materialize_all(), prefix=self._package.path)
-
-    def kept_alive_by_dead_branches(self) -> set[SymbolNode]:
-        return _find_kept_alive_by_dead_branches(
-            self._analysis.materialize_all(), prefix=self._package.path
+    def dead(self, *, seed_flags: NodeFlags = KEEPALIVE_DEFAULT) -> Iterator[SymbolNode]:
+        return _iter_dead(
+            self._analysis.materialize_all(),
+            seed_flags=seed_flags,
+            prefix=self._package.path,
         )
 
-    def kept_alive_by_flags_only(self, flags: NodeFlags) -> set[SymbolNode]:
+    def kept_alive_by_dead_branches(
+        self, *, seed_flags: NodeFlags = KEEPALIVE_DEFAULT
+    ) -> set[SymbolNode]:
+        return _find_kept_alive_by_dead_branches(
+            self._analysis.materialize_all(),
+            seed_flags=seed_flags,
+            prefix=self._package.path,
+        )
+
+    def kept_alive_by_flags_only(
+        self, flags: NodeFlags, *, seed_flags: NodeFlags = KEEPALIVE_DEFAULT
+    ) -> set[SymbolNode]:
         return _find_kept_alive_by_flags_only(
-            self._analysis.materialize_all(), flags, prefix=self._package.path
+            self._analysis.materialize_all(),
+            flags,
+            seed_flags=seed_flags,
+            prefix=self._package.path,
         )
 
     def count_nodes(self) -> dict[str, int]:
@@ -305,11 +349,11 @@ class PackageView:
             prefix=None,
         )
 
-    def remove_dead_code(self) -> None:
+    def remove_dead_code(self, *, seed_flags: NodeFlags = KEEPALIVE_DEFAULT) -> None:
         from .codemod import remove_code
 
         g = self._analysis.materialize_all()
-        reachable = _find_reachable(g, _entrypoint_seeds(g))
+        reachable = _find_reachable(g, _keepalive_seeds(g, seed_flags))
         dead_nodes = [
             n for n in g.nodes if n not in reachable and n.path.is_relative_to(self._package.path)
         ]

--- a/dead_cst/cli.py
+++ b/dead_cst/cli.py
@@ -13,9 +13,9 @@ from typing import Annotated, Sequence
 import typer
 
 from ._graphstore import SymbolGraph
-from .analyze import Analysis, _count_nodes_by_prefix, _entrypoint_seeds, _find_reachable
+from .analyze import Analysis, _count_nodes_by_prefix, _find_reachable, _keepalive_seeds
 from .codemod import generate_patch
-from .graph import NodeFlags, SymbolNode
+from .graph import KEEPALIVE_DEFAULT, SymbolNode
 from .plugins import (
     EXTERNAL_PREFIXES,
     ExplicitEntrypointPlugin,
@@ -148,7 +148,7 @@ def analyze(
     )
     analysis = Analysis(root, resolver=path_resolver, plugins=plugins)
     graph = analysis.materialize_all()
-    reachable = _find_reachable(graph, _entrypoint_seeds(graph))
+    reachable = _find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
 
     unreachable_graph = graph.subgraph([n for n in graph.nodes if n not in reachable])
 
@@ -397,13 +397,13 @@ def unused_exports(
         plugin_names=plugin or [],
     )
     graph = Analysis(root, resolver=path_resolver, plugins=plugins).materialize_all()
-    reachable = _find_reachable(graph, _entrypoint_seeds(graph))
+    reachable = _find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
 
     def _is_dunder_seed(node: SymbolNode) -> bool:
         return node.type == "synthetic" and node.fqname.startswith(DUNDER_PREFIX)
 
     visited_idx: set[int] = set()
-    stack: list[int] = [graph.index(n) for n in graph.nodes if n.flags & NodeFlags.ENTRYPOINT]
+    stack: list[int] = _keepalive_seeds(graph, KEEPALIVE_DEFAULT)
     while stack:
         i = stack.pop()
         if i in visited_idx:
@@ -484,7 +484,7 @@ def remove(
     )
     analysis = Analysis(root, resolver=path_resolver, plugins=plugins)
     graph = analysis.materialize_all()
-    reachable = _find_reachable(graph, _entrypoint_seeds(graph))
+    reachable = _find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
 
     unreachable_graph = graph.subgraph([n for n in graph.nodes if n not in reachable])
 

--- a/dead_cst/contrib/pytest.py
+++ b/dead_cst/contrib/pytest.py
@@ -74,7 +74,7 @@ def _mark_seed(
     yield native.AddNode(
         fqname=fqname,
         path=path,
-        flags=int(NodeFlags.ENTRYPOINT | NodeFlags.TESTCASE),
+        flags=int(NodeFlags.TESTCASE),
         edges_to=targets,
     )
 

--- a/dead_cst/contrib/unittest.py
+++ b/dead_cst/contrib/unittest.py
@@ -51,7 +51,7 @@ class UnittestPlugin:
             if simple in _MODULE_HOOKS:
                 decls_by_path.setdefault(node.path, []).append(node)
 
-        flags = int(NodeFlags.ENTRYPOINT | NodeFlags.TESTCASE)
+        flags = int(NodeFlags.TESTCASE)
         for path, decls in decls_by_path.items():
             module = ctx.module_for(path)
             if module is None:

--- a/dead_cst/graph.py
+++ b/dead_cst/graph.py
@@ -21,7 +21,20 @@ logger = logging.getLogger(__name__)
 
 
 class NodeFlags(enum.IntFlag):
-    """Analyzer-internal marker on :class:`SymbolNode`."""
+    """Analyzer-internal marker on :class:`SymbolNode`.
+
+    Each ``KEEPALIVE`` bit (:data:`ENTRYPOINT`, :data:`TESTCASE`,
+    :data:`NOQA`, :data:`NOTEBOOK`) independently says "the reachability
+    BFS seeds from nodes carrying this bit." :data:`KEEPALIVE_DEFAULT`
+    ORs all of them; pass a subset to
+    :meth:`Analysis.reachable(seed_flags=...)` /
+    :meth:`Analysis.dead(seed_flags=...)` to restrict the seeds.
+
+    The bits are independent metadata — ``TESTCASE`` alone keeps a node
+    alive; it does not have to be ORed with ``ENTRYPOINT``. That lets
+    callers ask focused questions: "what's alive ignoring tests?" is
+    ``reachable(seed_flags=KEEPALIVE_DEFAULT & ~NodeFlags.TESTCASE)``.
+    """
 
     NONE = 0
     SHADOWED = enum.auto()
@@ -30,6 +43,26 @@ class NodeFlags(enum.IntFlag):
     TESTCASE = enum.auto()
     NOQA = enum.auto()
     NOTEBOOK = enum.auto()
+
+
+#: Default seed mask for reachability queries. ORs together every
+#: :class:`NodeFlags` bit that semantically "keeps a node alive":
+#:
+#: * :data:`NodeFlags.ENTRYPOINT` — explicit entrypoints (plugin-emitted
+#:   seeds, ``-e`` CLI flag, ``[project.scripts]`` targets, ...).
+#: * :data:`NodeFlags.TESTCASE` — pytest / unittest discoveries.
+#: * :data:`NodeFlags.NOQA` — imports pinned by a ``# noqa: F401``
+#:   directive.
+#: * :data:`NodeFlags.NOTEBOOK` — notebook cells (run top-to-bottom,
+#:   never imported, always alive).
+#:
+#: :meth:`Analysis.reachable` / :meth:`Analysis.dead` default to this
+#: mask. Pass a subset to scope the question — e.g.
+#: ``reachable(seed_flags=NodeFlags.ENTRYPOINT)`` asks "what would be
+#: alive if the test suite, ``noqa`` pins, and notebooks didn't exist."
+KEEPALIVE_DEFAULT: NodeFlags = (
+    NodeFlags.ENTRYPOINT | NodeFlags.TESTCASE | NodeFlags.NOQA | NodeFlags.NOTEBOOK
+)
 
 
 class EdgeFlags(enum.IntFlag):
@@ -83,6 +116,7 @@ class SymbolNode:
 
 
 __all__ = [
+    "KEEPALIVE_DEFAULT",
     "EdgeFlags",
     "Import",
     "NodeFlags",

--- a/tests/e2e/test_flux0.py
+++ b/tests/e2e/test_flux0.py
@@ -27,7 +27,8 @@ import pytest
 from typer.testing import CliRunner
 
 from dead_cst import Analysis
-from dead_cst.analyze import _entrypoint_seeds, _find_reachable as find_reachable
+from dead_cst.analyze import _find_reachable as find_reachable, _keepalive_seeds
+from dead_cst.graph import KEEPALIVE_DEFAULT
 from dead_cst.cli import app
 from dead_cst.plugins import MainBlockPlugin, ModuleDundersPlugin
 from dead_cst.resolvers import ManualResolver
@@ -151,7 +152,7 @@ def test_flux0_cli_cmds_dead_without_plugin(flux0_cli_src):
     """Sanity: without the dynamic-loader plugin, the cmds modules are dead."""
     base = Path(flux0_cli_src)
     graph = _build_graph(base, MainBlockPlugin())
-    reachable = find_reachable(graph, _entrypoint_seeds(graph))
+    reachable = find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
 
     cmds_agents = _module_node(graph, "flux0_cli.cmds.agents")
     assert cmds_agents is not None, "cmds.agents module should be in the graph"
@@ -178,7 +179,7 @@ def test_flux0_cli_commands_revives_click_groups(flux0_cli_src):
     """
     base = Path(flux0_cli_src)
     graph = _build_graph(base, MainBlockPlugin(), Flux0CliCommandsPlugin())
-    reachable = find_reachable(graph, _entrypoint_seeds(graph))
+    reachable = find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
 
     for fqname in (
         "flux0_cli.cmds.agents.agents",  # @click.group() in agents.py
@@ -213,7 +214,7 @@ def test_flux0_internal_modules_revives_replay_agent(flux0_server_src):
     """
     base = Path(flux0_server_src)
     graph = _build_graph(base, MainBlockPlugin(), Flux0InternalModulesPlugin())
-    reachable = find_reachable(graph, _entrypoint_seeds(graph))
+    reachable = find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
 
     for fqname in (
         "flux0_server.replay_agent",  # __init__ module
@@ -241,7 +242,7 @@ def test_flux0_server_dead_set_pins_to_real_findings(flux0_server_src):
         ModuleDundersPlugin(),
         Flux0InternalModulesPlugin(),
     )
-    reachable = find_reachable(graph, _entrypoint_seeds(graph))
+    reachable = find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
     dead = {
         n.fqname
         for n in graph.nodes
@@ -270,7 +271,7 @@ def test_flux0_cli_dead_set_includes_real_findings_and_decorator_blind_spot(flux
         ModuleDundersPlugin(),
         Flux0CliCommandsPlugin(),
     )
-    reachable = find_reachable(graph, _entrypoint_seeds(graph))
+    reachable = find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
     dead = {
         n.fqname
         for n in graph.nodes
@@ -308,7 +309,7 @@ def test_flux0_internal_modules(flux0_server_src, tmp_path):
         resolver=ManualResolver(specs=["."]),
         plugins=plugins,
     ).materialize_all()
-    reachable = find_reachable(graph, _entrypoint_seeds(graph))
+    reachable = find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
     dead = {
         n.fqname
         for n in graph.nodes

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -1740,27 +1740,24 @@ def test_stub_only_decl_flagged_entrypoint_rust(build_decl_graph):
     )
 
 
-def test_notebook_decls_carry_notebook_and_entrypoint_flags(write_notebook, build_decl_graph):
-    """Every node minted from an ``.ipynb`` carries both
-    ``NodeFlags.NOTEBOOK`` and ``NodeFlags.ENTRYPOINT``:
+def test_notebook_decls_carry_notebook_flag(write_notebook, build_decl_graph):
+    """Every node minted from an ``.ipynb`` carries ``NodeFlags.NOTEBOOK``.
 
-    * ``ENTRYPOINT`` keeps the cells alive (notebooks are executed
-      top-to-bottom, not imported).
-    * ``NOTEBOOK`` tells the codemod to skip these nodes — it can't
-      rewrite cell JSON envelopes safely.
+    ``NOTEBOOK`` does two jobs:
 
-    The libcst pipeline ORs the flags via ``default_flags`` in
-    ``_refresh._process_one_file``; the rust path mirrors that via
-    ``file_default_flags`` consulted by every per-file node mint.
+    * It's a keepalive bit in :data:`KEEPALIVE_DEFAULT` so cells stay
+      alive (notebooks are executed top-to-bottom, not imported).
+    * It tells the codemod to skip these nodes — it can't rewrite cell
+      JSON envelopes safely.
     """
     from dead_cst.graph import NodeFlags
 
     write_notebook("analysis.ipynb", ["def helper():\n    return 42", "helper()"])
     graph = build_decl_graph({})
 
-    required = NodeFlags.NOTEBOOK | NodeFlags.ENTRYPOINT
     notebook_nodes = [n for n in graph.raw.nodes() if str(n.path).endswith(".ipynb")]
     assert notebook_nodes, "expected at least one decl minted from the .ipynb file"
     for n in notebook_nodes:
-        missing = required & ~NodeFlags(int(n.flags))
-        assert not missing, f"{n.fqname!r} missing flags: {missing!r}"
+        assert NodeFlags(int(n.flags)) & NodeFlags.NOTEBOOK, (
+            f"{n.fqname!r} missing NOTEBOOK flag (got {NodeFlags(int(n.flags))!r})"
+        )

--- a/tests/test_eclipsed_modules.py
+++ b/tests/test_eclipsed_modules.py
@@ -11,7 +11,8 @@ synthetics) keep working -- but consumer imports never see its decls.
 
 from __future__ import annotations
 
-from dead_cst.analyze import _entrypoint_seeds, _find_reachable as find_reachable
+from dead_cst.analyze import _find_reachable as find_reachable, _keepalive_seeds
+from dead_cst.graph import KEEPALIVE_DEFAULT
 from dead_cst.plugins import ExplicitEntrypointPlugin, MainBlockPlugin
 
 
@@ -36,7 +37,7 @@ def test_package_wins_trie_slot_for_cross_module_imports(tmp_path, write_files, 
     assert len(targets) == 1
     assert targets[0].path.name == "__init__.py"
 
-    reachable = find_reachable(graph, _entrypoint_seeds(graph))
+    reachable = find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
     package_x = next(
         n for n in graph.nodes if n.fqname == "pkg.foo.x" and n.path.name == "__init__.py"
     )
@@ -55,7 +56,7 @@ def test_eclipsed_file_keeps_main_block_entrypoint(tmp_path, write_files, make_a
     )
     analysis = make_analysis(plugins=[MainBlockPlugin()])
     graph = analysis.materialize_all()
-    reachable = find_reachable(graph, _entrypoint_seeds(graph))
+    reachable = find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
 
     helper = next(n for n in graph.nodes if n.fqname == "pkg.foo.helper")
     eclipsed_module = next(

--- a/tests/test_kept_alive_by_noqa.py
+++ b/tests/test_kept_alive_by_noqa.py
@@ -1,24 +1,26 @@
 """End-to-end tests for :data:`NodeFlags.NOQA` and ``kept_alive_by_flags_only(NodeFlags.NOQA)``.
 
-The visitor stamps ``ENTRYPOINT | NOQA`` on imports preserved by a
-ruff/pyflakes ``# noqa[: ...F401...]`` (per-line) or by a file-level
-``# ruff: noqa`` / ``# flake8: noqa``. The flag-taking blast-radius
-query returns modules and decls currently kept alive only because of
-those pinned imports.
+Imports preserved by a ruff/pyflakes ``# noqa[: ...F401...]`` (per-line)
+or a file-level ``# ruff: noqa`` / ``# flake8: noqa`` are stamped with
+:data:`NodeFlags.NOQA` -- one of the keepalive bits in
+:data:`KEEPALIVE_DEFAULT`, so reachability seeds from them by default.
+The flag-taking blast-radius query returns modules and decls currently
+kept alive only because of those pinned imports.
 """
 
 from __future__ import annotations
 
 from dead_cst import NodeFlags
 from dead_cst.analyze import (
-    _entrypoint_seeds,
     _find_kept_alive_by_flags_only,
     _find_reachable as find_reachable,
+    _keepalive_seeds,
 )
+from dead_cst.graph import KEEPALIVE_DEFAULT
 
 
 def find_reachable_excluding_noqa(graph):
-    return find_reachable(graph, _entrypoint_seeds(graph, NodeFlags.NOQA))
+    return find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT & ~NodeFlags.NOQA))
 
 
 def find_kept_alive_by_noqa_only(graph):
@@ -40,7 +42,7 @@ def test_noqa_pin_keeps_module_alive_only_via_noqa(make_analysis, write_files):
     )
     graph = make_analysis().materialize_all()
     side = next(n for n in graph.nodes if n.fqname == "pkg.side_effect")
-    assert side in find_reachable(graph, _entrypoint_seeds(graph))
+    assert side in find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
     assert side not in find_reachable_excluding_noqa(graph)
     assert side in find_kept_alive_by_noqa_only(graph)
 
@@ -68,10 +70,9 @@ def test_production_only_decl_survives_strict_pass(make_analysis, write_files):
 
 
 def test_pinned_import_carries_noqa_flag(build_decl_graph):
-    """Per-line ``# noqa: F401`` stamps both ENTRYPOINT and NOQA on the import node."""
+    """Per-line ``# noqa: F401`` stamps the NOQA keepalive bit on the import node."""
     graph = build_decl_graph({"m.py": "import os  # noqa: F401\n"})
     pinned = next(n for n in graph.nodes if n.fqname == "m.os")
-    assert pinned.flags & NodeFlags.ENTRYPOINT
     assert pinned.flags & NodeFlags.NOQA
 
 
@@ -111,8 +112,10 @@ def test_excluding_multiple_flags_in_one_pass(make_analysis, write_files):
 
     graph = make_analysis(plugins=[PytestPlugin()]).materialize_all()
     side = next(n for n in graph.nodes if n.fqname == "pkg.side_effect")
-    assert side in find_reachable(graph, _entrypoint_seeds(graph))
-    excluded = find_reachable(graph, _entrypoint_seeds(graph, NodeFlags.TESTCASE | NodeFlags.NOQA))
+    assert side in find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
+    excluded = find_reachable(
+        graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT & ~(NodeFlags.TESTCASE | NodeFlags.NOQA))
+    )
     assert side not in excluded
 
 

--- a/tests/test_kept_alive_by_tests.py
+++ b/tests/test_kept_alive_by_tests.py
@@ -11,15 +11,16 @@ from __future__ import annotations
 
 from dead_cst import NodeFlags
 from dead_cst.analyze import (
-    _entrypoint_seeds,
     _find_kept_alive_by_flags_only,
     _find_reachable as find_reachable,
+    _keepalive_seeds,
 )
+from dead_cst.graph import KEEPALIVE_DEFAULT
 from dead_cst.plugins import PytestPlugin, UnittestPlugin
 
 
 def find_reachable_excluding_tests(graph):
-    return find_reachable(graph, _entrypoint_seeds(graph, NodeFlags.TESTCASE))
+    return find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT & ~NodeFlags.TESTCASE))
 
 
 def find_kept_alive_by_tests_only(graph):
@@ -45,7 +46,7 @@ def test_test_only_helper_is_kept_alive_by_tests(make_analysis, write_files):
     )
     graph = make_analysis(plugins=[PytestPlugin()]).materialize_all()
     helper = next(n for n in graph.nodes if n.fqname == "pkg.lib.helper")
-    assert helper in find_reachable(graph, _entrypoint_seeds(graph))
+    assert helper in find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
     assert helper not in find_reachable_excluding_tests(graph)
     assert helper in find_kept_alive_by_tests_only(graph)
 
@@ -95,7 +96,7 @@ def test_unittest_kept_alive_by_tests(make_analysis, write_files):
     )
     graph = make_analysis(plugins=[UnittestPlugin()]).materialize_all()
     helper = next(n for n in graph.nodes if n.fqname == "pkg.lib.helper")
-    assert helper in find_reachable(graph, _entrypoint_seeds(graph))
+    assert helper in find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
     assert helper in find_kept_alive_by_tests_only(graph)
 
 

--- a/tests/test_noqa_pinning.py
+++ b/tests/test_noqa_pinning.py
@@ -1,6 +1,7 @@
 """Imports flagged with a ruff/pyflakes ``# noqa`` directive that silences
-F401 are pinned alive (treated as :data:`NodeFlags.ENTRYPOINT`), matching
-the semantics ruff itself uses for the unused-import rule.
+F401 are pinned alive (flagged with :data:`NodeFlags.NOQA`, which is one
+of the keepalive bits in :data:`KEEPALIVE_DEFAULT`), matching the
+semantics ruff itself uses for the unused-import rule.
 
 Both per-line directives (``# noqa``, ``# noqa: F401``, multi-rule
 ``# noqa: E501, F401``, case-insensitive ``noqa`` keyword) and file-level
@@ -21,7 +22,7 @@ def _import_nodes(graph):
 
 
 def _entrypoint_imports(graph) -> set[str]:
-    return {n.fqname for n in graph.nodes if n.type == "import" and n.flags & NodeFlags.ENTRYPOINT}
+    return {n.fqname for n in graph.nodes if n.type == "import" and n.flags & NodeFlags.NOQA}
 
 
 @pytest.mark.parametrize(
@@ -142,7 +143,7 @@ def test_unpinned_import_in_dead_module_stays_dead(make_analysis, write_files):
     assert "m.os" in dead_fqs
 
 
-def test_pinned_node_carries_entrypoint_flag(build_decl_graph):
+def test_pinned_node_carries_noqa_flag(build_decl_graph):
     graph = build_decl_graph({"m.py": "import os  # noqa: F401\n"})
     pinned = [n for n in _import_nodes(graph) if n.fqname == "m.os"]
-    assert pinned and pinned[0].flags & NodeFlags.ENTRYPOINT
+    assert pinned and pinned[0].flags & NodeFlags.NOQA

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 
 from dead_cst._graphstore import SymbolGraph
-from dead_cst.analyze import _entrypoint_seeds, _find_reachable as find_reachable
+from dead_cst.analyze import _find_reachable as find_reachable, _keepalive_seeds
 from dead_cst.codemod import generate_patch
-from dead_cst.graph import NodeFlags
+from dead_cst.graph import KEEPALIVE_DEFAULT, NodeFlags
 
 
-def test_every_notebook_node_is_notebook_and_entrypoint(write_notebook, make_analysis):
+def test_every_notebook_node_carries_notebook_flag(write_notebook, make_analysis):
     write_notebook(
         "explore.ipynb",
         [
@@ -20,15 +20,17 @@ def test_every_notebook_node_is_notebook_and_entrypoint(write_notebook, make_ana
     graph = make_analysis().materialize_all()
     notebook_nodes = [n for n in graph.nodes if n.flags & NodeFlags.NOTEBOOK]
     assert notebook_nodes
-    for n in notebook_nodes:
-        assert n.flags & NodeFlags.ENTRYPOINT, f"{n.fqname} missing ENTRYPOINT"
+    # ``NOTEBOOK`` alone is enough — it's a keepalive bit in
+    # ``KEEPALIVE_DEFAULT``, so the BFS seeds from these nodes by default
+    # without needing an explicit ``ENTRYPOINT`` overlay.
+    assert _keepalive_seeds(graph, KEEPALIVE_DEFAULT), "notebook nodes should be keepalive seeds"
 
 
 def test_notebook_keeps_referenced_py_code_alive(write_notebook, write_files, make_analysis):
     write_files({"lib.py": "def used(): return 1\ndef unused(): return 2\n"})
     write_notebook("use.ipynb", ["from lib import used\nused()\n"])
     graph = make_analysis().materialize_all()
-    reachable = find_reachable(graph, _entrypoint_seeds(graph))
+    reachable = find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
     used = next(n for n in graph.nodes if n.fqname == "lib.used")
     unused = next(n for n in graph.nodes if n.fqname == "lib.unused")
     assert used in reachable

--- a/tests/test_overloads_and_pyi.py
+++ b/tests/test_overloads_and_pyi.py
@@ -7,7 +7,8 @@ import textwrap
 
 
 from dead_cst import NodeFlags
-from dead_cst.analyze import _entrypoint_seeds, _find_reachable as find_reachable
+from dead_cst.analyze import _find_reachable as find_reachable, _keepalive_seeds
+from dead_cst.graph import KEEPALIVE_DEFAULT
 from dead_cst.codemod import remove_code
 from dead_cst.plugins import ExplicitEntrypointPlugin
 
@@ -100,7 +101,7 @@ def test_live_overloads_survive_codemod(tmp_path, make_analysis):
     )
     a = make_analysis(plugins=[ExplicitEntrypointPlugin(specs=["mod.f"])])
     graph = a.materialize_all()
-    reachable = find_reachable(graph, _entrypoint_seeds(graph))
+    reachable = find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
     unreachable = graph.subgraph([n for n in graph.nodes if n not in reachable])
     remove_code(unreachable, tmp_path)
 
@@ -126,7 +127,7 @@ def test_orphan_pyi_stub_uses_runtime_fqname(tmp_path, make_analysis):
 
     a = make_analysis(plugins=[ExplicitEntrypointPlugin(specs=["main"])])
     graph = a.materialize_all()
-    reachable = find_reachable(graph, _entrypoint_seeds(graph))
+    reachable = find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
 
     stub_compute = next(
         n for n in graph.nodes if n.fqname == "mypkg._native.compute" and n.type == "function"

--- a/tests/test_plugins/conftest.py
+++ b/tests/test_plugins/conftest.py
@@ -6,7 +6,8 @@ import pytest
 
 from dead_cst import Analysis
 from dead_cst._graphstore import SymbolGraph
-from dead_cst.analyze import _entrypoint_seeds, _find_reachable as find_reachable
+from dead_cst.analyze import _find_reachable as find_reachable, _keepalive_seeds
+from dead_cst.graph import KEEPALIVE_DEFAULT
 from dead_cst.resolvers import ManualResolver
 
 
@@ -15,7 +16,7 @@ def reachable_fqnames():
     """Return ``{fqname for n in find_reachable(graph) if not synthetic}``."""
 
     def _reachable(graph) -> set[str]:
-        reached = find_reachable(graph, _entrypoint_seeds(graph))
+        reached = find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
         return {n.fqname for n in reached if n.type != "synthetic"}
 
     return _reachable

--- a/tests/test_plugins/test_celery.py
+++ b/tests/test_plugins/test_celery.py
@@ -337,10 +337,13 @@ def test_celery_plugin_handles_factory_function(build_plugin_graph, reachable_fq
         },
         [CeleryPlugin()],
     )
-    from dead_cst.analyze import _entrypoint_seeds, _find_reachable as find_reachable
+    from dead_cst.analyze import _find_reachable as find_reachable, _keepalive_seeds
+    from dead_cst.graph import KEEPALIVE_DEFAULT
 
     reached = {
-        n.fqname for n in find_reachable(graph, _entrypoint_seeds(graph)) if n.type != "synthetic"
+        n.fqname
+        for n in find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
+        if n.type != "synthetic"
     }
     assert "app.celery.app" in reached
     assert "app.celery.run" in reached

--- a/tests/test_plugins/test_flask.py
+++ b/tests/test_plugins/test_flask.py
@@ -491,10 +491,13 @@ def test_flask_plugin_handles_factory_function(build_plugin_graph, reachable_fqn
         },
         [FlaskPlugin()],
     )
-    from dead_cst.analyze import _entrypoint_seeds, _find_reachable as find_reachable
+    from dead_cst.analyze import _find_reachable as find_reachable, _keepalive_seeds
+    from dead_cst.graph import KEEPALIVE_DEFAULT
 
     reached = {
-        n.fqname for n in find_reachable(graph, _entrypoint_seeds(graph)) if n.type != "synthetic"
+        n.fqname
+        for n in find_reachable(graph, _keepalive_seeds(graph, KEEPALIVE_DEFAULT))
+        if n.type != "synthetic"
     }
     assert "app.main.app" in reached
     assert "app.main.list_items" in reached

--- a/tests/test_plugins/test_pytest.py
+++ b/tests/test_plugins/test_pytest.py
@@ -153,7 +153,5 @@ def test_pytest_plugin_tags_seeds_as_testcase(build_plugin_graph):
         },
         [PytestPlugin()],
     )
-    seeds = [n for n in graph.nodes if n.flags & NodeFlags.ENTRYPOINT]
-    assert seeds, "expected pytest plugin to seed at least one entrypoint"
-    for seed in seeds:
-        assert seed.flags & NodeFlags.TESTCASE, seed.fqname
+    seeds = [n for n in graph.nodes if n.flags & NodeFlags.TESTCASE]
+    assert seeds, "expected pytest plugin to seed at least one TESTCASE node"

--- a/tests/test_plugins/test_unittest.py
+++ b/tests/test_plugins/test_unittest.py
@@ -188,10 +188,8 @@ def test_unittest_plugin_tags_seeds_as_testcase(build_plugin_graph):
         },
         [UnittestPlugin()],
     )
-    seeds = [n for n in graph.nodes if n.flags & NodeFlags.ENTRYPOINT]
-    assert seeds, "expected unittest plugin to seed at least one entrypoint"
-    for seed in seeds:
-        assert seed.flags & NodeFlags.TESTCASE, seed.fqname
+    seeds = [n for n in graph.nodes if n.flags & NodeFlags.TESTCASE]
+    assert seeds, "expected unittest plugin to seed at least one TESTCASE node"
 
 
 def test_unittest_plugin_marks_subclass_via_local_mixin(build_plugin_graph, reachable_fqnames):

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -24,6 +24,7 @@ EXPECTED_PUBLIC_API: dict[str, list[str]] = {
     "dead_cst.graph": [
         "EdgeFlags",
         "Import",
+        "KEEPALIVE_DEFAULT",
         "NodeFlags",
         "SymbolNode",
     ],


### PR DESCRIPTION
Previously every "keep this alive" bit was ORed with `ENTRYPOINT` so the reachability BFS could check a single flag — pytest seeds were `ENTRYPOINT|TESTCASE`, notebook nodes `ENTRYPOINT|NOTEBOOK`, noqa-pinned imports `ENTRYPOINT|NOQA`. That conflates "this is an explicit entrypoint" (a semantic claim) with "this seeds reachability" (a mechanical detail), and forces callers to pick the right bit pair.

Now each of `ENTRYPOINT`, `TESTCASE`, `NOQA`, `NOTEBOOK` is an independent keepalive bit. The new module-level constant `KEEPALIVE_DEFAULT` ORs all four together as the default seed mask for `Analysis.reachable`, `Analysis.dead`, and the `kept_alive_by_*` queries.

## API

```python
from dead_cst import Analysis, NodeFlags
from dead_cst.graph import KEEPALIVE_DEFAULT

# Default — every keepalive bit seeds reachability.
analysis.reachable()
analysis.reachable(seed_flags=KEEPALIVE_DEFAULT)  # same thing, explicit

# Narrow the seeds — "what would be alive if the test suite,
# noqa pins, and notebooks didn't exist?"
analysis.reachable(seed_flags=NodeFlags.ENTRYPOINT)

# Or build any subset:
analysis.reachable(seed_flags=NodeFlags.ENTRYPOINT | NodeFlags.NOQA)
```

The `kept_alive_by_flags_only(flags)` query keeps the same semantics — it's now defined as the diff between `reachable(seed_flags=KEEPALIVE_DEFAULT)` and `reachable(seed_flags=KEEPALIVE_DEFAULT & ~flags)`.

## Summary

- `dead_cst.graph`: new `KEEPALIVE_DEFAULT` constant. Docstring on `NodeFlags` explains the keepalive split.
- `dead_cst.analyze`: `_entrypoint_seeds` renamed to `_keepalive_seeds`; takes a `seed_flags` mask explicitly. `Analysis.reachable` / `dead` / `kept_alive_by_dead_branches` / `kept_alive_by_flags_only` / `PackageView.*` / `remove_dead_code` all gain `seed_flags=KEEPALIVE_DEFAULT`.
- `contrib/pytest.py` / `contrib/unittest.py`: drop the `NodeFlags.ENTRYPOINT` OR — test seeds carry only `TESTCASE`.
- Rust `NODE_FLAGS_NOTEBOOK_DEFAULT` / `NODE_FLAGS_NOQA_PIN` drop the `ENTRYPOINT` overlay (`NOTEBOOK` / `NOQA` are sufficient on their own now).
- Tests updated to assert the new flag shape; `test_public_api` snapshot adds `KEEPALIVE_DEFAULT` to `dead_cst.graph`.

## Test plan

- [x] `uv run pytest` → 617 passed, 1 skipped, 10 deselected
- [x] `uv run prek run --all-files` → ruff + ty + cargo fmt + clippy all green
- [ ] Sanity-check the `reachable(seed_flags=NodeFlags.ENTRYPOINT)` shape on a real project to make sure callers can answer "what's alive ignoring tests" cleanly

https://claude.ai/code/session_01R6GWpvWCUUNeYzJToopc9C

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6GWpvWCUUNeYzJToopc9C)_