### PR TITLE
ci: drop Intel macOS wheel from publish matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,6 @@ jobs:
         platform:
           - { runner: ubuntu-latest,  target: x86_64-unknown-linux-gnu,  manylinux: "2_28" }
           - { runner: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu, manylinux: "2_28" }
-          - { runner: macos-13,       target: x86_64-apple-darwin,        manylinux: "auto" }
           - { runner: macos-14,       target: aarch64-apple-darwin,       manylinux: "auto" }
           - { runner: windows-latest, target: x86_64-pc-windows-msvc,     manylinux: "auto" }
     steps:


### PR DESCRIPTION
## Summary
- Remove `x86_64-apple-darwin` (Intel Mac, `macos-13` runner) from the publish wheel matrix. The `aarch64-apple-darwin` wheel still covers Apple Silicon, which is the macOS hardware Apple has shipped since 2020.
- Intel Mac users on older hardware can still install from the sdist.

## Test plan
- [ ] Next push to `main`: confirm the wheel matrix no longer schedules a `macos-13` job, and that the remaining 4 targets still publish successfully to TestPyPI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCUkrmpEsaFpcxZV8So5Tx)_