### PR TITLE
rust: simplify the crate surface + add a unit-test suite

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10,7 +10,7 @@ use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use ruff_db::files::File;
 
-use crate::graph::SymbolNode;
+use crate::graph::{intern_kind, SymbolNode};
 use crate::helpers::NODE_FLAG_ENTRYPOINT;
 use crate::project::ProjectContext;
 
@@ -106,18 +106,7 @@ impl GraphBuilder {
         }
         let idx = self.intern_node(
             py,
-            SymbolNode {
-                fqname: fqname.clone(),
-                kind: "synthetic",
-                path: String::new(),
-                start_line: 0,
-                start_column: 0,
-                end_line: 0,
-                end_column: 0,
-                flags: 0,
-                imports: None,
-                cached_hash: OnceLock::new(),
-            },
+            synthetic_node(fqname.clone(), "synthetic", String::new(), 0),
         )?;
         self.synthetic_nodes.insert(fqname, idx);
         Ok(idx)
@@ -215,7 +204,7 @@ impl AddNode {
     ) -> PyResult<Self> {
         Ok(Self {
             fqname,
-            kind: static_kind_str(kind)?,
+            kind: intern_kind(kind)?,
             path,
             flags,
             edges_from,
@@ -285,6 +274,30 @@ pub(crate) fn bfs(
     visited
 }
 
+/// Construct a position-less `SymbolNode` (start/end zeroed, `imports`
+/// absent) for ops minted at plugin-apply time. The four
+/// caller-supplied fields are the only ones that vary across the
+/// synthetic / entrypoint / `AddNode` shapes.
+pub(crate) fn synthetic_node(
+    fqname: String,
+    kind: &'static str,
+    path: String,
+    flags: u32,
+) -> SymbolNode {
+    SymbolNode {
+        fqname,
+        kind,
+        path,
+        start_line: 0,
+        start_column: 0,
+        end_line: 0,
+        end_column: 0,
+        flags,
+        imports: None,
+        cached_hash: OnceLock::new(),
+    }
+}
+
 pub(crate) fn apply_graph_op(
     ctx: &Py<ProjectContext>,
     py: Python<'_>,
@@ -310,18 +323,7 @@ pub(crate) fn apply_graph_op(
         drop(decl);
         let marker_idx = outputs.builder.intern_node(
             py,
-            SymbolNode {
-                fqname: marker_fqname,
-                kind: "synthetic",
-                path,
-                start_line: 0,
-                start_column: 0,
-                end_line: 0,
-                end_column: 0,
-                flags: NODE_FLAG_ENTRYPOINT,
-                imports: None,
-                cached_hash: OnceLock::new(),
-            },
+            synthetic_node(marker_fqname, "synthetic", path, NODE_FLAG_ENTRYPOINT),
         )?;
         outputs.builder.add_edge(marker_idx, decl_idx, 0);
         return Ok(());
@@ -329,18 +331,12 @@ pub(crate) fn apply_graph_op(
     if let Ok(add_node) = op.extract::<PyRef<AddNode>>() {
         let node_idx = outputs.builder.intern_node(
             py,
-            SymbolNode {
-                fqname: add_node.fqname.clone(),
-                kind: add_node.kind,
-                path: add_node.path.clone(),
-                start_line: 0,
-                start_column: 0,
-                end_line: 0,
-                end_column: 0,
-                flags: add_node.flags,
-                imports: None,
-                cached_hash: OnceLock::new(),
-            },
+            synthetic_node(
+                add_node.fqname.clone(),
+                add_node.kind,
+                add_node.path.clone(),
+                add_node.flags,
+            ),
         )?;
         for src in &add_node.edges_from {
             let src_idx = lookup_idx(&outputs.builder, &src.borrow(py), "edges_from")?;
@@ -372,24 +368,4 @@ pub(crate) fn lookup_idx(builder: &GraphBuilder, node: &SymbolNode, side: &str) 
                 node.fqname
             ))
         })
-}
-
-/// Map a plugin-supplied `kind` string to one of the stable `&'static
-/// str` kinds SymbolNode carries.
-pub(crate) fn static_kind_str(kind: &str) -> PyResult<&'static str> {
-    Ok(match kind {
-        "synthetic" => "synthetic",
-        "module" => "module",
-        "import" => "import",
-        "function" => "function",
-        "class" => "class",
-        "variable" => "variable",
-        "type_alias" => "type_alias",
-        other => {
-            return Err(PyValueError::new_err(format!(
-                "unknown node kind {other:?} — expected one of synthetic, module, import, \
-                 function, class, variable, type_alias"
-            )))
-        }
-    })
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -369,3 +369,273 @@ pub(crate) fn lookup_idx(builder: &GraphBuilder, node: &SymbolNode, side: &str) 
             ))
         })
 }
+
+#[cfg(test)]
+mod tests {
+    //! Pure-rust tests for the graph-building primitives.
+    //!
+    //! The interning surface mints `Py<SymbolNode>` and so requires
+    //! pyo3-init / a GIL; those paths are exercised by the python suite
+    //! end-to-end. Here we cover the data-only pieces:
+    //!
+    //! * `NodeKey` equality / hashing (flags excluded from identity).
+    //! * `node_key_of` projection.
+    //! * `synthetic_node` field defaults.
+    //! * `bfs` traversal — direction switch + `skip_flags` filtering.
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    /// Build a bare `SymbolNode` for projection tests. Avoids pyo3
+    /// because the helper doesn't need to be reachable from Python.
+    fn raw_symbol(
+        fqname: &str,
+        kind: &'static str,
+        path: &str,
+        start_line: usize,
+        flags: u32,
+    ) -> SymbolNode {
+        SymbolNode {
+            fqname: fqname.to_string(),
+            kind,
+            path: path.to_string(),
+            start_line,
+            start_column: 0,
+            end_line: start_line,
+            end_column: 0,
+            flags,
+            imports: None,
+            cached_hash: OnceLock::new(),
+        }
+    }
+
+    fn hash_of(key: &NodeKey) -> u64 {
+        let mut h = DefaultHasher::new();
+        key.hash(&mut h);
+        h.finish()
+    }
+
+    // -- node_key_of / NodeKey -------------------------------------------
+
+    #[test]
+    fn node_key_of_projects_identity_fields() {
+        let n = raw_symbol("pkg.mod.f", "function", "pkg/mod.py", 12, 0);
+        let key = node_key_of(&n);
+        assert_eq!(key.fqname, "pkg.mod.f");
+        assert_eq!(key.kind, "function");
+        assert_eq!(key.path, "pkg/mod.py");
+        assert_eq!(key.start_line, 12);
+        assert_eq!(key.end_line, 12);
+    }
+
+    #[test]
+    fn node_key_excludes_flags_from_identity() {
+        // Principle 3 from CLAUDE.md: two nodes for the same
+        // (fqname, kind, path, position) are the same node regardless
+        // of which path computed their flags.
+        let a = node_key_of(&raw_symbol("m.f", "function", "m.py", 1, 0));
+        let b = node_key_of(&raw_symbol("m.f", "function", "m.py", 1, 7));
+        assert!(a == b);
+        assert_eq!(hash_of(&a), hash_of(&b));
+    }
+
+    #[test]
+    fn node_key_distinguishes_by_position() {
+        // Two `def f` at different lines must be distinct nodes
+        // (shadowing semantics).
+        let a = node_key_of(&raw_symbol("m.f", "function", "m.py", 1, 0));
+        let b = node_key_of(&raw_symbol("m.f", "function", "m.py", 9, 0));
+        assert!(a != b);
+    }
+
+    #[test]
+    fn node_key_distinguishes_by_kind() {
+        let a = node_key_of(&raw_symbol("m.X", "class", "m.py", 1, 0));
+        let b = node_key_of(&raw_symbol("m.X", "variable", "m.py", 1, 0));
+        assert!(a != b);
+    }
+
+    #[test]
+    fn node_key_distinguishes_by_path() {
+        let a = node_key_of(&raw_symbol("X", "class", "a/m.py", 1, 0));
+        let b = node_key_of(&raw_symbol("X", "class", "b/m.py", 1, 0));
+        assert!(a != b);
+    }
+
+    // -- synthetic_node ---------------------------------------------------
+
+    #[test]
+    fn synthetic_node_zeroes_positions_and_omits_imports() {
+        let n = synthetic_node(
+            "pkg".to_string(),
+            "synthetic",
+            "p.py".to_string(),
+            NODE_FLAG_ENTRYPOINT,
+        );
+        assert_eq!(n.fqname, "pkg");
+        assert_eq!(n.kind, "synthetic");
+        assert_eq!(n.path, "p.py");
+        assert_eq!(n.start_line, 0);
+        assert_eq!(n.start_column, 0);
+        assert_eq!(n.end_line, 0);
+        assert_eq!(n.end_column, 0);
+        assert_eq!(n.flags, NODE_FLAG_ENTRYPOINT);
+        assert!(n.imports.is_none());
+    }
+
+    #[test]
+    fn synthetic_node_accepts_arbitrary_kind() {
+        // The signature takes a `&'static str` so callers pass already-interned values.
+        let n = synthetic_node(String::from("m"), "module", String::new(), 0);
+        assert_eq!(n.kind, "module");
+        assert!(n.path.is_empty());
+    }
+
+    // -- GraphBuilder construction (no pyo3) -----------------------------
+
+    #[test]
+    fn graph_builder_new_starts_empty() {
+        let b = GraphBuilder::new();
+        assert!(b.nodes.is_empty());
+        assert!(b.node_index.is_empty());
+        assert!(b.edges.is_empty());
+        assert!(b.edge_set.is_empty());
+        assert!(b.forward_adj.is_empty());
+        assert!(b.reverse_adj.is_empty());
+        assert!(b.synthetic_nodes.is_empty());
+        assert!(b.peer_pyi_to_py.is_empty());
+    }
+
+    // -- bfs --------------------------------------------------------------
+
+    /// Build a `GraphBuilder` with `n` allocated adjacency slots so we
+    /// can push edges by hand for `bfs` tests.
+    fn empty_builder_with_n_slots(n: usize) -> GraphBuilder {
+        let mut b = GraphBuilder::new();
+        for _ in 0..n {
+            b.forward_adj.push(Vec::new());
+            b.reverse_adj.push(Vec::new());
+        }
+        b
+    }
+
+    /// Append a forward+reverse adjacency entry. The plain `Vec::push`
+    /// path is enough because `bfs` only reads `forward_adj` /
+    /// `reverse_adj` — it never inspects `edges` / `edge_set` / `nodes`.
+    fn add_edge_manual(b: &mut GraphBuilder, src: usize, dst: usize, flags: u32) {
+        b.forward_adj[src].push((dst, flags));
+        b.reverse_adj[dst].push((src, flags));
+    }
+
+    #[test]
+    fn bfs_forward_walks_descendants_from_single_seed() {
+        // 0 -> 1 -> 2 ;  0 -> 3
+        let mut b = empty_builder_with_n_slots(4);
+        add_edge_manual(&mut b, 0, 1, 0);
+        add_edge_manual(&mut b, 1, 2, 0);
+        add_edge_manual(&mut b, 0, 3, 0);
+        let reachable = bfs(&b, [0], Direction::Forward, 0);
+        let expected: HashSet<usize> = [0, 1, 2, 3].into_iter().collect();
+        assert_eq!(reachable, expected);
+    }
+
+    #[test]
+    fn bfs_reverse_walks_ancestors() {
+        let mut b = empty_builder_with_n_slots(4);
+        add_edge_manual(&mut b, 0, 1, 0);
+        add_edge_manual(&mut b, 1, 2, 0);
+        add_edge_manual(&mut b, 3, 2, 0);
+        let ancestors = bfs(&b, [2], Direction::Reverse, 0);
+        let expected: HashSet<usize> = [0, 1, 2, 3].into_iter().collect();
+        assert_eq!(ancestors, expected);
+    }
+
+    #[test]
+    fn bfs_skip_flags_filters_edges_by_any_intersecting_bit() {
+        // Dead-branch edge gates 0 -> 1.
+        let mut b = empty_builder_with_n_slots(3);
+        add_edge_manual(&mut b, 0, 1, 1 /* DEAD_BRANCH */);
+        add_edge_manual(&mut b, 0, 2, 0);
+        // With skip_flags = 1, the 0 -> 1 edge is filtered out.
+        let reachable = bfs(&b, [0], Direction::Forward, 1);
+        let expected: HashSet<usize> = [0, 2].into_iter().collect();
+        assert_eq!(reachable, expected);
+
+        // skip_flags = 0 keeps every edge.
+        let reachable_all = bfs(&b, [0], Direction::Forward, 0);
+        let expected_all: HashSet<usize> = [0, 1, 2].into_iter().collect();
+        assert_eq!(reachable_all, expected_all);
+    }
+
+    #[test]
+    fn bfs_skip_flags_intersects_any_bit() {
+        // flags = 0b11; skipping any of the bits should drop the edge.
+        let mut b = empty_builder_with_n_slots(2);
+        add_edge_manual(&mut b, 0, 1, 0b11);
+        for mask in [0b01, 0b10, 0b11, 0b100 | 0b01] {
+            let r = bfs(&b, [0], Direction::Forward, mask);
+            assert_eq!(
+                r,
+                [0].into_iter().collect::<HashSet<_>>(),
+                "skip_flags=0b{mask:b} should drop the edge"
+            );
+        }
+        // mask=0b100 doesn't intersect — edge survives.
+        let r = bfs(&b, [0], Direction::Forward, 0b100);
+        assert_eq!(r, [0, 1].into_iter().collect::<HashSet<_>>());
+    }
+
+    #[test]
+    fn bfs_handles_cycles_without_looping() {
+        let mut b = empty_builder_with_n_slots(3);
+        add_edge_manual(&mut b, 0, 1, 0);
+        add_edge_manual(&mut b, 1, 2, 0);
+        add_edge_manual(&mut b, 2, 0, 0);
+        let reachable = bfs(&b, [0], Direction::Forward, 0);
+        let expected: HashSet<usize> = [0, 1, 2].into_iter().collect();
+        assert_eq!(reachable, expected);
+    }
+
+    #[test]
+    fn bfs_empty_seeds_returns_empty_set() {
+        let b = empty_builder_with_n_slots(5);
+        let reachable = bfs(&b, std::iter::empty::<usize>(), Direction::Forward, 0);
+        assert!(reachable.is_empty());
+    }
+
+    #[test]
+    fn bfs_isolated_seed_returns_just_itself() {
+        let b = empty_builder_with_n_slots(3);
+        let r = bfs(&b, [2], Direction::Forward, 0);
+        assert_eq!(r, [2].into_iter().collect::<HashSet<_>>());
+    }
+
+    #[test]
+    fn bfs_multiple_seeds_unions_reachable() {
+        let mut b = empty_builder_with_n_slots(5);
+        add_edge_manual(&mut b, 0, 1, 0);
+        add_edge_manual(&mut b, 2, 3, 0);
+        let r = bfs(&b, [0, 2], Direction::Forward, 0);
+        let expected: HashSet<usize> = [0, 1, 2, 3].into_iter().collect();
+        assert_eq!(r, expected);
+    }
+
+    #[test]
+    fn bfs_includes_seed_node_in_result() {
+        let b = empty_builder_with_n_slots(1);
+        let r = bfs(&b, [0], Direction::Forward, 0);
+        assert!(r.contains(&0));
+        assert_eq!(r.len(), 1);
+    }
+
+    #[test]
+    fn bfs_reverse_skip_flags_also_filters() {
+        // Sanity check: skip_flags applies to reverse BFS too.
+        let mut b = empty_builder_with_n_slots(3);
+        add_edge_manual(&mut b, 0, 2, 1);
+        add_edge_manual(&mut b, 1, 2, 0);
+        let r = bfs(&b, [2], Direction::Reverse, 1);
+        let expected: HashSet<usize> = [1, 2].into_iter().collect();
+        assert_eq!(r, expected);
+    }
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -411,3 +411,80 @@ impl EdgeFlags {
     #[classattr]
     pub(crate) const DYNAMIC_IMPORT: u32 = 2;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intern_kind_accepts_every_known_kind() {
+        for kind in [
+            "function",
+            "class",
+            "variable",
+            "import",
+            "type_alias",
+            "module",
+            "synthetic",
+        ] {
+            let interned = intern_kind(kind).expect("known kinds must intern");
+            // The returned string is the static slice — pointer-equal to
+            // the entry in VALID_KINDS — so equality on bytes is enough.
+            assert_eq!(interned, kind);
+        }
+    }
+
+    #[test]
+    fn intern_kind_rejects_unknown_kinds() {
+        // pyo3 PyResult requires GIL to inspect the err; we can still
+        // assert that the call returns Err without a Python interpreter
+        // attached — the error construction itself doesn't touch the GIL
+        // (only message formatting does).
+        assert!(intern_kind("").is_err());
+        assert!(intern_kind("Function").is_err()); // case-sensitive
+        assert!(intern_kind("functio").is_err());
+        assert!(intern_kind("functions").is_err());
+        assert!(intern_kind("decorator").is_err());
+    }
+
+    #[test]
+    fn node_flags_constants_are_distinct_bits() {
+        // Each flag should be a single distinct bit (or zero for NONE).
+        let flags = [
+            NodeFlags::SHADOWED,
+            NodeFlags::ENTRYPOINT,
+            NodeFlags::OVERLOAD,
+            NodeFlags::TESTCASE,
+            NodeFlags::NOQA,
+            NodeFlags::NOTEBOOK,
+            NodeFlags::EXPORTED,
+            NodeFlags::STAR_REEXPORT,
+        ];
+        assert_eq!(NodeFlags::NONE, 0);
+        for &f in &flags {
+            // Single-bit invariant.
+            assert!(f.is_power_of_two(), "flag {f} is not a single bit");
+        }
+        // All distinct.
+        let mut seen = std::collections::HashSet::new();
+        for &f in &flags {
+            assert!(seen.insert(f), "duplicate flag value {f}");
+        }
+    }
+
+    #[test]
+    fn node_flags_combine_via_bitwise_or() {
+        let combo = NodeFlags::ENTRYPOINT | NodeFlags::NOQA;
+        assert!(combo & NodeFlags::ENTRYPOINT != 0);
+        assert!(combo & NodeFlags::NOQA != 0);
+        assert!(combo & NodeFlags::TESTCASE == 0);
+    }
+
+    #[test]
+    fn edge_flags_are_distinct_bits() {
+        assert_eq!(EdgeFlags::NONE, 0);
+        assert!(EdgeFlags::DEAD_BRANCH.is_power_of_two());
+        assert!(EdgeFlags::DYNAMIC_IMPORT.is_power_of_two());
+        assert_ne!(EdgeFlags::DEAD_BRANCH, EdgeFlags::DYNAMIC_IMPORT);
+    }
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -107,14 +107,15 @@ const VALID_KINDS: &[&str] = &[
 ];
 
 pub(crate) fn intern_kind(kind: &str) -> PyResult<&'static str> {
-    for valid in VALID_KINDS {
-        if *valid == kind {
-            return Ok(*valid);
-        }
-    }
-    Err(pyo3::exceptions::PyValueError::new_err(format!(
-        "invalid SymbolNode.kind: {kind:?}"
-    )))
+    VALID_KINDS
+        .iter()
+        .find(|&&v| v == kind)
+        .copied()
+        .ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "invalid SymbolNode.kind: {kind:?} — expected one of {VALID_KINDS:?}"
+            ))
+        })
 }
 
 #[pymethods]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -24,6 +24,14 @@ use crate::graph::{DeclIndex, EdgeFlags, NodeFlags, SymbolNode};
 use crate::ingest::collapse_attribute_chain;
 use crate::project::BuildOutputs;
 
