### PR TITLE
rust: parallelize + overlap dist-info lookup with Phase 1 ingest

### DIFF
--- a/scripts/_bench_common.py
+++ b/scripts/_bench_common.py
@@ -1,0 +1,173 @@
+"""Shared infrastructure for the scripts/profile_*.py benchmark scripts.
+
+Both ``profile_plugins_cold.py`` (cold rust path with one plugin at a
+time) and ``profile_graph_build.py`` (cold/warm rust-build profile with
+per-phase breakdown) need the same harness:
+
+* a tempdir-staged copy of ``python/dead_cst/`` as the "self" target
+* a pinned-SHA shallow clone of flux0 (for ``flux0_server`` /
+  ``flux0_cli`` / ``flux0_workspace``)
+* a ``uv sync --all-packages`` for the workspace target
+* a ``.py`` / ``.pyi`` file counter
+* a ``TargetConfig`` for the rust constructor kwargs
+
+Kept in one place so a layout change (`#191 moved the package from
+``dead_cst/`` to ``python/dead_cst/`` and one of the scripts forgot to
+follow) only has to land once.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+FLUX0_URL = "https://github.com/flux0-ai/flux0.git"
+FLUX0_SHA = "8d04176642b091ddb5c5020486f353d4e824460b"
+
+
+@dataclass
+class TargetConfig:
+    """One project to profile. ``project_kwargs`` is forwarded to
+    ``native.ProjectContext`` — typically ``python_env`` for workspace
+    targets so ty's module resolver picks up third-party packages from
+    the workspace's own ``.venv``."""
+
+    name: str
+    root: Path
+    project_kwargs: dict[str, object] = field(default_factory=dict)
+
+
+def require_native() -> None:
+    """Exit early when the rust extension isn't importable — measuring
+    a libcst fallback isn't useful for a rust-focused profile."""
+    try:
+        from dead_cst import _native  # noqa: F401
+    except ImportError as exc:
+        sys.exit(
+            f"ERROR: dead_cst._native not importable ({exc}). "
+            "Build with: uv run maturin develop --release"
+        )
+
+
+def stage_dead_cst() -> Path:
+    """Copy ``python/dead_cst/`` into a fresh tempdir so the analyzer
+    sees one clean package."""
+    stage = Path(tempfile.mkdtemp(prefix="dead-cst-bench-"))
+    src = Path(__file__).resolve().parent.parent / "python" / "dead_cst"
+    if not src.exists():
+        raise RuntimeError(f"dead_cst package source not found at {src}")
+    shutil.copytree(src, stage / "dead_cst", ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+    return stage
+
+
+def clone_flux0(cache_root: Path) -> Path:
+    """Shallow-clone flux0 at the pinned SHA into ``cache_root/flux0``.
+    Skipped when an existing clone already matches the SHA."""
+    if shutil.which("git") is None:
+        raise RuntimeError("git not on PATH")
+    dest = cache_root / "flux0"
+    marker = dest / ".sha"
+    if marker.is_file() and marker.read_text().strip() == FLUX0_SHA:
+        return dest
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.mkdir(parents=True)
+
+    def _git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=dest, check=True, capture_output=True)
+
+    _git("init", "-q")
+    _git("remote", "add", "origin", FLUX0_URL)
+    _git("fetch", "--depth=1", "-q", "--filter=blob:none", "origin", FLUX0_SHA)
+    _git("checkout", "-q", FLUX0_SHA)
+    marker.write_text(FLUX0_SHA + "\n")
+    return dest
+
+
+def ensure_flux0_venv(flux0_root: Path) -> Path:
+    """Run ``uv sync --all-packages`` so ty's workspace module resolver
+    finds a populated ``.venv``. Idempotent."""
+    venv = flux0_root / ".venv"
+    if venv.is_dir():
+        return venv
+    if shutil.which("uv") is None:
+        raise RuntimeError("uv not on PATH; cannot create flux0 workspace venv")
+    print(f"  (one-time setup: uv sync --all-packages in {flux0_root})", flush=True)
+    subprocess.run(["uv", "sync", "--all-packages"], cwd=flux0_root, check=True)
+    return venv
+
+
+def file_count(target_root: Path) -> int:
+    """Number of ``.py``/``.pyi`` files under ``target_root``, ignoring
+    ``__pycache__`` and ``.venv``."""
+    count = 0
+    for dirpath, dirnames, filenames in os.walk(target_root, followlinks=True):
+        dirnames[:] = [d for d in dirnames if d not in ("__pycache__", ".venv")]
+        count += sum(1 for f in filenames if f.endswith((".py", ".pyi")))
+    return count
+
+
+FLUX0_TARGETS = ("flux0_server", "flux0_cli", "flux0_workspace")
+
+
+def gather_flux0_targets(requested: Iterable[str], cache_root: Path) -> Iterable[TargetConfig]:
+    """Yield ``TargetConfig``s for the requested flux0 targets, cloning
+    flux0 and seeding the venv if needed. Swallows network / git /
+    uv failures with a ``SKIP`` message so the rest of the run can
+    proceed."""
+    requested_set = {name for name in requested if name.startswith("flux0_")}
+    if not requested_set:
+        return
+    cache_root.mkdir(parents=True, exist_ok=True)
+    try:
+        flux0_root = clone_flux0(cache_root)
+    except (RuntimeError, subprocess.CalledProcessError) as exc:
+        print(f"\nflux0 SKIP: {exc}", flush=True)
+        return
+
+    if "flux0_server" in requested_set:
+        yield TargetConfig(name="flux0 server", root=flux0_root / "packages" / "server" / "src")
+    if "flux0_cli" in requested_set:
+        yield TargetConfig(name="flux0 cli", root=flux0_root / "packages" / "cli" / "src")
+    if "flux0_workspace" in requested_set:
+        try:
+            venv = ensure_flux0_venv(flux0_root)
+        except (RuntimeError, subprocess.CalledProcessError) as exc:
+            print(f"\nflux0_workspace SKIP: {exc}", flush=True)
+        else:
+            yield TargetConfig(
+                name="flux0 workspace (uv)",
+                root=flux0_root,
+                project_kwargs={"python_env": str(venv)},
+            )
+
+
+def add_common_target_args(parser: argparse.ArgumentParser, default_targets: list[str]) -> None:
+    """Add the ``--targets`` / ``--no-flux0`` / ``--cache-root`` args
+    every bench script accepts. Caller provides the default target list
+    so each script picks its own appropriate default."""
+    parser.add_argument(
+        "--targets",
+        nargs="+",
+        default=default_targets,
+        choices=("dead_cst", *FLUX0_TARGETS),
+        help="Which real targets to profile.",
+    )
+    parser.add_argument(
+        "--no-flux0",
+        action="store_true",
+        help="Skip flux0 targets even if listed (offline / no git).",
+    )
+    parser.add_argument(
+        "--cache-root",
+        type=Path,
+        default=Path.home() / ".cache" / "dead-cst-bench",
+        help="Where to cache the flux0 clone.",
+    )

