### PR TITLE
Prep v0.11.0: cut changelog, bump Cargo.toml, refresh docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,10 +1,10 @@
 # Architecture / program flow
 
-This doc walks the code path a single `dead-cst` invocation takes, from CLI
-arguments to a written file. It's the developer-facing companion to
-[`README.md`](README.md) (user-facing) and [`CLAUDE.md`](CLAUDE.md) (LLM-
-oriented summary). Read this before adding a plugin, resolver, or detector,
-or before touching the visitor.
+This doc walks the code path a single `dead-cst` invocation takes, from
+CLI arguments to a written patch. It's the developer-facing companion
+to [`README.md`](README.md) (user-facing) and [`CLAUDE.md`](CLAUDE.md)
+(LLM-oriented summary). Read this before adding a plugin, resolver, or
+touching the rust crate.
 
 ## At a glance
 
@@ -15,511 +15,318 @@ or before touching the visitor.
 ┌──────────────────┐
 │   PathResolver   │  resolve(project_root) -> tuple[Package, ...]
 └─────────┬────────┘
-          │ Packages (path, name, exported, deps)
+          │ Packages (path, name, deps)
           ▼
 ┌──────────────────┐
 │     Analysis     │  cheap construction; everything below is lazy
 └─────────┬────────┘
-          │ refresh(packages=…)
+          │ materialize_all()
           ▼
 ┌──────────────────────────────────────────────────────────────┐
-│  per-file pipeline (cached in SQLite by file SHA-256)        │
+│  rust crate: native.ProjectContext.materialize()             │
 │                                                              │
-│   source ─► SymbolVisitor ─► VisitorPayload                  │
-│                  │                                           │
-│                  └─► UnreachableRegionDetector.find_regions  │
-│                                                              │
-│   each EdgePlugin.observe(ctx) -> VisitorPayload | None      │
-│   ────────────────────────────────────────────────────────   │
-│   combined payload pickled into GraphCache                   │
+│   Phase 1 — decls       ty SemanticIndex + ruff AST          │
+│   Phase 2 — chain       parent-module + import edges         │
+│   Phase 3 — references  ty use-def chains for every Name     │
+│   Plugins               plugin.run(ctx) -> AddNode/AddEdge   │
 └────────────────────────────┬─────────────────────────────────┘
-                             │
+                             │ live ProjectContext
                              ▼
-┌──────────────────────────────────────────────────────────────┐
-│  per-package contribution                                    │
-│  (SymbolTrie + package-local graph slice + unresolved imps)  │
-└────────────────────────────┬─────────────────────────────────┘
-                             │
-                             ▼
-┌──────────────────────────────────────────────────────────────┐
-│  cross-package composition (uncached)                        │
-│                                                              │
-│   merge contributions ─► resolve_edges (against merged trie  │
-│                          + PathResolver fallback)            │
-│                                                              │
-│   each EdgePlugin.finalize(ctx) -> Iterable[GraphOp]         │
-└────────────────────────────┬─────────────────────────────────┘
-                             │ SymbolGraph
-                             ▼
-                ┌────────────┴────────────┐
-                ▼                         ▼
-        reachability BFS         codemod (remove_code /
-        from entrypoint=True       generate_patch)
+              ┌──────────────┴──────────────┐
+              ▼                             ▼
+       Analysis queries              codemod (libcst)
+       (reachable / dead /           remove_code,
+        descendants / ancestors      generate_patch
+        — all run in rust)
+              │
+              ▼
+       graph persistence
+       write_graph / read_graph
+       (bincode)
 ```
 
-The cache boundary is the line that matters most when reasoning about
-performance: stages 1–4 ride the per-file SQLite cache; stage 5 onward
-runs every invocation. That's why import classification deliberately
-moved out of the visitor — keeping the cache survival surface as small
-as possible was worth re-stitching edges every run.
+The entire graph build runs inside the rust extension. There is no
+per-file Python cache; ty's Salsa database already provides incremental
+re-analysis. The only stage still in Python is the LibCST codemod, and
+the only stage still in pure Python is `Analysis`'s thin wrapper around
+the rust BFS queries.
 
-The assembled graph at stage 5 and beyond is a `SymbolGraph`
-(`dead_cst/_graphstore.py`) — a thin wrapper around a
-`rustworkx.PyDiGraph` paired with a `SymbolNode <-> int` index map.
-The wrapper exposes the bookkeeping (`add`, `add_edge`, `index`,
-`node`, `subgraph`, `nodes`, `__contains__`/`__iter__`/`__len__`) and
-nothing else; edge-payload-aware iteration, traversal
-(`successor_indices` / `predecessor_indices`), `has_edge`, and every
-algorithm go through `SymbolGraph.raw` directly. BFS-shaped code in
-`analyze.py` / `cli.py` / the plugins operates in index space —
-`set[int]` visited sets, deferred `raw[i]` resolution at the point
-the loop body actually reads payload.
+## The rust crate
 
-## The `Cacheable` contract
+The pyo3 extension lives in `src/` (a maturin-managed cdylib that ships
+as `python/dead_cst/_native.{abi3.so,pyd}`). Type stubs live alongside
+at `python/dead_cst/_native.pyi`.
 
-Four moving parts satisfy `Cacheable` (`dead_cst/_cacheable.py`) — just
-`name: str` + `version: int`:
+Module layout (`src/lib.rs` is the pymodule entry point):
 
-| Component                    | Where                       | In the fingerprint? |
-| ---------------------------- | --------------------------- | ------------------- |
-| `SymbolVisitor`              | `dead_cst/_visitor.py`      | yes                 |
-| `EdgePlugin`                 | `dead_cst/plugins/`         | yes                 |
-| `UnreachableRegionDetector`  | `dead_cst/branches.py`      | yes                 |
-| `PathResolver`               | `dead_cst/resolvers/`       | **no**              |
+| File | Purpose |
+| ---- | ------- |
+| `lib.rs`     | pymodule registration, top-level `query()` helper |
+| `project.rs` | `Project`, `ProjectContext`, the `build()` pipeline |
+| `builder.rs` | `NodeKey`, `GraphBuilder`, `AddNode` / `AddEdge` / `AddEntrypoint`, generic BFS |
+| `graph.rs`   | `SymbolNode`, `Import`, `NativeGraph`, `NodeFlags`, `EdgeFlags` |
+| `ingest.rs`  | the three build phases (decls / chain / references) |
+| `query.rs`   | the plugin-facing `query(ctx).decorators()....collect()` builder |
+| `helpers.rs` | shared utilities (noqa parser, notebook decoder, dist-info lookup, …) |
+| `io.rs`      | `write_graph` / `read_graph` (bincode + a hard-versioned header) |
 
-The visitor / plugin / detector triple plus the package's `exported`
-subdirs (canonicalized relative to `package.path` for cross-machine
-portability) feed `compute_fingerprint` (`dead_cst/cache.py`).
-`Package.exported` enters because it stamps `NodeFlags.EXPORTED` onto
-every node via the visitor's `default_flags`, so editing it changes
-the cached payload; resolver swaps, `search_paths`, and
-`Package.path` / `name` / `deps` re-stitch edges through the
-(uncached) stage 5 pass instead of invalidating the per-file cache.
-`version` is a Unix epoch int *by convention* — concurrent bumps on
-different branches merge with `max()`-wins semantics rather than
-colliding on a re-used label. The package `__version__` is **not** in
-the fingerprint: every component whose output can shift between
-releases owns its own knob.
+The deeper crate-level rules live in `src/CLAUDE.md` — ty is the source
+of truth for every piece of Python semantics, every import binds a
+local declaration, and shadowed declarations are first-class graph
+nodes.
 
 ## The pipeline, top-down
 
 ### 1. Path resolution — `dead_cst/resolvers/`
 
-A `PathResolver` answers two questions about the project layout:
+A `PathResolver` answers one question: what packages exist in this
+project, and which other packages does each depend on?
 
-* `resolve(project_root) -> tuple[Package, ...]` — what packages exist,
-  what subdirs do they export to consumers, and which other packages
-  do they depend on (referenced by `name`).
-* `resolve_import(name, search_paths) -> str | Path | None` — fallback
-  classifier when an import misses the per-package symbol trie.
+```python
+resolve(project_root) -> tuple[Package, ...]
+```
 
-Builtins:
+Each `Package` carries `path`, `name`, and `deps: tuple[str, ...]`
+(referencing other packages by name). Builtins:
 
 * `ManualResolver` (`dead_cst/resolvers/manual.py`) — explicit
-  `package:dep1,dep2` specs from the CLI's `-p` flag. Auto-promotes
-  inline dep paths to their own `Package` records.
+  `package:dep1,dep2` specs from the CLI's `-p` flag.
 * `UvResolver` (`dead_cst/contrib/uv.py`) — parses `uv.lock` to
-  discover workspace members and inter-member edges; lazily splices
-  the workspace `.venv/site-packages` onto `sys.path` inside its own
-  `resolve_import`.
+  discover workspace members and inter-member edges.
 
 `Analysis` takes exactly one resolver — no chain. CLI flags `-p` and
 `--resolver` are mutually exclusive. Construction validates the
-resolver's output (name uniqueness, dep references, `exported` entries
-under `path`) via `_validate_packages`.
+resolver's output (name uniqueness, dep references resolve) via
+`_validate_packages`.
 
-### 2. Per-file visitor — `dead_cst/_visitor.py`
+### 2. `Analysis` — `dead_cst/analyze.py`
 
-`SymbolVisitor` walks one `.py` (or `.pyi`) file and returns a
-`VisitorPayload` (defined in `dead_cst/graph.py`) with four fields:
+Cheap to construct: the resolver runs once at `__init__` and packages
+are sorted into a dep-first BFS order, but nothing else happens until
+you ask a question (`materialize_all`, `reachable`, `dead`,
+`descendants`, `ancestors`, `kept_alive_by_flags_only`,
+`kept_alive_by_dead_branches`).
 
-| Field          | Shape                                          | Notes                                   |
-| -------------- | ---------------------------------------------- | --------------------------------------- |
-| `nodes`        | `tuple[SymbolNode, ...]`                       | every real decl, including `SHADOWED`   |
-| `edges`        | `tuple[(src, dst, EdgeFlags), ...]`            | resolved decl-to-decl refs in this file |
-| `imports`      | `tuple[(src, Import, EdgeFlags), ...]`         | **raw** — just the dotted name written  |
-| `dead_suites`  | `tuple[CodeRange, ...]`                        | every statically-dead suite             |
+`Analysis._ctx` holds the live `native.ProjectContext` after the first
+`materialize_all()` call, so subsequent BFS queries run on the already-
+built graph — one FFI hop per query, no rebuild.
 
-Crucially the visitor never calls a resolver and never reads `sys.path` —
-its output is purely a function of the file's source plus the plugin /
-detector chain. That's what lets the per-file cache survive
-`search_paths` / resolver swaps.
+### 3. Graph materialization — `native.ProjectContext.materialize()`
 
-Heavy lifting comes from LibCST `ScopeProvider`,
-`FullyQualifiedNameProvider` (wrapped via `_fqn.FixedFullyQualifiedNameProvider`),
-and the flow-sensitive shadowing in `_flow.py`.
+Driven from Python by `Analysis.materialize_all()`:
 
-### 3. Unreachable-region detection — `dead_cst/branches.py`
-
-Invoked once per file from inside `SymbolVisitor.visit_Module` reusing
-the analyzer's resolved `PositionProvider`. The shipped
-`DefaultUnreachableRegionDetector` is a two-pass design:
-
-1. A single `cst.CSTVisitor` walk collects every `If` / `While` plus
-   every statement-bearing suite (module body and every
-   `IndentedBlock`).
-2. A `TruthinessResolver` (also in `branches.py`) answers truthiness
-   queries on demand: `unreachable_suites` for the conditional sites,
-   plus a per-suite scan that marks statements after an unconditional
-   `return` / `raise` / `break` / `continue` / `assert <falsy>` as
-   dead *within the same suite* — a `raise` in a `try` body doesn't
-   kill the matching `except`. Compound statements (`if` / `with` /
-   `try`) themselves count as terminators when every reachable path
-   inside them terminates, so a constant-folded `if True: return`
-   (and its `FLAG = True` / `if cond: return; else: return` cousins)
-   kills the rest of the enclosing suite. The resolver is goal-directed: it
-   lazily resolves `ScopeProvider` / `ParentNodeProvider` only when
-   the first `Name` query lands, walks `live_referents` only for the
-   names that actually feed a query, memoizes by access node id, and
-   uses a `_PENDING` sentinel to bottom out cyclic references like
-   `a = b; b = a`.
-
-The apply step compares each `access_pos` in `edges` against
-`dead_suites` to flag `EdgeFlags.DEAD_BRANCH`. Reachability still
-follows those edges by default; `Analysis.kept_alive_by_dead_branches`
-is the opt-in inverse.
-
-To layer in domain knowledge, subclass `DefaultUnreachableRegionDetector`
-and override `resolve(self, expr) -> bool | None` — it gets first crack
-at every non-keyword expression routed through the resolver chain. Pass
-an instance via `Analysis(unreachable_detector=...)`. Bump `version`
-whenever the override's logic changes. From-scratch detectors that
-need name-aware truthiness construct `TruthinessResolver(wrapper,
-resolve_expr=...)` once per file and pass `resolver.evaluate` as the
-`resolve_expr` callback to `unreachable_suites` / `evaluate_truthiness`.
-
-### 4. Visitor + observe cache — `dead_cst/cache.py`
-
-SQLite-backed `GraphCache` at `<root>/.dead-cst-cache/cache.db` stores
-pickled per-file payloads keyed by file SHA-256. Each row carries a
-per-package fingerprint over Python version, schema version, every
-visitor / plugin / detector `(name, version)` pair, and the package's
-`exported` setting (canonicalized relative to `package.path`).
-`Package.exported` enters because it feeds `NodeFlags.EXPORTED` into
-every node via the visitor's `default_flags`; editing it invalidates
-only the affected package's rows.
-
-A cache row covers both the visitor's payload **and** every plugin's
-`observe()` output for that file — warm runs skip both. Bypass with
-`--no-cache`; force-clear with `dead-cst cache clear`.
-
-The orchestration around this stage — file enumeration, stale detection,
-the parallel worker pool — lives in `dead_cst/_refresh.py`; the
-per-package apply step (`PackageContribution`, `build_contribution`,
-`_apply_payload`, `eclipsed_paths`) lives in `dead_cst/_package.py`
-so `analyze.py` can stay focused on cross-package composition. File enumeration walks the tree
-once via `Path.rglob("*")` and dispatches by suffix into `.py` /
-`.pyi` / `.ipynb` buckets — directory I/O dominates the per-name
-fnmatch cost on large repos, so one walk beats three suffix-specific
-globs. Jupyter notebooks are converted to a single Python source
-string by `_notebooks.notebook_to_module` before the visitor sees
-them, and the visitor is constructed with
-`default_flags=NodeFlags.NOTEBOOK | NodeFlags.ENTRYPOINT` so every
-emitted node carries those flags from the start. When `libcst`
-rejects a file's syntax (or a notebook's JSON is malformed), the
-per-file work logs a warning and substitutes a placeholder payload
-pairing the real module node with a `[unparseable] <module>`
-synthetic flagged `ENTRYPOINT` — the file stays alive in reachability
-and rides the per-file cache like any other miss, so a fresh source
-SHA picks up the fix automatically. The pool consumes worker results via
-`concurrent.futures.as_completed`, so cache writes land in completion
-order — a single slow file does not block the cache from warming with
-the fast files behind it. Per-task failures other than the in-band
-`OSError` / parse cases are collected and re-raised as a single
-`ExceptionGroup` after the run drains, so one bad file does not waste
-the rest of the work; successful payloads are cache-warmed before the
-group is raised. The pool installs SIGTERM/SIGINT handlers for its
-lifetime, so a signal cancels pending futures and re-raises
-`KeyboardInterrupt`; files that completed before the signal stay
-cache-warmed.
-
-`build_contribution` runs two passes per package. Pass 1 is the
-per-file apply step above (visitor payloads land in `trie`, `nodes`,
-`edges`, `import_edges`). Pass 2 — `_materialize_star_reexports` —
-walks every module-level `from X import *` in `import_edges`, looks
-`X` up in `compose_lookup(own_trie, dep_contributions)` (the own
-trie plus each dep's exported view, the same recipe
-`Analysis._build_symbol_lookup` uses at compose time), and
-synthesizes one `"import"`-typed `SymbolNode` per re-exported name
-in the importing module. Each synthetic gets `STAR_REEXPORT` (so the
-codemod skips it), `EXPORTED` inherited from the importing module
-(so `merge_exported` flows it to consumers), parent edges, a
-`module -> synthetic` keep-alive edge, and its own entry in
-`import_edges` so `resolve_edges` later stitches the
-`synthetic -> target.<name>` chain. Star chains converge via
-fixed-point iteration with a `(importer, target, name)` `seen` set
-breaking cycles. The refresh loop walks packages in
-`Analysis.packages` (dep-first) order, so by the time pass 2 runs
-on a dependent each dep's contribution is already in
-`self._contributions`.
-
-### 5. Edge stitching — `dead_cst/_edges.py`
-
-`resolve_edges` runs **unconditionally** every analysis (it isn't
-cached). It walks the raw `(src, Import, flags)` triples against the
-per-package `SymbolTrie`, **canonicalizing** each `Import` first by
-pushing decl parts into `module` while they resolve as submodules in
-the trie:
-
-```
-from p import functions
-   trie has p.functions as a submodule?
-   -> module="p.functions", decl=None
+```python
+ctx = native.ProjectContext(project_root, src_roots=[pkg.path, ...])
+for plugin in self._plugins:
+    ctx.add_plugin(plugin)
+ctx.materialize()
 ```
 
