### PR TITLE
ci: fix dev version stamping (read base from Cargo.toml, SemVer suffix)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,10 @@ jobs:
       - name: Stamp dev version
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         shell: bash
-        run: sed -i.bak 's/^version = .*/version = "0.10.0.dev${{ github.run_number }}"/' Cargo.toml && rm Cargo.toml.bak
+        run: |
+          base=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)
+          sed -i.bak "s/^version = .*/version = \"${base}-dev${{ github.run_number }}\"/" Cargo.toml
+          rm Cargo.toml.bak
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
@@ -66,7 +69,10 @@ jobs:
           cache-dependency-glob: "**/uv.lock"
       - name: Stamp dev version
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: sed -i.bak 's/^version = .*/version = "0.10.0.dev${{ github.run_number }}"/' Cargo.toml && rm Cargo.toml.bak
+        run: |
+          base=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)
+          sed -i.bak "s/^version = .*/version = \"${base}-dev${{ github.run_number }}\"/" Cargo.toml
+          rm Cargo.toml.bak
       - uses: PyO3/maturin-action@v1
         with:
           command: sdist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ Implement `PathResolver`: `resolve(project_root) -> tuple[Package, ...]`. Drop g
 
 - **Python 3.11+**. Ruff line length 100. `known-first-party = ["dead_cst"]`. `from __future__ import annotations` is used throughout the package.
 - **`ty` type-checks `dead_cst/` only** — tests, examples, and workspace fixtures intentionally exercise untyped third-party internals.
-- **Versioning is mostly manual**. `pyproject.toml` is `dynamic = ["version"]`; maturin reads the version from `Cargo.toml`'s `[package].version`. Bump that field by hand before tagging a release. On every push to `main`, the publish workflow rewrites it to `<base>.dev${{ github.run_number }}` (in-CI only, never committed) so TestPyPI gets a unique version per commit. Never hand-edit a version on a non-release commit.
+- **Versioning is mostly manual**. `pyproject.toml` is `dynamic = ["version"]`; maturin reads the version from `Cargo.toml`'s `[package].version`. Bump that field by hand before tagging a release. On every push to `main`, the publish workflow rewrites it to `<base>-dev${{ github.run_number }}` (in-CI only, never committed) so TestPyPI gets a unique version per commit. The SemVer pre-release suffix (`-dev`, not `.dev`) is required so Cargo accepts the version; maturin normalizes it to PEP 440 `<base>.dev<N>` for the wheel. Never hand-edit a version on a non-release commit.
 - **No optional arguments without a real reason.** When a parameter would be supplied by every caller anyway, make it required. The project is pre-1.0 and breaking the public API is fine.
 - **PRs**: one logical change per PR, add/update tests, add a `[Unreleased]` `CHANGELOG.md` entry for user-visible changes.
 


### PR DESCRIPTION
## Summary
- The `Stamp dev version` steps in `publish.yml` hardcoded `0.10.0` as the base, so bumping `Cargo.toml` would silently keep stamping the old version onto TestPyPI uploads.
- They also produced `<base>.dev<N>` (PEP 440), which Cargo rejects as non-SemVer — the maturin build fails before a wheel is ever produced.
- Now both steps (wheels + sdist) read the current base from `Cargo.toml` at stamp time and emit `<base>-dev<run_number>`. That's valid SemVer pre-release, Cargo accepts it, and maturin normalizes it to PEP 440 `<base>.dev<N>` in the wheel metadata.
- Updated the CLAUDE.md versioning note to match the new format.

## Test plan
- [ ] Merge to `main` and confirm the next publish run stamps `0.10.0-dev<N>` into `Cargo.toml`, the maturin wheels build, and TestPyPI receives a `0.10.0.dev<N>` release.
- [ ] Bump `Cargo.toml` to a new base (e.g. `0.11.0`) and confirm a follow-up dev publish stamps `0.11.0-dev<N>` rather than `0.10.0-dev<N>`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCUkrmpEsaFpcxZV8So5Tx)_