--- a/scripts/profile_graph_build.py
+++ b/scripts/profile_graph_build.py
@@ -1,0 +1,342 @@
+"""Thorough perf profile of rust graph building (no plugins).
+
+Measures ``ProjectContext.materialize()`` end-to-end and breaks it
+down into the rust-side build phases that the
+``DEAD_CST_TIMING=1`` env var exposes:
+
+* ``enum``       — project-files enumeration + ``path_to_file`` /
+                   peer-``.pyi`` registration
+* ``phase1``     — per-file decl ingest (parse + ``SemanticIndex`` +
+                   intern global-scope bindings as nodes)
+* ``dist_lookup``— site-packages ``.dist-info`` walk to map third-party
+                   files to canonical distribution names
+* ``phase2``     — cross-file import-edge emission (alias → upstream)
+* ``phase3``     — per-file reference-edge emission (Name → decl)
+* ``fqname``     — post-pass ``fqname → idx`` index build
+
+Two run modes per target:
+
+* **cold** — a fresh ``ProjectContext`` per iteration. ty's Salsa db
+  starts empty so every phase pays its real first-call cost. This is
+  what the CLI's typical "run once on commit" path looks like.
+* **warm** — the same ``ProjectContext`` reused. Salsa returns
+  memoised parses / semantic indexes so the per-phase cost collapses
+  to the work that doesn't go through Salsa (mostly node interning
+  and Py allocation).
+
+Each mode runs one warm-up iteration (the first call hits process-
+global typeshed loading) plus ``--repeats`` steady-state iterations.
+Steady-state reports best / mean / stdev so you can see how much
+the numbers are jumping around.
+
+Usage::
+
+    uv run python scripts/profile_graph_build.py
+    uv run python scripts/profile_graph_build.py --repeats 6
+    uv run python scripts/profile_graph_build.py --targets flux0_workspace
+    uv run python scripts/profile_graph_build.py --synthetic 50 200
+    uv run python scripts/profile_graph_build.py --no-flux0
+
+The rust extension must be importable; the script exits early
+otherwise — measuring the python-only fallback isn't useful for a
+rust-build profile.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Iterable
+
+from _bench_common import (
+    TargetConfig,
+    add_common_target_args,
+    file_count,
+    gather_flux0_targets,
+    require_native,
+    stage_dead_cst,
+)
+
+# Silence the visitor's WARNING-level breadcrumbs.
+logging.getLogger("dead_cst").setLevel(logging.ERROR)
+
+require_native()
+from dead_cst import _native as native  # noqa: E402  (require_native gates this)
+
+
+def _generate_synthetic(num_files: int) -> Path:
+    """Generate a synthetic project with ``num_files`` modules in a
+    single package, each importing a couple of siblings so the graph
+    has realistic cross-file fan-out.
+
+    Each module gets one class, one function, and ~2 cross-file
+    from-imports — enough that every build phase has something to chew
+    on, without standing up a real project or venv."""
+    stage = Path(tempfile.mkdtemp(prefix=f"synthetic-{num_files}-"))
+    pkg = stage / "synth"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    for i in range(num_files):
+        lines: list[str] = []
+        for j in range(max(0, i - 2), i):
+            lines.append(f"from .mod_{j} import C as Sib{j}")
+        lines.extend(
+            [
+                "",
+                f"class C{'(Sib%d)' % (i - 1) if i > 0 else ''}:",
+                "    def method(self) -> int:",
+                f"        return {i}",
+                "",
+                "",
+                "def helper() -> int:",
+                "    return C().method()",
+                "",
+                'if __name__ == "__main__":',
+                "    helper()",
+                "",
+            ]
+        )
+        (pkg / f"mod_{i}.py").write_text("\n".join(lines))
+    return stage
+
+
+# ---------------------------------------------------------------------------
+# Per-phase timing
+# ---------------------------------------------------------------------------
+
+# `[dead-cst-timing] files=8 nodes=175 edges=487 enum=2ms phase1=4ms dist_lookup=89ms phase2=4ms phase3=5ms fqname=84µs total=106ms`
+_TIMING_RE = re.compile(r"\[dead-cst-timing\]\s+(.*)")
+_PHASE_KEYS = ("enum", "phase1", "dist_lookup", "phase2", "phase3", "fqname", "total")
+
+
+def _parse_duration(s: str) -> float:
+    """Parse a rust ``{:?}`` Duration ("12.345ms" / "789µs" / "1.2s")
+    into seconds."""
+    units = {"ns": 1e-9, "µs": 1e-6, "us": 1e-6, "ms": 1e-3, "s": 1.0}
+    for suffix, mul in units.items():
+        if s.endswith(suffix):
+            return float(s[: -len(suffix)]) * mul
+    raise ValueError(f"unrecognised duration {s!r}")
+
+
+def _parse_timing_line(line: str) -> dict[str, float] | None:
+    """Parse one `[dead-cst-timing]` line into a {phase: seconds} map
+    (plus ``files`` / ``nodes`` / ``edges`` counts)."""
+    m = _TIMING_RE.search(line)
+    if not m:
+        return None
+    out: dict[str, float] = {}
+    for token in m.group(1).strip().split():
+        if "=" not in token:
+            continue
+        k, v = token.split("=", 1)
+        if k in ("files", "nodes", "edges"):
+            out[k] = float(v)
+        elif k in _PHASE_KEYS:
+            out[k] = _parse_duration(v)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Bench
+# ---------------------------------------------------------------------------
+
+
+def _materialize(
+    target: TargetConfig, *, reuse: native.ProjectContext | None
+) -> tuple[float, native.ProjectContext]:
+    """Run one materialize. If ``reuse`` is None build a fresh
+    ProjectContext (cold). Returns ``(wall_seconds, ctx)`` so warm
+    runs can reuse the ctx."""
+    ctx = (
+        reuse
+        if reuse is not None
+        else native.ProjectContext(str(target.root), **target.project_kwargs)
+    )
+    t0 = time.perf_counter()
+    ctx.materialize()
+    return time.perf_counter() - t0, ctx
+
+
+def _bench(target: TargetConfig, repeats: int, *, mode: str) -> tuple[float, list[float]]:
+    """Returns ``(warmup_seconds, steady_seconds_list)`` for either
+    ``mode="cold"`` or ``mode="warm"``. Warm mode reuses one
+    ``ProjectContext`` across all iterations (warm-up + steady)."""
+    if mode == "warm":
+        # Build once, prime, then measure the same ctx repeatedly.
+        ctx = native.ProjectContext(str(target.root), **target.project_kwargs)
+        warmup, ctx = _materialize(target, reuse=ctx)
+        steady = [_materialize(target, reuse=ctx)[0] for _ in range(repeats)]
+        return warmup, steady
+    # cold
+    warmup, _ = _materialize(target, reuse=None)
+    steady = [_materialize(target, reuse=None)[0] for _ in range(repeats)]
+    return warmup, steady
+
+
+def _bench_with_phases(target: TargetConfig, repeats: int) -> list[dict[str, float]]:
+    """Run ``repeats + 1`` cold iterations with DEAD_CST_TIMING=1 in a
+    subprocess; collect the per-phase breakdown. Subprocess so the
+    env var only affects this measurement and so the stderr output
+    is captured cleanly.
+
+    Returns ``repeats`` steady-state dicts (drops iter 1)."""
+    code = (
+        "from pathlib import Path\n"
+        "from dead_cst import _native as native\n"
+        f"target_root = {str(target.root)!r}\n"
+        f"kwargs = {target.project_kwargs!r}\n"
+        f"for _ in range({repeats + 1}):\n"
+        "    ctx = native.ProjectContext(target_root, **kwargs)\n"
+        "    ctx.materialize()\n"
+    )
+    env = os.environ.copy()
+    env["DEAD_CST_TIMING"] = "1"
+    out = subprocess.run(
+        ["uv", "run", "python", "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    rows: list[dict[str, float]] = []
+    for line in out.stderr.splitlines():
+        parsed = _parse_timing_line(line)
+        if parsed is not None:
+            rows.append(parsed)
+    # Drop the warm-up iter — it includes process-global typeshed
+    # / module-resolver init, which dwarfs steady-state.
+    return rows[1:]
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def _stats(times: list[float]) -> tuple[float, float, float]:
+    """Return ``(best_ms, mean_ms, stdev_ms)``."""
+    if not times:
+        return 0.0, 0.0, 0.0
+    best = min(times) * 1000
+    mean = statistics.fmean(times) * 1000
+    stdev = statistics.stdev(times) * 1000 if len(times) > 1 else 0.0
+    return best, mean, stdev
+
+
+def _fmt_stats(times: list[float]) -> str:
+    best, mean, stdev = _stats(times)
+    return f"best {best:7.1f} ms  mean {mean:7.1f}±{stdev:.1f}"
+
+
+def _run_target(target: TargetConfig, repeats: int, *, phases: bool) -> None:
+    files = file_count(target.root)
+    print(f"\n=== {target.name} === ({files} files)")
+    print(f"  path: {target.root}")
+
+    # Run cold and warm side-by-side, in-process for cleanest timing.
+    cold_warmup, cold_steady = _bench(target, repeats, mode="cold")
+    warm_warmup, warm_steady = _bench(target, repeats, mode="warm")
+
+    # Best-of for ms/file rate.
+    cold_best_ms = min(cold_steady) * 1000
+    warm_best_ms = min(warm_steady) * 1000
+
+    print(
+        f"  cold (fresh ctx)  : {_fmt_stats(cold_steady)}  ({cold_best_ms / max(files, 1):.2f} ms/file)"
+    )
+    print(
+        f"  warm (reused ctx) : {_fmt_stats(warm_steady)}  ({warm_best_ms / max(files, 1):.2f} ms/file)"
+    )
+    print(f"  cold warm-up iter : {cold_warmup * 1000:7.1f} ms — typeshed / module-resolver init")
+
+    if phases:
+        # Subprocess sweep with DEAD_CST_TIMING=1 to get per-phase
+        # breakdown. Steady iters only.
+        rows = _bench_with_phases(target, repeats)
+        if not rows:
+            print("  (per-phase timing unavailable — no rows captured)")
+            return
+
+        nodes = int(rows[0].get("nodes", 0))
+        edges = int(rows[0].get("edges", 0))
+        print(f"  nodes={nodes}  edges={edges}")
+        print(f"  per-phase (cold, best of {len(rows)}):")
+        for phase in _PHASE_KEYS:
+            phase_vals = [r[phase] for r in rows if phase in r]
+            if not phase_vals:
+                continue
+            best_ms = min(phase_vals) * 1000
+            print(f"    {phase:14s} {best_ms:7.1f} ms")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def _gather_targets(args: argparse.Namespace) -> Iterable[TargetConfig]:
+    if "dead_cst" in args.targets:
+        yield TargetConfig(name="dead_cst (self)", root=stage_dead_cst())
+    if not args.no_flux0:
+        yield from gather_flux0_targets(args.targets, args.cache_root)
+    for n in args.synthetic or ():
+        yield TargetConfig(name=f"synthetic ({n} files)", root=_generate_synthetic(n))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=4,
+        help="Steady-state iterations per (target, mode) (default 4). "
+        "One extra warm-up iteration always runs and is reported separately.",
+    )
+    add_common_target_args(
+        parser, default_targets=["dead_cst", "flux0_server", "flux0_cli", "flux0_workspace"]
+    )
+    parser.add_argument(
+        "--synthetic",
+        nargs="+",
+        type=int,
+        metavar="N",
+        help="Generate synthetic projects with the given file counts "
+        "(e.g. ``--synthetic 50 200 500``). Each file imports a couple "
+        "of siblings so cross-file edge work is realistic.",
+    )
+    parser.add_argument(
+        "--phases",
+        action="store_true",
+        help="Also dump the per-phase breakdown (enum / phase1 / "
+        "dist_lookup / phase2 / phase3 / fqname) via a "
+        "``DEAD_CST_TIMING=1`` subprocess sweep.",
+    )
+    args = parser.parse_args()
+
+    print(f"python: {sys.version.split()[0]}")
+    print(f"native: {native.__file__}")
+    print(f"repeats: {args.repeats}")
+    if args.phases:
+        print("per-phase breakdown: ON (subprocess with DEAD_CST_TIMING=1)")
+
+    targets = list(_gather_targets(args))
+    if not targets:
+        sys.exit("no targets to profile")
+
+    for target in targets:
+        _run_target(target, args.repeats, phases=args.phases)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_plugins_cold.py
+++ b/scripts/profile_plugins_cold.py
@@ -29,15 +29,18 @@ from __future__ import annotations
 
 import argparse
 import logging
-import shutil
 import statistics
-import subprocess
 import sys
-import tempfile
 import time
-from dataclasses import dataclass, field
-from pathlib import Path
 
+from _bench_common import (
+    TargetConfig,
+    add_common_target_args,
+    file_count,
+    gather_flux0_targets,
+    require_native,
+    stage_dead_cst,
+)
 from dead_cst.plugins import BUILTIN_PLUGINS
 
 # Silence the visitor's WARNING-level breadcrumbs (e.g.
@@ -45,98 +48,8 @@ from dead_cst.plugins import BUILTIN_PLUGINS
 # runs, pure noise when we want a clean timing table.
 logging.getLogger("dead_cst").setLevel(logging.ERROR)
 
-try:
-    from dead_cst import _native as native
-except ImportError as exc:
-    sys.exit(
-        f"ERROR: dead_cst._native not importable ({exc}). "
-        "Build with: uv run maturin develop --release "
-        "--manifest-path Cargo.toml"
-    )
-
-FLUX0_URL = "https://github.com/flux0-ai/flux0.git"
-FLUX0_SHA = "8d04176642b091ddb5c5020486f353d4e824460b"
-
-
-# ---------------------------------------------------------------------------
-# Target staging
-# ---------------------------------------------------------------------------
-
-
-def _stage_dead_cst() -> Path:
-    """Copy ``dead_cst/`` into a fresh tempdir as a clean project root.
-
-    Mirrors ``profile_backends.py``: a flat copy of the package gives
-    the analyzer a project root that contains exactly one package.
-    """
-    stage = Path(tempfile.mkdtemp(prefix="dead-cst-plugin-bench-"))
-    src = Path(__file__).resolve().parent.parent / "dead_cst"
-    shutil.copytree(src, stage / "dead_cst", ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
-    return stage
-
-
-def _clone_flux0(cache_root: Path) -> Path:
-    """Shallow-clone flux0 at the pinned SHA. Same protocol as
-    ``profile_backends.py``."""
-    if shutil.which("git") is None:
-        raise RuntimeError("git not on PATH")
-    dest = cache_root / "flux0"
-    marker = dest / ".sha"
-    if marker.is_file() and marker.read_text().strip() == FLUX0_SHA:
-        return dest
-    if dest.exists():
-        shutil.rmtree(dest)
-    dest.mkdir(parents=True)
-
-    def _git(*args: str) -> None:
-        subprocess.run(["git", *args], cwd=dest, check=True, capture_output=True)
-
-    _git("init", "-q")
-    _git("remote", "add", "origin", FLUX0_URL)
-    _git("fetch", "--depth=1", "-q", "--filter=blob:none", "origin", FLUX0_SHA)
-    _git("checkout", "-q", FLUX0_SHA)
-    marker.write_text(FLUX0_SHA + "\n")
-    return dest
-
-
-def _ensure_flux0_venv(flux0_root: Path) -> Path:
-    """Run ``uv sync --all-packages`` so :class:`UvResolver` and ty's
-    workspace module resolver find a ``.venv``. Idempotent."""
-    venv = flux0_root / ".venv"
-    if venv.is_dir():
-        return venv
-    if shutil.which("uv") is None:
-        raise RuntimeError("uv not on PATH; cannot create flux0 workspace venv")
-    print(f"  (one-time setup: uv sync --all-packages in {flux0_root})")
-    subprocess.run(["uv", "sync", "--all-packages"], cwd=flux0_root, check=True)
-    return venv
-
-
-# ---------------------------------------------------------------------------
-# Targets
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class TargetConfig:
-    """Cold-rust target. ``project_kwargs`` are forwarded to
-    ``native.ProjectContext`` — typically ``python_env`` for workspace
-    targets so ty's module resolver picks up third-party packages from
-    the workspace's own ``.venv``."""
-
-    name: str
-    root: Path
-    project_kwargs: dict[str, object] = field(default_factory=dict)
-
-
-def _file_count(target_root: Path) -> int:
-    import os
-
-    count = 0
-    for dirpath, dirnames, filenames in os.walk(target_root, followlinks=True):
-        dirnames[:] = [d for d in dirnames if d not in ("__pycache__", ".venv")]
-        count += sum(1 for f in filenames if f.endswith(".py"))
-    return count
+require_native()
+from dead_cst import _native as native  # noqa: E402  (require_native gates this)
 
 
 # ---------------------------------------------------------------------------
