### PR TITLE
plugins: structured SyntheticTag for plugin coordination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@ two versions.
   shape is now surfaced to plugins.
 
 ### Added
+- :class:`native.SyntheticTag` (frozen pyclass) and a
+  ``tag: SyntheticTag | None`` field on both :class:`native.AddNode`
+  and :class:`native.SymbolNode`. Plugins can now stamp structured
+  metadata onto each synthetic node they emit (``plugin`` /
+  ``kind`` / ``payload``) and look those markers up via the new
+  :meth:`native.ProjectContext.find_synthetic(plugin, kind=None)`
+  query — instead of parsing the node's ``fqname`` string with
+  ``startswith(...)``. The tag participates in the node intern key,
+  so two ``AddNode`` ops that share fqname/path but differ in their
+  tag mint distinct nodes. Migrated :class:`DispatchAppPlugin`'s
+  factory-walk lookup, :class:`DecoratedDeclPlugin`,
+  :class:`LiteralListPlugin`, :class:`CeleryPlugin` (``shared_task``
+  markers), :class:`MockPatchPlugin`, and :class:`DiscordPyPlugin`
+  (cog + extension markers) to emit tags.
 - :class:`dead_cst.plugins.DynamicImportFallbackPlugin` — a plugin
   that reads :attr:`EdgeFlags.DYNAMIC_IMPORT` edges and fans each
   flagged ``src -> module`` edge out to the module's exports. Gives

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -130,6 +130,34 @@ class Import:
         star: bool = ...,
     ) -> None: ...
 
+class SyntheticTag:
+    """Structured metadata stamped onto a synthetic node by the plugin
+    that emitted it. Lets plugins find their own markers by *role*
+    rather than parsing the marker fqname string.
+
+    ``plugin`` is the emitting plugin's short marker label
+    (``"flask"`` / ``"celery"`` / ``"discordpy"`` / …). ``kind`` is
+    the role of the synthetic within that plugin (``"app"`` /
+    ``"factory"`` / ``"per-file"`` / ``"entry"`` / …). ``payload`` is
+    free-form per-plugin context (typically the decl fqname, file
+    basename, or constructor name).
+
+    The synthetic node's ``fqname`` string is still produced and is
+    still the user-facing label ``why-alive`` reads from; the tag is
+    *parallel* metadata used for structured lookup via
+    :meth:`ProjectContext.find_synthetic`.
+
+    Frozen + hashable. Participates in the node intern key, so two
+    ``AddNode`` ops with identical ``fqname`` / ``path`` / position
+    but different tags produce distinct synthetic nodes.
+    """
+
+    plugin: str
+    kind: str
+    payload: str
+
+    def __init__(self, *, plugin: str, kind: str, payload: str) -> None: ...
+
 class SymbolNode:
     """A single node in a ``NativeGraph``.
 
@@ -141,6 +169,9 @@ class SymbolNode:
     ``NodeFlags`` values. ``imports`` is populated only for
     ``kind="import"`` nodes (one per alias, plus one per name brought
     in by ``from X import *``); all other kinds carry ``None``.
+    ``tag`` is populated only for synthetic nodes minted via
+    ``AddNode(..., tag=SyntheticTag(...))``; all other nodes carry
+    ``None``.
     """
 
     fqname: str
@@ -152,6 +183,7 @@ class SymbolNode:
     end_column: int
     flags: int
     imports: Import | None
+    tag: SyntheticTag | None
 
     def __init__(
         self,
@@ -165,6 +197,7 @@ class SymbolNode:
         end_column: int = ...,
         flags: int = ...,
         imports: Import | None = ...,
+        tag: SyntheticTag | None = ...,
     ) -> None: ...
 
 # ----- Graph operations (yielded from plugin.run) ------------------------
@@ -214,6 +247,12 @@ class AddNode:
     ``flags = NodeFlags.ENTRYPOINT`` to make the node a reachability
     seed; for the common single-target entrypoint pattern, prefer
     ``AddEntrypoint(decl, marker=...)``.
+
+    ``tag`` attaches structured per-plugin metadata to the resulting
+    node, queryable via :meth:`ProjectContext.find_synthetic`. Two
+    ``AddNode`` ops with the same ``fqname`` / ``path`` / position but
+    different tags mint distinct nodes — the tag participates in the
+    intern key.
     """
 
     fqname: str
@@ -222,6 +261,7 @@ class AddNode:
     flags: int
     edges_from: list[SymbolNode]
     edges_to: list[SymbolNode]
+    tag: SyntheticTag | None
 
     def __init__(
         self,
@@ -232,6 +272,7 @@ class AddNode:
         flags: int = 0,
         edges_from: Iterable[SymbolNode] = ...,
         edges_to: Iterable[SymbolNode] = ...,
+        tag: SyntheticTag | None = ...,
     ) -> None: ...
 
 GraphOp = AddEdge | AddEntrypoint | AddNode
@@ -391,6 +432,22 @@ class ProjectContext:
     def find_module(self, fqname: str) -> SymbolNode | None:
         """Return the module node for the given dotted fqname, if one
         exists in the project graph."""
+        ...
+
+    def find_synthetic(self, plugin: str, kind: str | None = None) -> list[SymbolNode]:
+        """Every synthetic node tagged with the given ``plugin`` marker
+        (and optional ``kind`` role).
+
+        Plugins use this to find their own markers without parsing the
+        node ``fqname`` string: each :class:`AddNode` op that carries a
+        :class:`SyntheticTag` lands in an index keyed by
+        ``(plugin, kind)``. ``kind=None`` (the default) returns every
+        tagged synthetic for the plugin regardless of role; passing a
+        ``kind`` narrows to that one role.
+
+        Results are returned in emission order — the order the
+        ``AddNode`` ops carrying the tag were applied to the graph.
+        """
         ...
 
     def module_for(self, path: str) -> SymbolNode | None:

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -480,6 +480,24 @@ class ProjectContext:
         """
         ...
 
+    def find_nodes_matching_specs(
+        self,
+        project_root: str,
+        regexes: list[str],
+        str_specs: list[str],
+        abs_paths: list[str],
+    ) -> list[SymbolNode]:
+        """Match nodes against pre-classified path / fqname specs.
+
+        Avoids the per-node FFI hop + ``pathlib.Path`` allocation that
+        a ``for node in ctx.nodes(): ...`` loop pays. ``regexes`` are
+        anchored at the start of input (``re.Pattern.match`` semantics).
+        ``str_specs`` match exactly against the relative path OR the
+        node's fqname. ``abs_paths`` match exactly against the
+        absolute path.
+        """
+        ...
+
     # ----- Traversal -----------------------------------------------------
 
     def descendants(self, root: SymbolNode, *, skip_flags: int = 0) -> list[SymbolNode]:
@@ -748,12 +766,13 @@ class QueryBuilder:
     :meth:`subclasses` / :meth:`imports` / :meth:`classes` /
     :meth:`factories`.
 
