### PR TITLE
plugins: unify duplicated query/ctx API surface

### DIFF
--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -480,6 +480,24 @@ class ProjectContext:
         """
         ...
 
+    def find_nodes_matching_specs(
+        self,
+        project_root: str,
+        regexes: list[str],
+        str_specs: list[str],
+        abs_paths: list[str],
+    ) -> list[SymbolNode]:
+        """Match nodes against pre-classified path / fqname specs.
+
+        Avoids the per-node FFI hop + ``pathlib.Path`` allocation that
+        a ``for node in ctx.nodes(): ...`` loop pays. ``regexes`` are
+        anchored at the start of input (``re.Pattern.match`` semantics).
+        ``str_specs`` match exactly against the relative path OR the
+        node's fqname. ``abs_paths`` match exactly against the
+        absolute path.
+        """
+        ...
+
     # ----- Traversal -----------------------------------------------------
 
     def descendants(self, root: SymbolNode, *, skip_flags: int = 0) -> list[SymbolNode]:
@@ -748,12 +766,13 @@ class QueryBuilder:
     :meth:`subclasses` / :meth:`imports` / :meth:`classes` /
     :meth:`factories`.
 
-    Point lookups (no ``.collect()`` — direct methods returning
-    ``SymbolNode`` / ``list[SymbolNode]`` / etc.):
-    :meth:`module` / :meth:`declarations` /
-    :meth:`module_top_level_decls` / :meth:`module_dunder_all_exports` /
-    :meth:`module_dunders` / :meth:`main_blocks` /
-    :meth:`comment_patterns`.
+    Point lookups (e.g. :meth:`ProjectContext.find_module`,
+    :meth:`ProjectContext.find_declarations`,
+    :meth:`ProjectContext.find_main_blocks`,
+    :meth:`ProjectContext.find_comment_patterns`,
+    :meth:`ProjectContext.find_module_dunders`,
+    :meth:`ProjectContext.find_literal_list_entries`) live directly on
+    :class:`ProjectContext`.
     """
 
     def decorators(self) -> DecoratorQuery: ...
@@ -763,89 +782,6 @@ class QueryBuilder:
     def imports(self) -> ImportQuery: ...
     def classes(self) -> ClassQuery: ...
     def factories(self) -> FactoryQuery: ...