@@ -239,7 +152,7 @@ def _fmt_delta(seconds: float) -> str:
 
 
 def _run_target(target: TargetConfig, plugins: list[tuple[str, object]], repeats: int) -> None:
-    files = _file_count(target.root)
+    files = file_count(target.root)
     print(f"\n=== {target.name} === ({files} files)")
     print(f"  path: {target.root}")
 
@@ -278,9 +191,6 @@ def _run_target(target: TargetConfig, plugins: list[tuple[str, object]], repeats
 # ---------------------------------------------------------------------------
 
 
-TARGET_NAMES = ("dead_cst", "flux0_server", "flux0_cli", "flux0_workspace")
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
@@ -292,29 +202,12 @@ def main() -> None:
         help="Steady-state iterations per (target, plugin) combo (default 3). "
         "One extra warm-up iteration is always run and reported separately.",
     )
-    parser.add_argument(
-        "--targets",
-        nargs="+",
-        default=["dead_cst", "flux0_server"],
-        choices=TARGET_NAMES,
-        help="Which targets to profile (default: dead_cst flux0_server)",
-    )
+    add_common_target_args(parser, default_targets=["dead_cst", "flux0_server"])
     parser.add_argument(
         "--plugins",
         nargs="+",
         default=None,
         help="Restrict to a subset of plugins by name (default: all rust-capable builtins)",
-    )
-    parser.add_argument(
-        "--no-flux0",
-        action="store_true",
-        help="Skip flux0 targets even if requested (offline / no git)",
-    )
-    parser.add_argument(
-        "--cache-root",
-        type=Path,
-        default=Path.home() / ".cache" / "dead-cst-bench",
-        help="Where to cache the flux0 clone (default ~/.cache/dead-cst-bench)",
     )
     args = parser.parse_args()
 