-    Point lookups (no ``.collect()`` — direct methods returning
-    ``SymbolNode`` / ``list[SymbolNode]`` / etc.):
-    :meth:`module` / :meth:`declarations` /
-    :meth:`module_top_level_decls` / :meth:`module_dunder_all_exports` /
-    :meth:`module_dunders` / :meth:`main_blocks` /
-    :meth:`comment_patterns`.
+    Point lookups (e.g. :meth:`ProjectContext.find_module`,
+    :meth:`ProjectContext.find_declarations`,
+    :meth:`ProjectContext.find_main_blocks`,
+    :meth:`ProjectContext.find_comment_patterns`,
+    :meth:`ProjectContext.find_module_dunders`,
+    :meth:`ProjectContext.find_literal_list_entries`) live directly on
+    :class:`ProjectContext`.
     """
 
     def decorators(self) -> DecoratorQuery: ...
@@ -763,89 +782,6 @@ class QueryBuilder:
     def imports(self) -> ImportQuery: ...
     def classes(self) -> ClassQuery: ...
     def factories(self) -> FactoryQuery: ...
-
-    # ----- Point lookups (no filter chain) ------------------------------
-
-    def module(self, fqname: str) -> SymbolNode | None:
-        """Look up a module's synthetic node by dotted fqname.
-
-        Mirrors :meth:`ProjectContext.find_module`.
-        """
-        ...
-
-    def declarations(self, fqname: str) -> list[SymbolNode]:
-        """All top-level declarations bound to the given dotted fqname.
-
-        Mirrors :meth:`ProjectContext.find_declarations`.
-        """
-        ...
-
-    def module_top_level_decls(self, fqname: str) -> list[SymbolNode]:
-        """Every top-level declaration node of the named module.
-
-        Mirrors :meth:`ProjectContext.find_module_top_level_decls`.
-        """
-        ...
-
-    def module_dunder_all_exports(self, fqname: str) -> list[SymbolNode] | None:
-        """Exported names listed in a module's ``__all__``, or
-        ``None`` when the module declares no ``__all__``.
-
-        Mirrors :meth:`ProjectContext.find_module_dunder_all_exports`.
-        """
-        ...
-
-    def literal_list_entries(self, var_fqn: str) -> list[str] | None:
-        """Read the literal-list value of a top-level variable
-        assignment and return the entries as strings.
-
-        Mirrors :meth:`ProjectContext.find_literal_list_entries`.
-        """
-        ...
-
-    def module_dunders(self) -> list[SymbolNode]:
-        """All top-level ``__dunder__`` declarations across the
-        project.
-
-        Mirrors :meth:`ProjectContext.find_module_dunders`.
-        """
-        ...
-
-    def main_blocks(self) -> list[tuple[SymbolNode, list[SymbolNode]]]:
-        """Every ``if __name__ == "__main__":`` block, paired with
-        the module and the decls inside.
-
-        Mirrors :meth:`ProjectContext.find_main_blocks`.
-        """
-        ...
-
-    def nodes_matching_specs(
-        self,
-        project_root: str,
-        regexes: list[str],
-        str_specs: list[str],
-        abs_paths: list[str],
-    ) -> list[SymbolNode]:
-        """Match nodes against pre-classified path / fqname specs.
-
-        Avoids the per-node FFI hop + ``pathlib.Path`` allocation that
-        a ``for node in ctx.nodes(): ...`` loop pays. ``regexes`` are
-        anchored at the start of input (``re.Pattern.match`` semantics).
-        ``str_specs`` match exactly against the relative path OR the
-        node's fqname. ``abs_paths`` match exactly against the
-        absolute path.
-
-        Mirrors :meth:`ProjectContext.find_nodes_matching_specs`.
-        """
-        ...
-
-    def comment_patterns(self, pattern: str) -> list[tuple[SymbolNode, str]]:
-        """Comments matching ``pattern`` paired with the next
-        declaration.
-
-        Mirrors :meth:`ProjectContext.find_comment_patterns`.
-        """
-        ...
 
 class DecoratorQuery:
     """Find decorated top-level functions / classes. Pick exactly one

--- a/python/dead_cst/contrib/celery.py
+++ b/python/dead_cst/contrib/celery.py
@@ -46,4 +46,9 @@ class CeleryPlugin(DispatchAppPlugin):
                 path=path,
                 flags=int(NodeFlags.ENTRYPOINT),
                 edges_to=targets,
+                tag=native.SyntheticTag(
+                    plugin="celery",
+                    kind="shared",
+                    payload=Path(path).name,
+                ),
             )

--- a/python/dead_cst/contrib/discordpy.py
+++ b/python/dead_cst/contrib/discordpy.py
@@ -107,6 +107,11 @@ class DiscordPyPlugin(Plugin):
                     path=path,
                     flags=int(NodeFlags.ENTRYPOINT),
                     edges_to=targets,
+                    tag=native.SyntheticTag(
+                        plugin="discordpy",
+                        kind="cog",
+                        payload=filename,
+                    ),
                 )
 
         # 5. load_extension / load_extensions string-literal targets.
@@ -126,4 +131,9 @@ class DiscordPyPlugin(Plugin):
                     path=cref.owner.path,
                     flags=int(NodeFlags.ENTRYPOINT),
                     edges_to=targets,
+                    tag=native.SyntheticTag(
+                        plugin="discordpy",
+                        kind="extension",
+                        payload=cref.string_arg,
+                    ),
                 )

--- a/python/dead_cst/contrib/mock_patch.py
+++ b/python/dead_cst/contrib/mock_patch.py
@@ -56,8 +56,8 @@ class MockPatchPlugin(Plugin):
             owners_by_fqname.setdefault(ref.string_arg, []).append(ref.owner)
 
         for fqname, owners in owners_by_fqname.items():
-            targets = list(native.query(ctx).declarations(fqname))
-            mod = native.query(ctx).module(fqname)
+            targets = list(ctx.find_declarations(fqname))
+            mod = ctx.find_module(fqname)
             if mod is not None:
                 targets.append(mod)
             yield native.AddNode(

--- a/python/dead_cst/contrib/mock_patch.py
+++ b/python/dead_cst/contrib/mock_patch.py
@@ -65,4 +65,9 @@ class MockPatchPlugin(Plugin):
                 path=owners[0].path,
                 edges_from=owners,
                 edges_to=targets,
+                tag=native.SyntheticTag(
+                    plugin="mock_patch",
+                    kind="target",
+                    payload=fqname,
+                ),
             )

--- a/python/dead_cst/plugins/decl_shapes.py
+++ b/python/dead_cst/plugins/decl_shapes.py
@@ -312,7 +312,7 @@ class LiteralListPlugin(Plugin):
         # The visitor doesn't emit ``var -> referent`` edges for
         # non-``__all__`` string-list assignments, so the plugin can't
         # rely on a descendant walk.
-        entries = native.query(ctx).literal_list_entries(var_fqname)
+        entries = ctx.find_literal_list_entries(var_fqname)
         if not entries:
             return
 
@@ -324,7 +324,7 @@ class LiteralListPlugin(Plugin):
             # (e.g. ``pkg.foo`` where ``foo`` is also a re-exported decl
             # in ``pkg/__init__.py``).
             targets: list[native.SymbolNode] = list(ctx.module_surface(entry))
-            targets.extend(native.query(ctx).declarations(entry))
+            targets.extend(ctx.find_declarations(entry))
             if not targets:
                 continue
             yield native.AddNode(

--- a/python/dead_cst/plugins/decl_shapes.py
+++ b/python/dead_cst/plugins/decl_shapes.py
@@ -89,6 +89,11 @@ class DecoratedDeclPlugin(Plugin):
                 path=path,
                 flags=int(NodeFlags.ENTRYPOINT),
                 edges_to=targets,
+                tag=native.SyntheticTag(
+                    plugin=self.marker_prefix,
+                    kind="per-file",
+                    payload=Path(path).name,
+                ),
             )
 
 
@@ -230,6 +235,11 @@ class DispatchAppPlugin(Plugin):
                     path=ref.var.path,
                     flags=int(NodeFlags.ENTRYPOINT),
                     edges_to=[ref.var],
+                    tag=native.SyntheticTag(
+                        plugin=self.marker_prefix,
+                        kind="app",
+                        payload=ref.var.fqname,
+                    ),
                 )
 
         # 4. Emit factory markers so the descendant walk in step 6 can
@@ -239,6 +249,11 @@ class DispatchAppPlugin(Plugin):
                 fqname=f"{factory_prefix}{kind}:{fref.decl.fqname}",
                 path=fref.decl.path,
                 edges_from=[fref.decl],
+                tag=native.SyntheticTag(
+                    plugin=self.marker_prefix,
+                    kind="factory",
+                    payload=f"{kind}:{fref.decl.fqname}",
+                ),
             )
 
         # 5. Wire decorator handlers to their owner var.
@@ -264,6 +279,11 @@ class DispatchAppPlugin(Plugin):
         # whose descendant graph reaches a factory marker get
         # entrypoint-promoted too. Skipped under seed_as_entrypoint=False.
         if self.seed_as_entrypoint:
+            # Tag-based lookup: the factory markers emitted in step 4
+            # carry ``SyntheticTag(plugin=marker_prefix, kind="factory")``.
+            # Pre-collect them into a set for O(1) descendant filtering
+            # instead of parsing each descendant's fqname string.
+            factory_synthetics = set(ctx.find_synthetic(plugin=self.marker_prefix, kind="factory"))
             classified: set[tuple[str, str]] = set()
             for h in handlers:
                 key = (h.decorated.path, h.decorator_owner or "")