-
-    # ----- Point lookups (no filter chain) ------------------------------
-
-    def module(self, fqname: str) -> SymbolNode | None:
-        """Look up a module's synthetic node by dotted fqname.
-
-        Mirrors :meth:`ProjectContext.find_module`.
-        """
-        ...
-
-    def declarations(self, fqname: str) -> list[SymbolNode]:
-        """All top-level declarations bound to the given dotted fqname.
-
-        Mirrors :meth:`ProjectContext.find_declarations`.
-        """
-        ...
-
-    def module_top_level_decls(self, fqname: str) -> list[SymbolNode]:
-        """Every top-level declaration node of the named module.
-
-        Mirrors :meth:`ProjectContext.find_module_top_level_decls`.
-        """
-        ...
-
-    def module_dunder_all_exports(self, fqname: str) -> list[SymbolNode] | None:
-        """Exported names listed in a module's ``__all__``, or
-        ``None`` when the module declares no ``__all__``.
-
-        Mirrors :meth:`ProjectContext.find_module_dunder_all_exports`.
-        """
-        ...
-
-    def literal_list_entries(self, var_fqn: str) -> list[str] | None:
-        """Read the literal-list value of a top-level variable
-        assignment and return the entries as strings.
-
-        Mirrors :meth:`ProjectContext.find_literal_list_entries`.
-        """
-        ...
-
-    def module_dunders(self) -> list[SymbolNode]:
-        """All top-level ``__dunder__`` declarations across the
-        project.
-
-        Mirrors :meth:`ProjectContext.find_module_dunders`.
-        """
-        ...
-
-    def main_blocks(self) -> list[tuple[SymbolNode, list[SymbolNode]]]:
-        """Every ``if __name__ == "__main__":`` block, paired with
-        the module and the decls inside.
-
-        Mirrors :meth:`ProjectContext.find_main_blocks`.
-        """
-        ...
-
-    def nodes_matching_specs(
-        self,
-        project_root: str,
-        regexes: list[str],
-        str_specs: list[str],
-        abs_paths: list[str],
-    ) -> list[SymbolNode]:
-        """Match nodes against pre-classified path / fqname specs.
-
-        Avoids the per-node FFI hop + ``pathlib.Path`` allocation that
-        a ``for node in ctx.nodes(): ...`` loop pays. ``regexes`` are
-        anchored at the start of input (``re.Pattern.match`` semantics).
-        ``str_specs`` match exactly against the relative path OR the
-        node's fqname. ``abs_paths`` match exactly against the
-        absolute path.
-
-        Mirrors :meth:`ProjectContext.find_nodes_matching_specs`.
-        """
-        ...
-
-    def comment_patterns(self, pattern: str) -> list[tuple[SymbolNode, str]]:
-        """Comments matching ``pattern`` paired with the next
-        declaration.
-
-        Mirrors :meth:`ProjectContext.find_comment_patterns`.
-        """
-        ...
 
 class DecoratorQuery:
     """Find decorated top-level functions / classes. Pick exactly one

--- a/python/dead_cst/contrib/mock_patch.py
+++ b/python/dead_cst/contrib/mock_patch.py
@@ -56,8 +56,8 @@ class MockPatchPlugin(Plugin):
             owners_by_fqname.setdefault(ref.string_arg, []).append(ref.owner)
 
         for fqname, owners in owners_by_fqname.items():
-            targets = list(native.query(ctx).declarations(fqname))
-            mod = native.query(ctx).module(fqname)
+            targets = list(ctx.find_declarations(fqname))
+            mod = ctx.find_module(fqname)
             if mod is not None:
                 targets.append(mod)
             yield native.AddNode(

--- a/python/dead_cst/plugins/decl_shapes.py
+++ b/python/dead_cst/plugins/decl_shapes.py
@@ -312,7 +312,7 @@ class LiteralListPlugin(Plugin):
         # The visitor doesn't emit ``var -> referent`` edges for
         # non-``__all__`` string-list assignments, so the plugin can't
         # rely on a descendant walk.
-        entries = native.query(ctx).literal_list_entries(var_fqname)
+        entries = ctx.find_literal_list_entries(var_fqname)
         if not entries:
             return
 
@@ -324,7 +324,7 @@ class LiteralListPlugin(Plugin):
             # (e.g. ``pkg.foo`` where ``foo`` is also a re-exported decl
             # in ``pkg/__init__.py``).
             targets: list[native.SymbolNode] = list(ctx.module_surface(entry))
-            targets.extend(native.query(ctx).declarations(entry))
+            targets.extend(ctx.find_declarations(entry))
             if not targets:
                 continue
             yield native.AddNode(

--- a/python/dead_cst/plugins/dynamic_import.py
+++ b/python/dead_cst/plugins/dynamic_import.py
@@ -68,9 +68,9 @@ class DynamicImportFallbackPlugin(Plugin):
             return cached
         exports = None
         if self.respect_dunder_all:
-            exports = native.query(ctx).module_dunder_all_exports(module_fqname)
+            exports = ctx.find_module_dunder_all_exports(module_fqname)
         if exports is None:
-            decls = native.query(ctx).module_top_level_decls(module_fqname)
+            decls = ctx.find_module_top_level_decls(module_fqname)
             if self.include_underscore:
                 exports = decls
             else:

--- a/python/dead_cst/plugins/explicit_entrypoint.py
+++ b/python/dead_cst/plugins/explicit_entrypoint.py
@@ -46,7 +46,5 @@ class ExplicitEntrypointPlugin(Plugin):
                 abs_paths.append(str(spec))
             elif isinstance(spec, str):
                 str_specs.append(spec)
-        for node in native.query(ctx).nodes_matching_specs(
-            ctx.project_root, regexes, str_specs, abs_paths
-        ):
+        for node in ctx.find_nodes_matching_specs(ctx.project_root, regexes, str_specs, abs_paths):
             yield native.AddEntrypoint(node, marker="<entrypoint>")

--- a/python/dead_cst/plugins/main_block.py
+++ b/python/dead_cst/plugins/main_block.py
@@ -22,7 +22,7 @@ class MainBlockPlugin(Plugin):
     """
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
-        for module, block_decls in native.query(ctx).main_blocks():
+        for module, block_decls in ctx.find_main_blocks():
             yield native.AddNode(
                 fqname=f"{MAIN_BLOCK_PREFIX}{module.fqname}",
                 path=module.path,

--- a/python/dead_cst/plugins/module_dunders.py
+++ b/python/dead_cst/plugins/module_dunders.py
@@ -22,7 +22,7 @@ class ModuleDundersPlugin(Plugin):
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
         for target in [
-            *native.query(ctx).module_dunders(),
+            *ctx.find_module_dunders(),
             *native.query(ctx).imports().of("__future__").collect(),
         ]:
             yield native.AddEntrypoint(target, marker="<dunder>")

--- a/python/dead_cst/plugins/project_scripts.py
+++ b/python/dead_cst/plugins/project_scripts.py
@@ -38,9 +38,9 @@ class ProjectScriptsPlugin(Plugin):
         for script_name, target in scripts.items():
             module_part, _, decl_part = target.partition(":")
             fqname = f"{module_part}.{decl_part}" if decl_part else module_part
-            targets = native.query(ctx).declarations(fqname)
+            targets = ctx.find_declarations(fqname)
             if not targets:
-                module_node = native.query(ctx).module(module_part)
+                module_node = ctx.find_module(module_part)
                 if module_node is not None:
                     targets = [module_node]
             if not targets:

--- a/src/project.rs
+++ b/src/project.rs
@@ -588,8 +588,9 @@ impl ProjectContext {
     }
 }
 