@@ -330,41 +223,9 @@ def main() -> None:
 
     targets: list[TargetConfig] = []
     if "dead_cst" in args.targets:
-        targets.append(TargetConfig(name="dead_cst (self)", root=_stage_dead_cst()))
-
-    flux0_requested = [t for t in args.targets if t.startswith("flux0_")]
-    if flux0_requested and not args.no_flux0:
-        args.cache_root.mkdir(parents=True, exist_ok=True)
-        try:
-            flux0_root = _clone_flux0(args.cache_root)
-        except (RuntimeError, subprocess.CalledProcessError) as exc:
-            print(f"\nflux0 SKIP: {exc}")
-            flux0_root = None
-        if flux0_root is not None:
-            if "flux0_server" in flux0_requested:
-                targets.append(
-                    TargetConfig(
-                        name="flux0 server",
-                        root=flux0_root / "packages" / "server" / "src",
-                    )
-                )
-            if "flux0_cli" in flux0_requested:
-                targets.append(
-                    TargetConfig(name="flux0 cli", root=flux0_root / "packages" / "cli" / "src")
-                )
-            if "flux0_workspace" in flux0_requested:
-                try:
-                    venv = _ensure_flux0_venv(flux0_root)
-                except (RuntimeError, subprocess.CalledProcessError) as exc:
-                    print(f"\nflux0_workspace SKIP: {exc}")
-                else:
-                    targets.append(
-                        TargetConfig(
-                            name="flux0 workspace (uv)",
-                            root=flux0_root,
-                            project_kwargs={"python_env": str(venv)},
-                        )
-                    )
+        targets.append(TargetConfig(name="dead_cst (self)", root=stage_dead_cst()))
+    if not args.no_flux0:
+        targets.extend(gather_flux0_targets(args.targets, args.cache_root))
 
     if not targets:
         sys.exit("no targets to profile")

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -15,7 +15,7 @@
 //! `emit_visitor_warning`) round out the dynamic-import lane.
 
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use pyo3::prelude::*;
@@ -640,8 +640,19 @@ pub(crate) fn pep503_canonicalize(name: &str) -> String {
     out
 }
 