@@ -273,9 +293,7 @@ class DispatchAppPlugin(Plugin):
                 if var is None:
                     continue
                 for desc in ctx.descendants(var):
-                    if desc.kind != "synthetic":
-                        continue
-                    if not desc.fqname.startswith(factory_prefix):
+                    if desc not in factory_synthetics:
                         continue
                     classified.add(key)
                     yield native.AddNode(
@@ -283,6 +301,11 @@ class DispatchAppPlugin(Plugin):
                         path=var.path,
                         flags=int(NodeFlags.ENTRYPOINT),
                         edges_to=[var],
+                        tag=native.SyntheticTag(
+                            plugin=self.marker_prefix,
+                            kind="app",
+                            payload=var.fqname,
+                        ),
                     )
                     break
 
@@ -332,4 +355,9 @@ class LiteralListPlugin(Plugin):
                 path=targets[0].path,
                 flags=int(NodeFlags.ENTRYPOINT),
                 edges_to=targets,
+                tag=native.SyntheticTag(
+                    plugin=self.marker_prefix,
+                    kind="entry",
+                    payload=entry,
+                ),
             )

--- a/python/dead_cst/plugins/dynamic_import.py
+++ b/python/dead_cst/plugins/dynamic_import.py
@@ -68,9 +68,9 @@ class DynamicImportFallbackPlugin(Plugin):
             return cached
         exports = None
         if self.respect_dunder_all:
-            exports = native.query(ctx).module_dunder_all_exports(module_fqname)
+            exports = ctx.find_module_dunder_all_exports(module_fqname)
         if exports is None:
-            decls = native.query(ctx).module_top_level_decls(module_fqname)
+            decls = ctx.find_module_top_level_decls(module_fqname)
             if self.include_underscore:
                 exports = decls
             else:

--- a/python/dead_cst/plugins/explicit_entrypoint.py
+++ b/python/dead_cst/plugins/explicit_entrypoint.py
@@ -46,7 +46,5 @@ class ExplicitEntrypointPlugin(Plugin):
                 abs_paths.append(str(spec))
             elif isinstance(spec, str):
                 str_specs.append(spec)
-        for node in native.query(ctx).nodes_matching_specs(
-            ctx.project_root, regexes, str_specs, abs_paths
-        ):
+        for node in ctx.find_nodes_matching_specs(ctx.project_root, regexes, str_specs, abs_paths):
             yield native.AddEntrypoint(node, marker="<entrypoint>")