-// ----- Queries (rust-only, exposed to Python via the chainable QueryBuilder) -
+// ----- Point-lookup queries (exposed to Python directly on ProjectContext) -
 
+#[pymethods]
 impl ProjectContext {
     /// Return every top-level variable node whose name matches `__xxx__`.
     ///
@@ -859,6 +860,7 @@ impl ProjectContext {
     }
 }
 
+#[pymethods]
 impl ProjectContext {
     /// Return ``module_fqn``'s immediate top-level decls — every
     /// function / class / variable / import bound at its module scope.
@@ -1142,6 +1144,7 @@ impl ProjectContext {
     }
 }
 
+#[pymethods]
 impl ProjectContext {
     /// Return ``(module_node, [decls inside the block])`` for every
     /// file with a top-level ``if __name__ == "__main__":`` block.
@@ -1184,9 +1187,9 @@ impl ProjectContext {
         }
         Ok(out)
     }
+}
 
-    /// Return every class that defines a method with the given name.
-    ///
+impl ProjectContext {
     /// Return every top-level function decorated with ``@<decorator_module>.<name>``
     /// or ``@<name>`` for any ``name`` in ``decorator_names``.
     ///
@@ -1580,7 +1583,12 @@ impl ProjectContext {
             .map(|(idx, arg, call_args)| (outputs.builder.nodes[idx].clone_ref(py), arg, call_args))
             .collect())
     }
+}
 
+#[pymethods]
+impl ProjectContext {
+    /// Top-level functions / classes whose body constructs one of
+    /// ``ctor_names`` imported from ``module``.
     ///
     /// Recursively walks each candidate's body looking for ``<Ctor>(...)``
     /// or ``<module>.<Ctor>(...)`` call expressions. Returns
@@ -1651,7 +1659,9 @@ impl ProjectContext {
             .map(|(idx, kinds)| (outputs.builder.nodes[idx].clone_ref(py), kinds))
             .collect())
     }
+}
 
+impl ProjectContext {
     /// Find calls to a callable imported from ``module`` with the name
     /// ``name``. Returns ``(owning_decl, string_literal_arg)`` pairs
     /// where the call resolves through the file's local imports.
@@ -1801,7 +1811,12 @@ impl ProjectContext {
             .map(|(idx, arg, call_args)| (outputs.builder.nodes[idx].clone_ref(py), arg, call_args))
             .collect())
     }
+}
 