+/// Site-packages roots ty's resolver is configured with, canonicalised
+/// upfront so the worker thread that runs ``build_dist_lookup`` doesn't
+/// need to borrow ``db`` (Salsa's ``ProjectDatabase`` is !Sync).
+pub(crate) fn site_packages_roots(db: &dyn ty_python_semantic::Db) -> Vec<PathBuf> {
+    search_paths(db, ModuleResolveMode::StubsAllowed)
+        .filter(|sp| sp.is_site_packages())
+        .filter_map(|sp| sp.as_system_path().map(|p| p.as_str()))
+        .map(|s| std::fs::canonicalize(s).unwrap_or_else(|_| PathBuf::from(s)))
+        .collect()
+}
+
 /// Build the dist-file lookup by walking ``*.dist-info/`` under every
-/// site-packages search path ty's resolver is configured with.
+/// site-packages search path.
 ///
 /// For each dist-info directory:
 ///
@@ -658,57 +669,55 @@ pub(crate) fn pep503_canonicalize(name: &str) -> String {
 /// Failures (missing METADATA, malformed RECORD, unreadable site-
 /// packages) are silently skipped — the file just won't appear in
 /// the lookup and the caller falls through to ``[external file]``.
-pub(crate) fn build_dist_lookup(db: &dyn ty_python_semantic::Db) -> DistLookup {
-    let mut out: DistLookup = HashMap::new();
-    for sp in search_paths(db, ModuleResolveMode::StubsAllowed) {
-        if !sp.is_site_packages() {
-            continue;
-        }
-        let Some(system_path) = sp.as_system_path() else {
-            continue;
-        };
-        let sp_root = std::fs::canonicalize(system_path.as_str())
-            .unwrap_or_else(|_| PathBuf::from(system_path.as_str()));
-        let Ok(entries) = std::fs::read_dir(&sp_root) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let dist_info = entry.path();
-            if dist_info.extension().is_none_or(|e| e != "dist-info") {
-                continue;
-            }
-            // METADATA — find the ``Name:`` header.
-            let Ok(metadata) = std::fs::read_to_string(dist_info.join("METADATA")) else {
-                continue;
-            };
-            let mut canonical = None;
-            for line in metadata.lines() {
-                if line.is_empty() {
-                    break;
-                }
-                if let Some(value) = line.strip_prefix("Name:") {
-                    canonical = Some(pep503_canonicalize(value.trim()));
-                    break;
-                }
-            }
-            let Some(canonical) = canonical else {
-                continue;
-            };
-            // RECORD — index every owned file's absolute path.
-            let Ok(record) = std::fs::read_to_string(dist_info.join("RECORD")) else {
-                continue;
-            };
-            for line in record.lines() {
-                let Some((rel, _)) = line.split_once(',') else {
-                    continue;
-                };
+///
+/// Per-dist work is dispatched across a rayon pool: a typical venv
+/// has dozens of dists and the per-RECORD ``canonicalize`` syscalls
+/// (~2.5k in dead-cst's own dev venv) dominate everything else.
+pub(crate) fn build_dist_lookup(site_packages: &[PathBuf]) -> DistLookup {
+    use rayon::prelude::*;
+
+    site_packages
+        .iter()
+        .flat_map(|sp_root| {
+            std::fs::read_dir(sp_root)
+                .into_iter()
+                .flatten()
+                .flatten()
+                .map(|e| e.path())
+                .filter(|p| p.extension().is_some_and(|e| e == "dist-info"))
+                .map(move |dist_info| (dist_info, sp_root.as_path()))
+        })
+        .collect::<Vec<_>>()
+        .par_iter()
+        .filter_map(|(dist_info, sp_root)| process_dist_info(dist_info, sp_root))
+        .flatten()
+        .collect()
+}
+
+/// One ``*.dist-info/`` directory's ``(absolute file path, canonical
+/// dist name)`` pairs. ``None`` when METADATA / RECORD are missing or
+/// the ``Name:`` header isn't found.
+fn process_dist_info(dist_info: &Path, sp_root: &Path) -> Option<Vec<(PathBuf, String)>> {
+    let metadata = std::fs::read_to_string(dist_info.join("METADATA")).ok()?;
+    let canonical = metadata
+        .lines()
+        .take_while(|l| !l.is_empty())
+        .find_map(|line| {
+            line.strip_prefix("Name:")
+                .map(|v| pep503_canonicalize(v.trim()))
+        })?;
+    let record = std::fs::read_to_string(dist_info.join("RECORD")).ok()?;
+    Some(
+        record
+            .lines()
+            .filter_map(|line| {
+                let (rel, _) = line.split_once(',')?;
                 let joined = sp_root.join(rel);
                 let abs = std::fs::canonicalize(&joined).unwrap_or(joined);
-                out.insert(abs, canonical.clone());
-            }
-        }
-    }
-    out
+                Some((abs, canonical.clone()))
+            })
+            .collect(),
+    )
 }
 
 /// Classify a dotted module name relative to the file that imports it.

--- a/src/project.rs
+++ b/src/project.rs
@@ -246,88 +246,100 @@ pub(crate) fn build_project_graph(
         }
     }
     let t_enum = t0.elapsed();