-Trie misses fall back to the `PathResolver` chain for stdlib /
-external-dist / external-file / unresolved classification — the *only*
-place that reads `sys.path` and the resolver LRU caches.
-`Analysis._materialize` rebinds `sys.path` to each package's
-`(path, *deps)` view before composing it and calls
-`clear_module_specs_cache()` at every transition, restoring `sys.path`
-on the way out. That narrow clear drops only the fullname-keyed
-`safe_resolve_module` cache; `distribution_lookup` and
-`editable_distribution_roots` are keyed on the dist-bearing slice of
-`sys.path` (site-packages / dist-packages / purelib / platlib entries)
-so they survive the rebind for free — only the first-party prefix
-moves, and that prefix never enters the key. A real venv change (uv
-splicing in a workspace `.venv`) flips the key and triggers a single
-rebuild. `clear_path_caches()` is still available as the heavy-hammer
-full reset for callers that mutate the venv slice themselves.
+Each package's path is registered as a `src_root` so the rust backend
+mounts files at the right module FQN (`pkg_a/A/__init__.py` → `A`, not
+`pkg_a.A`). Inside `materialize()` the rust pipeline runs in three
+phases (see `src/lib.rs` for the canonical comment):
 
-Stdlib imports drop silently — they aren't surfaced as graph nodes.
-External-dist / external-file / unresolved misses produce one synthetic
-node per group so plugins can still answer "which files imported X?".
-A dotted name whose own `find_spec` returns nothing (`collections.abc`
-and friends, synthesized in their parent's `__init__`) falls back to
-the parent's classification, so the child inherits stdlib / dist
-attribution instead of being misfiled as `[unresolved]`.
+**Phase 1 — decls.** For every project file, iterate every binding in
+the file's global scope via `UseDefMap::all_definitions_with_usage`,
+minting a `SymbolNode` per binding (including each name brought in by
+`from foo import *`). Each node lands in a global
+`(File, target_range) → node_idx` index so cross-file edges can find
+it later. Shadowed declarations are first-class — two `def f` at
+different lines stay as distinct nodes, distinguished by their
+positional `NodeKey`.
 
-Star imports follow the same path; `Import.speculative` (set on
-`__import__` fromlist synthesis) drops a trie+resolver miss without
-emitting an `[unresolved]` node. Module-level first-party stars are
-also routed through synthetics by `_materialize_star_reexports`
-(stage 4.5 above); the fan-out here covers the non-module-level case
-(`def a(): __import__('p.functions')`), where the materializer can't
-attach synthetics because they need a module home.
+**Phase 2 — chain.** For every module node, emit the parent-module
+edge so `__init__.py` stays alive as long as anything in the package
+does. For every import-kind binding, resolve the upstream target via
+`ty_module_resolver::resolve_module` and emit `alias_node →
+upstream_node`. Targets outside the project (stdlib, site-packages)
+get lazily minted module-only nodes under the
+`[stdlib] X` / `[external dist] X` / `[external file] X` /
+`[unresolved] X` synthetic prefixes.
 
-Re-running this every analysis is what makes single-file edits cheap:
-only the edited file's payload is recomputed; importers re-stitch for
-free.
+**Phase 3 — references.** For every `Definition` that owns an
+expression (function body, class body, assignment RHS, annotation),
+walk the contained `Name`s and resolve each to its reaching def via
+ty's `visible_ancestor_scopes` + `end_of_scope_symbol_bindings`. The
+local alias is the target, not the upstream definition. Module-level
+non-definition statements attribute to the module node itself.
+Statically-dead regions identified by ty's reachability constraints
+get their outgoing edges flagged `EdgeFlags.DEAD_BRANCH`.
 
-Resolution is memoized at three nested layers per call so the per-
-package compose loop stays additive in importer count: equal-spelling
-`Import` instances (the visitor builds fresh objects per file but they
-hash equal because `Import` is frozen) share one `_resolve_targets`
-entry; different `Import` shapes that canonicalize to the same trie
-state share one `_walk` entry; and the resolver fallback runs once per
-unique `(module, speculative)` external. The walk's worklist DFS is
-cycle-protected via a per-walk `visited` set keyed on
-`(id(SymbolTrie), parts_tail)`, so a pathological re-export cycle
-(`A.x: from B import x` / `B.x: from A import x`) terminates after one
-trip with the encountered decls still emitted.
+### 4. Plugins — `dead_cst/plugins/` and `dead_cst/contrib/`
 
-Edge deduplication is centralized in the compose pass: one
-`emitted: set[(src, dst, EdgeFlags)]` owned by
-`Analysis._materialize` is threaded through `_compose_contribution`
-into all three edge sources — contribution edges, `resolve_edges`
-import resolution, and `apply_ops` (plugin `AddEdge`). The shared
-`graph._claim_edge` helper records each triple once, so cross-source
-and cross-package duplicates (e.g. two packages re-exporting the
-same external) collapse to one edge instead of accumulating as
-parallel multigraph edges. Plugin edges carry no flags, so they
-key as `(src, dst, EdgeFlags.NONE)`; `RemoveEdge` drops that key so
-remove-then-add still re-adds the edge.
+After the three phases, each registered plugin's `run(ctx)` is invoked
+with the in-progress `ProjectContext`. Plugins yield `AddNode` /
+`AddEdge` / `AddEntrypoint` ops; the rust apply pass folds them into
+the graph atomically before `materialize()` returns. There is no
+two-phase observe/finalize split anymore — one method, one pass.
 
-### 6. Plugins — `dead_cst/plugins/`
+The plugin contract:
 
-Two phases per `EdgePlugin`:
+```python
+class Plugin:
+    def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
+        ...
+```
 
-* `observe(ctx: ObserveContext) -> VisitorPayload | None` — runs once
-  per file inside the visitor loop, with the parsed `cst.Module` and
-  the visitor's just-built payload. Returns a new payload (or `None`)
-  whose `nodes` / `edges` extend the file's contribution; the result
-  is cached alongside the visitor's output. **Cross-file work does
-  not belong here.**
-* `finalize(ctx: PluginContext) -> Iterable[GraphOp]` — runs once per
-  package after `resolve_edges` has stitched cross-file imports.
-  Operates purely on the assembled graph (no CST access) and emits
-  `AddNode` / `AddEdge` / `RemoveEdge` ops.
+Plugin queries live on `native.ProjectContext`. For common shapes use
+the chainable builder:
 
-`PluginContext` provides helpers (`find_module`, `find_declarations`,
-`module_surface`, …) and exposes the current package's raw build product via
-`ctx.contribution: PackageContribution` — the
-`Package`, the package-local `SymbolTrie`, the contributed
-`frozenset[SymbolNode]` (`ctx.contribution.nodes`), the raw edge and
-import-edge triples, and the per-file dead-suite map.
+```python
+for ref in query(ctx).decorators().where_module("flask").collect():
+    yield AddEdge(...)
+```
 
-Builtins ship in `cli._BUILTIN_PLUGINS`, a `dict[str, Plugin]`
-populated by direct imports of every shipped plugin. Generic-Python
-plugins live as siblings of `plugins/__init__.py` (`MainBlockPlugin`,
-`ProjectScriptsPlugin`, `ExplicitEntrypointPlugin`,
-`ModuleDundersPlugin`, `InitSubclassPlugin`). Third-party-aware
-plugins live under `dead_cst/contrib/` and are re-exported from
-`dead_cst.contrib`. `CeleryPlugin` is the full-featured reference for
-two-phase plugins (factory-aware `DispatchAppPlugin` plus a per-file
-`@shared_task` channel spliced in via an `observe()` override);
-`FlaskPlugin` / `FastAPIPlugin` for the factory-aware
-`DispatchAppPlugin` shape; `TyperPlugin` / `CycloptsPlugin` for the
-pure-dispatch `DispatchAppPlugin` shape; `ClickPlugin` for the
-`DecoratedDeclPlugin` subclass shape.
+Direct accessors (`find_module`, `find_declarations`, `module_for`,
+`find_main_blocks`, …) cover the rest. See `python/dead_cst/_native.pyi`
+for the full surface.
 
-For the common dynamic-import idioms, three abstract bases ship as
-scaffolding (`plugins/decl_shapes.py`):
+Three declarative bases ship as scaffolding for common shapes
+(`plugins/decl_shapes.py`):
 
-* `DecoratedDeclPlugin` — "decorated decls in files matching a search path."
-* `LiteralListPlugin` — "read `<owner>.<var> = ['fqn', ...]` and revive each entry."
-* `DispatchAppPlugin` — "wire `@<instance>.<reg>(...)` handlers to an app instance."
-  Pure-dispatch by default (Typer / Cyclopts: `X = App(); @X.command(...)`); opt into
-  factory-aware mode (Flask / FastAPI / Celery) by setting `instance_kinds: Mapping[str, bool]`
-  to emit `<{name}-app>` / `<{name}-pending>` / `<{name}-factory>` synthetics and run a
-  cross-package finalize walk that classifies factory chains (`X = create_app()`) and
-  promotes auto-entrypoint kinds.
+* `DecoratedDeclPlugin` — decorated decls in files matching a search
+  path.
+* `LiteralListPlugin` — `<owner>.<var> = ['fqn', ...]` registries.
+* `DispatchAppPlugin` — `@<instance>.<reg>(...)` handlers wired to an
+  app instance. Pure-dispatch by default (Typer / Cyclopts); opt into
+  factory-aware mode by setting `instance_kinds: Mapping[str, bool]`
+  (Flask / FastAPI / Celery) — the plugin then emits
+  `<{name}-app>` / `<{name}-pending>` / `<{name}-factory>` synthetics
+  and classifies factory chains across files.
 
-### 7. Reachability — `Analysis.reachable`
+Builtins ship in `cli._BUILTIN_PLUGINS`. Generic-Python plugins live
+in `dead_cst/plugins/` (`MainBlockPlugin`, `ProjectScriptsPlugin`,
+`ExplicitEntrypointPlugin`, `ModuleDundersPlugin`,
+`InitSubclassPlugin`, `DynamicImportFallbackPlugin`); framework-aware
+plugins live in `dead_cst/contrib/` (FastAPI, Flask, Typer, Click,
+Cyclopts, pytest, unittest, Celery, FastMCP, DiscordPy, MockPatch,
+ServerConfig).
 
-BFS from every node with `entrypoint=True`. Default traversal **does**
-follow `DEAD_BRANCH` edges (preserving today's behavior).
-`Analysis.kept_alive_by_dead_branches()` is the opt-in inverse, returning
-the blast radius of removing every dead suite by skipping those edges.
-`Analysis.kept_alive_by_flags_only(flags)` returns the blast radius of
-dropping every entrypoint carrying any of those flag bits. Pass `NodeFlags.TESTCASE`
-for "production code currently kept alive only because tests still
-touch it" (`PytestPlugin` / `UnittestPlugin` stamp `ENTRYPOINT |
-TESTCASE`); pass `NodeFlags.NOQA` for "decls kept alive only by an
-F401 pin" (the visitor stamps `ENTRYPOINT | NOQA` on imports
-preserved by a per-line or file-level ruff/pyflakes directive); OR
-the bits to combine.
+### 5. Reachability — `Analysis.reachable` and friends
 
-For the raw dead-suite positions themselves (the input to the
-`EdgeFlags.DEAD_BRANCH` flagging from stage 3), iterate
-`ctx.edges()` and filter on `EdgeFlags.DEAD_BRANCH`.
+BFS from every node whose flags overlap `seed_flags`. Default seed
+mask is `KEEPALIVE_DEFAULT = ENTRYPOINT | TESTCASE | NOQA | NOTEBOOK`.
+Default traversal **does** follow `DEAD_BRANCH` edges (preserving
+historical behavior). Three queries cover the standard slicing:
 
-### 8. Codemod — `dead_cst/codemod.py`
+* `Analysis.dead(seed_flags=...)` — every decl not reached from any
+  seed in the mask.
+* `Analysis.kept_alive_by_dead_branches()` — diff of the default
+  closure against the strict closure that skips dead-branch edges.
+* `Analysis.kept_alive_by_flags_only(flags, ...)` — diff of
+  `reachable(seed_flags)` against `reachable(seed_flags & ~flags)`.
+  Pass `NodeFlags.TESTCASE` for the "what dies if the test suite goes
+  away" question, `NodeFlags.NOQA` for the stale-F401 audit, or OR
+  them together.
 
-`remove_code` runs a LibCST `RemoveDeadSymbols` transformer keyed on
-`(fqname, CodeRange)` pairs (position disambiguates shadowed decls),
-then prunes now-unused imports via `RemoveImportsVisitor`. Position
-keying is critical — losing it conflates a dead decl with a live shadow.
+All four delegate to a rust BFS in one FFI call — there is no Python
+adjacency walk on the hot path.
 
-Callers feed the unreachable subgraph in directly, e.g.
-`remove_code(list(analysis.dead()), project_root)`.
+### 6. Graph persistence — `dead_cst.graph.write_graph` / `read_graph`
 
-`generate_patch(G, root)` is the non-destructive twin: same selection
-logic, same two-pass LibCST pipeline (a private `_rewrite_one` helper
-keeps the two functions from drifting), but instead of writing back it
-emits a `git apply`-compatible unified diff with `diff --git` headers
-and a `deleted file mode 100644` extended header for module-node
-deletions. Selection is driven entirely by `G.nodes`, so callers can
-slice the unreachable graph however they like (e.g. one SCC at a time)
-to review a big codebase as a series of focused patches. The
-`dead-cst remove` CLI uses `generate_patch` exclusively — it emits a
+`dead-cst build ROOT -o PATH` materializes the graph once and writes it
+to disk as a bincode blob prefixed with the magic bytes `DEADCSTG` and
+a `u32` format version. `dead-cst analyze --graph PATH` /
+`dead-cst remove --graph PATH` skip the build entirely and load the
+file instead.
+
+The library-level twin:
+
+```python
+from dead_cst.graph import write_graph, read_graph
+
+graph = Analysis(root, resolver=...).materialize_all()
+write_graph("graph.bin", graph, meta=[("branch", "main")])
+
+loaded, metadata = read_graph("graph.bin")
+loaded.reachable(seed_flags=NodeFlags.ENTRYPOINT)  # pure-Python BFS
+```
+
+Loaders are strict — a version mismatch is a fatal error with no
+migration path (rebuilding is cheap). The metadata block records
+`created_at`, node / edge / file / line counts, and any
+user-supplied `(key, value)` pairs the CLI's `--meta` flag threads
+through.
+
+Plugins deliberately do **not** round-trip. Loading a graph gives you
+a `LoadedGraph` (not a `ProjectContext`), and only the materialized
+adjacency is captured — a project that needs plugin-emitted edges has
+to rebuild rather than load.
+
+### 7. Codemod — `dead_cst/codemod.py`
+
+`remove_code(dead_nodes, package_path)` runs a LibCST
+`RemoveDeadSymbols` transformer keyed on `(fqname, start_line)` pairs
+(line disambiguates shadowed decls), then prunes now-unused imports
+via libcst's `RemoveImportsVisitor`. Position keying is critical —
+losing it conflates a dead decl with a live shadow.
+
+`generate_patch(dead_nodes, root)` is the non-destructive twin: same
+selection logic, same two-pass LibCST pipeline, but emits a
+`git apply`-compatible unified diff with `diff --git` headers (and
+`deleted file mode 100644` for module-node deletions) instead of
+writing back. Selection is driven entirely by the input iterable, so
+callers can slice the unreachable set however they like (e.g. one SCC
+at a time) to review a big codebase as a series of focused patches.
+`dead-cst remove` uses `generate_patch` exclusively — it emits the
 patch to stdout (or `--output PATH`) and never mutates source.
 
-## Lazy materialization on `Analysis`
-
-`Analysis` is cheap to construct — the resolver runs once at `__init__`,
-but no source files are read or parsed until you ask. Three coarse
-stages happen on demand:
-
-1. **File enumeration + visitor pass** — `refresh()`. Walks each
-   requested package's tree, collapses every package's cache misses
-   into one global stale-file list, and runs the visitor + observe
-   pass once across the whole batch.
-2. **Per-package contribution build** — the per-package
-   `SymbolTrie` + raw `frozenset[SymbolNode]` / `frozenset[(src, dst,
-   EdgeFlags)]` / `Mapping[Path, tuple[CodeRange, ...]]` (dead-suite
-   positions) + the unresolved cross-file import set. Built once per
-   package from the payloads above by `dead_cst._package.build_contribution`,
-   memoized for the lifetime of the `Analysis`.
-3. **Cross-package composition** — `materialize_all()`. The rust
-   backend assembles the whole project graph in one pass via ty's
-   Salsa db; there is no cheaper per-package closure path.
+The codemod is the only stage that still uses LibCST.
 
 ## Graph model invariants
 
-* One node per top-level declaration plus one synthetic module node per
-  file. Nested defs (inner functions, methods, nested classes) are
+* One node per top-level declaration plus one synthetic module node
+  per file. Nested defs (inner functions, methods, nested classes) are
   deliberately not given their own nodes — refs from inside them
   attribute to the enclosing top-level decl.
 * A module-level `import` / `from ... import ...` is itself a node of
-  type `"import"`. Local uses of an imported name go through the import
-  node, which points at the upstream module / symbol. This is how
-  `dead-cst remove` knows to drop now-unused imports.
-* Imports whose source line carries a ruff/pyflakes `# noqa` directive
-  that silences F401 (bare `# noqa`, `# noqa: F401`, multi-rule
-  `# noqa: E501, F401`, case-variant `# NOQA`) are flagged
-  `NodeFlags.ENTRYPOINT | NodeFlags.NOQA` so reachability keeps them
-  alive — matching ruff's own semantics. File-level `# ruff: noqa` and
-  `# flake8: noqa` directives (`ruff:` / `flake8:` matched
-  case-sensitively per ruff; `noqa` is not) pin every import in the
-  file. The visitor scans for these in `visit_Comment` plus a
-  per-import-statement `SimpleStatementLine` walk, so per-alias
-  comments inside a parenthesized `from x import (a, b)` are honored.
-  The `NOQA` bit is metadata layered on `ENTRYPOINT` (parallel to
-  `TESTCASE`); the single `Analysis.kept_alive_by_flags_only(flags)`
-  method takes either flag (or both ORed) to return the blast radius
-  of dropping the matching entrypoints.
-* Submodules edge to their parent package, so `__init__.py` stays alive
+  type `"import"`. Local uses of an imported name always edge to the
+  local alias (the codemod invariant: an unused import has zero
+  in-edges). When ty's module resolver / global-scope lookup can pin
+  the use to specific upstream targets, the use *also* emits direct
+  edges to each of them.
+* Submodules edge to their parent package so `__init__.py` stays alive
   as long as anything in the package does.
-* `EdgeFlags.DEAD_BRANCH` is metadata only.
-* `NodeFlags.SHADOWED` decls are emitted into the graph but excluded
-  from the trie, so cross-module imports never resolve to them.
-  `NodeFlags.OVERLOAD` follows the same trie-exclusion rule but its
-  lifetime is anchored to the matching same-file impl via explicit
-  `impl -> overload` edges.
-* `.pyi` stubs are ingested only for the compiled-extension layout
-  (`_native.so` + `_native.pyi`, no `.py` twin). Peer-mode `.pyi` is
-  dropped at file-enumeration time — the runtime always wins.
-* `.ipynb` (Jupyter) files are concatenated cell-by-cell into one
-  parseable Python module by `_notebooks.notebook_to_module`. IPython
-  magics, shell escapes, and trailing-help forms are rewritten to
-  `pass  # <line>` so libcst accepts the source. The visitor is
-  constructed with `default_flags=NodeFlags.NOTEBOOK | NodeFlags.ENTRYPOINT`
-  so every node carries those flags from the start; `NOTEBOOK` also
-  keeps the decl out of the cross-module lookup trie alongside
-  `SHADOWED` / `OVERLOAD`. The codemod skips any node flagged
-  `NOTEBOOK`.
-* A `foo.py` next to a `foo/__init__.py` is **eclipsed** by the package
-  (mirroring CPython's `FileFinder`). `_package.eclipsed_paths` flags
-  the `.py` before `_apply_payload` runs, and the apply pass skips its
-  trie additions only — its nodes still land in the contribution so
-  observe-time entrypoints (`__main__`, plugin synthetics) keep
-  working, but cross-module imports of `pkg.foo` route to the
-  package's `__init__.py` alone. Disambiguates from
-  `NodeFlags.SHADOWED` (intra-file decl rebinding) and the `.pyi`
-  peer-stub filter.
-* `NodeFlags.EXPORTED` tags every node from a file under
-  `Package.exported`. The visitor's `default_flags` mechanism stamps
-  it at construction; the single per-package lookup trie holds every
-  visible decl, and consumer-side merges use `SymbolTrie.merge_exported`
-  to filter to entries with this bit set (the package's own self-lookup
-  uses plain `merge` and sees everything). `Package.exported` is in
-  the per-package fingerprint, so editing it invalidates that
-  package's cache.
-* `NodeFlags.STAR_REEXPORT` tags synthetic `"import"`-typed decls
-  that `_materialize_star_reexports` synthesizes for every name a
-  `from X import *` re-exports. They live in the trie like real
-  re-export imports (so cross-module lookups resolve through them)
-  and inherit `EXPORTED` from their importing module. The codemod
-  skips them: the file has only `from X import *`, not the per-name
-  `from X import <decl>` line `RemoveImportsVisitor` would otherwise
-  chase.
-* `[unparseable] <module>` synthetics stand in for files `libcst`
-  cannot parse. They carry `NodeFlags.ENTRYPOINT` and edge at the real
-  module node, so the file stays alive even though its decls are
-  invisible.
+* `EdgeFlags.DEAD_BRANCH` is metadata only; default reachability still
+  follows the edge.
+* `NodeFlags.SHADOWED` decls (a `def f` rebound later in the same
+  file) are kept in the graph but excluded from the cross-module
+  lookup so consumer imports route to the live binding.
+* `NodeFlags.OVERLOAD` follows the same trie-exclusion rule as
+  `SHADOWED`; lifetime is anchored to the matching same-file impl via
+  explicit `impl -> overload` edges.
+* `NodeFlags.NOQA` flags import aliases preserved by a user
+  ruff/pyflakes noqa directive (per-line `# noqa`, `# noqa: F401`,
+  `# noqa: E501, F401`, or file-level `# ruff: noqa` / `# flake8:
+  noqa`). Layered on `ENTRYPOINT`.
+* `NodeFlags.NOTEBOOK` tags every node sourced from a Jupyter
+  `.ipynb` file. Notebook cells run top-to-bottom rather than being
+  imported, so the bit alone keeps the node alive (no `ENTRYPOINT`
+  overlay needed — `NOTEBOOK` is in `KEEPALIVE_DEFAULT`). The codemod
+  skips notebook nodes (cell-aware writeback into the JSON envelope is
+  out of scope today).
+* `NodeFlags.STAR_REEXPORT` tags synthetic `kind="import"` nodes
+  minted for each name brought in by `from X import *`. They live in
+  the cross-module lookup like real re-export imports; the codemod
+  skips them (there is no per-name source line to remove).
+* `.pyi` stubs are ingested only for the **compiled-extension** layout
+  (`_native.so` + `_native.pyi`, no `.py` twin). Peer-mode stubs
+  alongside a real `.py` are dropped — the runtime always wins.
 
 ## Where to make changes
 
-| If you want to…                                          | Touch                                          |
-| -------------------------------------------------------- | ---------------------------------------------- |
-| Recognize a new decl shape                               | `_visitor.py` (bump `SymbolVisitor.version`)   |
-| Fold a domain-specific expression to a known truthiness  | subclass `DefaultUnreachableRegionDetector`    |
-| Keep alive symbols a framework registers dynamically     | new `EdgePlugin` under `contrib/`              |
-| Support a new project layout / lockfile                  | new `PathResolver` under `contrib/`            |
-| Change how cross-file imports get classified             | `_edges.resolve_edges` + the resolver fallback |
-| Change how `from X import *` re-exports are materialized | `_package._materialize_star_reexports`         |
-| Change codemod output shape                              | `codemod.py` (`RemoveDeadSymbols` / `_rewrite_one`) |
-| Change patch format / per-SCC patch slicing              | `codemod.generate_patch`                       |
+| If you want to…                                                | Touch                                              |
+| -------------------------------------------------------------- | -------------------------------------------------- |
+| Recognize a new decl shape                                     | `src/ingest.rs` (Phase 1)                          |
+| Tweak how imports resolve                                      | `src/ingest.rs` (Phase 2, `emit_import_edges`)     |
+| Tweak how references attribute                                 | `src/ingest.rs` (Phase 3, `emit_reference_edges`)  |
+| Add a new plugin query                                         | `src/query.rs` (extend `QueryBuilder`)             |
+| Keep alive symbols a framework registers dynamically           | new `Plugin` under `dead_cst/contrib/`             |
+| Support a new project layout / lockfile                        | new `PathResolver` under `dead_cst/contrib/`       |
+| Change graph persistence format                                | `src/io.rs` (bump the format version)              |
+| Change codemod output shape                                    | `dead_cst/codemod.py` (`RemoveDeadSymbols` / `_rewrite_one`) |
+| Change patch format / per-SCC patch slicing                    | `dead_cst/codemod.py` (`generate_patch`)           |
 
-See `CLAUDE.md` for the per-stage cache-invalidation discipline.
+See `CLAUDE.md` for the top-level invariants and `src/CLAUDE.md` for
+the rust crate's principles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,182 +12,78 @@ two versions.
 ## [0.11.0] - 2026-05-20
 
 ### Added
-- **`dead-cst build`** materializes the project graph and persists it
-  to disk in a bincode-encoded binary file (header + node / edge lists
-  + a small metadata block). Subsequent `dead-cst analyze` and
-  `dead-cst remove` runs can then skip the build with
-  `--graph PATH`, which is useful for CI shapes that run multiple
-  reachability queries against the same code state. Plugins
-  intentionally do *not* round-trip — only the materialized adjacency
-  is captured, so a project that needs plugin-emitted edges must
-  rebuild rather than load.
-- **`--meta key=value`** on `build` stashes arbitrary user-supplied
-  metadata (branch name, commit SHA, etc.) into the graph file's
-  metadata block alongside the auto-recorded `created_at`, node /
-  edge / file / line counts.
-- **`--query {dead,test-only}`** on `analyze` and `remove`. The
-  default `dead` reproduces the previous behaviour; `test-only` runs
-  `kept_alive_by_flags_only(NodeFlags.TESTCASE)` and returns the
-  blast-radius set — code that goes dead the moment you drop the
-  test suite. Plumbs through to the patch emitter, so
-  `dead-cst remove ROOT --query test-only` is the one-shot "delete
-  the test suite and every helper that backed it" workflow.
-- **`--entrypoint-regex REGEX`** as an explicit replacement for the
-  old `-e re:<pattern>` magic prefix.
-- **`--exit-zero`** on `analyze` makes the command always exit 0 even
-  when dead code is found.
-- **Public Python API** for graph persistence:
-  :func:`dead_cst.graph.write_graph`,
-  :func:`dead_cst.graph.read_graph`, and
-  :class:`dead_cst.graph.GraphMetadata`. All I/O lives in the rust
-  crate (`dead_cst._native.write_graph` / `.read_graph`); the Python
-  wrappers handle `SymbolGraph` ↔ `NativeGraph` translation. The
-  on-disk format has a hard-versioned header — version mismatch is a
-  fatal error, with no migration path (rebuilding a graph is cheap).
+- `dead-cst build ROOT -o PATH` persists the materialized graph to a
+  bincode file; `analyze` / `remove --graph PATH` reuse it. Plugins
+  don't round-trip; rebuild to re-run them.
+- `--meta key=value` on `build` stashes user-supplied metadata in the
+  graph file alongside auto-recorded counts.
+- `--query {dead,test-only}` on `analyze` / `remove`. `test-only` runs
+  the `NodeFlags.TESTCASE` blast-radius query.
+- `--entrypoint-regex REGEX` replaces the old `-e re:<pattern>` magic
+  prefix.
+- `--exit-zero` on `analyze` always exits 0.
+- Public graph persistence API: `dead_cst.graph.write_graph`,
+  `read_graph`, `GraphMetadata`, `LoadedGraph`. Hard-versioned header;
+  version mismatch fails fast.
+- `EdgeFlags.DEAD_BRANCH` edges (from `if False:`, post-`return`,
+  etc.) via ty's reachability constraints.
+- `EdgeFlags.DYNAMIC_IMPORT` edges for string-literal `__import__()` /
+  `importlib.import_module()` calls.
+- `.pyi` stub ingestion for compiled-extension layouts.
 
-### Removed
-- **``tqdm`` runtime dependency.** Progress reporting moved entirely
-  to the rust crate's ``indicatif`` bars during the rust refactor;
-  the Python ``dead_cst._progress`` shim that wrapped ``tqdm`` had
-  no callers left.
-- **``dead_cst._notebooks`` helper module.** Notebook ingestion lives
-  in the rust crate (``src/helpers.rs``); the Python helper that
-  preceded it had no callers.
-- **``PackageView`` class (and its accessors).** The per-package view
-  was a thin filter over ``Analysis`` results; ``Analysis.package(p)``,
-  ``Analysis.views()``, and ``Analysis.materialize_closure(p)`` are
-  gone with it. Callers that need a per-package slice filter the
-  project-wide query inline (e.g.
-  ``[n for n in analysis.dead() if Path(n.path).is_relative_to(pkg)]``).
-  ``Analysis.count_nodes()`` and ``PackageView.count_nodes()`` had no
-  external callers and were removed in the same pass; the CLI's
-  per-package histograms go through ``analyze._count_nodes_by_prefix``
-  directly.
-
-### Changed
-- **Annotation references to native types are unquoted.** With
-  ``from __future__ import annotations`` already in place across the
-  package, ``"native.ProjectContext"``-style string annotations in
-  function signatures and variable annotations are no longer needed —
-  they're plain ``native.ProjectContext`` references that the
-  ``TYPE_CHECKING``-guarded import satisfies for type-checkers and
-  that runtime never evaluates. The CLI's ``GraphView`` type alias
-  moves inside the ``TYPE_CHECKING`` block for the same reason.
+### Changed (breaking)
+- Rust-native graph builder. libcst visitor, SQLite per-file cache,
+  and networkx are replaced by a pyo3 extension on ty's
+  `SemanticIndex`. libcst is only used by the codemod now.
+- Build system: hatchling → maturin. Crate in `src/`, Python in
+  `python/dead_cst/`, wheel ships `_native.{abi3.so,pyd}`.
+- CLI trimmed to `build` / `analyze` / `remove`. `why-alive`,
+  `dependencies`, `unused-exports` removed (still in the Python API).
+- `Analysis.materialize_all()` returns a live
+  `native.ProjectContext`; the Python `SymbolGraph` facade is gone.
+  Iterate `ctx.nodes()` / `ctx.edges()`; walk via `ctx.reachable()` /
+  `descendants()` / `ancestors()`.
+- `PackageView` removed. Filter `analysis.dead()` by
+  `Path(n.path).is_relative_to(pkg)` for per-package slices.
+- `codemod.remove_code` / `generate_patch` take an iterable of dead
+  `SymbolNode`s (not a graph).
+- Plugin protocol: subclass `Plugin`, implement `run(ctx)` yielding
+  `AddNode` / `AddEdge` / `AddEntrypoint`. `observe()` / `finalize()`
+  and per-file caching are gone.
+- `Plugin.name` / `version` fields dropped. Progress label is
+  `type(plugin).__qualname__`. The three declarative bases
+  (`DecoratedDeclPlugin`, `DispatchAppPlugin`, `LiteralListPlugin`)
+  gained a required `marker_prefix` field.
+- Framework plugins are now factory functions (`fastapi_plugin()`,
+  `flask_plugin()`, `typer_plugin()`, `cyclopts_plugin()`,
+  `fastmcp_plugin()`). Plugins with custom `run()` or per-instance
+  config remain classes.
+- Plugin query API: chainable builder
+  (`query(ctx).decorators().where_module(...).collect()`) replaces
+  `ctx.find_*` helpers.
+- Plugin / resolver registries live in `dead_cst.cli`. Contrib plugin
+  re-exports from `dead_cst.plugins` are gone, as is `UvResolver` from
+  `dead_cst.resolvers` — import from `dead_cst.contrib`.
+- `BUILTIN_PLUGINS` / `BUILTIN_RESOLVERS` / `load_plugin` /
+  `load_resolver` removed.
+- `-e re:<pattern>` magic prefix dropped (use `--entrypoint-regex`);
+  plain `-e` is now path-or-FQN only.
 
 ### Fixed
-- **`ModuleDundersPlugin` now pins module-level dunder *functions*.**
-  PEP 562 ``__getattr__`` / ``__dir__`` defined at module scope are
-  observable to the import / attribute-access machinery, the same way
-  module dunder *variables* are. The plugin previously filtered to
-  ``kind == "variable"`` only, so these functions (and any imports /
-  helper vars they depended on) were falsely reported dead. Dunder
-  *methods* inside a class are unaffected — they ride on their
-  enclosing class's reachability.
-- **Quoted type annotations contribute use edges.** Names that appear
-  only inside a string annotation (``"Helper"`` in
-  ``def f(x: "Helper")``, common under ``if TYPE_CHECKING:`` /
-  ``from __future__ import annotations``) now resolve through ty's
-  ``enter_string_annotation`` sub-model and emit the same alias /
-  upstream edges they would unquoted. Regular string literals in
-  non-annotation positions are untouched.
-- **``from .submod import X`` inside ``__init__.py`` no longer reports
-  the submodule attribute as dead.** ty mints an extra
-  ``ImportFromSubmodule`` binding for the side-effect ``pkg.submod``
-  attribute that Python rebinds whenever the statement executes; the
-  graph now wires ``sibling_alias → submodule_alias`` edges so the
-  attribute alias stays alive as long as any sibling alias from the
-  same statement does. When every sibling is dead, the whole statement
-  collapses normally.
-
-### Changed (breaking)
-- **CLI trimmed to three commands.** `dead-cst why-alive`,
-  `dead-cst dependencies`, and `dead-cst unused-exports` are
-  removed; the data they exposed is still available through the
-  Python API (:meth:`Analysis.ancestors`, the synthetic external-dep
-  nodes under :data:`EXTERNAL_PREFIXES`, and the `__all__`-only
-  blast-radius query, respectively). The supported surface is
-  `dead-cst build` / `dead-cst analyze` / `dead-cst remove`.
-- **`-e re:<pattern>` magic prefix** is no longer recognized. Use
-  `--entrypoint-regex <pattern>` instead. The plain `-e` flag now
-  treats its argument as a file path or FQN literal.
-- **Plugin and resolver registries moved into the CLI.** The CLI's
-  `--plugin` and `--resolver` flags now resolve names against maps
-  declared in :mod:`dead_cst.cli`, populated by direct imports of
-  every builtin; out-of-tree plugins / resolvers still register under
-  the `dead_cst.plugins` / `dead_cst.resolvers` entry-point groups.
-  The public re-exports of contrib plugins from :mod:`dead_cst.plugins`
-  are gone, as is the `UvResolver` re-export from
-  :mod:`dead_cst.resolvers` — import them from :mod:`dead_cst.contrib`
-  (or the specific contrib submodule). `dead_cst.plugins.load_plugin`,
-  `dead_cst.plugins.BUILTIN_PLUGINS`,
-  `dead_cst.resolvers.load_resolver`, and
-  `dead_cst.resolvers.BUILTIN_RESOLVERS` are removed;
-  :mod:`dead_cst.contrib` no longer uses a lazy ``__getattr__``
-  indirection.
-
-### Changed (breaking)
-- **Dropped the Python ``SymbolGraph`` adjacency facade.**
-  ``Analysis.materialize_all()`` and ``PackageView.graph()`` now return
-  the live :class:`native.ProjectContext` directly — no Python-side
-  dict-of-lists copy, no per-node ``_idx`` allocation. Callers iterate
-  ``ctx.nodes()`` / ``ctx.edges()`` and route adjacency walks through
-  ``ctx.reachable(...)`` / ``ctx.descendants(...)`` / ``ctx.ancestors(...)``.
-  ``codemod.remove_code`` and ``codemod.generate_patch`` now take an
-  iterable of dead ``SymbolNode``\ s instead of a graph; edges were
-  ignored anyway.
-- **Rust-native graph builder.** The libcst CST visitor pipeline, SQLite
-  per-file cache, and networkx graph are all replaced by a pyo3 native
-  extension built on ty's ``SemanticIndex``. Graph construction, import
-  resolution, and reachability walks run entirely in Rust. The only
-  remaining libcst usage is the codemod source rewriter.
-- **Build system.** Switched from hatchling to maturin. The Rust crate
-  lives in ``src/``, Python sources under ``python/dead_cst/``, and the
-  wheel ships ``_native.{abi3.so,pyd}`` alongside the Python code.
-- **``networkx`` → ``rustworkx``.** ``SymbolNode`` and ``Import`` are
-  now frozen pyo3 classes, not Python dataclasses.
-- **Plugin protocol.** Plugins subclass :class:`~dead_cst.plugins.Plugin`
-  and implement a single ``run(ctx: ProjectContext)`` that yields
-  :class:`~dead_cst._native.GraphOp` values (``AddNode`` / ``AddEdge`` /
-  ``AddEntrypoint``). The old ``observe()`` / ``finalize()`` two-phase
-  split and per-file caching are gone.
-- **Plugin ``name`` / ``version`` fields dropped.** The Rust progress bar
-  derives its label from ``type(plugin).__qualname__``. The three
-  declarative bases (:class:`DecoratedDeclPlugin`,
-  :class:`DispatchAppPlugin`, :class:`LiteralListPlugin`) gained a
-  required ``marker_prefix: str`` field that controls the synthetic
-  fqname prefix.
-- **``BUILTIN_PLUGINS``** is now a ``list[Plugin]`` of instances instead
-  of a ``dict[str, type]``. CLI ``--plugin <key>`` lookup is unchanged.
-- **Framework plugins are factory functions.** ``FastAPIPlugin``,
-  ``FastMCPPlugin``, ``FlaskPlugin``, ``TyperPlugin``,
-  ``CycloptsPlugin`` are replaced by lowercase factory functions
-  (e.g. :func:`~dead_cst.plugins.fastapi_plugin`). Plugins with custom
-  ``run()`` logic or per-instance configuration remain classes.
-- **Plugin query API.** ``ctx.find_*`` helpers replaced by a chainable
-  builder (``query(ctx).decorators().where_module(...).collect()``) with
-  Rust-backed cross-file lookups, subclass closures, and
-  decorator/call matching.
-- **Reachability queries.** ``ctx.reachable()`` / ``ctx.descendants()`` /
-  ``ctx.ancestors()`` delegate to a Rust BFS in a single FFI call
-  instead of per-node Python ↔ networkx round-trips.
-
-### Added
-- **Dead-branch detection.** Edges from statically-dead code regions
-  (``if False:``, post-``return``) carry :attr:`EdgeFlags.DEAD_BRANCH`,
-  identified via ty's reachability constraints instead of a custom
-  ``TruthinessResolver``.
-- **Dynamic-import edges.** ``__import__()`` and
-  ``importlib.import_module()`` calls with string-literal args emit
-  :attr:`EdgeFlags.DYNAMIC_IMPORT` edges.
-- **Stub-file support.** ``.pyi`` stubs are ingested for
-  compiled-extension layouts (``_native.so`` + ``_native.pyi`` with no
-  ``.py`` twin).
-- ``ConstructionRef`` gained ``args`` and ``kwargs`` fields (mirroring
-  ``CallRef`` and ``DecoratorRef``).
+- `ModuleDundersPlugin` pins module-level dunder *functions*
+  (`__getattr__` / `__dir__` per PEP 562), not just variables.
+- Quoted type annotations (`def f(x: "Helper")`) contribute use edges
+  via ty's `enter_string_annotation`.
+- `from .submod import X` in `__init__.py` no longer reports the
+  submodule attribute as dead; sibling aliases keep it alive.
 
 ### Removed
-- The libcst graph builder, ``TruthinessResolver``, SQLite per-file
-  cache, and ``networkx`` dependency.
+- `tqdm` runtime dep (rust uses `indicatif`).
+- `PackageView`, `Analysis.count_nodes`, `Analysis.materialize_closure`,
+  `Analysis.package`, `Analysis.views`.
+- `dead_cst._notebooks` helper (notebook ingestion is in rust).
+- libcst graph builder, SQLite cache, `TruthinessResolver`,
+  `networkx` / `rustworkx` deps.
 
 ## [0.10.0] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ two versions.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-20
+
 ### Added
 - **`dead-cst build`** materializes the project graph and persists it
   to disk in a bincode-encoded binary file (header + node / edge lists
@@ -1654,7 +1656,8 @@ versions until the first stable release.
 - `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, and `ROADMAP.md` with a
   stack-ranked plan from alpha to 1.0.
 
-[Unreleased]: https://github.com/lpetre/dead-cst/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/lpetre/dead-cst/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/lpetre/dead-cst/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/lpetre/dead-cst/compare/v0.9.4...v0.10.0
 [0.9.4]: https://github.com/lpetre/dead-cst/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/lpetre/dead-cst/compare/v0.9.2...v0.9.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,18 @@
 # Contributing to dead-cst
 
-Thanks for your interest. `dead-cst` is small and pre-release — bug reports with minimal repros, real-world test cases, and PRs are all welcome. Expect APIs and CLI flags to keep moving until the first stable release. See [`ROADMAP.md`](ROADMAP.md) for the planned trajectory.
+Thanks for your interest. `dead-cst` is small and pre-release — bug
+reports with minimal repros, real-world test cases, and PRs are all
+welcome. Expect APIs and CLI flags to keep moving until the first
+stable release. See [`ROADMAP.md`](ROADMAP.md) for the planned
+trajectory.
 
 ## Development setup
 
-`dead-cst` uses [uv](https://github.com/astral-sh/uv) for environment management.
+`dead-cst` uses [uv](https://github.com/astral-sh/uv) and
+[maturin](https://github.com/PyO3/maturin) — the rust extension under
+`src/` builds into `python/dead_cst/_native.{abi3.so,pyd}` on
+`uv sync`. You need a Rust toolchain (`rustup`); everything else (uv,
+pytest, ruff, prek, ty, maturin) is installed by `uv sync`.
 
 ```bash
 git clone https://github.com/lpetre/dead-cst
@@ -12,126 +20,132 @@ cd dead-cst
 uv sync
 ```
 
-That installs the package in editable mode along with the `dev` group: `pytest`, `ruff`, `prek`, and `ty`.
-
 ## Running tests
 
 ```bash
-uv run pytest
-```
-
-For a tight inner loop while editing the visitor, resolver, or a plugin, `pytest-watcher` is in the dev group:
-
-```bash
-uv run ptw
-```
-
-To collect coverage locally:
-
-```bash
+uv run pytest                          # full suite (e2e is deselected by default)
+uv run pytest tests/test_imports.py    # one file
+uv run pytest -k name_substring        # one test by name
+uv run pytest -m e2e                   # opt-in e2e suite (clones real GitHub repos)
 uv run pytest --cov=dead_cst --cov-branch --cov-report=term-missing
+uv run ptw                             # pytest-watcher for a tight inner loop
 ```
 
-CI uploads branch coverage from the 3.13 matrix entry to Codecov on every push and PR.
+`pyproject.toml` pins `addopts = "-m 'not e2e'"`, so the standard
+`uv run pytest` is hermetic. CI runs the matrix `pytest` on Python
+3.11–3.14 plus `prek run --all-files` on every push and pull request.
 
-## Coverage policy
+## Linting, formatting, type-checking
 
-Per-component thresholds reflect blast radius, not total LOC. The full
-configuration lives in `codecov.yml`; the targets are:
-
-| Component | Target | Why |
-|---|---|---|
-| `_codemod.py` | 95% | Rewrites user files. Regressions corrupt source. |
-| `cli.py` | 80% | User-visible trust surface. |
-| `_plugins/**` | 85% | Each plugin is a framework promise. |
-| `_resolvers/**` | 85% | Path resolution drives every analysis. |
-| `_analyze.py`, `_visitor.py`, `_resolve.py`, `_flow.py`, `_branches.py`, `_symbols.py`, `_fqn.py` | 80% | Analytical core. |
-
-Per-component statuses are **informational** until Tier 1 of `ROADMAP.md`
-(CLI integration tests, remaining framework presets) lands and the numbers
-clear the bars above. The patch-coverage gate on new code is **enforcing**
-at 90% — regressions are caught at the diff, not in aggregate.
-
-`if TYPE_CHECKING:` blocks, `@overload` stubs, and `_version.py` are
-excluded; see `[tool.coverage.*]` in `pyproject.toml`.
-
-## Linting and formatting
-
-Ruff (lint + format), `ty` (type check), and a small set of hooks run on every commit via [`prek`](https://github.com/j178/prek), a fast Rust-based drop-in replacement for `pre-commit` that reads the same `.pre-commit-config.yaml`.
+Ruff (lint + format), `ty` (type check), and a small set of hooks run
+on every commit via [prek](https://github.com/j178/prek), a
+Rust-based drop-in replacement for `pre-commit`:
 
 ```bash
 uv run prek install        # one-time, sets up the git hook
 uv run prek run --all-files
 ```
 
-CI runs `prek run --all-files` on every push and pull request, so running it locally before committing avoids round-trips.
+`ty` type-checks `dead_cst/` only — tests, examples, and workspace
+fixtures intentionally exercise untyped third-party internals.
 
 ## Project layout
 
 ```
-dead_cst/
-  __init__.py            # public API surface
-  _analyze.py            # build_symbol_graph, find_reachable, count_nodes, order_paths
-  _codemod.py            # remove_code -- LibCST transformer + import pruner
-  _resolve.py            # import resolution (stdlib / first-party / third-party)
-  _resolvers/            # path resolvers:
-    manual.py            #   explicit base:dep1,dep2 specs (the CLI's -p)
-    uv.py                #   uv.lock workspace members + inter-member deps (lives under contrib/)
-    _exports.py          #   exported_roots: hide internal dirs from consumers
-  _symbols.py            # SymbolNode, SymbolTrie data classes
-  _visitor.py            # SymbolVisitor -- walks each file and emits symbols + edges
-  _flow.py               # flow-sensitive live-at-exit analysis for shadowing
-  _branches.py           # statically-dead suite detection
-  _fqn.py                # FullyQualifiedNameProvider patches / wrappers
-  _plugins/              # edge plugins:
-    main_block.py        #   if __name__ == "__main__"
-    project_scripts.py   #   pyproject.toml [project.scripts]
-    explicit.py          #   user-supplied -e specs
-    module_dunders.py    #   __all__, __version__, ...
-    pytest.py            #   conftest, test_*.py, @pytest.fixture
-    fastapi.py           #   FastAPI / APIRouter route handlers
-  cli.py                 # Typer entrypoints: analyze, why-alive, unused-exports,
-                         #                    dependencies, remove
-tests/                   # pytest suite, fixture-driven from inline source snippets
+src/                  # ty-backed rust crate (pyo3, builds via maturin)
+  lib.rs              # pymodule entry point
+  project.rs          # Project / ProjectContext / build() pipeline
+  builder.rs          # GraphBuilder, AddNode / AddEdge / AddEntrypoint, BFS
+  graph.rs            # SymbolNode / Import / NativeGraph / NodeFlags / EdgeFlags
+  ingest.rs           # the three build phases (decls / chain / references)
+  query.rs            # plugin-facing chainable query builder
+  helpers.rs          # noqa parser, notebook decoder, dist-info lookup, …
+  io.rs               # write_graph / read_graph (bincode + versioned header)
+python/dead_cst/      # Python source tree (ships alongside _native.so in the wheel)
+  __init__.py         # public API: Analysis, SymbolNode, Import, NodeFlags, EdgeFlags
+  analyze.py          # Analysis (wraps the rust ProjectContext for BFS queries)
+  cli.py              # build / analyze / remove + builtin plugin & resolver maps
+  codemod.py          # remove_code, generate_patch (only stage still on libcst)
+  graph.py            # graph data types + write_graph / read_graph / LoadedGraph
+  _native.pyi         # hand-written type stubs for the rust extension
+  plugins/            # generic-Python plugins (main_block, project_scripts, …)
+  contrib/            # framework-aware plugins + UvResolver
+  resolvers/          # PathResolver, ManualResolver
+tests/                # fixture-driven pytest suite (e2e under tests/e2e/)
 ```
 
-Modules prefixed with `_` are internal; only the names re-exported from `dead_cst/__init__.py` are part of the supported API. Within the package, plugins and resolvers are stable extension points — see below.
+Modules whose name starts with `_` are internal. The supported surface
+is the names re-exported from `dead_cst/__init__.py` plus the focused
+public submodules listed in `python/dead_cst/__init__.py`'s docstring.
+`tests/test_public_api.py` pins each module's `__all__` against a
+snapshot.
 
 ## Adding a plugin
 
-A plugin is any class that satisfies `EdgePlugin` (or `CSTAwareEdgePlugin` if it needs LibCST metadata). Implement `name: str` and a `contribute(ctx)` method that yields `AddNode`, `AddEdge`, or `RemoveEdge` ops.
+Define a class that subclasses `dead_cst.plugins.Plugin` and
+implements `run(ctx) -> Iterable[GraphOp]`:
 
 ```python
-from dead_cst import AddEdge, AddNode, GraphOp, PluginContext, synthetic_node
+from dead_cst.plugins import Plugin
+from dead_cst._native import AddEntrypoint, query
 
-class FlaskRoutesPlugin:
-    name = "flask_routes"
-
-    def contribute(self, ctx: PluginContext):
-        for node in ctx.graph.nodes:
-            ...  # detect @app.route handlers and emit AddNode(..., entrypoint=True)
+class MyPlugin(Plugin):
+    def run(self, ctx):
+        for ref in query(ctx).decorators().where_module("myframework").collect():
+            yield AddEntrypoint(ref.owner)
 ```
 
-Built-in plugins live in `dead_cst/_plugins/<name>.py`; out-of-tree plugins register under the `dead_cst.plugins` entry-point group:
+For common shapes, subclass one of the declarative bases in
+`dead_cst/plugins/decl_shapes.py`:
+
+* `DecoratedDeclPlugin` — decorated decls in files matching a search
+  path.
+* `LiteralListPlugin` — `<owner>.<var> = ['fqn', ...]` registries.
+* `DispatchAppPlugin` — `@<instance>.<reg>(...)` handlers wired to an
+  app instance. Pure-dispatch (Typer / Cyclopts) or factory-aware
+  (Flask / FastAPI / Celery) via `instance_kinds: Mapping[str, bool]`.
+
+Drop generic-Python plugins in `dead_cst/plugins/<name>.py`
+(re-exported from `dead_cst/plugins/__init__.py`); drop
+framework-aware plugins in `dead_cst/contrib/<name>.py` (re-exported
+from `dead_cst/contrib/__init__.py`). Register the CLI key in
+`_BUILTIN_PLUGINS` in `dead_cst/cli.py`, importing the plugin
+directly.
+
+Out-of-tree plugins register under the `dead_cst.plugins`
+entry-point group:
 
 ```toml
 [project.entry-points."dead_cst.plugins"]
-flask_routes = "myproj.plugins:FlaskRoutesPlugin"
+my_plugin = "myproj.plugins:MyPlugin"
 ```
 
-`FastAPIPlugin` is a good full-featured reference — it walks each module's CST, recognises the `FastAPI()` / `APIRouter()` instance pattern, and wires `instance -> handler` edges through decorator detection.
+The CLI's `_load_plugin` checks `_BUILTIN_PLUGINS` first, then the
+entry-point group.
+
+`CeleryPlugin` is the full-featured reference (factory-aware
+`DispatchAppPlugin` plus a per-file `@shared_task` channel);
+`FastAPIPlugin` / `FlaskPlugin` are the factory-aware shape;
+`TyperPlugin` / `CycloptsPlugin` are the pure-dispatch shape.
 
 ## Adding a resolver
 
-A resolver implements `PathResolver`: a `name: str` attribute and a `resolve(project_root)` method returning a `{base: [dep_paths]}` dict. Built-in resolvers live in `_resolvers.py`; third-party resolvers register under `dead_cst.resolvers`.
-
-## Adding an unreachable-region detector
-
-A detector implements `UnreachableRegionDetector`: `find_regions(wrapper) -> list[CodeRange]` plus the standard `Cacheable` `(name, version)` pair. The built-in `DefaultUnreachableRegionDetector` covers literal-only truthiness on `if` / `while` tests, fixpoint constant-folding over simple `Name = literal` assignments, and post-terminator regions inside every suite. To layer in domain knowledge — e.g. "`check_flag("migration-abc")` is always `True` in production" — subclass it and override `resolve(self, expr) -> bool | None`. The override is consulted recursively for every non-keyword expression in every `if` / `while` / `assert` test and every foldable assignment RHS, so guard with an early `isinstance` check to keep it cheap. Returning `None` defers to the built-in literal handling. For detectors that don't fit the constant-folding model at all, write a fresh class that implements `find_regions` directly. Pass an instance via `build_symbol_graph(unreachable_detector=...)`. The detector's `(name, version)` participates in the per-file cache fingerprint, so bumping `version` (epoch-int by convention) after a logic change invalidates stale `VisitorPayload` blobs automatically.
+Implement `PathResolver`: a `resolve(project_root) -> tuple[Package, ...]`
+method. Drop generic resolvers in `dead_cst/resolvers/<name>.py`
+(re-exported from `dead_cst/resolvers/__init__.py`); resolvers that
+target a specific external tool (like `UvResolver` for `uv.lock`)
+belong in `dead_cst/contrib/<name>.py` (re-exported from
+`dead_cst/contrib/__init__.py`). Register the CLI key in
+`_BUILTIN_RESOLVERS` in `dead_cst/cli.py`.
 
 ## Adding a test
 
-Tests use the `build_decl_graph` fixture (in `tests/conftest.py`), which writes a dict of `{filename: source}` to a tmpdir, runs `build_symbol_graph` on it, and returns the resulting graph. The `assert_edges` fixture compares edges as `"src.fqname -> dst.fqname"` strings.
+Tests are fixture-driven from inline source snippets — no checked-in
+`.py` fixture files under `tests/`. The `build_decl_graph` fixture
+(in `tests/conftest.py`) writes a `{filename: source}` dict to a
+tmpdir, runs `Analysis(...).materialize_all()` on it, and returns the
+resulting `ProjectContext`. The `assert_edges` family compares edges
+as `"src.fqname -> dst.fqname"` strings.
 
 ```python
 def test_something(build_decl_graph, assert_edges):
@@ -139,19 +153,38 @@ def test_something(build_decl_graph, assert_edges):
     assert_edges(graph, {"mod.a -> mod", "mod -> mod.a"})
 ```
 
-Plugin tests follow the same pattern in `tests/test_plugins/`. For codemod regressions, `tests/test_codemod.py` writes a source snippet, runs `remove_code`, and asserts on the rewritten text.
+Plugin tests live in `tests/test_plugins/` with their own
+`conftest.py`; resolver tests in `tests/test_resolvers/`. Codemod
+tests (`tests/test_codemod.py`) write a snippet, call `remove_code`,
+and assert on the rewritten text. E2E tests (`tests/e2e/`) shallow-
+clone real repos at pinned SHAs behind the `e2e` marker (deselected
+by default).
 
 ## Reporting bugs
 
-A good bug report contains a minimal `.py` file (or pair of files) and the entrypoint flag you ran, plus the actual vs. expected dead-symbol output. The smaller the repro, the faster it gets fixed.
+A good bug report contains a minimal `.py` file (or pair of files)
+and the entrypoint flag you ran, plus the actual vs. expected dead-
+symbol output. The smaller the repro, the faster it gets fixed.
 
 ## Pull requests
 
 - Keep PRs focused — one logical change per PR.
 - Add or update tests for behaviour changes.
 - Run `prek run --all-files` and `pytest` before pushing.
-- If your change is user-visible, add an entry to `CHANGELOG.md` under `[Unreleased]`.
+- If your change is user-visible, add an entry to `CHANGELOG.md`
+  under `[Unreleased]`.
 
 ## Releasing
 
-Releases are GitHub-Release-driven. Publishing a GitHub Release with a `vX.Y.Z` tag name (the Releases UI creates the tag for you, which makes it possible from mobile) triggers `.github/workflows/publish.yml`, which builds the package with `uv build`, publishes to PyPI via OIDC, and attaches the built sdist/wheel to the release. The version is read from the tag by `hatch-vcs`, so no manual version bumps in source files are needed.
+The version is read from `Cargo.toml`'s `[package].version` by maturin
+(`pyproject.toml` is `dynamic = ["version"]`). Bump that field by
+hand before tagging a release. On every push to `main` the publish
+workflow rewrites the version to `<base>-dev${{ github.run_number }}`
+in-CI (never committed) so TestPyPI gets a unique version per commit;
+the SemVer pre-release suffix is normalized by maturin to PEP 440
+`<base>.dev<N>` for the wheel.
+
+Publishing a GitHub Release with a `vX.Y.Z` tag triggers
+`.github/workflows/publish.yml`, which builds wheels + sdist with
+`uv build` / `maturin`, publishes to PyPI via OIDC, and attaches the
+artifacts to the release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "dead-cst-native"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bincode",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dead-cst-native"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 publish = false
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -146,6 +146,46 @@ demand.
 
 Folded down from earlier tiers as they landed:
 
+- **v0.11.0**: Rust-native graph builder. libcst visitor, SQLite cache,
+  and networkx are replaced by a pyo3 extension on ty's ``SemanticIndex``;
+  libcst now only powers the codemod.
+- **v0.11.0**: ``dead-cst build ROOT -o PATH`` persists the materialized
+  graph; ``analyze`` / ``remove --graph PATH`` reuse it. ``--meta``
+  stashes user-supplied metadata. Public Python API:
+  ``dead_cst.graph.write_graph`` / ``read_graph`` / ``LoadedGraph``.
+- **v0.11.0**: CLI trimmed to ``build`` / ``analyze`` / ``remove``.
+  ``why-alive`` / ``dependencies`` / ``unused-exports`` are removed
+  (still in the Python API). ``--query {dead,test-only}`` plumbs the
+  ``NodeFlags.TESTCASE`` blast-radius query through to the codemod.
+  ``--entrypoint-regex`` replaces the ``-e re:`` magic prefix.
+  ``--exit-zero`` keeps the exit code at 0.
+- **v0.11.0**: Build system switched from hatchling to maturin. Rust
+  crate in ``src/``, Python in ``python/dead_cst/``, wheel ships
+  ``_native.{abi3.so,pyd}``.
+- **v0.11.0**: Plugin protocol simplified. Subclass ``Plugin`` and
+  implement ``run(ctx)`` yielding ``AddNode`` / ``AddEdge`` /
+  ``AddEntrypoint``; ``observe()`` / ``finalize()`` are gone. Framework
+  plugins are factory functions (``fastapi_plugin()``, ``flask_plugin()``,
+  etc.). Plugin queries use a chainable builder
+  (``query(ctx).decorators().where_module(...)``); ``ctx.find_*`` helpers
+  are gone.
+- **v0.11.0**: Python ``SymbolGraph`` facade dropped.
+  ``Analysis.materialize_all()`` returns the live
+  ``native.ProjectContext`` directly; reachability walks are a single
+  FFI BFS. ``PackageView`` removed (filter ``analysis.dead()`` by
+  ``Path(n.path).is_relative_to(pkg)`` for per-package slices).
+  ``codemod.remove_code`` / ``generate_patch`` take an iterable of dead
+  ``SymbolNode``\ s instead of a graph.
+- **v0.11.0**: ``EdgeFlags.DEAD_BRANCH`` edges via ty's reachability
+  constraints (replacing ``TruthinessResolver``).
+  ``EdgeFlags.DYNAMIC_IMPORT`` edges for string-literal ``__import__()`` /
+  ``importlib.import_module()``. ``.pyi`` ingestion for
+  compiled-extension layouts.
+- **v0.11.0**: Fixes — ``ModuleDundersPlugin`` pins module-level dunder
+  *functions* (PEP 562 ``__getattr__`` / ``__dir__``); quoted type
+  annotations contribute use edges via ty's
+  ``enter_string_annotation``; ``from .submod import X`` in
+  ``__init__.py`` no longer reports the submodule attribute as dead.
 - **v0.10.0**: ``from <pkg> import <name>`` now resolves through
   ``from <other> import *`` re-exports. ``build_contribution`` runs a
   second pass after applying per-file payloads: for every module-level

--- a/python/dead_cst/__init__.py
+++ b/python/dead_cst/__init__.py
@@ -17,8 +17,9 @@ The deeper public surface lives in focused sub-packages:
 * :mod:`dead_cst.codemod` -- the LibCST-based source rewriter.
 * :mod:`dead_cst.plugins` -- the synthetic-node prefix constants and
   every built-in plugin.
-* :mod:`dead_cst.resolvers` -- the :class:`PathResolver` protocol,
-  :class:`ManualResolver`, :class:`UvResolver`.
+* :mod:`dead_cst.resolvers` -- the :class:`PathResolver` protocol and
+  :class:`ManualResolver`. (:class:`UvResolver` lives under
+  :mod:`dead_cst.contrib`.)
 * :mod:`dead_cst.contrib` -- third-party-aware extensions.
 
 ``dead-cst`` is alpha; APIs, CLI flags, and output formats may change.


### PR DESCRIPTION
## Summary

- Cut `[Unreleased]` → `[0.11.0] - 2026-05-20` in `CHANGELOG.md` with terse one-bullet-per-change entries; refresh compare links.
- Bump `Cargo.toml` `[package].version` from `0.10.0` to `0.11.0` (maturin reads the wheel version from there per CLAUDE.md's "bump by hand before tagging a release").
- Rewrite `ARCHITECTURE.md` for the current rust pipeline. The old doc described the deleted libcst pipeline (`SymbolVisitor`, SQLite cache, `observe()` / `finalize()`, rustworkx); the new version walks the three-phase rust build (decls / chain / references), the single-method `Plugin.run()` protocol, graph persistence (`write_graph` / `read_graph`), and the codemod (the only remaining libcst stage). New "Where to make changes" cheat sheet points at the rust modules.
- Rewrite `CONTRIBUTING.md` for the current project layout (rust crate under `src/`, Python under `python/dead_cst/`), plugin contract (`Plugin.run()` yielding `AddNode` / `AddEdge` / `AddEntrypoint`), resolver contract, and release workflow (hand-bump `Cargo.toml` under maturin; was hatch-vcs).
- Add 7 terse v0.11.0 entries to `ROADMAP.md` "Recently shipped" covering the rust backend swap, `dead-cst build`, CLI trim, build-system migration, plugin protocol, `SymbolGraph` removal, and dead-branch / dynamic-import edges. Historical v0.10.0 paragraphs left untouched.
- Docstring fix in `python/dead_cst/__init__.py`: `UvResolver` was listed under `dead_cst.resolvers` but actually lives in `dead_cst.contrib`.

## Test plan

- [ ] CI green (lint + matrix `pytest` on Python 3.11–3.14).
- [ ] Sanity-check the rendered `CHANGELOG.md` / `ROADMAP.md` / `ARCHITECTURE.md` / `CONTRIBUTING.md` in the GitHub preview.
- [ ] After merge, tag `v0.11.0` via a GitHub Release to trigger the publish workflow.

## Notes

- `c2ba897` (publish workflow switch to `setuptools-scm`) was merged in from `main`. The doc rewrites describe the manual `Cargo.toml` bump for tagged releases — the setuptools-scm change only affects the dev-version stamp on push-to-main builds.
- This branch is docs-only plus the single-line `Cargo.toml` version bump; no code paths were touched.
