### PR TITLE
ci: cache cargo + uv in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,9 +33,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - uses: actions/setup-python@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
+          enable-cache: true
+          cache-dependency-glob: "**/uv.lock"
       - name: Stamp dev version
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         shell: bash
@@ -45,6 +47,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: ${{ matrix.platform.manylinux }}
           args: --release --out dist --interpreter 3.11
+          sccache: true
       - uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ matrix.platform.target }}
@@ -56,9 +59,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - uses: actions/setup-python@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
+          enable-cache: true
+          cache-dependency-glob: "**/uv.lock"
       - name: Stamp dev version
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: sed -i.bak 's/^version = .*/version = "0.10.0.dev${{ github.run_number }}"/' Cargo.toml && rm Cargo.toml.bak


### PR DESCRIPTION
## Summary
- Swap `actions/setup-python@v6` → `astral-sh/setup-uv@v7` with `enable-cache: true` so the publish jobs reuse the same lockfile-keyed cache CI already maintains.
- Add `sccache: true` to the `PyO3/maturin-action@v1` invocation so the five-platform wheel matrix reuses compilation artifacts run-over-run instead of cold-compiling the 200+ crate dep tree every time. Works across the Linux manylinux Docker runners as well as the native macOS / Windows runners.

Multi-platform coverage is unchanged — already builds Linux x86_64, Linux aarch64, macOS Intel, macOS Apple Silicon, and Windows x86_64.

Deliberately did not add `Swatinem/rust-cache@v2` here: it would need conditional handling for the manylinux Docker mounts and would overlap with `sccache`. Easy to layer on later for the native runners if we want target-dir caching on top.

## Test plan
- [ ] Push lands and the next main-branch run of `Publish` succeeds across all five matrix targets.
- [ ] Second consecutive run shows reduced wheel-build wall-clock thanks to sccache hits (visible in maturin-action logs as `sccache stats`).
- [ ] TestPyPI dev upload still succeeds (version still stamped to `0.10.0.dev<run_number>`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuYzLbiQNZk1fianCKdShc)_