-    let t1 = std::time::Instant::now();
-    // Two-pass ingest so the per-decl ``.pyi`` stub flagging in
-    // ``ingest_decls`` has the .py twin's ``globals_by_name`` entries
-    // to probe. Pass 1 = everything that isn't a .pyi; pass 2 = .pyi.
-    // The split doesn't change the graph for non-peer files; it's
-    // ordering for the peer-stub flag-check only.
+    // Phase 1 (per-file decl ingest) doesn't read ``dist_lookup``, so
+    // it overlaps with the site-packages walk on a worker thread.
+    // ``ProjectDatabase`` is !Sync (Salsa's per-thread query stack),
+    // so we pre-extract just the search paths the walk needs.
+    let site_packages = crate::ingest::site_packages_roots(db);
+
     let progress = ProgressBars::new(show_progress, project_files.len() as u64);
-    for file in &project_files {
-        if file_path_string(db, *file).ends_with(".pyi") {
-            continue;
+    let t1 = std::time::Instant::now();
+    let (dist_lookup, t_phase1, t_dist_lookup) = std::thread::scope(|s| -> PyResult<_> {
+        let sp_ref = &site_packages;
+        let lookup_handle = s.spawn(move || {
+            let t = std::time::Instant::now();
+            (build_dist_lookup(sp_ref), t.elapsed())
+        });
+
+        // Two-pass ingest so the per-decl ``.pyi`` stub flagging in
+        // ``ingest_decls`` has the .py twin's ``globals_by_name`` entries
+        // to probe. Pass 1 = everything that isn't a .pyi; pass 2 = .pyi.
+        // The split doesn't change the graph for non-peer files; it's
+        // ordering for the peer-stub flag-check only.
+        for file in &project_files {
+            if file_path_string(db, *file).ends_with(".pyi") {
+                continue;
+            }
+            ingest_decls(
+                py,
+                db,
+                *file,
+                &mut builder,
+                &mut global_index,
+                &mut module_nodes,
+                &mut alias_imports,
+                &mut live_decls,
+                &mut globals_by_name,
+                &mut star_reexports,
+                &mut class_by_selection,
+                &mut decl_by_name_range,
+            )?;
+            progress.ingest.inc(1);
         }
-        ingest_decls(
-            py,
-            db,
-            *file,
-            &mut builder,
-            &mut global_index,
-            &mut module_nodes,
-            &mut alias_imports,
-            &mut live_decls,
-            &mut globals_by_name,
-            &mut star_reexports,
-            &mut class_by_selection,
-            &mut decl_by_name_range,
-        )?;
-        progress.ingest.inc(1);
-    }
-    for file in &project_files {
-        if !file_path_string(db, *file).ends_with(".pyi") {
-            continue;
+        for file in &project_files {
+            if !file_path_string(db, *file).ends_with(".pyi") {
+                continue;
+            }
+            ingest_decls(
+                py,
+                db,
+                *file,
+                &mut builder,
+                &mut global_index,
+                &mut module_nodes,
+                &mut alias_imports,
+                &mut live_decls,
+                &mut globals_by_name,
+                &mut star_reexports,
+                &mut class_by_selection,
+                &mut decl_by_name_range,
+            )?;
+            progress.ingest.inc(1);
         }
-        ingest_decls(
-            py,
-            db,
-            *file,
-            &mut builder,
-            &mut global_index,
-            &mut module_nodes,
-            &mut alias_imports,
-            &mut live_decls,
-            &mut globals_by_name,
-            &mut star_reexports,
-            &mut class_by_selection,
-            &mut decl_by_name_range,
-        )?;
-        progress.ingest.inc(1);
-    }
-    progress.ingest.finish_and_clear();
-    // Per-decl ``pyi_decl -> py_decl`` edges for each peer .pyi whose
-    // matching .py defines the same simple name. The edge documents
-    // the stub-runtime relationship in the graph: consumers that ty
-    // resolved through the stub get reachability into the runtime
-    // decl via ``alias -> pyi_decl -> py_decl`` rather than stopping
-    // at the stub. Stub-only decls (no matching .py decl) are
-    // separately kept alive by the per-decl ENTRYPOINT flag set in
-    // ``ingest_decls``.
-    let peer_stubs: Vec<(File, File)> = builder
-        .peer_pyi_to_py
-        .iter()
-        .map(|(&pyi, &py)| (pyi, py))
-        .collect();
-    for (pyi_file, py_twin) in peer_stubs {
-        let pyi_decls: Vec<(String, usize)> = globals_by_name
+        progress.ingest.finish_and_clear();
+        // Per-decl ``pyi_decl -> py_decl`` edges for each peer .pyi whose
+        // matching .py defines the same simple name. The edge documents
+        // the stub-runtime relationship in the graph: consumers that ty
+        // resolved through the stub get reachability into the runtime
+        // decl via ``alias -> pyi_decl -> py_decl`` rather than stopping
+        // at the stub. Stub-only decls (no matching .py decl) are
+        // separately kept alive by the per-decl ENTRYPOINT flag set in
+        // ``ingest_decls``.
+        let peer_stubs: Vec<(File, File)> = builder
+            .peer_pyi_to_py
             .iter()
-            .filter(|((file, _), _)| *file == pyi_file)
-            .flat_map(|((_, name), idxs)| idxs.iter().map(move |&idx| (name.clone(), idx)))
+            .map(|(&pyi, &py)| (pyi, py))
             .collect();
-        for (name, pyi_idx) in pyi_decls {
-            if let Some(py_idxs) = globals_by_name.get(&(py_twin, name)) {
-                for &py_idx in py_idxs {
-                    builder.add_edge(pyi_idx, py_idx, 0);
+        for (pyi_file, py_twin) in peer_stubs {
+            let pyi_decls: Vec<(String, usize)> = globals_by_name
+                .iter()
+                .filter(|((file, _), _)| *file == pyi_file)
+                .flat_map(|((_, name), idxs)| idxs.iter().map(move |&idx| (name.clone(), idx)))
+                .collect();
+            for (name, pyi_idx) in pyi_decls {
+                if let Some(py_idxs) = globals_by_name.get(&(py_twin, name)) {
+                    for &py_idx in py_idxs {
+                        builder.add_edge(pyi_idx, py_idx, 0);
+                    }
                 }
             }
         }
-    }
-    let t_phase1 = t1.elapsed();
-    // Walk every site-packages search path's ``*.dist-info/`` to build
-    // the file -> canonical-dist-name map. Cheap (one read_dir + a
-    // couple of read_to_string per installed dist), runs once per
-    // ``materialize`` call. Both Phase 2 (alias minting) and Phase 3
-    // (use-site emit_upstream) need the same map.
-    let dist_lookup = build_dist_lookup(db);
+        let t_phase1 = t1.elapsed();
+        // Block on the dist-info walker (no-op when Phase 1 finished
+        // last, which is the common case on medium-to-large projects).
+        let (lookup, t_dist) = lookup_handle.join().expect("dist_lookup thread panicked");
+        Ok((lookup, t_phase1, t_dist))
+    })?;
     let t2 = std::time::Instant::now();
     for file in &project_files {
         emit_module_hierarchy(db, *file, &module_nodes, &mut builder);
@@ -367,12 +379,13 @@ pub(crate) fn build_project_graph(
     let t_fqname = t4.elapsed();
     if timing {
         eprintln!(
-            "[dead-cst-timing] files={} nodes={} edges={} enum={:?} phase1={:?} phase2={:?} phase3={:?} fqname={:?} total={:?}",
+            "[dead-cst-timing] files={} nodes={} edges={} enum={:?} phase1={:?} dist_lookup={:?} phase2={:?} phase3={:?} fqname={:?} total={:?}",
             project_files.len(),
             builder.nodes.len(),
             builder.edges.len(),
             t_enum,
             t_phase1,
+            t_dist_lookup,
             t_phase2,
             t_phase3,
             t_fqname,


### PR DESCRIPTION
> **Base: `rust_proto`** (not `main`). One commit; targets cold path only.

## Summary

A new `scripts/profile_graph_build.py` (cold/warm rust-build profile with per-phase breakdown via `DEAD_CST_TIMING=1`) made the dominant cold-path cost obvious: **`build_dist_lookup` was ~80 ms on small projects (90% of cold time on flux0/cli)** — ~2.5k `std::fs::canonicalize` syscalls in dead-cst's own venv resolving uv's per-file symlinks back to the global wheel cache. Two complementary changes target the cold path. Warm-mode caching was considered and dropped — every realistic `dead-cst` invocation is one-shot, so cache hits don't happen in practice.

## 1. rayon-parallel `build_dist_lookup`

Each `*.dist-info/` is independent. Materialise the dist-info list across all site-packages roots, then `par_iter().filter_map(process_dist_info).flatten().collect()` directly into the `DistLookup` HashMap. New `process_dist_info` helper reads METADATA + RECORD and emits the `(abs_path, canonical_dist_name)` pairs for one dist.

**80 ms → 32 ms** on a single venv walk (2.5×).

## 2. `thread::scope` overlap with Phase 1

Phase 1 (per-file decl ingest) doesn't read `dist_lookup` — only Phase 2 (import edges) and Phase 3 (reference edges) do. So we can kick the site-packages walk off on a worker thread and run Phase 1 on the main thread concurrently, joining before Phase 2.

`ProjectDatabase` is `!Sync` (Salsa's per-thread query stack), so we pre-extract the site-packages roots as `Vec<PathBuf>` (canonicalised once on the main thread — cheap sync call, new `ingest::site_packages_roots`) and hand that to the spawned task. `build_dist_lookup` now takes `&[PathBuf]` instead of `&dyn Db`. The scope closure returns `(DistLookup, t_phase1, t_dist_lookup)` so the cold-path values flow back through the type system — no `Option<>` + `expect("populated above")` boilerplate.

For `Phase 1 ≥ dist_lookup`, the walk is fully hidden. For `Phase 1 < dist_lookup`, we wait the difference. Either way the cold time drops to `max(Phase 1, dist_lookup) + Phase 2 + Phase 3`.

## Combined impact (cold, best of 4)

| target               | before  | after   | savings |
|----------------------|--------:|--------:|--------:|
| dead_cst self        | 118 ms  |  50 ms  | -58%    |
| flux0 server         | 105 ms  |  45 ms  | -57%    |
| flux0 cli            |  92 ms  |  40 ms  | -57%    |
| flux0 workspace      | 217 ms  | 179 ms  | -18%    |
| synthetic 50         |  97 ms  |  40 ms  | -59%    |
| synthetic 200        | 116 ms  |  56 ms  | -52%    |

Workspace gain is smaller because Phase 1 (50 ms) outlives `dist_lookup` (20 ms) — the overlap is bounded by the slower of the two, and the saving caps at the smaller. Remaining headroom on workspace is Phase 3 (~90 ms reference-edge emission), the natural next target.

**Big-monorepo projection:** 1000+ files puts Phase 1 at hundreds of ms while `dist_lookup` stays at a few dozen — fully overlapped, cold cost ≈ Phase 1 alone. The overlap scales naturally with monorepo size.

## New profile script

`scripts/profile_graph_build.py` measures `materialize()` with no plugins:

- **real targets** — dead_cst self, flux0_server, flux0_cli, flux0_workspace
- **synthetic projects** — `--synthetic 50 200 500` generates a package of N modules with realistic cross-file imports
- cold (fresh ctx per iter) and warm (reused ctx) timings with best/mean/stdev across `--repeats` iters, plus a warm-up iter separately
- `--phases` runs a subprocess sweep with `DEAD_CST_TIMING=1` and dumps the per-phase breakdown

```
cold (fresh ctx)  : best   179 ms  mean 185±6      (1.79 ms/file)
cold warm-up iter :   219 ms — typeshed / module-resolver init
nodes=1939  edges=6206
per-phase (cold, best of 4):
  enum               3.2 ms
  phase1            50.7 ms
  dist_lookup       20.0 ms     ← runs concurrently with phase1
  phase2            37.0 ms
  phase3            91.2 ms
  fqname             1.1 ms
  total            184.4 ms
```

## Shared bench infrastructure

`scripts/_bench_common.py` (new) holds the harness both this script and the existing `profile_plugins_cold.py` need: `TargetConfig`, `stage_dead_cst`, `clone_flux0`, `ensure_flux0_venv`, `file_count`, `gather_flux0_targets`, `require_native`, and the shared `--targets / --no-flux0 / --cache-root` arg block. Refactoring `profile_plugins_cold.py` to use it dropped ~150 lines from each script and fixed a latent bug (its `_stage_dead_cst` still pointed at the old top-level `dead_cst/` dir from before the maturin layout change).

## Test plan
- [x] `cargo test --release --no-default-features` — 4 / 4 passed
- [x] `cargo clippy --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `uv run pytest tests/` — 630 / 630 passed
- [x] `uv run prek run ruff --files scripts/...` and `ruff-format` — clean
- [x] `uv run python scripts/profile_graph_build.py --targets dead_cst flux0_server flux0_cli flux0_workspace --synthetic 50 200 --repeats 4 --phases` — runs to completion, numbers in tables above
- [x] `uv run python scripts/profile_plugins_cold.py --targets flux0_cli --plugins ExplicitEntrypointPlugin` — still works after the refactor

## Followups (not in this PR)

- Cold `dist_lookup` is still ~32 ms when it can't be fully overlapped. Could be sped up further by skipping per-RECORD `canonicalize` and only canonicalising on the lookup side — but that risks breaking uv-style symlinks; needs its own careful investigation.
- Phase 3 (~90 ms reference-edge emission on workspace) is now the biggest single cold-path chunk. Per-file work; could parallelize across files too if `RefCollector` becomes thread-safe.

https://claude.ai/code/session_013bbfv7aTfShcRvuAQr9HCt