### PR TITLE
ingest: resolve cross-scope reads to annotation-only module decls

### DIFF
--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1639,6 +1639,36 @@ impl<'a, 'db> RefCollector<'a, 'db> {
             if saw_binding {
                 return results;
             }
+            // ``X: T`` (annotation-only assignment) is a *declaration*
+            // in ty's model, not a runtime binding, so it doesn't
+            // appear in ``bindings_at_use`` /
+            // ``end_of_scope_symbol_bindings``. For dead-code purposes
+            // an annotation-only decl is still the only "this name
+            // exists" signal for that symbol, so when no bindings
+            // reach the use, fall back to end-of-scope declarations.
+            // Declarations aren't flow-sensitive the way bindings are,
+            // so we don't need a position-keyed variant here.
+            for declaration in use_def_map.end_of_scope_symbol_declarations(symbol_id) {
+                let Some(def) = declaration.declaration.definition() else {
+                    continue;
+                };
+                if def.file(db) != self.file {
+                    continue;
+                }
+                let kind = def.kind(db);
+                let place_id = def.place(db);
+                let key = (
+                    self.file,
+                    place_id,
+                    range_key(kind.target_range(self.parsed)),
+                );
+                if let Some(&idx) = self.global_index.get(&key) {
+                    results.push(Resolution::Alias(idx));
+                }
+            }
+            if !results.is_empty() {
+                return results;
+            }
             first = false;
         }
         Vec::new()

--- a/tests/e2e/test_flux0.py
+++ b/tests/e2e/test_flux0.py
@@ -249,13 +249,6 @@ def test_flux0_server_dead_set_pins_to_real_findings(flux0_server_src):
     assert dead == {
         "flux0_server.main.DEFAULT_PORT",
         "flux0_server.main.SERVER_ADDRESS",
-        # Module-level annotation-only decl (``X: T``) rebound inside a
-        # function via ``global X``. The cross-file uses of the name
-        # route to the function-scope binding, leaving the module-level
-        # decl with zero incoming edges. Known dead-cst limitation, not
-        # a real dead finding -- documenting it here so the test still
-        # pins the durable set.
-        "flux0_server.main.BACKGROUND_TASK_SERVICE",
     }, f"unexpected server dead set: {sorted(dead)}"
 
 
@@ -323,5 +316,4 @@ def test_flux0_internal_modules(flux0_server_src, tmp_path):
     assert dead == {
         "flux0_server.main.DEFAULT_PORT",
         "flux0_server.main.SERVER_ADDRESS",
-        "flux0_server.main.BACKGROUND_TASK_SERVICE",  # See above test.
     }

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -328,6 +328,24 @@ import pytest
         ),
         pytest.param(
             """
+            class T: pass
+            X: T
+            def use():
+                print(X)
+            use()
+            """,
+            {
+                "mod.T -> mod",
+                "mod.X -> mod",
+                "mod.use -> mod",
+                "mod.X -> mod.T",
+                "mod.use -> mod.X",
+                "mod -> mod.use",
+            },
+            id="annotation-only-decl-read-from-nested-function",
+        ),
+        pytest.param(
+            """
             a, b = 1, 2
             c, d = a, b
             """,


### PR DESCRIPTION
## Summary

`find_local_bindings` (in `src/ingest.rs`) was missing edges from a function-scope read to a module-scope annotation-only decl. ty distinguishes **bindings** (runtime value assignments) from **declarations** (type annotations) — `X: T` produces a *declaration*, never a *binding*. The existing walk only queried `bindings_at_use` / `end_of_scope_symbol_bindings`, so a function reading `X` walked into module scope, found no binding for `X`, and silently emitted no edge.

Fix: when no bindings reach the use in a scope, fall back to `end_of_scope_symbol_declarations` for the same symbol. Each matching declaration resolves through `global_index` the same way a binding would. Declarations aren't flow-sensitive the way bindings are, so no position-keyed variant is needed.

## Affected pattern

```python
# mod.py
X: SomeType                  # annotation-only module-level decl

def init():
    global X
    X = SomeType()           # rebind via ``global``

def main():
    print(X)                 # this read now correctly attributes
                             # to mod.X (was silently dropped before)
```

This is the shape flux0's `BACKGROUND_TASK_SERVICE` was hitting — a module-level `X: T` rebound inside a function via `global X`, then read from other functions in the same module.

## Diff

| File | Change |
|---|---|
| `src/ingest.rs` | Add the declarations fallback in `find_local_bindings` — five-line addition after the existing `if saw_binding { return results; }` block. |
| `tests/test_declarations.py` | New regression test case `annotation-only-decl-read-from-nested-function`. |
| `tests/e2e/test_flux0.py` | Removes the `BACKGROUND_TASK_SERVICE` workaround that PR #195 had to leave in the dead-set pins because the underlying ingest bug wasn't fixed yet. |

## Test plan

- [x] `uv run pytest -q tests/test_declarations.py -k annotation-only-decl-read-from-nested-function` — 1 passed.
- [x] `uv run pytest -q -m e2e` — 10 passed without the `BACKGROUND_TASK_SERVICE` workaround.
- [x] Full `uv run pytest -q` — 630 passed (was 629; +1 regression test), 10 deselected.
- [x] `uv run prek run --all-files` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZf2rbhxbQjRYGckcRuSCE)_