### PR TITLE
ci: drop unused setup-uv from publish wheels + sdist jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,11 +33,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - uses: astral-sh/setup-uv@v7
-        with:
-          python-version: "3.12"
-          enable-cache: true
-          cache-dependency-glob: "**/uv.lock"
       - name: Stamp dev version
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         shell: bash
@@ -62,11 +57,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - uses: astral-sh/setup-uv@v7
-        with:
-          python-version: "3.12"
-          enable-cache: true
-          cache-dependency-glob: "**/uv.lock"
       - name: Stamp dev version
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |


### PR DESCRIPTION
## Summary
- `PyO3/maturin-action` provisions its own Python/maturin toolchain inside the action, so the preceding `astral-sh/setup-uv@v7` step in the `wheels` and `sdist` jobs wasn't actually feeding the build — just adding setup time and a flakiness vector.
- Drop the step from both jobs in `publish.yml`. No other publish job referenced it.

## Test plan
- [ ] Next push to `main`: confirm the wheels matrix and sdist job both still build and upload artifacts without the setup-uv step.
- [ ] TestPyPI receives the dev release as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCUkrmpEsaFpcxZV8So5Tx)_