+/// Sentinel value stored in a file's local imports map (the value half
+/// of ``{local_name: target}`` returned by
+/// [`collect_module_imports_local`]) when the local binding is the
+/// module object itself (`import flask` / `import flask as f`), not a
+/// specific name from inside it. Matchers test against this exact
+/// string when classifying attribute-style decorator / call references.
+pub(crate) const MODULE_ALIAS_MARKER: &str = "<module>";
+
 pub(crate) fn is_dunder_name(fqname: &str) -> bool {
     let name = fqname.rsplit('.').next().unwrap_or("");
     name.len() > 4 && name.starts_with("__") && name.ends_with("__")
@@ -47,7 +55,7 @@ pub(crate) fn class_body_defines_method(class_def: &StmtClassDef, method_name: &
 /// * ``@<name>(...)`` / ``@<name>`` where ``imports[name]`` is in ``names``
 ///   (covers ``from module import name`` and aliased variants).
 /// * ``@<alias>.<attr>(...)`` / ``@<alias>.<attr>`` where
-///   ``imports[alias] == "<module>"`` and ``attr`` is in ``names``
+///   ``imports[alias] == MODULE_ALIAS_MARKER`` and ``attr`` is in ``names``
 ///   (covers ``import module`` and ``import module as alias``).
 pub(crate) fn decorators_match_imports<'ast>(
     decorators: &'ast [ruff_python_ast::Decorator],
@@ -69,7 +77,8 @@ pub(crate) fn decorators_match_imports<'ast>(
             }
             Expr::Attribute(attr) => {
                 if let Expr::Name(prefix) = attr.value.as_ref() {
-                    if imports.get(prefix.id.as_str()).map(String::as_str) == Some("<module>")
+                    if imports.get(prefix.id.as_str()).map(String::as_str)
+                        == Some(MODULE_ALIAS_MARKER)
                         && names.contains(attr.attr.as_str())
                     {
                         return Some(call_form);
@@ -91,10 +100,6 @@ pub(crate) fn iter_top_level_classes(
     })
 }
 
-/// Locate a class's File + name TextRange from its SymbolNode positions.
-///
-/// We don't store ty `Definition<'db>` references across plugin calls
-/// (the `'db` lifetime is tied to the active borrow), so this re-walks
 /// Locate a class's File + name TextRange from its SymbolNode positions.
 ///
 /// We don't store ty `Definition<'db>` references across plugin calls
@@ -463,8 +468,8 @@ pub(crate) fn collect_all_imports_local(parsed: &ParsedModuleRef) -> HashMap<Str
 /// Build the file-local imports map ``{local_name: target}`` for
 /// names imported from ``module``. ``target`` is the upstream
 /// constructor / decl name (e.g. ``"Flask"`` when bound via
-/// ``from flask import Flask``) or the sentinel ``"<module>"``
-/// when bound via ``import flask`` / ``import flask as f``.
+/// ``from flask import Flask``) or [`MODULE_ALIAS_MARKER`] when bound
+/// via ``import flask`` / ``import flask as f``.
 ///
 /// Only entries whose target is in ``allowed`` survive — keeps the
 /// map small and lets call-site matchers do a cheap second check.
@@ -498,7 +503,7 @@ pub(crate) fn collect_module_imports_local(
                                 continue;
                             }
                             let local = alias.asname.as_ref().map(|n| n.as_str()).unwrap_or(last);
-                            out.insert(local.to_string(), "<module>".to_string());
+                            out.insert(local.to_string(), MODULE_ALIAS_MARKER.to_string());
                         }
                     }
                 }
@@ -509,7 +514,7 @@ pub(crate) fn collect_module_imports_local(
                         continue;
                     }
                     let local = alias.asname.as_ref().map(|n| n.as_str()).unwrap_or(module);
-                    out.insert(local.to_string(), "<module>".to_string());
+                    out.insert(local.to_string(), MODULE_ALIAS_MARKER.to_string());
                 }
             }
             _ => {}