--- a/python/dead_cst/plugins/main_block.py
+++ b/python/dead_cst/plugins/main_block.py
@@ -22,7 +22,7 @@ class MainBlockPlugin(Plugin):
     """
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
-        for module, block_decls in native.query(ctx).main_blocks():
+        for module, block_decls in ctx.find_main_blocks():
             yield native.AddNode(
                 fqname=f"{MAIN_BLOCK_PREFIX}{module.fqname}",
                 path=module.path,

--- a/python/dead_cst/plugins/module_dunders.py
+++ b/python/dead_cst/plugins/module_dunders.py
@@ -22,7 +22,7 @@ class ModuleDundersPlugin(Plugin):
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
         for target in [
-            *native.query(ctx).module_dunders(),
+            *ctx.find_module_dunders(),
             *native.query(ctx).imports().of("__future__").collect(),
         ]:
             yield native.AddEntrypoint(target, marker="<dunder>")

--- a/python/dead_cst/plugins/project_scripts.py
+++ b/python/dead_cst/plugins/project_scripts.py
@@ -38,9 +38,9 @@ class ProjectScriptsPlugin(Plugin):
         for script_name, target in scripts.items():
             module_part, _, decl_part = target.partition(":")
             fqname = f"{module_part}.{decl_part}" if decl_part else module_part
-            targets = native.query(ctx).declarations(fqname)
+            targets = ctx.find_declarations(fqname)
             if not targets:
-                module_node = native.query(ctx).module(module_part)
+                module_node = ctx.find_module(module_part)
                 if module_node is not None:
                     targets = [module_node]
             if not targets:

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10,15 +10,28 @@ use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use ruff_db::files::File;
 
-use crate::graph::SymbolNode;
+use crate::graph::{SymbolNode, SyntheticTag};
 use crate::helpers::NODE_FLAG_ENTRYPOINT;
 use crate::project::ProjectContext;
+
+/// Plain hashable triple of a `SyntheticTag`'s three string fields,
+/// for participation in `NodeKey`. Reading the `Py<SyntheticTag>` to
+/// hash it requires the GIL; this triple is the GIL-free projection
+/// used as a `HashMap` key.
+pub(crate) type TagKey = (String, String, String);
 
 /// Positional identity for a node.
 ///
 /// Per `CLAUDE.md` principle 3, `flags` is deliberately *not* part of
 /// the key: two nodes for the same `(fqname, kind, path, position)` are
 /// the same node regardless of which path computed their flags.
+///
+/// `tag` *does* participate: two `AddNode` ops with the same
+/// fqname/path/position but different `SyntheticTag` payloads are
+/// distinct nodes. This keeps the intern table consistent with
+/// `SymbolNode.__eq__` (which also includes the tag) and lets a
+/// plugin emit multiple synthetics that share an fqname template but
+/// differ in their structured payload.
 #[derive(Hash, Eq, PartialEq, Clone)]
 pub(crate) struct NodeKey {
     pub(crate) fqname: String,
@@ -28,6 +41,7 @@ pub(crate) struct NodeKey {
     pub(crate) start_column: usize,
     pub(crate) end_line: usize,
     pub(crate) end_column: usize,
+    pub(crate) tag: Option<TagKey>,
 }
 
 pub(crate) struct GraphBuilder {
@@ -81,7 +95,7 @@ impl GraphBuilder {
     }
 
     pub(crate) fn intern_node(&mut self, py: Python<'_>, node: SymbolNode) -> PyResult<usize> {
-        let key = node_key_of(&node);
+        let key = node_key_of(py, &node);
         if let Some(&idx) = self.node_index.get(&key) {
             return Ok(idx);
         }
@@ -116,6 +130,7 @@ impl GraphBuilder {
                 end_column: 0,
                 flags: 0,
                 imports: None,
+                tag: None,
                 cached_hash: OnceLock::new(),
             },
         )?;
@@ -183,6 +198,12 @@ impl AddEntrypoint {
 /// doesn't need a separate handle to reference the freshly-minted node
 /// from subsequent ops. Set ``flags = NodeFlags.ENTRYPOINT`` to make
 /// the node a seed (``AddEntrypoint`` is the single-target sugar).
+///
+/// ``tag`` attaches a structured :class:`SyntheticTag` to the resulting
+/// node, queryable via ``ProjectContext.find_synthetic(plugin, kind)``.
+/// When two ``AddNode`` ops share fqname / path / position but have
+/// different tags they mint distinct nodes (the tag participates in
+/// the intern key).
 #[pyclass(frozen, get_all)]
 pub(crate) struct AddNode {
     pub(crate) fqname: String,
@@ -191,6 +212,7 @@ pub(crate) struct AddNode {
     pub(crate) flags: u32,
     pub(crate) edges_from: Vec<Py<SymbolNode>>,
     pub(crate) edges_to: Vec<Py<SymbolNode>>,
+    pub(crate) tag: Option<Py<SyntheticTag>>,
 }
 
 #[pymethods]
@@ -204,6 +226,7 @@ impl AddNode {
         flags = 0,
         edges_from = Vec::new(),
         edges_to = Vec::new(),
+        tag = None,
     ))]
     fn new(
         fqname: String,
@@ -212,6 +235,7 @@ impl AddNode {
         flags: u32,
         edges_from: Vec<Py<SymbolNode>>,
         edges_to: Vec<Py<SymbolNode>>,
+        tag: Option<Py<SyntheticTag>>,
     ) -> PyResult<Self> {
         Ok(Self {
             fqname,
@@ -220,6 +244,7 @@ impl AddNode {
             flags,
             edges_from,
             edges_to,
+            tag,
         })
     }
 }
@@ -232,9 +257,11 @@ pub(crate) fn not_materialized(op: &str) -> PyErr {
 }
 
 /// Project a `SymbolNode` onto the `NodeKey` used for intern-table
-/// identity. Clones the two `String` fields (`fqname`, `path`); the
-/// rest are `Copy`.
-pub(crate) fn node_key_of(node: &SymbolNode) -> NodeKey {
+/// identity. Clones the two `String` fields (`fqname`, `path`) plus
+/// the three `SyntheticTag` strings when the node carries a tag; the
+/// rest are `Copy`. Needs the GIL because reading the tag goes
+/// through `Py<SyntheticTag>::borrow`.
+pub(crate) fn node_key_of(py: Python<'_>, node: &SymbolNode) -> NodeKey {
     NodeKey {
         fqname: node.fqname.clone(),
         kind: node.kind,
@@ -243,6 +270,10 @@ pub(crate) fn node_key_of(node: &SymbolNode) -> NodeKey {
         start_column: node.start_column,
         end_line: node.end_line,
         end_column: node.end_column,
+        tag: node.tag.as_ref().map(|t| {
+            let t = t.borrow(py);
+            (t.plugin.clone(), t.kind.clone(), t.payload.clone())
+        }),
     }
 }
 
@@ -297,14 +328,14 @@ pub(crate) fn apply_graph_op(
         .ok_or_else(|| not_materialized("apply_graph_op"))?;
 
     if let Ok(add_edge) = op.extract::<PyRef<AddEdge>>() {
-        let src_idx = lookup_idx(&outputs.builder, &add_edge.src.borrow(py), "src")?;
-        let dst_idx = lookup_idx(&outputs.builder, &add_edge.dst.borrow(py), "dst")?;
+        let src_idx = lookup_idx(py, &outputs.builder, &add_edge.src.borrow(py), "src")?;
+        let dst_idx = lookup_idx(py, &outputs.builder, &add_edge.dst.borrow(py), "dst")?;
         outputs.builder.add_edge(src_idx, dst_idx, add_edge.flags);
         return Ok(());
     }
     if let Ok(add_ep) = op.extract::<PyRef<AddEntrypoint>>() {
         let decl = add_ep.decl.borrow(py);
-        let decl_idx = lookup_idx(&outputs.builder, &decl, "decl")?;
+        let decl_idx = lookup_idx(py, &outputs.builder, &decl, "decl")?;
         let marker_fqname = format!("{}:{}", add_ep.marker, decl.fqname);
         let path = decl.path.clone();
         drop(decl);
@@ -320,6 +351,7 @@ pub(crate) fn apply_graph_op(
                 end_column: 0,
                 flags: NODE_FLAG_ENTRYPOINT,
                 imports: None,
+                tag: None,
                 cached_hash: OnceLock::new(),
             },
         )?;
@@ -327,6 +359,7 @@ pub(crate) fn apply_graph_op(
         return Ok(());
     }
     if let Ok(add_node) = op.extract::<PyRef<AddNode>>() {
+        let tag = add_node.tag.as_ref().map(|t| t.clone_ref(py));
         let node_idx = outputs.builder.intern_node(
             py,
             SymbolNode {
@@ -339,15 +372,36 @@ pub(crate) fn apply_graph_op(
                 end_column: 0,
                 flags: add_node.flags,
                 imports: None,
+                tag,
                 cached_hash: OnceLock::new(),
             },
         )?;
+        // Index the new node by its tag (if any) so
+        // ``ProjectContext.find_synthetic`` can answer in O(1) instead
+        // of scanning every node. Mirrors the per-fqname dedup map for
+        // visitor-synth nodes, but at the tag granularity plugins
+        // coordinate on.
+        if let Some(tag_py) = &add_node.tag {
+            let tag_ref = tag_py.borrow(py);
+            let key = (tag_ref.plugin.clone(), Some(tag_ref.kind.clone()));
+            outputs
+                .synthetic_by_tag
+                .entry(key)
+                .or_default()
+                .push(node_idx);
+            let key_all = (tag_ref.plugin.clone(), None);
+            outputs
+                .synthetic_by_tag
+                .entry(key_all)
+                .or_default()
+                .push(node_idx);
+        }
         for src in &add_node.edges_from {
-            let src_idx = lookup_idx(&outputs.builder, &src.borrow(py), "edges_from")?;
+            let src_idx = lookup_idx(py, &outputs.builder, &src.borrow(py), "edges_from")?;
             outputs.builder.add_edge(src_idx, node_idx, 0);
         }
         for dst in &add_node.edges_to {
-            let dst_idx = lookup_idx(&outputs.builder, &dst.borrow(py), "edges_to")?;
+            let dst_idx = lookup_idx(py, &outputs.builder, &dst.borrow(py), "edges_to")?;
             outputs.builder.add_edge(node_idx, dst_idx, 0);
         }
         return Ok(());
@@ -361,10 +415,15 @@ pub(crate) fn apply_graph_op(
 /// Resolve a `SymbolNode` reference to its builder-side index for an
 /// edge endpoint. Surfaces a precise `ValueError` (with `side`) when
 /// the node was never interned in this context.
-pub(crate) fn lookup_idx(builder: &GraphBuilder, node: &SymbolNode, side: &str) -> PyResult<usize> {
+pub(crate) fn lookup_idx(
+    py: Python<'_>,
+    builder: &GraphBuilder,
+    node: &SymbolNode,
+    side: &str,
+) -> PyResult<usize> {
     builder
         .node_index
-        .get(&node_key_of(node))
+        .get(&node_key_of(py, node))
         .copied()
         .ok_or_else(|| {
             PyValueError::new_err(format!(

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -63,11 +63,81 @@ impl Import {
     }
 }
 
+/// Structured metadata stamped onto a synthetic node by the plugin
+/// that emitted it. Lets plugins find their own markers by *role*
+/// rather than parsing the marker fqname string.
+///
+/// `plugin` is the emitting plugin's short marker label (``"flask"``,
+/// ``"celery"``, ``"discordpy"``, …). `kind` is the role of the
+/// synthetic within that plugin (``"app"`` / ``"factory"`` /
+/// ``"per-file"`` / ``"entry"`` / …). `payload` is free-form
+/// per-plugin context (typically the decl fqname, file basename, or
+/// constructor name). The synthetic node's `fqname` string is still
+/// produced and is still the user-facing label ``why-alive`` reads
+/// from; the tag is *parallel* metadata used for structured lookup,
+/// not a replacement.
+///
+/// Frozen + hashable: tags participate in the node intern key, so two
+/// `AddNode` ops with identical fqname/path but different tags
+/// produce distinct synthetic nodes.
+#[pyclass(get_all, frozen)]
+#[derive(Clone)]
+pub(crate) struct SyntheticTag {
+    pub(crate) plugin: String,
+    pub(crate) kind: String,
+    pub(crate) payload: String,
+}
+
+#[pymethods]
+impl SyntheticTag {
+    #[new]
+    #[pyo3(signature = (*, plugin, kind, payload))]
+    fn new(plugin: String, kind: String, payload: String) -> Self {
+        Self {
+            plugin,
+            kind,
+            payload,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "SyntheticTag(plugin={:?}, kind={:?}, payload={:?})",
+            self.plugin, self.kind, self.payload,
+        )
+    }
+
+    fn __hash__(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.plugin.hash(&mut hasher);
+        self.kind.hash(&mut hasher);
+        self.payload.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn __eq__(&self, other: &Bound<'_, PyAny>) -> bool {
+        match other.extract::<PyRef<SyntheticTag>>() {
+            Ok(other) => {
+                self.plugin == other.plugin
+                    && self.kind == other.kind
+                    && self.payload == other.payload
+            }
+            Err(_) => false,
+        }
+    }
+}
+
 /// A single node in a `NativeGraph`.
 ///
 /// `imports` is populated for `kind="import"` nodes only (one per
 /// alias, plus one per name brought in by `from X import *`). All
 /// other kinds carry `None`.
+///
+/// `tag` is populated only for synthetic nodes minted via
+/// `AddNode(..., tag=SyntheticTag(...))`; all other nodes carry
+/// `None`. It is structured metadata about *which plugin emitted the
+/// synthetic and in what role*, queryable via
+/// `ProjectContext.find_synthetic(plugin, kind)`.
 ///
 /// `cached_hash` memoizes `__hash__` so repeated hashing (graph
 /// builds, set membership, codemod walks) pays the full SipHash cost
@@ -93,6 +163,8 @@ pub(crate) struct SymbolNode {
     pub(crate) flags: u32,
     #[pyo3(get)]
     pub(crate) imports: Option<Py<Import>>,
+    #[pyo3(get)]
+    pub(crate) tag: Option<Py<SyntheticTag>>,
     pub(crate) cached_hash: OnceLock<u64>,
 }
 
@@ -131,6 +203,7 @@ impl SymbolNode {
         end_column = 0,
         flags = 0,
         imports = None,
+        tag = None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -143,6 +216,7 @@ impl SymbolNode {
         end_column: usize,
         flags: u32,
         imports: Option<Py<Import>>,
+        tag: Option<Py<SyntheticTag>>,
     ) -> PyResult<Self> {
         Ok(Self {
             fqname,
@@ -154,6 +228,7 @@ impl SymbolNode {
             end_column,
             flags,
             imports,
+            tag,
             cached_hash: OnceLock::new(),
         })
     }
@@ -192,6 +267,15 @@ impl SymbolNode {
                 // Discriminate "no imports" from "imports = ()".
                 0u8.hash(&mut hasher);
             }
+            if let Some(tag) = &self.tag {
+                let tag_ref = tag.borrow(py);
+                1u8.hash(&mut hasher);
+                tag_ref.plugin.hash(&mut hasher);
+                tag_ref.kind.hash(&mut hasher);
+                tag_ref.payload.hash(&mut hasher);
+            } else {
+                0u8.hash(&mut hasher);
+            }
             hasher.finish()
         })
     }
@@ -212,12 +296,24 @@ impl SymbolNode {
             return false;
         }
         let py = other.py();
-        match (&self.imports, &other.imports) {
+        let imports_eq = match (&self.imports, &other.imports) {
             (None, None) => true,
             (Some(a), Some(b)) => {
                 let a = a.borrow(py);
                 let b = b.borrow(py);
                 a.module == b.module && a.decl == b.decl && a.star == b.star
+            }
+            _ => false,
+        };
+        if !imports_eq {
+            return false;
+        }
+        match (&self.tag, &other.tag) {
+            (None, None) => true,
+            (Some(a), Some(b)) => {
+                let a = a.borrow(py);
+                let b = b.borrow(py);
+                a.plugin == b.plugin && a.kind == b.kind && a.payload == b.payload
             }
             _ => false,
         }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -102,6 +102,7 @@ pub(crate) fn ingest_decls(
             end_column: mec,
             flags: default_flags,
             imports: None,
+            tag: None,
             cached_hash: OnceLock::new(),
         },
     )?;
@@ -249,6 +250,7 @@ pub(crate) fn ingest_decls(
                 end_column: ec,
                 flags,
                 imports,
+                tag: None,
                 cached_hash: OnceLock::new(),
             },
         )?;
@@ -1035,6 +1037,7 @@ pub(crate) fn mint_module_node(
             end_column: ec,
             flags,
             imports: None,
+            tag: None,
             cached_hash: OnceLock::new(),
         },
     )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ mod query;
 use pyo3::prelude::*;
 
 use crate::builder::{AddEdge, AddEntrypoint, AddNode};
-use crate::graph::{EdgeFlags, Import, NativeGraph, NodeFlags, SymbolNode};
+use crate::graph::{EdgeFlags, Import, NativeGraph, NodeFlags, SymbolNode, SyntheticTag};
 use crate::project::{Project, ProjectContext};
 use crate::query::{
     CallQuery, CallRef, ClassQuery, ConstructionQuery, ConstructionRef, DecoratorQuery,
@@ -62,6 +62,7 @@ fn query_fn(slf: Py<ProjectContext>, _py: Python<'_>) -> QueryBuilder {
 #[pyo3(name = "_native")]
 fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Import>()?;
+    m.add_class::<SyntheticTag>()?;
     m.add_class::<SymbolNode>()?;
     m.add_class::<NativeGraph>()?;
     m.add_class::<Project>()?;

--- a/src/project.rs
+++ b/src/project.rs
@@ -588,8 +588,9 @@ impl ProjectContext {
     }
 }
 
-// ----- Queries (rust-only, exposed to Python via the chainable QueryBuilder) -
+// ----- Point-lookup queries (exposed to Python directly on ProjectContext) -
 
+#[pymethods]
 impl ProjectContext {
     /// Return every top-level variable node whose name matches `__xxx__`.
     ///
@@ -859,6 +860,7 @@ impl ProjectContext {
     }
 }
 
+#[pymethods]
 impl ProjectContext {
     /// Return ``module_fqn``'s immediate top-level decls — every
     /// function / class / variable / import bound at its module scope.
@@ -1142,6 +1144,7 @@ impl ProjectContext {
     }
 }
 
+#[pymethods]
 impl ProjectContext {
     /// Return ``(module_node, [decls inside the block])`` for every
     /// file with a top-level ``if __name__ == "__main__":`` block.
@@ -1184,9 +1187,9 @@ impl ProjectContext {
         }
         Ok(out)
     }
+}
 
-    /// Return every class that defines a method with the given name.
-    ///
+impl ProjectContext {
     /// Return every top-level function decorated with ``@<decorator_module>.<name>``
     /// or ``@<name>`` for any ``name`` in ``decorator_names``.
     ///
@@ -1580,7 +1583,12 @@ impl ProjectContext {
             .map(|(idx, arg, call_args)| (outputs.builder.nodes[idx].clone_ref(py), arg, call_args))
             .collect())
     }
+}
 
+#[pymethods]
+impl ProjectContext {
+    /// Top-level functions / classes whose body constructs one of
+    /// ``ctor_names`` imported from ``module``.
     ///
     /// Recursively walks each candidate's body looking for ``<Ctor>(...)``
     /// or ``<module>.<Ctor>(...)`` call expressions. Returns
@@ -1651,7 +1659,9 @@ impl ProjectContext {
             .map(|(idx, kinds)| (outputs.builder.nodes[idx].clone_ref(py), kinds))
             .collect())
     }
+}
 
+impl ProjectContext {
     /// Find calls to a callable imported from ``module`` with the name
     /// ``name``. Returns ``(owning_decl, string_literal_arg)`` pairs
     /// where the call resolves through the file's local imports.
@@ -1801,7 +1811,12 @@ impl ProjectContext {
             .map(|(idx, arg, call_args)| (outputs.builder.nodes[idx].clone_ref(py), arg, call_args))
             .collect())
     }
+}
 
+#[pymethods]
+impl ProjectContext {
+    /// Every class that defines a method with the given name.
+    ///
     /// Walks each class's `DefinitionKind::Class` body for an
     /// `Stmt::FunctionDef` whose name matches. ty's `parsed_module` is
     /// Salsa-cached, so this is just a body scan per class.
@@ -1895,7 +1910,9 @@ impl ProjectContext {
             .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
             .collect())
     }
+}
 
+impl ProjectContext {
     // ----- Convenience helpers used by the chainable QueryBuilder ----------
 
     #[allow(clippy::type_complexity)]
@@ -1970,7 +1987,10 @@ impl ProjectContext {
         }
         Ok(out)
     }
+}
 
+#[pymethods]
+impl ProjectContext {
     /// Subclasses of the class addressed by ``base_fqn``.
     ///
     /// Works for both project classes (where the fqn resolves to a
@@ -1979,6 +1999,7 @@ impl ProjectContext {
     /// ``type_hierarchy_subtypes``. ``transitive=True`` (default)
     /// walks the full subclass closure; ``transitive=False`` returns
     /// only direct subclasses.
+    #[pyo3(signature = (base_fqn, *, transitive = true))]
     pub(crate) fn find_subclasses(
         &self,
         py: Python<'_>,

--- a/src/project.rs
+++ b/src/project.rs
@@ -128,6 +128,14 @@ pub(crate) struct BuildOutputs {
     /// `module_fqname -> node idx`. Lets ``find_module`` answer in
     /// O(1) instead of scanning all nodes.
     pub(crate) module_by_fqname: HashMap<String, usize>,
+    /// `(plugin_marker, Some(kind)) -> [node idx]` plus a parallel
+    /// `(plugin_marker, None) -> [node idx]` rollup. Backs
+    /// :meth:`ProjectContext.find_synthetic` so plugins can query for
+    /// their own tagged synthetics in O(1) without parsing fqname
+    /// strings. Populated by ``apply_graph_op`` as ``AddNode`` ops with
+    /// a ``tag`` land in the builder; emission order is preserved
+    /// so callers get a stable result list.
+    pub(crate) synthetic_by_tag: HashMap<(String, Option<String>), Vec<usize>>,
 }
 
 /// Run the three build phases (ingest → hierarchy+imports → references)
@@ -384,6 +392,7 @@ pub(crate) fn build_project_graph(
         decl_by_name_range,
         decl_by_fqname,
         module_by_fqname,
+        synthetic_by_tag: HashMap::new(),
     })
 }
 
@@ -769,6 +778,41 @@ impl ProjectContext {
             .get(fqname)
             .map(|&idx| outputs.builder.nodes[idx].clone_ref(py)))
     }
+
+    /// Return every synthetic node tagged with the given
+    /// ``plugin`` marker (and optional ``kind`` role).
+    ///
+    /// Plugins use this to find their own markers without parsing the
+    /// node ``fqname`` string: each :class:`AddNode` op that carries a
+    /// :class:`SyntheticTag` lands in an index keyed by
+    /// ``(plugin, Some(kind))`` and ``(plugin, None)``. ``kind=None``
+    /// returns every tagged synthetic for the plugin regardless of
+    /// role; ``kind="factory"`` filters to that one role.
+    ///
+    /// Results are returned in emission order — the order ``AddNode``
+    /// ops carrying the tag were applied to the graph.
+    #[pyo3(signature = (plugin, kind = None))]
+    pub(crate) fn find_synthetic(
+        &self,
+        py: Python<'_>,
+        plugin: &str,
+        kind: Option<&str>,
+    ) -> PyResult<Vec<Py<SymbolNode>>> {
+        let outputs = self.outputs.borrow();
+        let outputs = outputs
+            .as_ref()
+            .ok_or_else(|| not_materialized("find_synthetic"))?;
+        let key = (plugin.to_string(), kind.map(str::to_string));
+        Ok(outputs
+            .synthetic_by_tag
+            .get(&key)
+            .map(|idxs| {
+                idxs.iter()
+                    .map(|&i| outputs.builder.nodes[i].clone_ref(py))
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
 }
 
 #[pymethods]
@@ -1087,7 +1131,7 @@ impl ProjectContext {
         let outputs = outputs
             .as_ref()
             .ok_or_else(|| not_materialized("descendants"))?;
-        let root_idx = lookup_idx(&outputs.builder, root, "root")?;
+        let root_idx = lookup_idx(py, &outputs.builder, root, "root")?;
         Ok(
             bfs(&outputs.builder, [root_idx], Direction::Forward, skip_flags)
                 .into_iter()
@@ -1109,7 +1153,7 @@ impl ProjectContext {
         let outputs = outputs
             .as_ref()
             .ok_or_else(|| not_materialized("ancestors"))?;
-        let idx = lookup_idx(&outputs.builder, decl, "decl")?;
+        let idx = lookup_idx(py, &outputs.builder, decl, "decl")?;
         Ok(bfs(&outputs.builder, [idx], Direction::Reverse, skip_flags)
             .into_iter()
             .map(|i| outputs.builder.nodes[i].clone_ref(py))

--- a/src/query.rs
+++ b/src/query.rs
@@ -11,7 +11,7 @@ use ruff_db::files::File;
 use ty_project::Db as ProjectDb;
 
 use crate::builder::not_materialized;
-use crate::graph::{MainBlock, SymbolNode};
+use crate::graph::SymbolNode;
 use crate::helpers::{
     args_to_py_vec, call_args_match_kwargs, file_path_string, kwarg_matcher_from_py,
     kwargs_to_py_map, KwargMatcher,
@@ -112,7 +112,11 @@ impl CallRef {
 
 /// Entry point for the chainable query API. Returned by
 /// :meth:`ProjectContext.query`. Pick a stream type:
-/// :meth:`decorators`, :meth:`constructions`, or :meth:`calls`.
+/// :meth:`decorators`, :meth:`constructions`, :meth:`calls`,
+/// :meth:`subclasses`, :meth:`imports`, :meth:`classes`, or
+/// :meth:`factories`. Point lookups (``module``, ``declarations``,
+/// ``main_blocks``, etc.) live directly on
+/// :class:`ProjectContext`.
 #[pyclass(unsendable)]
 pub(crate) struct QueryBuilder {
     pub(crate) ctx: Py<ProjectContext>,
@@ -140,89 +144,6 @@ impl QueryBuilder {
     }
     fn factories(&self, py: Python<'_>) -> FactoryQuery {
         FactoryQuery::new(self.ctx.clone_ref(py))
-    }
-
-    // ----- Point lookups (no filter chain) ------------------------------
-
-    /// Look up a module's synthetic node by dotted fqname. Mirrors
-    /// :meth:`ProjectContext.find_module`.
-    fn module(&self, py: Python<'_>, fqname: &str) -> PyResult<Option<Py<SymbolNode>>> {
-        self.ctx.borrow(py).find_module(py, fqname)
-    }
-    /// All top-level declarations bound to the given dotted fqname.
-    /// Mirrors :meth:`ProjectContext.find_declarations`.
-    fn declarations(&self, py: Python<'_>, fqname: &str) -> PyResult<Vec<Py<SymbolNode>>> {
-        self.ctx.borrow(py).find_declarations(py, fqname)
-    }
-    /// Every top-level declaration node of the named module.
-    /// Mirrors :meth:`ProjectContext.find_module_top_level_decls`.
-    fn module_top_level_decls(
-        &self,
-        py: Python<'_>,
-        fqname: &str,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        self.ctx.borrow(py).find_module_top_level_decls(py, fqname)
-    }
-    /// The exported names listed in a module's ``__all__`` (when
-    /// statically resolvable), or ``None`` when the module has no
-    /// ``__all__``.
-    /// Mirrors :meth:`ProjectContext.find_module_dunder_all_exports`.
-    fn module_dunder_all_exports(
-        &self,
-        py: Python<'_>,
-        fqname: &str,
-    ) -> PyResult<Option<Vec<Py<SymbolNode>>>> {
-        self.ctx
-            .borrow(py)
-            .find_module_dunder_all_exports(py, fqname)
-    }
-    /// Read the literal-list value of a top-level variable assignment
-    /// (``X = ["a", "b"]``) and return the entries as strings.
-    /// Returns ``None`` when the variable isn't a list / tuple of
-    /// string literals.
-    /// Mirrors :meth:`ProjectContext.find_literal_list_entries`.
-    fn literal_list_entries(&self, py: Python<'_>, var_fqn: &str) -> PyResult<Option<Vec<String>>> {
-        self.ctx.borrow(py).find_literal_list_entries(var_fqn)
-    }
-    /// All top-level ``__dunder__`` declarations across the project.
-    /// Mirrors :meth:`ProjectContext.find_module_dunders`.
-    fn module_dunders(&self, py: Python<'_>) -> PyResult<Vec<Py<SymbolNode>>> {
-        self.ctx.borrow(py).find_module_dunders(py)
-    }
-    /// Every ``if __name__ == "__main__":`` block in the project,
-    /// paired with the module and the decls inside.
-    /// Mirrors :meth:`ProjectContext.find_main_blocks`.
-    fn main_blocks(&self, py: Python<'_>) -> PyResult<Vec<MainBlock>> {
-        self.ctx.borrow(py).find_main_blocks(py)
-    }
-    /// Match nodes against pre-classified path / fqname specs without
-    /// crossing the FFI boundary per node.
-    /// Mirrors :meth:`ProjectContext.find_nodes_matching_specs`.
-    fn nodes_matching_specs(
-        &self,
-        py: Python<'_>,
-        project_root: &str,
-        regexes: Vec<String>,
-        str_specs: Vec<String>,
-        abs_paths: Vec<String>,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        self.ctx.borrow(py).find_nodes_matching_specs(
-            py,
-            project_root,
-            regexes,
-            str_specs,
-            abs_paths,
-        )
-    }
-    /// Comments matching ``pattern`` paired with the next
-    /// declaration. Mirrors :meth:`ProjectContext.find_comment_patterns`.
-    #[allow(clippy::type_complexity)]
-    fn comment_patterns(
-        &self,
-        py: Python<'_>,
-        pattern: &str,
-    ) -> PyResult<Vec<(Py<SymbolNode>, String)>> {
-        self.ctx.borrow(py).find_comment_patterns(py, pattern)
     }
 }
 

--- a/tests/prototype/plugin_protocol.py
+++ b/tests/prototype/plugin_protocol.py
@@ -95,5 +95,5 @@ class KeepAliveCommentPlugin:
     name = "keep_alive_comment"
 
     def run(self, ctx: "native.ProjectContext") -> "Iterable[native.GraphOp]":
-        for decl, _comment in native.query(ctx).comment_patterns(r"#\s*dead-cst:\s*keep\b"):
+        for decl, _comment in ctx.find_comment_patterns(r"#\s*dead-cst:\s*keep\b"):
             yield native.AddEntrypoint(decl, marker="<keep>")

--- a/tests/prototype/test_kwarg_matchers.py
+++ b/tests/prototype/test_kwarg_matchers.py
@@ -392,7 +392,7 @@ def test_where_kwarg_with_nativenode_raises(make_ctx):
     captured: list[Exception] = []
 
     def capture(ctx):
-        mod = native.query(ctx).module("tests")
+        mod = ctx.find_module("tests")
         assert mod is not None
         try:
             (

--- a/tests/prototype/test_plugin_protocol.py
+++ b/tests/prototype/test_plugin_protocol.py
@@ -70,7 +70,7 @@ def test_plugin_runs_once_per_project(make_ctx):
         name = "counter"
 
         def run(self, ctx: native.ProjectContext) -> None:
-            calls.append(len(native.query(ctx).module_dunders()))
+            calls.append(len(ctx.find_module_dunders()))
 
     ctx = make_ctx(
         {
@@ -258,7 +258,7 @@ def test_query_outside_materialize_raises(make_ctx):
     """Calling a query method on an un-materialized context errors clearly."""
     ctx = make_ctx({"mod.py": "x = 1\n"})
     with pytest.raises(RuntimeError, match="find_module_dunders"):
-        native.query(ctx).module_dunders()
+        ctx.find_module_dunders()
 
 
 def test_materialize_is_idempotent(make_ctx):

--- a/tests/prototype/test_synthetic_tag.py
+++ b/tests/prototype/test_synthetic_tag.py
@@ -1,0 +1,266 @@
+"""Tests for the structured `SyntheticTag` plugin-coordination contract.
+
+`SyntheticTag(plugin, kind, payload)` lets plugins stamp typed metadata
+onto a synthetic node they emit via `AddNode(..., tag=...)`. Other
+plugins (and the emitting plugin's own second-pass code) look the
+synthetics up via `ctx.find_synthetic(plugin, kind=None)` instead of
+parsing the fqname string.
+
+These tests pin:
+
+* The pyclass round-trips: emit with a tag, observe the same three
+  fields back on the resulting `SymbolNode.tag`.
+* `find_synthetic(plugin, kind)` and `find_synthetic(plugin)` discriminate
+  correctly across plugins and roles.
+* Untagged `AddNode` ops produce nodes with `tag is None`.
+* The tag participates in the node intern key — two `AddNode` ops that
+  share fqname/path but differ in their tag are interned as distinct
+  nodes (so a plugin can emit two markers under the same fqname
+  template with different structured payloads).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+
+native = pytest.importorskip("dead_cst._native")
+
+
+@pytest.fixture
+def make_ctx(tmp_path: Path):
+    def make(files: dict[str, str], **kwargs) -> native.ProjectContext:
+        for relpath, source in files.items():
+            target = tmp_path / relpath
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(source, encoding="utf-8")
+        return native.ProjectContext(str(tmp_path), **kwargs)
+
+    return make
+
+
+def _tagged_nodes(graph: native.NativeGraph) -> list[native.SymbolNode]:
+    return [n for n in graph.nodes if n.tag is not None]
+
+
+def _find_node(graph: native.NativeGraph, fqname: str) -> native.SymbolNode:
+    for n in graph.nodes:
+        if n.fqname == fqname:
+            return n
+    raise AssertionError(f"node {fqname!r} not in graph")
+
+
+class _OnePlugin:
+    """Emits one tagged synthetic per call. Pinned for tag fields."""
+
+    def __init__(self, plugin: str, kind: str, payload: str):
+        self._plugin = plugin
+        self._kind = kind
+        self._payload = payload
+
+    def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
+        for n in ctx.nodes():
+            if n.fqname == "mod" and n.kind == "module":
+                yield native.AddNode(
+                    fqname=f"<{self._plugin}-{self._kind}>:marker",
+                    path=n.path,
+                    edges_to=[n],
+                    tag=native.SyntheticTag(
+                        plugin=self._plugin,
+                        kind=self._kind,
+                        payload=self._payload,
+                    ),
+                )
+                break
+
+
+def test_synthetic_tag_round_trips(make_ctx):
+    """A tag set on AddNode is observable on the resulting SymbolNode."""
+    ctx = make_ctx({"mod.py": "x = 1\n"})
+    ctx.add_plugin(_OnePlugin(plugin="p", kind="k", payload="v"))
+    graph = ctx.materialize()
+
+    tagged = _tagged_nodes(graph)
+    assert len(tagged) == 1
+    node = tagged[0]
+    assert node.tag is not None
+    assert node.tag.plugin == "p"
+    assert node.tag.kind == "k"
+    assert node.tag.payload == "v"
+
+
+def test_find_synthetic_by_plugin_and_kind(make_ctx):
+    """Two plugins emit disjoint tagged synthetics; the lookup
+    discriminates by (plugin, kind)."""
+
+    class TwoTags:
+        """Single plugin emitting two synthetics with different kinds.
+
+        Models how DispatchAppPlugin emits both ``app`` and ``factory``
+        markers, then queries for just the ``factory`` ones.
+        """
+
+        def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
+            for n in ctx.nodes():
+                if n.fqname == "mod" and n.kind == "module":
+                    yield native.AddNode(
+                        fqname="<mine-a>:1",
+                        path=n.path,
+                        edges_to=[n],
+                        tag=native.SyntheticTag(plugin="mine", kind="a", payload="1"),
+                    )
+                    yield native.AddNode(
+                        fqname="<mine-b>:2",
+                        path=n.path,
+                        edges_to=[n],
+                        tag=native.SyntheticTag(plugin="mine", kind="b", payload="2"),
+                    )
+                    yield native.AddNode(
+                        fqname="<other-a>:3",
+                        path=n.path,
+                        edges_to=[n],
+                        tag=native.SyntheticTag(plugin="other", kind="a", payload="3"),
+                    )
+                    break
+
+    seen_by_kind: dict[str, list[str]] = {}
+
+    class Probe:
+        def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
+            seen_by_kind["mine-a"] = [n.fqname for n in ctx.find_synthetic(plugin="mine", kind="a")]
+            seen_by_kind["mine-b"] = [n.fqname for n in ctx.find_synthetic(plugin="mine", kind="b")]
+            seen_by_kind["other-a"] = [
+                n.fqname for n in ctx.find_synthetic(plugin="other", kind="a")
+            ]
+            seen_by_kind["missing"] = [
+                n.fqname for n in ctx.find_synthetic(plugin="mine", kind="zzz")
+            ]
+            return None
+
+    ctx = make_ctx({"mod.py": "x = 1\n"})
+    ctx.add_plugin(TwoTags())
+    ctx.add_plugin(Probe())
+    ctx.materialize()
+
+    assert seen_by_kind["mine-a"] == ["<mine-a>:1"]
+    assert seen_by_kind["mine-b"] == ["<mine-b>:2"]
+    assert seen_by_kind["other-a"] == ["<other-a>:3"]
+    assert seen_by_kind["missing"] == []
+
+
+def test_find_synthetic_by_plugin_only(make_ctx):
+    """``kind=None`` returns every synthetic tagged with the plugin,
+    regardless of role."""
+
+    class TwoTags:
+        def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
+            for n in ctx.nodes():
+                if n.fqname == "mod" and n.kind == "module":
+                    yield native.AddNode(
+                        fqname="<mine-a>:1",
+                        path=n.path,
+                        edges_to=[n],
+                        tag=native.SyntheticTag(plugin="mine", kind="a", payload="1"),
+                    )
+                    yield native.AddNode(
+                        fqname="<mine-b>:2",
+                        path=n.path,
+                        edges_to=[n],
+                        tag=native.SyntheticTag(plugin="mine", kind="b", payload="2"),
+                    )
+                    yield native.AddNode(
+                        fqname="<other-a>:3",
+                        path=n.path,
+                        edges_to=[n],
+                        tag=native.SyntheticTag(plugin="other", kind="a", payload="3"),
+                    )
+                    break
+
+    seen: list[str] = []
+
+    class Probe:
+        def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
+            seen.extend(n.fqname for n in ctx.find_synthetic(plugin="mine"))
+            return None
+
+    ctx = make_ctx({"mod.py": "x = 1\n"})
+    ctx.add_plugin(TwoTags())
+    ctx.add_plugin(Probe())
+    ctx.materialize()
+
+    # Emission order preserved; ``other-a`` excluded by the plugin
+    # filter.
+    assert seen == ["<mine-a>:1", "<mine-b>:2"]
+
+
+def test_untagged_synthetic_node_tag_is_none(make_ctx):
+    """``AddNode`` without ``tag=`` produces a node with ``tag is None``."""
+
+    class Untagged:
+        def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
+            for n in ctx.nodes():
+                if n.fqname == "mod" and n.kind == "module":
+                    yield native.AddNode(
+                        fqname="<untagged>:1",
+                        path=n.path,
+                        edges_to=[n],
+                    )
+                    break
+
+    ctx = make_ctx({"mod.py": "x = 1\n"})
+    ctx.add_plugin(Untagged())
+    graph = ctx.materialize()
+
+    node = _find_node(graph, "<untagged>:1")
+    assert node.tag is None
+    # The visitor-side module / decl nodes are also untagged.
+    module = _find_node(graph, "mod")
+    assert module.tag is None
+
+
+def test_two_addnode_with_same_fqname_different_tag_dedup(make_ctx):
+    """Two ``AddNode`` ops with the same fqname/path but different
+    tags intern as distinct nodes — tag participates in the intern key.
+
+    Mirrors ``SymbolNode.__eq__`` semantics: nodes that compare equal
+    share an intern slot; nodes that differ in any field (including
+    tag) do not.
+    """
+
+    class TwoOps:
+        def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
+            for n in ctx.nodes():
+                if n.fqname == "mod" and n.kind == "module":
+                    # Identical fqname / path; tag differs only in kind.
+                    yield native.AddNode(
+                        fqname="<dup>:1",
+                        path=n.path,
+                        edges_to=[n],
+                        tag=native.SyntheticTag(plugin="dup", kind="a", payload="1"),
+                    )
+                    yield native.AddNode(
+                        fqname="<dup>:1",
+                        path=n.path,
+                        edges_to=[n],
+                        tag=native.SyntheticTag(plugin="dup", kind="b", payload="1"),
+                    )
+                    # And another with no tag — also a third intern
+                    # slot (tag=None is distinguishable from tag=Some).
+                    yield native.AddNode(
+                        fqname="<dup>:1",
+                        path=n.path,
+                        edges_to=[n],
+                    )
+                    break
+
+    ctx = make_ctx({"mod.py": "x = 1\n"})
+    ctx.add_plugin(TwoOps())
+    graph = ctx.materialize()
+
+    dup_nodes = [n for n in graph.nodes if n.fqname == "<dup>:1"]
+    assert len(dup_nodes) == 3
+
+    tag_kinds = sorted(n.tag.kind if n.tag is not None else "<none>" for n in dup_nodes)
+    assert tag_kinds == ["<none>", "a", "b"]


### PR DESCRIPTION
## Summary

Structured plugin coordination. Replaces `desc.fqname.startswith("<flask-factory>:")`-style string-grammar contracts with a typed `SyntheticTag(plugin, kind, payload)` + `ctx.find_synthetic(plugin, kind)` lookup. Both API review agents converged on this shape; the fqname strings stay for `why-alive` display, but plugins stop parsing them.

**Stacked on #202** (query/ctx unify) — the first commit is #202's content, the second is this work. Merge #202 first.

## New surface

```python
# Frozen pyclass, hashable. Mirrors graph.Import in style.
class SyntheticTag:
    plugin: str    # emitting plugin's marker prefix (e.g. "flask")
    kind: str      # role within that plugin (e.g. "app" / "factory" / "per-file")
    payload: str   # free-form per-plugin context

# Optional new kwarg on the existing op.
AddNode(..., tag: SyntheticTag | None = None)

# New getter on SymbolNode — populated only for tagged synthetics.
node.tag: SyntheticTag | None

# Indexed lookup on ProjectContext.
ctx.find_synthetic(plugin: str, kind: str | None = None) -> list[SymbolNode]
```

The lookup is backed by `synthetic_by_tag: HashMap<(String, Option<String>), Vec<usize>>` populated during `apply_graph_op`. Stable insertion-order iteration.

## NodeKey participates

`tag` is part of `NodeKey`. Two `AddNode` ops with identical fqname/path/position but different tags intern as distinct nodes.

Rationale: consistency with `SymbolNode.__eq__` / `__hash__` (both include the tag fields). If the intern key omitted tag, two nodes that compare unequal could share an intern slot — corruption risk. Tag is `(String, String, String)` — cheap to clone into the key.

Behavior pinned by `test_two_addnode_with_same_fqname_different_tag_dedup` in `tests/prototype/test_synthetic_tag.py`.

## Plugin migration

### `DispatchAppPlugin` (main motivating consumer)

Before — step 6 factory walk parsed its own fqname grammar:

```python
for desc in ctx.descendants(var):
    if desc.kind != "synthetic": continue
    if not desc.fqname.startswith(factory_prefix): continue   # ← string parse
    # promote var to entrypoint
```

After — pre-collected tag lookup:

```python
factory_synthetics = set(ctx.find_synthetic(plugin=self.marker_prefix, kind="factory"))
for desc in ctx.descendants(var):
    if desc in factory_synthetics:
        # promote var to entrypoint
```

### Tagged emissions

| Plugin | `kind` | `payload` |
|---|---|---|
| `DispatchAppPlugin` direct app | `"app"` | `var.fqname` |
| `DispatchAppPlugin` factory marker | `"factory"` | `"{kind}:{decl.fqname}"` |
| `DispatchAppPlugin` factory-promoted app | `"app"` | `var.fqname` |
| `DecoratedDeclPlugin` per-file | `"per-file"` | `Path(path).name` |
| `LiteralListPlugin` per-entry | `"entry"` | `entry` |
| `CeleryPlugin` `<celery-shared>` | `"shared"` | `Path(path).name` |
| `MockPatchPlugin` `<patch-target>` | `"target"` | `fqname` |
| `DiscordPyPlugin` cog | `"cog"` | `filename` |
| `DiscordPyPlugin` extension | `"extension"` | `cref.string_arg` |

### Intentionally untagged

`AddEntrypoint` synthetics (separate code path) and `AddNode` synthetics from plugins with no consumer that would query them (`InitSubclassPlugin`, `MainBlockPlugin`, `ProjectScriptsPlugin`, `ServerConfigPlugin`, `UnittestPlugin`, `PytestPlugin`, `DiscordPyPlugin`'s app-level entrypoints). Easy to add tags later.

## `src/CLAUDE.md` invariants cross-checked

- **ty for everything** — resolution code untouched.
- **No per-file cache** — `synthetic_by_tag` is a build-time index keyed on tag, not a parallel snapshot.
- **Every import binds a local decl** — import-edge emission untouched.
- **Shadowed decls are first-class** — `tag` field added to `NodeKey`, but non-synthetic nodes always carry `tag = None`, so shadowed-decl dedup is unchanged.

## Test plan

- [x] `uv run pytest -q` — **635 passed** (was 630; +5 in `tests/prototype/test_synthetic_tag.py`), 10 deselected.
- [x] `uv run pytest -q -m e2e` — **10 passed**.
- [x] `uv run prek run --all-files` — clean.

`test_synthetic_tag.py` covers: round-trip, find by `(plugin, kind)`, find by `plugin` only, untagged → `None`, dedup decision.

## Diffstat

21 files changed, +677 / -213 vs `rust_proto`. ~half is the new test file + the `SyntheticTag` pyclass definition.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZf2rbhxbQjRYGckcRuSCE)_