### PR TITLE
Use setuptools-scm for dev version stamp in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --quiet setuptools-scm
-          version=$(python -c "from setuptools_scm import get_version; print(get_version(version_scheme='no-guess-dev', local_scheme='no-local-version'))" | sed 's/\.dev/-dev/')
+          version=$(python -c "from setuptools_scm import get_version; print(get_version(local_scheme='no-local-version'))" | sed 's/\.dev/-dev/')
           sed -i.bak "s/^version = .*/version = \"$version\"/" Cargo.toml
           rm Cargo.toml.bak
       - uses: PyO3/maturin-action@v1
@@ -63,7 +63,7 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           python -m pip install --quiet setuptools-scm
-          version=$(python -c "from setuptools_scm import get_version; print(get_version(version_scheme='no-guess-dev', local_scheme='no-local-version'))" | sed 's/\.dev/-dev/')
+          version=$(python -c "from setuptools_scm import get_version; print(get_version(local_scheme='no-local-version'))" | sed 's/\.dev/-dev/')
           sed -i.bak "s/^version = .*/version = \"$version\"/" Cargo.toml
           rm Cargo.toml.bak
       - uses: PyO3/maturin-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,12 +32,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+          fetch-depth: 0
       - name: Stamp dev version
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         shell: bash
         run: |
-          base=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)
-          sed -i.bak "s/^version = .*/version = \"${base}-dev${{ github.run_number }}\"/" Cargo.toml
+          python -m pip install --quiet setuptools-scm
+          version=$(python -c "from setuptools_scm import get_version; print(get_version(version_scheme='no-guess-dev', local_scheme='no-local-version'))" | sed 's/\.dev/-dev/')
+          sed -i.bak "s/^version = .*/version = \"$version\"/" Cargo.toml
           rm Cargo.toml.bak
       - uses: PyO3/maturin-action@v1
         with:
@@ -56,11 +58,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+          fetch-depth: 0
       - name: Stamp dev version
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          base=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)
-          sed -i.bak "s/^version = .*/version = \"${base}-dev${{ github.run_number }}\"/" Cargo.toml
+          python -m pip install --quiet setuptools-scm
+          version=$(python -c "from setuptools_scm import get_version; print(get_version(version_scheme='no-guess-dev', local_scheme='no-local-version'))" | sed 's/\.dev/-dev/')
+          sed -i.bak "s/^version = .*/version = \"$version\"/" Cargo.toml
           rm Cargo.toml.bak
       - uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
Replaces the manual base-from-Cargo.toml + github.run_number stamp with
a setuptools-scm-derived version. On the next tag, push-to-main builds
will pick up the clean tag as the version; until then, the version is
derived from distance to the latest tag.

Requires fetch-depth: 0 so tags are visible to setuptools-scm.