@@ -548,7 +553,7 @@ pub(crate) fn matched_call_target(
             }
             match attr.value.as_ref() {
                 Expr::Name(prefix) => (imports.get(prefix.id.as_str()).map(String::as_str)
-                    == Some("<module>"))
+                    == Some(MODULE_ALIAS_MARKER))
                 .then(|| attr_name.to_string()),
                 _ => {
                     let (root, segs) = collapse_attribute_chain(attr.value.as_ref())?;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1704,3 +1704,939 @@ pub(crate) fn module_fqname_for_file(db: &dyn ProjectDb, file: File) -> String {
         .unwrap_or(rel);
     stem.replace(['/', '\\'], ".")
 }
+
+#[cfg(test)]
+mod tests {
+    //! Pure-rust tests for the AST / string helpers.
+    //!
+    //! Anything that takes a `Python<'_>` GIL token, a `Py<SymbolNode>`,
+    //! a `Bound<'_, PyAny>`, a Salsa `ProjectDatabase`, a `File`, or a
+    //! `ParsedModuleRef` (which is also DB-backed) is intentionally NOT
+    //! covered here — the FFI surface is exercised end-to-end by the
+    //! python suite. We focus on pure functions over primitives + raw
+    //! AST nodes built from `parse_module(...)` / `parse_expression(...)`.
+    use super::*;
+    use ruff_python_parser::{parse_expression, parse_module};
+
+    fn parse_expr(source: &str) -> Box<Expr> {
+        parse_expression(source).unwrap().into_syntax().body
+    }
+
+    fn parse_stmts(source: &str) -> Vec<Stmt> {
+        parse_module(source).unwrap().into_syntax().body
+    }
+
+    // -- is_dunder_name ----------------------------------------------------
+
+    #[test]
+    fn is_dunder_name_true_for_typical_dunders() {
+        assert!(is_dunder_name("__init__"));
+        assert!(is_dunder_name("__repr__"));
+        assert!(is_dunder_name("mod.cls.__init__"));
+    }
+
+    #[test]
+    fn is_dunder_name_false_for_single_underscore() {
+        assert!(!is_dunder_name("_x"));
+        assert!(!is_dunder_name("__x"));
+        assert!(!is_dunder_name("x__"));
+    }
+
+    #[test]
+    fn is_dunder_name_false_for_short_dunder() {
+        // ``__`` and ``____`` are <= 4 chars after stripping `__` —
+        // the helper requires len() > 4 so the dunder body is at least 1 char.
+        assert!(!is_dunder_name("__"));
+        assert!(!is_dunder_name("____"));
+    }
+
+    #[test]
+    fn is_dunder_name_empty_string_ok() {
+        assert!(!is_dunder_name(""));
+        assert!(!is_dunder_name("foo.bar.baz"));
+    }
+
+    // -- rel_path ----------------------------------------------------------
+
+    #[test]
+    fn rel_path_roundtrips_unix_path() {
+        let p = rel_path("foo/bar.py");
+        assert_eq!(p.path().as_str(), "foo/bar.py");
+    }
+
+    #[test]
+    fn rel_path_handles_empty_input() {
+        // Should not panic on empty input — the `SystemPath::new` path
+        // accepts zero-length strings.
+        let p = rel_path("");
+        assert_eq!(p.path().as_str(), "");
+    }
+
+    // -- is_name / is_string_literal --------------------------------------
+
+    #[test]
+    fn is_name_matches_bare_name() {
+        let expr = parse_expr("foo");
+        assert!(is_name(&expr, "foo"));
+        assert!(!is_name(&expr, "bar"));
+    }
+
+    #[test]
+    fn is_name_rejects_non_name_exprs() {
+        let expr = parse_expr("foo.bar");
+        assert!(!is_name(&expr, "foo"));
+        assert!(!is_name(&expr, "bar"));
+        let expr = parse_expr("123");
+        assert!(!is_name(&expr, "123"));
+    }
+
+    #[test]
+    fn is_string_literal_matches_exact_value() {
+        let expr = parse_expr("'__main__'");
+        assert!(is_string_literal(&expr, "__main__"));
+        assert!(!is_string_literal(&expr, "other"));
+    }
+
+    #[test]
+    fn is_string_literal_rejects_non_string() {
+        let expr = parse_expr("123");
+        assert!(!is_string_literal(&expr, "123"));
+        let expr = parse_expr("foo");
+        assert!(!is_string_literal(&expr, "foo"));
+    }
+
+    // -- is_name_eq_main --------------------------------------------------
+
+    #[test]
+    fn is_name_eq_main_matches_both_orderings() {
+        let a = parse_expr("__name__ == '__main__'");
+        let b = parse_expr("'__main__' == __name__");
+        assert!(is_name_eq_main(&a));
+        assert!(is_name_eq_main(&b));
+    }
+
+    #[test]
+    fn is_name_eq_main_rejects_wrong_constant() {
+        let expr = parse_expr("__name__ == 'main'");
+        assert!(!is_name_eq_main(&expr));
+    }
+
+    #[test]
+    fn is_name_eq_main_rejects_other_comparisons() {
+        // !=, multiple comparators, non-name LHS, non-string RHS, etc.
+        assert!(!is_name_eq_main(&parse_expr("__name__ != '__main__'")));
+        assert!(!is_name_eq_main(&parse_expr("x == y == z")));
+        assert!(!is_name_eq_main(&parse_expr("foo == '__main__'")));
+        assert!(!is_name_eq_main(&parse_expr("123 == 456")));
+    }
+
+    // -- top_level_assign_to_name -----------------------------------------
+
+    #[test]
+    fn top_level_assign_to_name_matches_simple_assignment() {
+        let stmts = parse_stmts("x = 42\n");
+        let got = top_level_assign_to_name(&stmts[0]);
+        assert!(got.is_some());
+        let (_, expr) = got.unwrap();
+        assert!(matches!(expr, Expr::NumberLiteral(_)));
+    }
+
+    #[test]
+    fn top_level_assign_to_name_matches_ann_assignment() {
+        let stmts = parse_stmts("x: int = 42\n");
+        let got = top_level_assign_to_name(&stmts[0]);
+        assert!(got.is_some());
+    }
+
+    #[test]
+    fn top_level_assign_to_name_rejects_tuple_target() {
+        let stmts = parse_stmts("x, y = 1, 2\n");
+        assert!(top_level_assign_to_name(&stmts[0]).is_none());
+    }
+
+    #[test]
+    fn top_level_assign_to_name_rejects_attribute_target() {
+        let stmts = parse_stmts("obj.attr = 1\n");
+        assert!(top_level_assign_to_name(&stmts[0]).is_none());
+    }
+
+    #[test]
+    fn top_level_assign_to_name_rejects_ann_without_value() {
+        let stmts = parse_stmts("x: int\n");
+        assert!(top_level_assign_to_name(&stmts[0]).is_none());
+    }
+
+    #[test]
+    fn top_level_assign_to_name_rejects_non_assign() {
+        let stmts = parse_stmts("def foo(): pass\n");
+        assert!(top_level_assign_to_name(&stmts[0]).is_none());
+    }
+
+    // -- class_body_defines_method -----------------------------------------
+
+    #[test]
+    fn class_body_defines_method_finds_named_method() {
+        let stmts = parse_stmts("class C:\n    def m(self): pass\n    def n(self): pass\n");
+        let cls = match &stmts[0] {
+            Stmt::ClassDef(c) => c,
+            _ => unreachable!(),
+        };
+        assert!(class_body_defines_method(cls, "m"));
+        assert!(class_body_defines_method(cls, "n"));
+        assert!(!class_body_defines_method(cls, "missing"));
+    }
+
+    #[test]
+    fn class_body_defines_method_ignores_non_function_members() {
+        let stmts = parse_stmts("class C:\n    x = 1\n    class Inner: pass\n");
+        let cls = match &stmts[0] {
+            Stmt::ClassDef(c) => c,
+            _ => unreachable!(),
+        };
+        assert!(!class_body_defines_method(cls, "x"));
+        assert!(!class_body_defines_method(cls, "Inner"));
+    }
+
+    // -- nth_positional_string --------------------------------------------
+
+    fn first_call(source: &str) -> ruff_python_ast::ExprCall {
+        let expr = parse_expr(source);
+        match *expr {
+            Expr::Call(c) => c,
+            _ => panic!("expected a call expression"),
+        }
+    }
+
+    #[test]
+    fn nth_positional_string_returns_literal_value() {
+        let call = first_call("f('hello', 'world')");
+        assert_eq!(nth_positional_string(&call, 0), Some("hello".to_string()));
+        assert_eq!(nth_positional_string(&call, 1), Some("world".to_string()));
+    }
+
+    #[test]
+    fn nth_positional_string_returns_none_for_non_string() {
+        let call = first_call("f(42, foo)");
+        assert_eq!(nth_positional_string(&call, 0), None);
+        assert_eq!(nth_positional_string(&call, 1), None);
+    }
+
+    #[test]
+    fn nth_positional_string_out_of_range_returns_none() {
+        let call = first_call("f('a')");
+        assert_eq!(nth_positional_string(&call, 5), None);
+    }
+
+    #[test]
+    fn nth_positional_string_rejects_f_string() {
+        // f-strings are not StringLiteral nodes — should be rejected.
+        let call = first_call("f(f'value-{x}')");
+        assert_eq!(nth_positional_string(&call, 0), None);
+    }
+
+    // -- call_callee_matches_var ------------------------------------------
+
+    #[test]
+    fn call_callee_matches_var_matches_owner_attr() {
+        let call = first_call("mocker.patch('x')");
+        assert!(call_callee_matches_var(&call, "mocker", "patch", None));
+        assert!(call_callee_matches_var(&call, "mocker", "patch", Some(1)));
+        assert!(!call_callee_matches_var(&call, "mocker", "patch", Some(2)));
+    }
+
+    #[test]
+    fn call_callee_matches_var_rejects_wrong_owner_or_attr() {
+        let call = first_call("mocker.patch('x')");
+        assert!(!call_callee_matches_var(&call, "other", "patch", None));
+        assert!(!call_callee_matches_var(&call, "mocker", "spy", None));
+    }
+
+    #[test]
+    fn call_callee_matches_var_rejects_non_attribute_callee() {
+        let call = first_call("f('x')");
+        assert!(!call_callee_matches_var(&call, "f", "patch", None));
+    }
+
+    #[test]
+    fn call_callee_matches_var_rejects_chained_receiver() {
+        // ``a.b.patch(...)`` has ``a.b`` (Attribute) as the receiver, not
+        // a bare Name — should not match.
+        let call = first_call("a.b.patch('x')");
+        assert!(!call_callee_matches_var(&call, "b", "patch", None));
+    }
+
+    // -- range_key ---------------------------------------------------------
+
+    #[test]
+    fn range_key_packs_start_end() {
+        use ruff_text_size::TextSize;
+        let range = TextRange::new(TextSize::from(5), TextSize::from(12));
+        assert_eq!(range_key(range), (5, 12));
+    }
+
+    // -- arg_value_eq_literal ---------------------------------------------
+
+    #[test]
+    fn arg_value_eq_literal_compares_simple_scalars() {
+        assert!(arg_value_eq_literal(&ArgValue::None, &ArgValue::None));
+        assert!(arg_value_eq_literal(
+            &ArgValue::Bool(true),
+            &ArgValue::Bool(true)
+        ));
+        assert!(!arg_value_eq_literal(
+            &ArgValue::Bool(true),
+            &ArgValue::Bool(false)
+        ));
+        assert!(arg_value_eq_literal(&ArgValue::Int(42), &ArgValue::Int(42)));
+        assert!(arg_value_eq_literal(
+            &ArgValue::Str("hi".into()),
+            &ArgValue::Str("hi".into())
+        ));
+        assert!(!arg_value_eq_literal(
+            &ArgValue::Str("hi".into()),
+            &ArgValue::Str("ho".into())
+        ));
+    }
+
+    #[test]
+    fn arg_value_eq_literal_int_float_cross_compares() {
+        // The helper opts into mixed int/float equality (ergonomic match).
+        assert!(arg_value_eq_literal(
+            &ArgValue::Int(5),
+            &ArgValue::Float(5.0)
+        ));
+        assert!(arg_value_eq_literal(
+            &ArgValue::Float(5.0),
+            &ArgValue::Int(5)
+        ));
+        assert!(!arg_value_eq_literal(
+            &ArgValue::Int(5),
+            &ArgValue::Float(5.5)
+        ));
+    }
+
+    #[test]
+    fn arg_value_eq_literal_unknown_never_matches() {
+        assert!(!arg_value_eq_literal(
+            &ArgValue::Unknown,
+            &ArgValue::Unknown
+        ));
+        assert!(!arg_value_eq_literal(&ArgValue::Unknown, &ArgValue::None));
+    }
+
+    #[test]
+    fn arg_value_eq_literal_list_tuple_interchangeable() {
+        let list = ArgValue::List(vec![ArgValue::Int(1), ArgValue::Int(2)]);
+        let tup = ArgValue::Tuple(vec![ArgValue::Int(1), ArgValue::Int(2)]);
+        let diff = ArgValue::List(vec![ArgValue::Int(1), ArgValue::Int(3)]);
+        let short = ArgValue::List(vec![ArgValue::Int(1)]);
+        assert!(arg_value_eq_literal(&list, &tup));
+        assert!(arg_value_eq_literal(&tup, &list));
+        assert!(!arg_value_eq_literal(&list, &diff));
+        assert!(!arg_value_eq_literal(&list, &short));
+    }
+
+    #[test]
+    fn arg_value_eq_literal_mixed_types_rejected() {
+        assert!(!arg_value_eq_literal(
+            &ArgValue::Int(0),
+            &ArgValue::Bool(false)
+        ));
+        assert!(!arg_value_eq_literal(&ArgValue::None, &ArgValue::Int(0)));
+        assert!(!arg_value_eq_literal(
+            &ArgValue::Str("".into()),
+            &ArgValue::List(vec![])
+        ));
+    }
+
+    // -- evaluate_truthiness ----------------------------------------------
+
+    #[test]
+    fn evaluate_truthiness_literals() {
+        let empty: NameTable = HashMap::new();
+        assert_eq!(evaluate_truthiness(&parse_expr("True"), &empty), Some(true));
+        assert_eq!(
+            evaluate_truthiness(&parse_expr("False"), &empty),
+            Some(false)
+        );
+        assert_eq!(
+            evaluate_truthiness(&parse_expr("None"), &empty),
+            Some(false)
+        );
+        assert_eq!(evaluate_truthiness(&parse_expr("..."), &empty), Some(true));
+        assert_eq!(evaluate_truthiness(&parse_expr("0"), &empty), Some(false));
+        assert_eq!(evaluate_truthiness(&parse_expr("1"), &empty), Some(true));
+        assert_eq!(evaluate_truthiness(&parse_expr("0.0"), &empty), Some(false));
+        assert_eq!(evaluate_truthiness(&parse_expr("3.14"), &empty), Some(true));
+        assert_eq!(evaluate_truthiness(&parse_expr("''"), &empty), Some(false));
+        assert_eq!(evaluate_truthiness(&parse_expr("'x'"), &empty), Some(true));
+        assert_eq!(evaluate_truthiness(&parse_expr("[]"), &empty), Some(false));
+        assert_eq!(evaluate_truthiness(&parse_expr("[1]"), &empty), Some(true));
+        assert_eq!(evaluate_truthiness(&parse_expr("()"), &empty), Some(false));
+        assert_eq!(evaluate_truthiness(&parse_expr("(1,)"), &empty), Some(true));
+        assert_eq!(evaluate_truthiness(&parse_expr("{}"), &empty), Some(false));
+        assert_eq!(
+            evaluate_truthiness(&parse_expr("{'a': 1}"), &empty),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn evaluate_truthiness_names_via_table() {
+        let mut table: NameTable = HashMap::new();
+        table.insert("DEBUG".into(), true);
+        table.insert("RELEASE".into(), false);
+        assert_eq!(
+            evaluate_truthiness(&parse_expr("DEBUG"), &table),
+            Some(true)
+        );
+        assert_eq!(
+            evaluate_truthiness(&parse_expr("RELEASE"), &table),
+            Some(false)
+        );
+        assert_eq!(evaluate_truthiness(&parse_expr("OTHER"), &table), None);
+    }
+
+    #[test]
+    fn evaluate_truthiness_unary_not() {
+        let empty: NameTable = HashMap::new();
+        assert_eq!(
+            evaluate_truthiness(&parse_expr("not True"), &empty),
+            Some(false)
+        );
+        assert_eq!(
+            evaluate_truthiness(&parse_expr("not False"), &empty),
+            Some(true)
+        );
+        assert_eq!(
+            evaluate_truthiness(&parse_expr("not unknown_name"), &empty),
+            None
+        );
+        // Other unary ops aren't folded.
+        assert_eq!(evaluate_truthiness(&parse_expr("-1"), &empty), None);
+    }
+
+    #[test]
+    fn evaluate_truthiness_bool_ops_short_circuit_or() {
+        let empty: NameTable = HashMap::new();
+        assert_eq!(
+            evaluate_truthiness(&parse_expr("True or unknown"), &empty),
+            Some(true)
+        );
+        assert_eq!(
+            evaluate_truthiness(&parse_expr("False or unknown"), &empty),
+            None
+        );
+        assert_eq!(
+            evaluate_truthiness(&parse_expr("False or False"), &empty),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn evaluate_truthiness_bool_ops_short_circuit_and() {
+        let empty: NameTable = HashMap::new();
+        assert_eq!(
+            evaluate_truthiness(&parse_expr("False and unknown"), &empty),
+            Some(false)
+        );
+        assert_eq!(
+            evaluate_truthiness(&parse_expr("True and unknown"), &empty),
+            None
+        );
+        assert_eq!(
+            evaluate_truthiness(&parse_expr("True and True"), &empty),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn evaluate_truthiness_returns_none_for_unsupported() {
+        let empty: NameTable = HashMap::new();
+        assert_eq!(evaluate_truthiness(&parse_expr("f()"), &empty), None);
+        assert_eq!(evaluate_truthiness(&parse_expr("a.b"), &empty), None);
+        assert_eq!(evaluate_truthiness(&parse_expr("a == b"), &empty), None);
+    }
+
+    #[test]
+    fn evaluate_truthiness_walrus_unwraps_value() {
+        let empty: NameTable = HashMap::new();
+        // ``(x := True)`` should fold to True (the walrus's value).
+        assert_eq!(
+            evaluate_truthiness(&parse_expr("(x := True)"), &empty),
+            Some(true)
+        );
+    }
+
+    // -- stmt_is_terminator / suite_terminates ----------------------------
+
+    #[test]
+    fn stmt_is_terminator_basic_terminators() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("def f():\n    return 1\n");
+        let body = match &stmts[0] {
+            Stmt::FunctionDef(f) => &f.body,
+            _ => unreachable!(),
+        };
+        assert!(stmt_is_terminator(&body[0], &empty));
+
+        let stmts = parse_stmts("def f():\n    raise X\n");
+        let body = match &stmts[0] {
+            Stmt::FunctionDef(f) => &f.body,
+            _ => unreachable!(),
+        };
+        assert!(stmt_is_terminator(&body[0], &empty));
+    }
+
+    #[test]
+    fn stmt_is_terminator_break_continue_inside_loop() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("for _ in []:\n    break\n");
+        let body = match &stmts[0] {
+            Stmt::For(f) => &f.body,
+            _ => unreachable!(),
+        };
+        assert!(stmt_is_terminator(&body[0], &empty));
+
+        let stmts = parse_stmts("for _ in []:\n    continue\n");
+        let body = match &stmts[0] {
+            Stmt::For(f) => &f.body,
+            _ => unreachable!(),
+        };
+        assert!(stmt_is_terminator(&body[0], &empty));
+    }
+
+    #[test]
+    fn stmt_is_terminator_assert_falsy() {
+        let empty: NameTable = HashMap::new();
+        // `assert False` is a terminator; `assert True` is not.
+        let stmts = parse_stmts("assert False\n");
+        assert!(stmt_is_terminator(&stmts[0], &empty));
+        let stmts = parse_stmts("assert True\n");
+        assert!(!stmt_is_terminator(&stmts[0], &empty));
+        let stmts = parse_stmts("assert 0\n");
+        assert!(stmt_is_terminator(&stmts[0], &empty));
+        let stmts = parse_stmts("assert unknown_var\n");
+        assert!(!stmt_is_terminator(&stmts[0], &empty));
+    }
+
+    #[test]
+    fn stmt_is_terminator_if_constant_truthy_body_terminates() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("if True:\n    return\n");
+        assert!(stmt_is_terminator(&stmts[0], &empty));
+    }
+
+    #[test]
+    fn stmt_is_terminator_if_without_else_not_terminator() {
+        let empty: NameTable = HashMap::new();
+        // No else clause + a non-constant test means the if might be
+        // skipped — not a terminator.
+        let stmts = parse_stmts("if cond:\n    return\n");
+        assert!(!stmt_is_terminator(&stmts[0], &empty));
+    }
+
+    #[test]
+    fn stmt_is_terminator_if_else_both_terminate() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("if cond:\n    return\nelse:\n    raise X\n");
+        assert!(stmt_is_terminator(&stmts[0], &empty));
+    }
+
+    #[test]
+    fn stmt_is_terminator_if_else_one_falls_through() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("if cond:\n    return\nelse:\n    pass\n");
+        assert!(!stmt_is_terminator(&stmts[0], &empty));
+    }
+
+    #[test]
+    fn stmt_is_terminator_try_finally_terminates() {
+        let empty: NameTable = HashMap::new();
+        let stmts =
+            parse_stmts("try:\n    x = 1\nexcept Exception:\n    pass\nfinally:\n    return\n");
+        assert!(stmt_is_terminator(&stmts[0], &empty));
+    }
+
+    #[test]
+    fn stmt_is_terminator_try_body_and_all_handlers_terminate() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("try:\n    return\nexcept Exception:\n    raise\n");
+        assert!(stmt_is_terminator(&stmts[0], &empty));
+    }
+
+    #[test]
+    fn stmt_is_terminator_try_handler_falls_through_not_terminator() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("try:\n    return\nexcept Exception:\n    pass\n");
+        assert!(!stmt_is_terminator(&stmts[0], &empty));
+    }
+
+    #[test]
+    fn stmt_is_terminator_with_body_terminates() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("with cm as c:\n    return\n");
+        assert!(stmt_is_terminator(&stmts[0], &empty));
+        let stmts = parse_stmts("with cm as c:\n    pass\n");
+        assert!(!stmt_is_terminator(&stmts[0], &empty));
+    }
+
+    #[test]
+    fn stmt_is_terminator_pass_is_not() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("pass\n");
+        assert!(!stmt_is_terminator(&stmts[0], &empty));
+    }
+
+    #[test]
+    fn suite_terminates_finds_any_terminator() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("def f():\n    x = 1\n    return 2\n    y = 3\n");
+        let body = match &stmts[0] {
+            Stmt::FunctionDef(f) => &f.body,
+            _ => unreachable!(),
+        };
+        assert!(suite_terminates(body, &empty));
+
+        let stmts = parse_stmts("def f():\n    x = 1\n    y = 2\n");
+        let body = match &stmts[0] {
+            Stmt::FunctionDef(f) => &f.body,
+            _ => unreachable!(),
+        };
+        assert!(!suite_terminates(body, &empty));
+    }
+
+    // -- walk_suite_for_dead / detect_dead_ranges (via module body) -------
+
+    #[test]
+    fn walk_suite_for_dead_marks_post_terminator_statements() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("def f():\n    return 1\n    x = 2\n    y = 3\n");
+        let body = match &stmts[0] {
+            Stmt::FunctionDef(f) => f.body.clone(),
+            _ => unreachable!(),
+        };
+        let mut dead = Vec::new();
+        walk_suite_for_dead(&body, &empty, &mut dead);
+        // x = 2 and y = 3 should both be marked.
+        assert_eq!(dead.len(), 2);
+    }
+
+    #[test]
+    fn walk_suite_for_dead_handles_if_false() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("if False:\n    x = 1\n    y = 2\n");
+        let mut dead = Vec::new();
+        walk_suite_for_dead(&stmts, &empty, &mut dead);
+        // Both statements in the False body are marked individually.
+        assert_eq!(dead.len(), 2);
+    }
+
+    #[test]
+    fn walk_suite_for_dead_handles_if_true_drops_else() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("if True:\n    x = 1\nelse:\n    y = 2\n");
+        let mut dead = Vec::new();
+        walk_suite_for_dead(&stmts, &empty, &mut dead);
+        // The else clause is dead.
+        assert_eq!(dead.len(), 1);
+    }
+
+    #[test]
+    fn walk_suite_for_dead_recurses_into_function_body() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("def outer():\n    return\n    nested = 1\n");
+        let mut dead = Vec::new();
+        walk_suite_for_dead(&stmts, &empty, &mut dead);
+        assert_eq!(dead.len(), 1);
+    }
+
+    #[test]
+    fn walk_suite_for_dead_empty_input_yields_nothing() {
+        let empty: NameTable = HashMap::new();
+        let mut dead = Vec::new();
+        walk_suite_for_dead(&[], &empty, &mut dead);
+        assert!(dead.is_empty());
+    }
+
+    // -- build_scope_table / collect_scope_bindings -----------------------
+
+    #[test]
+    fn build_scope_table_folds_simple_constant() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("DEBUG = True\nX = False\n");
+        let table = build_scope_table(&stmts, &empty);
+        assert_eq!(table.get("DEBUG"), Some(&true));
+        assert_eq!(table.get("X"), Some(&false));
+    }
+
+    #[test]
+    fn build_scope_table_handles_chained_constants() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("A = False\nB = A or False\nC = B\n");
+        let table = build_scope_table(&stmts, &empty);
+        assert_eq!(table.get("A"), Some(&false));
+        assert_eq!(table.get("B"), Some(&false));
+        assert_eq!(table.get("C"), Some(&false));
+    }
+
+    #[test]
+    fn build_scope_table_drops_conflicting_bindings() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("X = True\nX = False\n");
+        let table = build_scope_table(&stmts, &empty);
+        assert!(!table.contains_key("X"));
+    }
+
+    #[test]
+    fn build_scope_table_inherits_enclosing_table() {
+        let mut enclosing: NameTable = HashMap::new();
+        enclosing.insert("OUTER".into(), true);
+        let stmts = parse_stmts("INNER = False\n");
+        let table = build_scope_table(&stmts, &enclosing);
+        assert_eq!(table.get("OUTER"), Some(&true));
+        assert_eq!(table.get("INNER"), Some(&false));
+    }
+
+    #[test]
+    fn build_scope_table_ignores_nested_function_bindings() {
+        let empty: NameTable = HashMap::new();
+        let stmts = parse_stmts("def f():\n    X = True\n");
+        let table = build_scope_table(&stmts, &empty);
+        // ``X`` is defined inside ``f`` — separate scope.
+        assert!(!table.contains_key("X"));
+    }
+
+    // -- collect_walrus_in_expr -------------------------------------------
+
+    #[test]
+    fn collect_walrus_in_expr_picks_up_assignment_target() {
+        let expr = parse_expr("(x := 5)");
+        let mut out: HashMap<String, Vec<&Expr>> = HashMap::new();
+        collect_walrus_in_expr(&expr, &mut out);
+        assert!(out.contains_key("x"));
+    }
+
+    #[test]
+    fn collect_walrus_in_expr_descends_compound_exprs() {
+        let expr = parse_expr("(a := 1) or (b := 2) and (c := 3)");
+        let mut out: HashMap<String, Vec<&Expr>> = HashMap::new();
+        collect_walrus_in_expr(&expr, &mut out);
+        assert!(out.contains_key("a"));
+        assert!(out.contains_key("b"));
+        assert!(out.contains_key("c"));
+    }
+
+    #[test]
+    fn collect_walrus_in_expr_no_walrus_yields_empty() {
+        let expr = parse_expr("a + b");
+        let mut out: HashMap<String, Vec<&Expr>> = HashMap::new();
+        collect_walrus_in_expr(&expr, &mut out);
+        assert!(out.is_empty());
+    }
+
+    // -- noqa helpers (extending the existing parse_noqa_tail tests) ------
+
+    #[test]
+    fn parse_noqa_tail_case_insensitive_prefix() {
+        assert_eq!(parse_noqa_tail("noqa"), Some(NoqaKind::Bare));
+        assert_eq!(parse_noqa_tail("NoQa"), Some(NoqaKind::Bare));
+        assert_eq!(parse_noqa_tail("nOqA"), Some(NoqaKind::Bare));
+    }
+
+    #[test]
+    fn parse_noqa_tail_rejects_non_noqa_comment() {
+        assert_eq!(parse_noqa_tail("type: ignore"), None);
+        assert_eq!(parse_noqa_tail("comment about noqa"), None);
+    }
+
+    #[test]
+    fn parse_noqa_tail_codes_are_trimmed_and_case_insensitive() {
+        assert_eq!(parse_noqa_tail("noqa: f401"), Some(NoqaKind::F401Present));
+        assert_eq!(
+            parse_noqa_tail("noqa:  F401  ,  E501"),
+            Some(NoqaKind::F401Present)
+        );
+        assert_eq!(
+            parse_noqa_tail("noqa: E501,  E502"),
+            Some(NoqaKind::OtherOnly)
+        );
+    }
+
+    #[test]
+    fn parse_noqa_tail_handles_leading_whitespace() {
+        assert_eq!(
+            parse_noqa_tail("    noqa: F401"),
+            Some(NoqaKind::F401Present)
+        );
+    }
+
+    #[test]
+    fn is_per_line_pin_basic() {
+        assert!(is_per_line_pin(" noqa"));
+        assert!(is_per_line_pin(" noqa: F401"));
+        assert!(is_per_line_pin(" noqa: E501, F401"));
+        assert!(!is_per_line_pin(" noqa: E501"));
+        assert!(!is_per_line_pin(" type: ignore"));
+        assert!(!is_per_line_pin(""));
+    }
+
+    #[test]
+    fn is_file_pin_recognizes_ruff_and_flake8_prefixes() {
+        assert!(is_file_pin(" ruff: noqa"));
+        assert!(is_file_pin(" ruff: noqa: F401"));
+        assert!(is_file_pin(" flake8: noqa"));
+        assert!(is_file_pin(" flake8: noqa: F401"));
+    }
+
+    #[test]
+    fn is_file_pin_other_codes_dont_pin_f401() {
+        assert!(!is_file_pin(" ruff: noqa: E501"));
+        assert!(!is_file_pin(" flake8: noqa: W292, E303"));
+    }
+
+    #[test]
+    fn is_file_pin_unrelated_comments_rejected() {
+        assert!(!is_file_pin(" pyright: ignore"));
+        assert!(!is_file_pin(" type: ignore"));
+        assert!(!is_file_pin(" noqa"));
+        assert!(!is_file_pin(""));
+    }
+
+    #[test]
+    fn is_file_pin_prefix_is_case_sensitive() {
+        // ``ruff:`` / ``flake8:`` are matched case-sensitively per ruff's docs.
+        assert!(!is_file_pin(" Ruff: noqa"));
+        assert!(!is_file_pin(" FLAKE8: noqa"));
+    }
+
+    // -- decorators_match_imports -----------------------------------------
+
+    #[test]
+    fn decorators_match_imports_via_local_alias() {
+        let stmts = parse_stmts("@register\ndef f(): pass\n");
+        let decorators = match &stmts[0] {
+            Stmt::FunctionDef(f) => &f.decorator_list,
+            _ => unreachable!(),
+        };
+        let mut imports: HashMap<String, String> = HashMap::new();
+        imports.insert("register".into(), "register".into());
+        let mut allowed: HashSet<&str> = HashSet::new();
+        allowed.insert("register");
+        let got = decorators_match_imports(decorators, &imports, &allowed);
+        assert!(got.is_some());
+    }
+
+    #[test]
+    fn decorators_match_imports_via_module_attr() {
+        let stmts = parse_stmts("@flask.route('/x')\ndef f(): pass\n");
+        let decorators = match &stmts[0] {
+            Stmt::FunctionDef(f) => &f.decorator_list,
+            _ => unreachable!(),
+        };
+        let mut imports: HashMap<String, String> = HashMap::new();
+        imports.insert("flask".into(), MODULE_ALIAS_MARKER.into());
+        let mut allowed: HashSet<&str> = HashSet::new();
+        allowed.insert("route");
+        let got = decorators_match_imports(decorators, &imports, &allowed);
+        // Has a call form.
+        assert!(matches!(got, Some(Some(_))));
+    }
+
+    #[test]
+    fn decorators_match_imports_bare_attribute() {
+        let stmts = parse_stmts("@app.task\ndef f(): pass\n");
+        let decorators = match &stmts[0] {
+            Stmt::FunctionDef(f) => &f.decorator_list,
+            _ => unreachable!(),
+        };
+        let mut imports: HashMap<String, String> = HashMap::new();
+        imports.insert("app".into(), MODULE_ALIAS_MARKER.into());
+        let mut allowed: HashSet<&str> = HashSet::new();
+        allowed.insert("task");
+        let got = decorators_match_imports(decorators, &imports, &allowed);
+        // Bare (no call) — outer Some, inner None.
+        assert!(matches!(got, Some(None)));
+    }
+
+    #[test]
+    fn decorators_match_imports_returns_none_when_no_match() {
+        let stmts = parse_stmts("@other\ndef f(): pass\n");
+        let decorators = match &stmts[0] {
+            Stmt::FunctionDef(f) => &f.decorator_list,
+            _ => unreachable!(),
+        };
+        let imports: HashMap<String, String> = HashMap::new();
+        let allowed: HashSet<&str> = HashSet::new();
+        assert!(decorators_match_imports(decorators, &imports, &allowed).is_none());
+    }
+
+    // -- matched_call_target ----------------------------------------------
+
+    #[test]
+    fn matched_call_target_via_local_name() {
+        let call = first_call("Flask(__name__)");
+        let mut imports: HashMap<String, String> = HashMap::new();
+        imports.insert("Flask".into(), "Flask".into());
+        let mut allowed: HashSet<&str> = HashSet::new();
+        allowed.insert("Flask");
+        assert_eq!(
+            matched_call_target(&call, &imports, "flask", &allowed),
+            Some("Flask".into())
+        );
+    }
+
+    #[test]
+    fn matched_call_target_via_module_alias_attr() {
+        let call = first_call("flask.Flask(__name__)");
+        let mut imports: HashMap<String, String> = HashMap::new();
+        imports.insert("flask".into(), MODULE_ALIAS_MARKER.into());
+        let mut allowed: HashSet<&str> = HashSet::new();
+        allowed.insert("Flask");
+        assert_eq!(
+            matched_call_target(&call, &imports, "flask", &allowed),
+            Some("Flask".into())
+        );
+    }
+
+    #[test]
+    fn matched_call_target_via_multi_seg_module() {
+        let call = first_call("unittest.mock.patch('x')");
+        // No file imports entry for the leftmost name — fallback to the
+        // literal dotted match against ``module``.
+        let imports: HashMap<String, String> = HashMap::new();
+        let mut allowed: HashSet<&str> = HashSet::new();
+        allowed.insert("patch");
+        assert_eq!(
+            matched_call_target(&call, &imports, "unittest.mock", &allowed),
+            Some("patch".into())
+        );
+    }
+
+    #[test]
+    fn matched_call_target_rejects_unknown_name() {
+        let call = first_call("unrelated()");
+        let imports: HashMap<String, String> = HashMap::new();
+        let allowed: HashSet<&str> = HashSet::new();
+        assert!(matched_call_target(&call, &imports, "x", &allowed).is_none());
+    }
+
+    #[test]
+    fn matched_call_target_rejects_disallowed_name() {
+        let call = first_call("Flask()");
+        let mut imports: HashMap<String, String> = HashMap::new();
+        imports.insert("Flask".into(), "Flask".into());
+        // Empty allowed set: target is present but not allowed.
+        let allowed: HashSet<&str> = HashSet::new();
+        assert!(matched_call_target(&call, &imports, "flask", &allowed).is_none());
+    }
+
+    // -- NoqaKind helper --------------------------------------------------
+
+    #[test]
+    fn noqakind_pins_f401() {
+        assert!(NoqaKind::Bare.pins_f401());
+        assert!(NoqaKind::F401Present.pins_f401());
+        assert!(!NoqaKind::OtherOnly.pins_f401());
+    }
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1046,27 +1046,7 @@ impl<'ast, 'a> Visitor<'ast> for AttrCallFinder<'a> {
             if let Expr::Attribute(attribute) = call.func.as_ref() {
                 if attribute.attr.as_str() == self.attr {
                     if let Some(arg) = call.arguments.args.get(self.arg_index) {
-                        let mut hits: Vec<String> = Vec::new();
-                        match arg {
-                            Expr::StringLiteral(s) => {
-                                hits.push(s.value.to_str().to_string());
-                            }
-                            Expr::List(list) => {
-                                for elt in &list.elts {
-                                    if let Expr::StringLiteral(s) = elt {
-                                        hits.push(s.value.to_str().to_string());
-                                    }
-                                }
-                            }
-                            Expr::Tuple(tup) => {
-                                for elt in &tup.elts {
-                                    if let Expr::StringLiteral(s) = elt {
-                                        hits.push(s.value.to_str().to_string());
-                                    }
-                                }
-                            }
-                            _ => {}
-                        }
+                        let hits = string_or_string_collection(arg);
                         if !hits.is_empty() {
                             let call_args = extract_call_args_kwargs(
                                 call,
@@ -1082,6 +1062,23 @@ impl<'ast, 'a> Visitor<'ast> for AttrCallFinder<'a> {
             }
         }
         walk_expr(self, expr);
+    }
+}
+
+/// Pull string-literal values out of either a single ``"..."`` or a
+/// homogeneous list/tuple of string literals. Non-string elements in a
+/// list/tuple are silently dropped; non-matching expressions yield an
+/// empty vec.
+fn string_or_string_collection(arg: &Expr) -> Vec<String> {
+    let lit = |e: &Expr| match e {
+        Expr::StringLiteral(s) => Some(s.value.to_str().to_string()),
+        _ => None,
+    };
+    match arg {
+        Expr::StringLiteral(s) => vec![s.value.to_str().to_string()],
+        Expr::List(list) => list.elts.iter().filter_map(lit).collect(),
+        Expr::Tuple(tup) => tup.elts.iter().filter_map(lit).collect(),
+        _ => Vec::new(),
     }
 }
 

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -617,6 +617,23 @@ pub(crate) enum ImportTarget {
     Unresolved(String),
 }
 
+impl ImportTarget {
+    /// Synthetic node fqname for the non-first-party variants, or
+    /// `None` for `Stdlib` / `FirstParty`. Single source of truth for
+    /// the ``[external dist] X`` / ``[external file] X`` /
+    /// ``[unresolved] X`` synthetic prefixes — both mint
+    /// (``target_to_node``) and lookup (``emit_upstream``) go through
+    /// this so the format strings can't drift apart.
+    pub(crate) fn synthetic_fqname(&self) -> Option<String> {
+        match self {
+            ImportTarget::Stdlib | ImportTarget::FirstParty(_) => None,
+            ImportTarget::ExternalDist(name) => Some(format!("[external dist] {name}")),
+            ImportTarget::ExternalFile(name) => Some(format!("[external file] {name}")),
+            ImportTarget::Unresolved(name) => Some(format!("[unresolved] {name}")),
+        }
+    }
+}
+
 /// ``abs_file_path -> PEP 503-canonical dist name``. Populated once
 /// per ``materialize`` call by walking every ``*.dist-info/`` directory
 /// under each ``is_site_packages()`` search path that ty knows about
@@ -811,15 +828,12 @@ pub(crate) fn target_to_node(
         ImportTarget::FirstParty(file) => {
             Ok(Some(mint_module_node(py, db, file, builder, module_nodes)?))
         }
-        ImportTarget::ExternalDist(name) => Ok(Some(
-            builder.intern_synthetic(py, format!("[external dist] {name}"))?,
-        )),
-        ImportTarget::ExternalFile(name) => Ok(Some(
-            builder.intern_synthetic(py, format!("[external file] {name}"))?,
-        )),
-        ImportTarget::Unresolved(top) => Ok(Some(
-            builder.intern_synthetic(py, format!("[unresolved] {top}"))?,
-        )),
+        ref t @ (ImportTarget::ExternalDist(_)
+        | ImportTarget::ExternalFile(_)
+        | ImportTarget::Unresolved(_)) => {
+            let fqname = t.synthetic_fqname().expect("non-stdlib non-first-party");
+            Ok(Some(builder.intern_synthetic(py, fqname)?))
+        }
     }
 }
 
@@ -1829,21 +1843,13 @@ impl<'a, 'db> RefCollector<'a, 'db> {
         let start_file = match target {
             ImportTarget::Stdlib => return,
             ImportTarget::FirstParty(f) => f,
-            ImportTarget::ExternalDist(name) => {
-                if let Some(&idx) = self.synthetic_nodes.get(&format!("[external dist] {name}")) {
-                    self.emit_edge(idx);
-                }
-                return;
-            }
-            ImportTarget::ExternalFile(name) => {
-                if let Some(&idx) = self.synthetic_nodes.get(&format!("[external file] {name}")) {
-                    self.emit_edge(idx);
-                }
-                return;
-            }
-            ImportTarget::Unresolved(top) => {
-                if let Some(&idx) = self.synthetic_nodes.get(&format!("[unresolved] {top}")) {
-                    self.emit_edge(idx);
+            t @ (ImportTarget::ExternalDist(_)
+            | ImportTarget::ExternalFile(_)
+            | ImportTarget::Unresolved(_)) => {
+                if let Some(fqname) = t.synthetic_fqname() {
+                    if let Some(&idx) = self.synthetic_nodes.get(&fqname) {
+                        self.emit_edge(idx);
+                    }
                 }
                 return;
             }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1106,6 +1106,20 @@ pub(crate) fn emit_reference_edges(
     // this phase and isn't mutated here, so swap-out / swap-in is safe.
     let synthetic_nodes = std::mem::take(&mut builder.synthetic_nodes);
 
+    let inputs = RefCollectorInputs {
+        model: &model,
+        file,
+        parsed: &parsed,
+        index,
+        global_index,
+        module_nodes,
+        alias_imports,
+        live_decls,
+        synthetic_nodes: &synthetic_nodes,
+        dist_lookup,
+        dead_ranges: &dead_ranges,
+    };
+
     // (a) Definitions that own an expression / body — attribute their
     //     contained Names to the owning decl.
     for (_def_id, state, _used) in use_def_map.all_definitions_with_usage() {
@@ -1122,20 +1136,7 @@ pub(crate) fn emit_reference_edges(
             continue;
         };
 
-        let mut coll = RefCollector::new(
-            owner_idx,
-            &model,
-            file,
-            &parsed,
-            index,
-            global_index,
-            module_nodes,
-            alias_imports,
-            live_decls,
-            &synthetic_nodes,
-            dist_lookup,
-            &dead_ranges,
-        );
+        let mut coll = RefCollector::new(inputs, owner_idx);
         walk_owned(kind, &parsed, &mut coll);
         coll.flush(builder);
     }
@@ -1146,20 +1147,7 @@ pub(crate) fn emit_reference_edges(
         if stmt_creates_top_level_definition(stmt) {
             continue;
         }
-        let mut coll = RefCollector::new(
-            module_idx,
-            &model,
-            file,
-            &parsed,
-            index,
-            global_index,
-            module_nodes,
-            alias_imports,
-            live_decls,
-            &synthetic_nodes,
-            dist_lookup,
-            &dead_ranges,
-        );
+        let mut coll = RefCollector::new(inputs, module_idx);
         coll.visit_stmt(stmt);
         coll.flush(builder);
     }
@@ -1503,35 +1491,39 @@ pub(crate) struct RefCollector<'a, 'db> {
     current_flags: u32,
 }
 
+/// All read-only inputs `RefCollector::new` needs apart from the owner.
+/// Built once per file in `emit_reference_edges` and reused for every
+/// owner walked in that file. Cheap to `Copy` — it's a bag of borrows.
+#[derive(Clone, Copy)]
+pub(crate) struct RefCollectorInputs<'a, 'db> {
+    pub(crate) model: &'a SemanticModel<'db>,
+    pub(crate) file: File,
+    pub(crate) parsed: &'a ParsedModuleRef,
+    pub(crate) index: &'a SemanticIndex<'db>,
+    pub(crate) global_index: &'a DeclIndex,
+    pub(crate) module_nodes: &'a HashMap<File, usize>,
+    pub(crate) alias_imports: &'a HashMap<usize, ImportSpec>,
+    pub(crate) live_decls: &'a LiveDeclIndex,
+    pub(crate) synthetic_nodes: &'a HashMap<String, usize>,
+    pub(crate) dist_lookup: &'a DistLookup,
+    pub(crate) dead_ranges: &'a [TextRange],
+}
+
 impl<'a, 'db> RefCollector<'a, 'db> {
-    #[allow(clippy::too_many_arguments)]
-    fn new(
-        owner: usize,
-        model: &'a SemanticModel<'db>,
-        file: File,
-        parsed: &'a ParsedModuleRef,
-        index: &'a SemanticIndex<'db>,
-        global_index: &'a DeclIndex,
-        module_nodes: &'a HashMap<File, usize>,
-        alias_imports: &'a HashMap<usize, ImportSpec>,
-        live_decls: &'a LiveDeclIndex,
-        synthetic_nodes: &'a HashMap<String, usize>,
-        dist_lookup: &'a DistLookup,
-        dead_ranges: &'a [TextRange],
-    ) -> Self {
+    fn new(inputs: RefCollectorInputs<'a, 'db>, owner: usize) -> Self {
         Self {
             owner,
-            model,
-            file,
-            parsed,
-            index,
-            global_index,
-            module_nodes,
-            alias_imports,
-            live_decls,
-            synthetic_nodes,
-            dist_lookup,
-            dead_ranges,
+            model: inputs.model,
+            file: inputs.file,
+            parsed: inputs.parsed,
+            index: inputs.index,
+            global_index: inputs.global_index,
+            module_nodes: inputs.module_nodes,
+            alias_imports: inputs.alias_imports,
+            live_decls: inputs.live_decls,
+            synthetic_nodes: inputs.synthetic_nodes,
+            dist_lookup: inputs.dist_lookup,
+            dead_ranges: inputs.dead_ranges,
             edges: HashMap::new(),
             nested_context: false,
             current_flags: 0,

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -468,6 +468,13 @@ pub(crate) fn emit_import_edges(
     let place_table = index.place_table(global);
     let use_def_map = index.use_def_map(global);
 
+    // The "is this target idx a module node?" check below used to
+    // rebuild this set on every iteration. Hoist it; the resolve_*
+    // calls below can add new module nodes, so refresh only when
+    // module_nodes actually grew.
+    let mut module_idx_set: HashSet<usize> = module_nodes.values().copied().collect();
+    let mut module_nodes_len = module_nodes.len();
+
     for (_def_id, state, _used) in use_def_map.all_definitions_with_usage() {
         let DefinitionState::Defined(def) = state else {
             continue;
@@ -544,7 +551,10 @@ pub(crate) fn emit_import_edges(
             DefinitionKind::StarImport(_) => Vec::new(),
             _ => continue,
         };
-        let module_idx_set: HashSet<usize> = module_nodes.values().copied().collect();
+        if module_nodes.len() != module_nodes_len {
+            module_idx_set.extend(module_nodes.values().copied());
+            module_nodes_len = module_nodes.len();
+        }
         let all_targets_are_modules =
             !targets.is_empty() && targets.iter().all(|idx| module_idx_set.contains(idx));
         for target_idx in &targets {

--- a/src/project.rs
+++ b/src/project.rs
@@ -2,7 +2,7 @@
 //! `build_project_graph` pipeline entrypoint. This module owns the
 //! Salsa-backed analysis context that the rest of the crate operates on.
 
-use std::cell::RefCell;
+use std::cell::{Ref, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 
@@ -625,6 +625,19 @@ impl ProjectContext {
     }
 }
 
+impl ProjectContext {
+    /// Borrow the active `BuildOutputs` or raise the standard
+    /// "not materialized" error. Threads the `op` label into the
+    /// error message so the caller name appears in the traceback.
+    ///
+    /// The returned `Ref` keeps the `RefCell` borrow alive for the
+    /// lifetime of the receiver, so callers can hold it across an
+    /// entire query body without re-borrowing.
+    pub(crate) fn materialized(&self, op: &str) -> PyResult<Ref<'_, BuildOutputs>> {
+        Ref::filter_map(self.outputs.borrow(), Option::as_ref).map_err(|_| not_materialized(op))
+    }
+}
+
 // ----- Point-lookup queries (exposed to Python directly on ProjectContext) -
 
 #[pymethods]
@@ -635,10 +648,7 @@ impl ProjectContext {
     /// because the visitor's decl pass already minted one node per
     /// global-scope variable binding.
     pub(crate) fn find_module_dunders(&self, py: Python<'_>) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_module_dunders"))?;
+        let outputs = self.materialized("find_module_dunders")?;
         let mut out = Vec::new();
         for node_py in &outputs.builder.nodes {
             let node = node_py.borrow(py);
@@ -695,10 +705,7 @@ impl ProjectContext {
         let abs_set: std::collections::HashSet<&str> =
             abs_paths.iter().map(String::as_str).collect();
 
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_nodes_matching_specs"))?;
+        let outputs = self.materialized("find_nodes_matching_specs")?;
         let mut out = Vec::new();
         for node_py in &outputs.builder.nodes {
             let node = node_py.borrow(py);
@@ -736,10 +743,7 @@ impl ProjectContext {
         py: Python<'_>,
         module_name: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_imports_of"))?;
+        let outputs = self.materialized("find_imports_of")?;
         // O(1) lookup against the pre-built ``imports_by_module``
         // index — no scan over all interned nodes. Empty when nothing
         // imports the module.
@@ -770,10 +774,7 @@ impl ProjectContext {
     /// project doesn't use it. O(1) — single hashmap probe against
     /// ``imports_by_module``, no node iteration, no PyObject clone.
     pub(crate) fn has_imports_of(&self, module_name: &str) -> PyResult<bool> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("has_imports_of"))?;
+        let outputs = self.materialized("has_imports_of")?;
         Ok(outputs
             .imports_by_module
             .get(module_name)
@@ -794,10 +795,7 @@ impl ProjectContext {
         py: Python<'_>,
         fqname: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_declarations"))?;
+        let outputs = self.materialized("find_declarations")?;
         // Try exact match first, then strip trailing segments.
         let mut prefix = fqname;
         loop {
@@ -821,10 +819,7 @@ impl ProjectContext {
         py: Python<'_>,
         fqname: &str,
     ) -> PyResult<Option<Py<SymbolNode>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_module"))?;
+        let outputs = self.materialized("find_module")?;
         Ok(outputs
             .module_by_fqname
             .get(fqname)
@@ -842,10 +837,7 @@ impl ProjectContext {
         py: Python<'_>,
         path: &str,
     ) -> PyResult<Option<Py<SymbolNode>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("module_for"))?;
+        let outputs = self.materialized("module_for")?;
         let Some(&file) = outputs.path_to_file.get(path) else {
             return Ok(None);
         };
@@ -863,10 +855,7 @@ impl ProjectContext {
     /// methods don't get their own graph nodes). Returns ``None`` when
     /// the fqname can't be found anywhere — never raises.
     pub(crate) fn resolve(&self, py: Python<'_>, fqname: &str) -> PyResult<Option<Py<SymbolNode>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("resolve"))?;
+        let outputs = self.materialized("resolve")?;
         let mut prefix = fqname;
         loop {
             if let Some(idxs) = outputs.decl_by_fqname.get(prefix) {
@@ -896,10 +885,7 @@ impl ProjectContext {
         py: Python<'_>,
         module_fqn: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("module_surface"))?;
+        let outputs = self.materialized("module_surface")?;
         let Some(&module_idx) = outputs.module_by_fqname.get(module_fqn) else {
             return Ok(Vec::new());
         };
@@ -937,10 +923,7 @@ impl ProjectContext {
         py: Python<'_>,
         module_fqn: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_module_top_level_decls"))?;
+        let outputs = self.materialized("find_module_top_level_decls")?;
         if !outputs.module_by_fqname.contains_key(module_fqn) {
             return Ok(Vec::new());
         }
@@ -985,10 +968,7 @@ impl ProjectContext {
         let Some(entries) = self.find_literal_list_entries(&all_fqn)? else {
             return Ok(None);
         };
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_module_dunder_all_exports"))?;
+        let outputs = self.materialized("find_module_dunder_all_exports")?;
         let mut out: Vec<Py<SymbolNode>> = Vec::new();
         for entry in entries {
             let entry_fqn = format!("{module_fqn}.{entry}");
@@ -1016,10 +996,7 @@ impl ProjectContext {
     /// stay independent of the visitor's ``__all__``-only string-list
     /// edge emission.
     pub(crate) fn find_literal_list_entries(&self, var_fqn: &str) -> PyResult<Option<Vec<String>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_literal_list_entries"))?;
+        let outputs = self.materialized("find_literal_list_entries")?;
         let Some(idxs) = outputs.decl_by_fqname.get(var_fqn) else {
             return Ok(None);
         };
@@ -1069,10 +1046,7 @@ impl ProjectContext {
         py: Python<'_>,
         path_prefix: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("decls_under"))?;
+        let outputs = self.materialized("decls_under")?;
         Ok(outputs
             .builder
             .nodes
@@ -1089,10 +1063,7 @@ impl ProjectContext {
         py: Python<'_>,
         substring: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("decls_matching"))?;
+        let outputs = self.materialized("decls_matching")?;
         Ok(outputs
             .builder
             .nodes
@@ -1112,10 +1083,7 @@ impl ProjectContext {
         pattern: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
         let regex = self.compile_regex(pattern)?;
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("decls_matching_name"))?;
+        let outputs = self.materialized("decls_matching_name")?;
         let mut out = Vec::new();
         for node_py in &outputs.builder.nodes {
             let node = node_py.borrow(py);
@@ -1144,10 +1112,7 @@ impl ProjectContext {
         root: &SymbolNode,
         skip_flags: u32,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("descendants"))?;
+        let outputs = self.materialized("descendants")?;
         let root_idx = lookup_idx(&outputs.builder, root, "root")?;
         Ok(
             bfs(&outputs.builder, [root_idx], Direction::Forward, skip_flags)
@@ -1166,10 +1131,7 @@ impl ProjectContext {
         decl: &SymbolNode,
         skip_flags: u32,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("ancestors"))?;
+        let outputs = self.materialized("ancestors")?;
         let idx = lookup_idx(&outputs.builder, decl, "decl")?;
         Ok(bfs(&outputs.builder, [idx], Direction::Reverse, skip_flags)
             .into_iter()
@@ -1188,10 +1150,7 @@ impl ProjectContext {
         skip_flags: u32,
         seed_flags: u32,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("reachable"))?;
+        let outputs = self.materialized("reachable")?;
         let seeds = outputs
             .builder
             .nodes
@@ -1215,10 +1174,7 @@ impl ProjectContext {
     /// range — same shape ``MainBlockPlugin``'s libcst path computes
     /// from the visitor's payload.
     pub(crate) fn find_main_blocks(&self, py: Python<'_>) -> PyResult<Vec<MainBlock>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_main_blocks"))?;
+        let outputs = self.materialized("find_main_blocks")?;
         let mut out: Vec<MainBlock> = Vec::new();
         for (&file, &module_idx) in &outputs.module_nodes_by_file {
             // Prefilter: ``if __name__ == "__main__":`` always has the
@@ -1272,10 +1228,7 @@ impl ProjectContext {
         decorator_names: Vec<String>,
         path_regex: Option<&str>,
     ) -> PyResult<Vec<(Py<SymbolNode>, CallArgs)>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_decorated_decls"))?;
+        let outputs = self.materialized("find_decorated_decls")?;
         let path_re = _compile_path_regex(path_regex)?;
         let names: HashSet<&str> = decorator_names.iter().map(String::as_str).collect();
         let needle_strs: Vec<&str> = decorator_names.iter().map(String::as_str).collect();
@@ -1353,10 +1306,7 @@ impl ProjectContext {
         ctor_names: Vec<String>,
         path_regex: Option<&str>,
     ) -> PyResult<Vec<(Py<SymbolNode>, String, CallArgs)>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_instance_constructions"))?;
+        let outputs = self.materialized("find_instance_constructions")?;
         let path_re = _compile_path_regex(path_regex)?;
         let allowed: HashSet<&str> = ctor_names.iter().map(String::as_str).collect();
         let needle_strs: Vec<&str> = ctor_names.iter().map(String::as_str).collect();
@@ -1423,10 +1373,7 @@ impl ProjectContext {
         decorator_attrs: Vec<String>,
         path_regex: Option<&str>,
     ) -> PyResult<Vec<(String, Py<SymbolNode>, CallArgs)>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_handler_decorators"))?;
+        let outputs = self.materialized("find_handler_decorators")?;
         let path_re = _compile_path_regex(path_regex)?;
         let attrs: HashSet<&str> = decorator_attrs.iter().map(String::as_str).collect();
         let needle_strs: Vec<&str> = decorator_attrs.iter().map(String::as_str).collect();
@@ -1503,10 +1450,7 @@ impl ProjectContext {
         decorator_attrs: Vec<String>,
         path_regex: Option<&str>,
     ) -> PyResult<Vec<(String, Py<SymbolNode>, CallArgs)>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_handler_decorators_via"))?;
+        let outputs = self.materialized("find_handler_decorators_via")?;
         let path_re = _compile_path_regex(path_regex)?;
         let attrs: HashSet<&str> = decorator_attrs.iter().map(String::as_str).collect();
         let decl_by_name_range = &outputs.decl_by_name_range;
@@ -1595,10 +1539,7 @@ impl ProjectContext {
         arg_index: usize,
         path_regex: Option<&str>,
     ) -> PyResult<Vec<(Py<SymbolNode>, String, CallArgs)>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_calls_on_attr"))?;
+        let outputs = self.materialized("find_calls_on_attr")?;
         let path_re = _compile_path_regex(path_regex)?;
         let decl_by_name_range = &outputs.decl_by_name_range;
         let decl_by_fqname = &outputs.decl_by_fqname;
@@ -1664,10 +1605,7 @@ impl ProjectContext {
         module: &str,
         ctor_names: Vec<String>,
     ) -> PyResult<Vec<(Py<SymbolNode>, Vec<String>)>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_factory_decls"))?;
+        let outputs = self.materialized("find_factory_decls")?;
         let allowed: HashSet<&str> = ctor_names.iter().map(String::as_str).collect();
         let needle_strs: Vec<&str> = ctor_names.iter().map(String::as_str).collect();
         let decl_by_name_range = &outputs.decl_by_name_range;
@@ -1739,10 +1677,7 @@ impl ProjectContext {
         arg_index: usize,
         path_regex: Option<&str>,
     ) -> PyResult<Vec<(Py<SymbolNode>, String, CallArgs)>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_calls_to_imported"))?;
+        let outputs = self.materialized("find_calls_to_imported")?;
         let path_re = _compile_path_regex(path_regex)?;
         let allowed: HashSet<&str> = [name].into_iter().collect();
         let decl_by_name_range = &outputs.decl_by_name_range;
@@ -1818,10 +1753,7 @@ impl ProjectContext {
         required_positional: Option<usize>,
         path_regex: Option<&str>,
     ) -> PyResult<Vec<(Py<SymbolNode>, String, CallArgs)>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_calls_on_var"))?;
+        let outputs = self.materialized("find_calls_on_var")?;
         let path_re = _compile_path_regex(path_regex)?;
         let decl_by_name_range = &outputs.decl_by_name_range;
         let decl_by_fqname = &outputs.decl_by_fqname;
@@ -1886,10 +1818,7 @@ impl ProjectContext {
         py: Python<'_>,
         method_name: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_classes_defining_method"))?;
+        let outputs = self.materialized("find_classes_defining_method")?;
         let global_index = &outputs.global_index;
         let project_files: &[File] = &outputs.project_files;
         let db_handle: Box<dyn ProjectDb> = ProjectDb::dyn_clone(&self.db);
@@ -1951,10 +1880,7 @@ impl ProjectContext {
         if class_node.kind != "class" {
             return Ok(Vec::new());
         }
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_subclasses_of"))?;
+        let outputs = self.materialized("find_subclasses_of")?;
 
         let Some((seed_file, seed_range)) = locate_class_def(
             &self.db,
@@ -1965,7 +1891,7 @@ impl ProjectContext {
             return Ok(Vec::new());
         };
         let out_idx =
-            find_subclass_indices_via_refs(&self.db, outputs, seed_file, seed_range, true);
+            find_subclass_indices_via_refs(&self.db, &outputs, seed_file, seed_range, true);
         Ok(out_idx
             .into_iter()
             .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
@@ -2067,16 +1993,13 @@ impl ProjectContext {
         base_fqn: &str,
         transitive: bool,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_subclasses"))?;
-        let Some((seed_file, seed_range)) = locate_class_seed(&self.db, outputs, py, base_fqn)
+        let outputs = self.materialized("find_subclasses")?;
+        let Some((seed_file, seed_range)) = locate_class_seed(&self.db, &outputs, py, base_fqn)
         else {
             return Ok(Vec::new());
         };
         let out_idx =
-            find_subclass_indices_via_refs(&self.db, outputs, seed_file, seed_range, transitive);
+            find_subclass_indices_via_refs(&self.db, &outputs, seed_file, seed_range, transitive);
         Ok(out_idx
             .into_iter()
             .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
@@ -2096,10 +2019,7 @@ impl ProjectContext {
         pattern: &str,
     ) -> PyResult<Vec<(Py<SymbolNode>, String)>> {
         let regex = self.compile_regex(pattern)?;
-        let outputs = self.outputs.borrow();
-        let outputs = outputs
-            .as_ref()
-            .ok_or_else(|| not_materialized("find_comment_patterns"))?;
+        let outputs = self.materialized("find_comment_patterns")?;
         let mut out = Vec::new();
         for &file in &outputs.project_files {
             let parsed = parsed_module(&self.db, file).load(&self.db);
@@ -2138,8 +2058,7 @@ impl ProjectContext {
 
     /// Live nodes in the in-progress graph. Cheap, no copy.
     pub(crate) fn nodes(&self, py: Python<'_>) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs.as_ref().ok_or_else(|| not_materialized("nodes"))?;
+        let outputs = self.materialized("nodes")?;
         Ok(outputs
             .builder
             .nodes
@@ -2150,9 +2069,7 @@ impl ProjectContext {
 
     /// Live edges as `(src_idx, dst_idx, flags)` triples.
     pub(crate) fn edges(&self) -> PyResult<Vec<(usize, usize, u32)>> {
-        let outputs = self.outputs.borrow();
-        let outputs = outputs.as_ref().ok_or_else(|| not_materialized("edges"))?;
-        Ok(outputs.builder.edges.clone())
+        Ok(self.materialized("edges")?.builder.edges.clone())
     }
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -274,6 +274,54 @@ pub(crate) fn _to_iter(py: Python<'_>, items: Vec<Py<impl PyClass>>) -> PyResult
     Ok(iter_obj.unbind())
 }
 
+/// Generate the `first` / `count` / `__iter__` boilerplate that every
+/// chainable query exposes. Each variant is what the query's `.collect()`
+/// supports — see the three call sites below.
+///
+/// `with_first $Q, $R`: query whose `collect()` returns `Vec<Py<$R>>`
+/// and that wants a typed `.first() -> Option<Py<$R>>` shortcut.
+///
+/// `no_first $Q`: query that wants only `.count()` + `.__iter__()`
+/// (typically returns plain `Py<SymbolNode>`).
+///
+/// `iter_only $Q`: query with a custom `.count()` (cheaper than
+/// materializing `.collect()`); just gets `.__iter__()`.
+macro_rules! impl_query_methods {
+    (with_first $q:ty, $r:ty) => {
+        #[pymethods]
+        impl $q {
+            fn first(&self, py: Python<'_>) -> PyResult<Option<Py<$r>>> {
+                Ok(self.collect(py)?.into_iter().next())
+            }
+            fn count(&self, py: Python<'_>) -> PyResult<usize> {
+                Ok(self.collect(py)?.len())
+            }
+            fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
+                _to_iter(py, self.collect(py)?)
+            }
+        }
+    };
+    (no_first $q:ty) => {
+        #[pymethods]
+        impl $q {
+            fn count(&self, py: Python<'_>) -> PyResult<usize> {
+                Ok(self.collect(py)?.len())
+            }
+            fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
+                _to_iter(py, self.collect(py)?)
+            }
+        }
+    };
+    (iter_only $q:ty) => {
+        #[pymethods]
+        impl $q {
+            fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
+                _to_iter(py, self.collect(py)?)
+            }
+        }
+    };
+}
+
 /// Find decorated top-level functions / classes. Pick exactly one of:
 /// * ``where_module(m).where_name(n)`` — ``@m.x`` / ``@x`` where ``x``
 ///   is imported from ``m``.
@@ -492,17 +540,9 @@ impl DecoratorQuery {
         }
         Ok(refs)
     }
-
-    fn first(&self, py: Python<'_>) -> PyResult<Option<Py<DecoratorRef>>> {
-        Ok(self.collect(py)?.into_iter().next())
-    }
-    fn count(&self, py: Python<'_>) -> PyResult<usize> {
-        Ok(self.collect(py)?.len())
-    }
-    fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
-        _to_iter(py, self.collect(py)?)
-    }
 }
+
+impl_query_methods!(with_first DecoratorQuery, DecoratorRef);
 
 /// Find module-scope ``<var> = <Ctor>(...)`` sites. Pick exactly one
 /// of ``where_module + where_name`` or
@@ -607,17 +647,9 @@ impl ConstructionQuery {
         }
         Ok(refs)
     }
-
-    fn first(&self, py: Python<'_>) -> PyResult<Option<Py<ConstructionRef>>> {
-        Ok(self.collect(py)?.into_iter().next())
-    }
-    fn count(&self, py: Python<'_>) -> PyResult<usize> {
-        Ok(self.collect(py)?.len())
-    }
-    fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
-        _to_iter(py, self.collect(py)?)
-    }
 }
+
+impl_query_methods!(with_first ConstructionQuery, ConstructionRef);
 
 /// Find call sites whose positional string-literal at the configured
 /// index is captured. :meth:`string_arg_at` is required. Pick one of:
@@ -757,17 +789,9 @@ impl CallQuery {
         }
         Ok(refs)
     }
-
-    fn first(&self, py: Python<'_>) -> PyResult<Option<Py<CallRef>>> {
-        Ok(self.collect(py)?.into_iter().next())
-    }
-    fn count(&self, py: Python<'_>) -> PyResult<usize> {
-        Ok(self.collect(py)?.len())
-    }
-    fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
-        _to_iter(py, self.collect(py)?)
-    }
 }
+
+impl_query_methods!(with_first CallQuery, CallRef);
 
 // ---------------------------------------------------------------------------
 // Subclass / Import / Class / Factory queries
@@ -826,13 +850,9 @@ impl SubclassQuery {
             ))
         }
     }
-    fn count(&self, py: Python<'_>) -> PyResult<usize> {
-        Ok(self.collect(py)?.len())
-    }
-    fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
-        _to_iter(py, self.collect(py)?)
-    }
 }
+
+impl_query_methods!(no_first SubclassQuery);
 
 /// Enumerate the ``kind="import"`` nodes that bind a name from a
 /// given module. Requires ``of(module)``.
@@ -846,6 +866,12 @@ impl ImportQuery {
     fn new(ctx: Py<ProjectContext>) -> Self {
         Self { ctx, module: None }
     }
+
+    fn module_or_err(&self) -> PyResult<&str> {
+        self.module
+            .as_deref()
+            .ok_or_else(|| PyValueError::new_err("ImportQuery requires .of(module)"))
+    }
 }
 
 #[pymethods]
@@ -855,39 +881,25 @@ impl ImportQuery {
         slf
     }
     fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<SymbolNode>>> {
-        let ctx = self.ctx.borrow(py);
-        let module = self
-            .module
-            .as_deref()
-            .ok_or_else(|| PyValueError::new_err("ImportQuery requires .of(module)"))?;
-        ctx.find_imports_of(py, module)
+        self.ctx
+            .borrow(py)
+            .find_imports_of(py, self.module_or_err()?)
     }
     /// O(1) presence probe — does any project file import the
     /// configured module? Short-circuits on the first match without
     /// materialising a Python list. Preferred over ``.count() > 0`` /
     /// ``.collect()`` for plugin guards that just need a boolean.
     fn exists(&self, py: Python<'_>) -> PyResult<bool> {
-        let ctx = self.ctx.borrow(py);
-        let module = self
-            .module
-            .as_deref()
-            .ok_or_else(|| PyValueError::new_err("ImportQuery requires .of(module)"))?;
-        ctx.has_imports_of(module)
+        self.ctx.borrow(py).has_imports_of(self.module_or_err()?)
     }
+    /// Count without allocating `Py<SymbolNode>` clones — read the
+    /// length of the pre-built index entry directly.
     fn count(&self, py: Python<'_>) -> PyResult<usize> {
-        let ctx = self.ctx.borrow(py);
-        let module = self
-            .module
-            .as_deref()
-            .ok_or_else(|| PyValueError::new_err("ImportQuery requires .of(module)"))?;
-        // Count without allocating Py<SymbolNode> clones — read the
-        // length of the pre-built index entry directly.
-        Ok(ctx.imports_of_count(module))
-    }
-    fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
-        _to_iter(py, self.collect(py)?)
+        Ok(self.ctx.borrow(py).imports_of_count(self.module_or_err()?))
     }
 }
+
+impl_query_methods!(iter_only ImportQuery);
 
 /// Enumerate classes by structural property. Today the only filter
 /// is ``defining_method(name)`` (matches classes whose body has a
@@ -921,13 +933,9 @@ impl ClassQuery {
             .ok_or_else(|| PyValueError::new_err("ClassQuery requires .defining_method(name)"))?;
         ctx.find_classes_defining_method(py, name)
     }
-    fn count(&self, py: Python<'_>) -> PyResult<usize> {
-        Ok(self.collect(py)?.len())
-    }
-    fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
-        _to_iter(py, self.collect(py)?)
-    }
 }
+
+impl_query_methods!(no_first ClassQuery);
 
 /// One result row from :class:`FactoryQuery`. ``decl`` is the
 /// owning top-level function or class; ``kinds`` is the sorted set
@@ -996,10 +1004,6 @@ impl FactoryQuery {
             .map(|(decl, kinds)| Py::new(py, FactoryRef { decl, kinds }))
             .collect()
     }
-    fn count(&self, py: Python<'_>) -> PyResult<usize> {
-        Ok(self.collect(py)?.len())
-    }
-    fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
-        _to_iter(py, self.collect(py)?)
-    }
 }
+
+impl_query_methods!(no_first FactoryQuery);

--- a/src/query.rs
+++ b/src/query.rs
@@ -1007,3 +1007,146 @@ impl FactoryQuery {
 }
 
 impl_query_methods!(no_first FactoryQuery);
+
+#[cfg(test)]
+mod tests {
+    //! Pure-rust tests for the identifier-prefilter helpers used by
+    //! every per-file query loop. The chainable query types themselves
+    //! depend on `Python<'_>` / `Py<ProjectContext>` and are covered
+    //! end-to-end by the python suite.
+    use super::*;
+
+    // -- _is_ident_continue -----------------------------------------------
+
+    #[test]
+    fn is_ident_continue_recognizes_word_bytes() {
+        for byte in b'a'..=b'z' {
+            assert!(_is_ident_continue(byte), "{byte} should be ident continue");
+        }
+        for byte in b'A'..=b'Z' {
+            assert!(_is_ident_continue(byte));
+        }
+        for byte in b'0'..=b'9' {
+            assert!(_is_ident_continue(byte));
+        }
+        assert!(_is_ident_continue(b'_'));
+    }
+
+    #[test]
+    fn is_ident_continue_rejects_punctuation_and_whitespace() {
+        for byte in [b'.', b',', b' ', b'\t', b'\n', b'(', b')', b'-', b'#', b':'] {
+            assert!(!_is_ident_continue(byte));
+        }
+    }
+
+    // -- _contains_identifier ---------------------------------------------
+
+    #[test]
+    fn contains_identifier_finds_isolated_match() {
+        assert!(_contains_identifier("foo", "foo"));
+        assert!(_contains_identifier("call(foo)", "foo"));
+        assert!(_contains_identifier(" foo ", "foo"));
+        assert!(_contains_identifier("foo.bar", "foo"));
+        assert!(_contains_identifier("a.foo", "foo"));
+    }
+
+    #[test]
+    fn contains_identifier_rejects_substring_inside_other_word() {
+        assert!(!_contains_identifier("foobar", "foo"));
+        assert!(!_contains_identifier("xfoo", "foo"));
+        assert!(!_contains_identifier("foo_bar", "foo"));
+        assert!(!_contains_identifier("foo1", "foo"));
+        // Underscore prefix is also an identifier continuation.
+        assert!(!_contains_identifier("_foo", "foo"));
+        // Digit prefix
+        assert!(!_contains_identifier("1foo", "foo"));
+    }
+
+    #[test]
+    fn contains_identifier_handles_match_at_boundaries() {
+        assert!(_contains_identifier("foo()", "foo"));
+        assert!(_contains_identifier("(foo)", "foo"));
+        assert!(_contains_identifier("foo+bar", "foo"));
+    }
+
+    #[test]
+    fn contains_identifier_empty_needle_returns_false() {
+        // Empty needle would otherwise match everywhere — explicitly handled.
+        assert!(!_contains_identifier("anything", ""));
+        assert!(!_contains_identifier("", ""));
+    }
+
+    #[test]
+    fn contains_identifier_empty_source_returns_false() {
+        assert!(!_contains_identifier("", "foo"));
+    }
+
+    #[test]
+    fn contains_identifier_multiple_occurrences_one_valid() {
+        // The first ("xfoo") is invalid; the second (" foo") matches.
+        assert!(_contains_identifier("xfoo foo", "foo"));
+        // Both fail.
+        assert!(!_contains_identifier("xfooy zfoow", "foo"));
+    }
+
+    #[test]
+    fn contains_identifier_handles_overlapping_advance() {
+        // Even when the first start position fails the boundary check,
+        // the scan must advance and try subsequent occurrences.
+        assert!(_contains_identifier("aaa a", "a"));
+    }
+
+    #[test]
+    fn contains_identifier_unicode_source_does_not_panic() {
+        // The function uses byte indexing for the boundary check. ASCII
+        // identifier continuations are all single-byte, and the
+        // multi-byte UTF-8 leading/continuation bytes all have the high
+        // bit set (>= 0x80), so they fail `_is_ident_continue` and the
+        // boundary holds — which makes `foo` adjacent to emoji a hit,
+        // even though Python would treat the unicode chars as
+        // identifier-continuation. The prefilter is approximate by
+        // design (`ty_ide::references::contains_identifier` has the
+        // same shape) — we exercise the byte path here to lock in the
+        // documented behavior.
+        assert!(_contains_identifier("héllo foo", "foo"));
+        assert!(_contains_identifier("foo🙂bar", "foo"));
+        // No needle present.
+        assert!(!_contains_identifier("héllo", "foo"));
+        // ASCII boundary still wins over surrounding unicode.
+        assert!(_contains_identifier(" foo ", "foo"));
+    }
+
+    #[test]
+    fn contains_identifier_multi_char_needle() {
+        assert!(_contains_identifier("def my_func(): pass", "my_func"));
+        assert!(!_contains_identifier("def my_function(): pass", "my_func"));
+        assert!(!_contains_identifier("my_funcx", "my_func"));
+    }
+
+    // -- _contains_any_identifier -----------------------------------------
+
+    #[test]
+    fn contains_any_identifier_returns_true_on_first_hit() {
+        assert!(_contains_any_identifier("call(foo)", &["bar", "foo"]));
+        assert!(_contains_any_identifier("foo()", &["foo"]));
+    }
+
+    #[test]
+    fn contains_any_identifier_empty_list_returns_false() {
+        assert!(!_contains_any_identifier("anything", &[]));
+        assert!(!_contains_any_identifier("", &[]));
+    }
+
+    #[test]
+    fn contains_any_identifier_returns_false_when_no_match() {
+        assert!(!_contains_any_identifier("this has none", &["foo", "bar"]));
+    }
+
+    #[test]
+    fn contains_any_identifier_respects_boundaries() {
+        // Same substring-inside-word rule as _contains_identifier.
+        assert!(!_contains_any_identifier("foobar", &["foo", "bar"]));
+        // But the standalone "foo" still hits if present.
+        assert!(_contains_any_identifier("foobar foo", &["foo"]));
+    }
+}

--- a/src/query.rs
+++ b/src/query.rs
@@ -10,7 +10,6 @@ use pyo3::PyClass;
 use ruff_db::files::File;
 use ty_project::Db as ProjectDb;
 
-use crate::builder::not_materialized;
 use crate::graph::SymbolNode;
 use crate::helpers::{
     args_to_py_vec, call_args_match_kwargs, file_path_string, kwarg_matcher_from_py,
@@ -430,10 +429,7 @@ impl DecoratorQuery {
         // Cache a snapshot of the build's node pool for arg materialization.
         // Keep the borrow alive for the duration of the loop so we don't
         // reborrow on every iteration.
-        let outputs_borrow = ctx.outputs.borrow();
-        let outputs = outputs_borrow
-            .as_ref()
-            .ok_or_else(|| not_materialized("DecoratorQuery.collect"))?;
+        let outputs = ctx.materialized("DecoratorQuery.collect")?;
         let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
         let kwarg_matchers = &self.kwarg_matchers;
         if let Some(owner_attrs) = &self.owner_attrs {
@@ -603,10 +599,7 @@ impl ConstructionQuery {
         let ctx = self.ctx.borrow(py);
         let path_regex = self.path_regex.as_deref();
         let mut refs: Vec<Py<ConstructionRef>> = Vec::new();
-        let outputs_borrow = ctx.outputs.borrow();
-        let outputs = outputs_borrow
-            .as_ref()
-            .ok_or_else(|| not_materialized("ConstructionQuery.collect"))?;
+        let outputs = ctx.materialized("ConstructionQuery.collect")?;
         let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
         if let Some(fqn) = &self.class_fqn {
             let pairs = ctx.find_constructions(py, fqn, self.include_subclasses, path_regex)?;
@@ -764,10 +757,7 @@ impl CallQuery {
                  where_owner(...) + where_attr(...); or where_attr(...)",
             ));
         };
-        let outputs_borrow = ctx.outputs.borrow();
-        let outputs = outputs_borrow
-            .as_ref()
-            .ok_or_else(|| not_materialized("CallQuery.collect"))?;
+        let outputs = ctx.materialized("CallQuery.collect")?;
         let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
         let kwarg_matchers = &self.kwarg_matchers;
         let mut refs: Vec<Py<CallRef>> = Vec::new();


### PR DESCRIPTION
Two commits, no behavior change.

## 1. `rust: simplify the crate surface` (65bb6e6)

Cleanup pass — dedupes patterns the recent rust PRs spread across multiple files.

- `builder.rs::static_kind_str` deleted — was a verbatim duplicate of `graph.rs::intern_kind`. `AddNode` goes through `intern_kind` now; the valid-kind enumeration in the error message lives in one place.
- `builder.rs::synthetic_node` factory replaces three near-identical `SymbolNode { ... }` literals in `apply_graph_op` + `intern_synthetic` (the position-less / no-imports shape).
- `helpers.rs::MODULE_ALIAS_MARKER` replaces five copies of the `"<module>"` magic string.
- `helpers.rs::locate_class_def` had a 4-line doc comment accidentally pasted twice; deduped.
- `query.rs::impl_query_methods!` macro generates the `first` / `count` / `__iter__` boilerplate the seven chainable queries shared verbatim (three variants: `with_first`, `no_first`, `iter_only` for `ImportQuery`'s custom `count`).
- `query.rs::ImportQuery::module_or_err` collapses the three repetitions of "require `.of(module)` or raise" across `collect` / `exists` / `count`.
- `ingest.rs::emit_import_edges` hoists `module_idx_set` out of the per-statement loop and refreshes it only when `module_nodes` actually grew. The O(n) rebuild on every import in a file is now O(n) once + O(delta) incremental.

Net diff: +147 / -149 across 5 files.

## 2. `rust: add unit-test suite for pure-rust helpers` (fa6e529)

125 new tests (129 total) covering the surface that doesn't need a pyo3 GIL token or a Salsa `ProjectDatabase` — the python suite already covers the db-backed paths end-to-end.

- `helpers.rs` (+87): `is_dunder_name`, `rel_path`, `is_name`, `is_string_literal`, `is_name_eq_main`, `top_level_assign_to_name`, `class_body_defines_method`, `nth_positional_string`, `call_callee_matches_var`, `range_key`, `arg_value_eq_literal`, `evaluate_truthiness` (literals / names / unary `not` / short-circuit `and`/`or` / walrus), `stmt_is_terminator` + `suite_terminates` (return/raise/break/continue, `assert False`, if/elif/else completeness, try/finally, with), `walk_suite_for_dead`, `build_scope_table` (chained constants, conflict-drop, enclosing inheritance, nested-scope isolation), `collect_walrus_in_expr`, extended `parse_noqa_tail` (case-insensitive, leading whitespace, code list), `is_per_line_pin`, `is_file_pin`, `decorators_match_imports`, `matched_call_target`, `NoqaKind::pins_f401`.
- `builder.rs` (+18): `NodeKey` identity (flags excluded, distinguished by position / kind / path), `synthetic_node` defaults, `GraphBuilder::new` empty invariant, `bfs` (forward / reverse, `skip_flags` intersection, cycles, empty seeds, multi-seed union, isolated seed).
- `graph.rs` (+5): `intern_kind` accept / reject, `NodeFlags` and `EdgeFlags` distinctness + OR-combinability.
- `query.rs` (+15): `_is_ident_continue`, `_contains_identifier` (boundaries, empty needle / source, substring-inside-word rejection, multi-occurrence advance, multi-char needles, unicode no-panic), `_contains_any_identifier`.

Run via `cargo test --no-default-features --release` (the `extension-module` feature breaks `cargo test`).

## Test plan

- [x] `cargo test --no-default-features --release` — 129 / 129 passed
- [x] `uv run pytest` — 613 / 613 passed
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRfcw7i5PjgAPUmKhkfEgf)_