+#[pymethods]
+impl ProjectContext {
+    /// Every class that defines a method with the given name.
+    ///
     /// Walks each class's `DefinitionKind::Class` body for an
     /// `Stmt::FunctionDef` whose name matches. ty's `parsed_module` is
     /// Salsa-cached, so this is just a body scan per class.
@@ -1895,7 +1910,9 @@ impl ProjectContext {
             .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
             .collect())
     }
+}
 
+impl ProjectContext {
     // ----- Convenience helpers used by the chainable QueryBuilder ----------
 
     #[allow(clippy::type_complexity)]
@@ -1970,7 +1987,10 @@ impl ProjectContext {
         }
         Ok(out)
     }
+}
 
+#[pymethods]
+impl ProjectContext {
     /// Subclasses of the class addressed by ``base_fqn``.
     ///
     /// Works for both project classes (where the fqn resolves to a
@@ -1979,6 +1999,7 @@ impl ProjectContext {
     /// ``type_hierarchy_subtypes``. ``transitive=True`` (default)
     /// walks the full subclass closure; ``transitive=False`` returns
     /// only direct subclasses.
+    #[pyo3(signature = (base_fqn, *, transitive = true))]
     pub(crate) fn find_subclasses(
         &self,
         py: Python<'_>,

--- a/src/query.rs
+++ b/src/query.rs
@@ -11,7 +11,7 @@ use ruff_db::files::File;
 use ty_project::Db as ProjectDb;
 
 use crate::builder::not_materialized;
-use crate::graph::{MainBlock, SymbolNode};
+use crate::graph::SymbolNode;
 use crate::helpers::{
     args_to_py_vec, call_args_match_kwargs, file_path_string, kwarg_matcher_from_py,
     kwargs_to_py_map, KwargMatcher,
@@ -112,7 +112,11 @@ impl CallRef {
 
 /// Entry point for the chainable query API. Returned by
 /// :meth:`ProjectContext.query`. Pick a stream type:
-/// :meth:`decorators`, :meth:`constructions`, or :meth:`calls`.
+/// :meth:`decorators`, :meth:`constructions`, :meth:`calls`,
+/// :meth:`subclasses`, :meth:`imports`, :meth:`classes`, or
+/// :meth:`factories`. Point lookups (``module``, ``declarations``,
+/// ``main_blocks``, etc.) live directly on
+/// :class:`ProjectContext`.
 #[pyclass(unsendable)]
 pub(crate) struct QueryBuilder {
     pub(crate) ctx: Py<ProjectContext>,
@@ -140,89 +144,6 @@ impl QueryBuilder {
     }
     fn factories(&self, py: Python<'_>) -> FactoryQuery {
         FactoryQuery::new(self.ctx.clone_ref(py))
-    }
-
-    // ----- Point lookups (no filter chain) ------------------------------
-
-    /// Look up a module's synthetic node by dotted fqname. Mirrors
-    /// :meth:`ProjectContext.find_module`.
-    fn module(&self, py: Python<'_>, fqname: &str) -> PyResult<Option<Py<SymbolNode>>> {
-        self.ctx.borrow(py).find_module(py, fqname)
-    }
-    /// All top-level declarations bound to the given dotted fqname.
-    /// Mirrors :meth:`ProjectContext.find_declarations`.
-    fn declarations(&self, py: Python<'_>, fqname: &str) -> PyResult<Vec<Py<SymbolNode>>> {
-        self.ctx.borrow(py).find_declarations(py, fqname)
-    }
-    /// Every top-level declaration node of the named module.
-    /// Mirrors :meth:`ProjectContext.find_module_top_level_decls`.
-    fn module_top_level_decls(
-        &self,
-        py: Python<'_>,
-        fqname: &str,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        self.ctx.borrow(py).find_module_top_level_decls(py, fqname)
-    }
-    /// The exported names listed in a module's ``__all__`` (when
-    /// statically resolvable), or ``None`` when the module has no
-    /// ``__all__``.
-    /// Mirrors :meth:`ProjectContext.find_module_dunder_all_exports`.
-    fn module_dunder_all_exports(
-        &self,
-        py: Python<'_>,
-        fqname: &str,
-    ) -> PyResult<Option<Vec<Py<SymbolNode>>>> {
-        self.ctx
-            .borrow(py)
-            .find_module_dunder_all_exports(py, fqname)
-    }
-    /// Read the literal-list value of a top-level variable assignment
-    /// (``X = ["a", "b"]``) and return the entries as strings.
-    /// Returns ``None`` when the variable isn't a list / tuple of
-    /// string literals.
-    /// Mirrors :meth:`ProjectContext.find_literal_list_entries`.
-    fn literal_list_entries(&self, py: Python<'_>, var_fqn: &str) -> PyResult<Option<Vec<String>>> {
-        self.ctx.borrow(py).find_literal_list_entries(var_fqn)
-    }
-    /// All top-level ``__dunder__`` declarations across the project.
-    /// Mirrors :meth:`ProjectContext.find_module_dunders`.
-    fn module_dunders(&self, py: Python<'_>) -> PyResult<Vec<Py<SymbolNode>>> {
-        self.ctx.borrow(py).find_module_dunders(py)
-    }
-    /// Every ``if __name__ == "__main__":`` block in the project,
-    /// paired with the module and the decls inside.
-    /// Mirrors :meth:`ProjectContext.find_main_blocks`.
-    fn main_blocks(&self, py: Python<'_>) -> PyResult<Vec<MainBlock>> {
-        self.ctx.borrow(py).find_main_blocks(py)
-    }
-    /// Match nodes against pre-classified path / fqname specs without
-    /// crossing the FFI boundary per node.
-    /// Mirrors :meth:`ProjectContext.find_nodes_matching_specs`.
-    fn nodes_matching_specs(
-        &self,
-        py: Python<'_>,
-        project_root: &str,
-        regexes: Vec<String>,
-        str_specs: Vec<String>,
-        abs_paths: Vec<String>,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        self.ctx.borrow(py).find_nodes_matching_specs(
-            py,
-            project_root,
-            regexes,
-            str_specs,
-            abs_paths,
-        )
-    }
-    /// Comments matching ``pattern`` paired with the next
-    /// declaration. Mirrors :meth:`ProjectContext.find_comment_patterns`.
-    #[allow(clippy::type_complexity)]
-    fn comment_patterns(
-        &self,
-        py: Python<'_>,
-        pattern: &str,
-    ) -> PyResult<Vec<(Py<SymbolNode>, String)>> {
-        self.ctx.borrow(py).find_comment_patterns(py, pattern)
     }
 }
 

--- a/tests/prototype/plugin_protocol.py
+++ b/tests/prototype/plugin_protocol.py
@@ -95,5 +95,5 @@ class KeepAliveCommentPlugin:
     name = "keep_alive_comment"
 
     def run(self, ctx: "native.ProjectContext") -> "Iterable[native.GraphOp]":
-        for decl, _comment in native.query(ctx).comment_patterns(r"#\s*dead-cst:\s*keep\b"):
+        for decl, _comment in ctx.find_comment_patterns(r"#\s*dead-cst:\s*keep\b"):
             yield native.AddEntrypoint(decl, marker="<keep>")

--- a/tests/prototype/test_kwarg_matchers.py
+++ b/tests/prototype/test_kwarg_matchers.py
@@ -392,7 +392,7 @@ def test_where_kwarg_with_nativenode_raises(make_ctx):
     captured: list[Exception] = []
 
     def capture(ctx):
-        mod = native.query(ctx).module("tests")
+        mod = ctx.find_module("tests")
         assert mod is not None
         try:
             (

--- a/tests/prototype/test_plugin_protocol.py
+++ b/tests/prototype/test_plugin_protocol.py
@@ -70,7 +70,7 @@ def test_plugin_runs_once_per_project(make_ctx):
         name = "counter"
 
         def run(self, ctx: native.ProjectContext) -> None:
-            calls.append(len(native.query(ctx).module_dunders()))
+            calls.append(len(ctx.find_module_dunders()))
 
     ctx = make_ctx(
         {
@@ -258,7 +258,7 @@ def test_query_outside_materialize_raises(make_ctx):
     """Calling a query method on an un-materialized context errors clearly."""
     ctx = make_ctx({"mod.py": "x = 1\n"})
     with pytest.raises(RuntimeError, match="find_module_dunders"):
-        native.query(ctx).module_dunders()
+        ctx.find_module_dunders()
 
 
 def test_materialize_is_idempotent(make_ctx):


### PR DESCRIPTION
## Summary

Plugin-API cleanup: unify the duplicated query/ctx surface. Point-lookup methods (single argument, return one node or one list, no predicates to chain) belong on `ctx`. Stream-with-predicate methods belong on `query(ctx)`. Today's `query(ctx).foo()` and `ctx.foo()` had several duplicates with no principled split. Deletes the duplicates from `QueryBuilder`; consumers now use the canonical `ctx.find_*(...)` form.

This is the second cleanup informed by the two-agent API review (the first was #200 — `Plugin` base, drop `name`/`version`, factory functions for simple framework subclasses).

## What changed

### Deleted from `QueryBuilder` (`src/query.rs`)

The entire "Point lookups (no filter chain)" section:

- `module(fqname)`
- `declarations(fqname)`
- `module_top_level_decls(fqname)`
- `module_dunder_all_exports(fqname)`
- `literal_list_entries(var_fqn)`
- `module_dunders()`
- `main_blocks()`
- `nodes_matching_specs(...)`
- `comment_patterns(pattern)`

Stream builders that stay on `QueryBuilder` (correctly chainable):
`decorators()`, `constructions()`, `calls()`, `subclasses()`, `imports()`, `classes()`, `factories()`.

### Promoted to `#[pymethods]` on `ProjectContext` (`src/project.rs`)

All previously `pub(crate) fn` in rust-only `impl` blocks. Some `impl` blocks split where rust-only helpers (returning `CallArgs` etc.) shared a block with pyo3-eligible methods:

- `find_module_dunders`
- `find_nodes_matching_specs` (was rust-only — newly exposed)
- `find_imports_of`
- `find_declarations`
- `find_module`
- `find_module_top_level_decls`
- `find_module_dunder_all_exports`
- `find_literal_list_entries`
- `find_main_blocks`
- `find_factory_decls`
- `find_classes_defining_method`
- `find_subclasses_of`
- `find_subclasses` (also gained `#[pyo3(signature = (base_fqn, *, transitive = true))]` to match the existing `.pyi` contract)
- `find_comment_patterns`

### Consumer call sites updated

`query(ctx).foo(...)` → `ctx.find_foo(...)` across:

- `python/dead_cst/contrib/mock_patch.py`
- `python/dead_cst/plugins/main_block.py`
- `python/dead_cst/plugins/dynamic_import.py`
- `python/dead_cst/plugins/project_scripts.py`
- `python/dead_cst/plugins/decl_shapes.py`
- `python/dead_cst/plugins/explicit_entrypoint.py`
- `python/dead_cst/plugins/module_dunders.py`
- `tests/prototype/plugin_protocol.py`
- `tests/prototype/test_kwarg_matchers.py`
- `tests/prototype/test_plugin_protocol.py`

## Out of scope (follow-ups)

- **Dropping the `find_*` prefix.** The `ctx.find_module(fqn)` shape reads as Rust-style noise in Python. Renaming to `ctx.module(fqn)` was deliberately punted — separate, easy mechanical PR.
- **Structured `SyntheticTag(plugin, kind, payload)` op + `ctx.find_synthetic(plugin=, kind=)` lookup** — replaces the `<flask-factory>:Blueprint:pkg.mod.make_bp` string-grammar plugin coordination. Bigger architectural change, deserves its own design pass.

## Test plan

- [x] `uv run pytest -q` — **630 passed**, 10 deselected.
- [x] `uv run pytest -q -m e2e` — **10 passed**.
- [x] `uv run prek run --all-files` — clean (ruff, ruff-format, ty, cargo fmt, cargo clippy).

## Diffstat

13 files changed, **-124 lines net** (+70 / -194). Most of the deletion is the dropped point-lookup section from `_native.pyi`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZf2rbhxbQjRYGckcRuSCE)_