### PR TITLE
Per-package env scoping for monorepo path resolution

### DIFF
--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -302,6 +302,7 @@ class ProjectContext:
         *,
         src_roots: Iterable[str] | None = ...,
         package_owned_paths: Iterable[str] | None = ...,
+        package_env_roots: Iterable[Iterable[str]] | None = ...,
         extra_paths: Iterable[str] | None = ...,
         python_env: str | None = ...,
         python_version: str | None = ...,

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -260,6 +260,7 @@ class Project:
         root: str,
         *,
         src_roots: Iterable[str] | None = ...,
+        package_owned_paths: Iterable[str] | None = ...,
         extra_paths: Iterable[str] | None = ...,
         python_env: str | None = ...,
         python_version: str | None = ...,
@@ -300,6 +301,7 @@ class ProjectContext:
         root: str,
         *,
         src_roots: Iterable[str] | None = ...,
+        package_owned_paths: Iterable[str] | None = ...,
         extra_paths: Iterable[str] | None = ...,
         python_env: str | None = ...,
         python_version: str | None = ...,
@@ -309,6 +311,26 @@ class ProjectContext:
     def add_plugin(self, plugin: _ProjectPluginLike | Any) -> None:
         """Register a plugin. Order of registration is order of
         invocation during :meth:`materialize`."""
+        ...
+
+    def files_for_package(self, owned_path: str) -> list[str]:
+        """File paths owned by a given package, in ``project_files`` order.
+
+        Looks up the partition computed once after file enumeration:
+        each ``File`` was assigned to the package whose ``path`` is
+        the longest matching prefix. ``owned_path`` must match one of
+        the ``package_owned_paths`` passed at construction (verbatim,
+        no resolution). Returns an empty list for a package that owns
+        no files; raises if :meth:`materialize` hasn't run.
+        """
+        ...
+
+    def unowned_files(self) -> list[str]:
+        """File paths enumerated by ty that fall under no package's
+        owned prefix. Empty for a well-formed monorepo; non-empty
+        when the project root holds stray modules outside the
+        resolver's package list.
+        """
         ...
 
     def set_src_roots(self, roots: list[str]) -> None:

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -311,6 +311,24 @@ class ProjectContext:
         invocation during :meth:`materialize`."""
         ...
 
+    def set_src_roots(self, roots: list[str]) -> None:
+        """Swap the first-party search paths on the live Salsa db.
+
+        Reuses the env options captured at construction for everything
+        except ``environment.root`` -- ``extra_paths`` / ``python`` /
+        ``typeshed`` / ``python_version`` / ``python_platform`` stay
+        fixed across swaps. The parse and per-file ``semantic_index``
+        Salsa queries are keyed on ``File`` (not on env), so they
+        survive the swap; only ``resolve_module`` / ``file_to_module``
+        answers and the project's file enumeration are invalidated.
+
+        Designed for the per-package pipeline: between iterations, set
+        ``roots = [pkg + transitive_deps]`` so ty's module resolver
+        only finds the deps that the current package's lockfile actually
+        permits, while the heavy parse + index work stays hot.
+        """
+        ...
+
     def materialize(self) -> NativeGraph:
         """Build the project-wide graph, run each registered plugin's
         ``run(ctx)``, then snapshot the final state.

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -260,7 +260,6 @@ class Project:
         root: str,
         *,
         src_roots: Iterable[str] | None = ...,
-        package_owned_paths: Iterable[str] | None = ...,
         extra_paths: Iterable[str] | None = ...,
         python_env: str | None = ...,
         python_version: str | None = ...,

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -150,40 +150,22 @@ class Analysis:
 
         from .plugins import Plugin
 
-        # Feed each package's ``exported_paths`` as src_roots so the
-        # rust backend mounts files at the right module fqname
-        # (``pkg_a/src/A/__init__.py`` -> ``A``, not ``src.A``). The
-        # default ``exported_paths`` is ``(path,)`` (set by
-        # ``_validate_packages``), so a single-package or manual-spec
-        # project sees identical behavior to before this split.
         src_roots = [str(e) for p in self.packages for e in p.exported_paths]
-        # Owned paths (one per ``Package.path``) drive the rust-side
-        # file partition that backs the per-package phase loop. The
-        # default ``exported_paths == (path,)`` means most projects
-        # pass identical owned/exported lists; multi-export and
-        # src-layout uv members are where the two diverge.
         owned_paths = [str(p.path) for p in self.packages]
-        # Per-package env roots, index-aligned with ``owned_paths``.
-        # Order matters: a package's own ``exported_paths`` come first
-        # (longest-match priority for fqname derivation), then its
-        # ``path`` (catch-all for owned-but-non-exported files like
-        # src-layout ``tests/``), then each dep's ``exported_paths``
-        # (so cross-package imports resolve into deps but not into
-        # non-dep packages). Single-package projects get a one-entry
-        # list = the same flat env as before; the per-package loop
-        # then has a single iteration with one ``set_src_roots`` call.
+        # Per-package env roots. Order matters: package's own
+        # ``exported_paths`` first (longest-match priority for fqname
+        # derivation), then ``path`` (catch-all for non-exported owned
+        # files like src-layout ``tests/``), then deps' ``exported_paths``
+        # (so cross-package imports resolve into deps but not non-deps).
         env_roots_per_package: list[list[str]] = []
         for p in self.packages:
-            roots: list[str] = [str(e) for e in p.exported_paths]
-            if str(p.path) not in roots:
-                roots.append(str(p.path))
-            for dep_path in self._dep_paths_by_package.get(p.path, ()):
-                dep_pkg = self._packages_by_path[dep_path]
-                for e in dep_pkg.exported_paths:
-                    se = str(e)
-                    if se not in roots:
-                        roots.append(se)
-            env_roots_per_package.append(roots)
+            dep_exports = (
+                str(e)
+                for dep_path in self._dep_paths_by_package.get(p.path, ())
+                for e in self._packages_by_path[dep_path].exported_paths
+            )
+            entries = [*(str(e) for e in p.exported_paths), str(p.path), *dep_exports]
+            env_roots_per_package.append(list(dict.fromkeys(entries)))
         ctx = _native.ProjectContext(
             str(self._project_root),
             src_roots=src_roots or None,

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -157,9 +157,16 @@ class Analysis:
         # ``_validate_packages``), so a single-package or manual-spec
         # project sees identical behavior to before this split.
         src_roots = [str(e) for p in self.packages for e in p.exported_paths]
+        # Owned paths (one per ``Package.path``) drive the rust-side
+        # file partition that backs ``ctx.files_for_package(...)``. The
+        # default ``exported_paths == (path,)`` means most projects
+        # pass identical lists; multi-export and src-layout uv members
+        # are where the two diverge.
+        owned_paths = [str(p.path) for p in self.packages]
         ctx = _native.ProjectContext(
             str(self._project_root),
             src_roots=src_roots or None,
+            package_owned_paths=owned_paths or None,
             show_progress=self._show_progress,
         )
         for plugin in self._plugins:

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -150,12 +150,16 @@ class Analysis:
 
         from .plugins import Plugin
 
-        # Pass each first-party package's path as a src_root so the
+        # Feed each package's ``exported_paths`` as src_roots so the
         # rust backend mounts files at the right module fqname
-        # (``pkg_a/A/__init__.py`` -> ``A``, not ``pkg_a.A``).
+        # (``pkg_a/src/A/__init__.py`` -> ``A``, not ``src.A``). The
+        # default ``exported_paths`` is ``(path,)`` (set by
+        # ``_validate_packages``), so a single-package or manual-spec
+        # project sees identical behavior to before this split.
+        src_roots = [str(e) for p in self.packages for e in p.exported_paths]
         ctx = _native.ProjectContext(
             str(self._project_root),
-            src_roots=[str(p.path) for p in self.packages] or None,
+            src_roots=src_roots or None,
             show_progress=self._show_progress,
         )
         for plugin in self._plugins:

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -158,15 +158,37 @@ class Analysis:
         # project sees identical behavior to before this split.
         src_roots = [str(e) for p in self.packages for e in p.exported_paths]
         # Owned paths (one per ``Package.path``) drive the rust-side
-        # file partition that backs ``ctx.files_for_package(...)``. The
+        # file partition that backs the per-package phase loop. The
         # default ``exported_paths == (path,)`` means most projects
-        # pass identical lists; multi-export and src-layout uv members
-        # are where the two diverge.
+        # pass identical owned/exported lists; multi-export and
+        # src-layout uv members are where the two diverge.
         owned_paths = [str(p.path) for p in self.packages]
+        # Per-package env roots, index-aligned with ``owned_paths``.
+        # Order matters: a package's own ``exported_paths`` come first
+        # (longest-match priority for fqname derivation), then its
+        # ``path`` (catch-all for owned-but-non-exported files like
+        # src-layout ``tests/``), then each dep's ``exported_paths``
+        # (so cross-package imports resolve into deps but not into
+        # non-dep packages). Single-package projects get a one-entry
+        # list = the same flat env as before; the per-package loop
+        # then has a single iteration with one ``set_src_roots`` call.
+        env_roots_per_package: list[list[str]] = []
+        for p in self.packages:
+            roots: list[str] = [str(e) for e in p.exported_paths]
+            if str(p.path) not in roots:
+                roots.append(str(p.path))
+            for dep_path in self._dep_paths_by_package.get(p.path, ()):
+                dep_pkg = self._packages_by_path[dep_path]
+                for e in dep_pkg.exported_paths:
+                    se = str(e)
+                    if se not in roots:
+                        roots.append(se)
+            env_roots_per_package.append(roots)
         ctx = _native.ProjectContext(
             str(self._project_root),
             src_roots=src_roots or None,
             package_owned_paths=owned_paths or None,
+            package_env_roots=env_roots_per_package or None,
             show_progress=self._show_progress,
         )
         for plugin in self._plugins:

--- a/python/dead_cst/contrib/uv.py
+++ b/python/dead_cst/contrib/uv.py
@@ -23,8 +23,13 @@ class UvResolver:
     :class:`~dead_cst.resolvers.Package`. The workspace root itself
     (``virtual = "."``) is skipped.
 
-    The src root for a member is ``<member_dir>/src`` if that directory
-    exists, else ``<member_dir>`` itself.
+    * ``Package.path`` is the *member directory* (everything the
+      member owns -- ``src/``, ``tests/``, ``scripts/``, ...).
+    * ``Package.exported_paths`` is the *published* dirs that
+      consumers see when they depend on the member:
+      ``(<member_dir>/src,)`` for src-layout (the wheel's contents) or
+      ``(<member_dir>,)`` for flat-layout. This keeps a member's
+      ``tests/`` package out of consumers' module-resolution namespace.
 
     Requires the workspace's shared venv to be present (uv puts a
     single ``.venv`` at the workspace root). If no venv is found,
@@ -60,20 +65,38 @@ class UvResolver:
             member_dirs[name] = member_dir
             member_deps[name] = [d["name"] for d in pkg.get("dependencies", [])]
 
-        src_roots: dict[str, Path] = {}
+        # Each member contributes (owned_dir, exported_dir) -- they
+        # differ for src-layout and coincide for flat. Members whose
+        # dir doesn't exist are dropped (matches today's behavior: an
+        # editable entry pointing at a deleted path can't be analyzed).
+        layouts: dict[str, tuple[Path, Path]] = {}
         for name, member_dir in member_dirs.items():
-            src_root = _src_root_for(member_dir)
-            if src_root is not None:
-                src_roots[name] = src_root
+            exported = _exported_for(member_dir)
+            if exported is None:
+                continue
+            layouts[name] = (member_dir, exported)
 
         out: list[Package] = []
-        for name, src_root in src_roots.items():
-            dep_names = [d for d in member_deps[name] if d in src_roots]
-            out.append(Package(path=src_root, name=name, deps=tuple(dep_names)))
+        for name, (owned, exported) in layouts.items():
+            dep_names = [d for d in member_deps[name] if d in layouts]
+            out.append(
+                Package(
+                    path=owned,
+                    name=name,
+                    deps=tuple(dep_names),
+                    exported_paths=(exported,),
+                )
+            )
         return tuple(out)
 
 
-def _src_root_for(member_dir: Path) -> Path | None:
+def _exported_for(member_dir: Path) -> Path | None:
+    """Return the directory consumers should put on their search path.
+
+    Mirrors uv's wheel-build conventions: a ``<member>/src/`` if it
+    exists (src-layout), otherwise the member dir itself (flat layout).
+    ``None`` if the member directory is missing entirely.
+    """
     if (member_dir / "src").is_dir():
         return member_dir / "src"
     if member_dir.is_dir():

--- a/python/dead_cst/resolvers/_core.py
+++ b/python/dead_cst/resolvers/_core.py
@@ -17,18 +17,33 @@ class Package:
 
     A resolver returns a list of these to describe a project layout.
 
-    * ``path`` -- the package directory. Resolved (absolute) by
-      :class:`~dead_cst.analyze.Analysis` at construction time.
+    * ``path`` -- the package's *owned* directory. Every source file
+      under this prefix is the package's responsibility (so it gets
+      processed during the package's edge pass and bucketed under it
+      for per-package dead-code reporting). Includes things the wheel
+      doesn't ship -- e.g. for an src-layout uv member, ``path`` is
+      the member dir and covers both ``src/`` and ``tests/``.
     * ``name`` -- a stable identifier for this package, unique within
       one :class:`~dead_cst.analyze.Analysis`. Other packages refer to
       it by name in :attr:`deps`.
     * ``deps`` -- names of other packages this one imports from.
       Cycles are tolerated.
+    * ``exported_paths`` -- directories *consumers* put on their
+      search path when they depend on this package. Defaults to
+      ``(path,)`` if the resolver doesn't specify them. For an
+      src-layout uv member this is ``(member_dir / "src",)`` -- the
+      wheel's published contents, NOT the whole member dir. This is
+      what keeps a member's ``tests/`` package from bleeding into a
+      consumer's lookup namespace.
+
+    All paths are resolved (absolute) by
+    :class:`~dead_cst.analyze.Analysis` at construction time.
     """
 
     path: Path
     name: str
     deps: tuple[str, ...] = ()
+    exported_paths: tuple[Path, ...] = ()
 
 
 @runtime_checkable
@@ -58,6 +73,13 @@ def _validate_packages(packages: Iterable[Package]) -> tuple[Package, ...]:
     name_to_path: dict[str, Path] = {}
     for pkg in packages:
         path = _absolute(pkg.path)
+        # ``exported_paths`` defaults to ``(path,)`` so resolvers that
+        # don't care about the owned-vs-exported split (manual specs,
+        # single-package layouts) get today's behavior for free. We
+        # absolutize each entry the same way ``path`` is normalized.
+        exported = (
+            tuple(_absolute(p) for p in pkg.exported_paths) if pkg.exported_paths else (path,)
+        )
         existing = by_path.get(path)
         if existing is None:
             claimed = name_to_path.get(pkg.name)
@@ -66,12 +88,19 @@ def _validate_packages(packages: Iterable[Package]) -> tuple[Package, ...]:
                     f"Duplicate package name {pkg.name!r}: both {claimed} and {path} claim it"
                 )
             name_to_path[pkg.name] = path
-            by_path[path] = Package(path=path, name=pkg.name, deps=pkg.deps)
+            by_path[path] = Package(
+                path=path, name=pkg.name, deps=pkg.deps, exported_paths=exported
+            )
         else:
+            # Merge deps + union exported_paths on duplicates -- a
+            # resolver that emits the same package twice with extra
+            # info gets both sets honored.
+            merged_exports = tuple(dict.fromkeys((*existing.exported_paths, *exported)))
             by_path[path] = Package(
                 path=path,
                 name=existing.name,
                 deps=tuple(dict.fromkeys((*existing.deps, *pkg.deps))),
+                exported_paths=merged_exports,
             )
 
     for pkg in by_path.values():

--- a/python/dead_cst/resolvers/_core.py
+++ b/python/dead_cst/resolvers/_core.py
@@ -73,10 +73,6 @@ def _validate_packages(packages: Iterable[Package]) -> tuple[Package, ...]:
     name_to_path: dict[str, Path] = {}
     for pkg in packages:
         path = _absolute(pkg.path)
-        # ``exported_paths`` defaults to ``(path,)`` so resolvers that
-        # don't care about the owned-vs-exported split (manual specs,
-        # single-package layouts) get today's behavior for free. We
-        # absolutize each entry the same way ``path`` is normalized.
         exported = (
             tuple(_absolute(p) for p in pkg.exported_paths) if pkg.exported_paths else (path,)
         )
@@ -92,9 +88,6 @@ def _validate_packages(packages: Iterable[Package]) -> tuple[Package, ...]:
                 path=path, name=pkg.name, deps=pkg.deps, exported_paths=exported
             )
         else:
-            # Merge deps + union exported_paths on duplicates -- a
-            # resolver that emits the same package twice with extra
-            # info gets both sets honored.
             merged_exports = tuple(dict.fromkeys((*existing.exported_paths, *exported)))
             by_path[path] = Package(
                 path=path,

--- a/src/project.rs
+++ b/src/project.rs
@@ -12,7 +12,7 @@ use pyo3::prelude::*;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
-use ruff_db::system::{OsSystem, SystemPathBuf};
+use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf};
 use ruff_db::Db as SourceDb;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::visitor::Visitor;
@@ -53,6 +53,7 @@ use crate::query::{
 #[pyclass(unsendable)]
 pub(crate) struct Project {
     pub(crate) db: ProjectDatabase,
+    pub(crate) package_owned_paths: Vec<SystemPathBuf>,
 }
 
 #[pymethods]
@@ -62,14 +63,17 @@ impl Project {
         root,
         *,
         src_roots = None,
+        package_owned_paths = None,
         extra_paths = None,
         python_env = None,
         python_version = None,
         typeshed = None,
     ))]
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         root: &str,
         src_roots: Option<Vec<String>>,
+        package_owned_paths: Option<Vec<String>>,
         extra_paths: Option<Vec<String>>,
         python_env: Option<&str>,
         python_version: Option<&str>,
@@ -77,12 +81,20 @@ impl Project {
     ) -> PyResult<Self> {
         let env = build_env_options(src_roots, extra_paths, python_env, python_version, typeshed)?;
         let db = make_db(root, env)?;
-        Ok(Self { db })
+        let owned = package_owned_paths
+            .unwrap_or_default()
+            .into_iter()
+            .map(SystemPathBuf::from)
+            .collect::<Vec<_>>();
+        Ok(Self {
+            db,
+            package_owned_paths: owned,
+        })
     }
 
     /// Build the project-wide symbol graph.
     pub(crate) fn build(&self, py: Python<'_>) -> PyResult<NativeGraph> {
-        let outputs = build_project_graph(py, &self.db, false)?;
+        let outputs = build_project_graph(py, &self.db, false, &self.package_owned_paths)?;
         Ok(NativeGraph {
             nodes: outputs.builder.nodes,
             edges: outputs.builder.edges,
@@ -128,6 +140,23 @@ pub(crate) struct BuildOutputs {
     /// nodes — and a cheap ``imports_of_exists`` short-circuit for
     /// plugins that just need a per-module presence check.
     pub(crate) imports_by_module: HashMap<String, Vec<usize>>,
+    /// `package_owned_path -> files under that prefix`, in
+    /// ``project_files`` order. Each ``File`` is assigned to the
+    /// LONGEST owned-path prefix it lives under, so a workspace where
+    /// one member's owned dir sits inside another's still partitions
+    /// cleanly. Files outside every owned path land in
+    /// ``unowned_files``. Drives the per-package edge pass: each
+    /// iteration scopes the resolver via ``set_src_roots`` and
+    /// processes only that package's bucket.
+    pub(crate) files_by_package: HashMap<SystemPathBuf, Vec<File>>,
+    /// Files enumerated by ty that don't fall under any owned-package
+    /// path. Empty for a well-formed monorepo (every first-party file
+    /// belongs to *some* package); non-empty when the project root
+    /// holds stray modules outside the resolver's package list. These
+    /// still need to be processed somewhere, so the build runs them
+    /// in a final catch-all pass under the union of all exported
+    /// paths.
+    pub(crate) unowned_files: Vec<File>,
 }
 
 /// Run the three build phases (ingest → hierarchy+imports → references)
@@ -200,6 +229,7 @@ pub(crate) fn build_project_graph(
     py: Python<'_>,
     db: &ProjectDatabase,
     show_progress: bool,
+    package_owned_paths: &[SystemPathBuf],
 ) -> PyResult<BuildOutputs> {
     let timing = std::env::var_os("DEAD_CST_TIMING").is_some();
     let mut builder = GraphBuilder::new();
@@ -218,6 +248,8 @@ pub(crate) fn build_project_graph(
     for &file in &project_files {
         path_to_file.insert(file_path_string(db, file), file);
     }
+    let (files_by_package, unowned_files) =
+        partition_files_by_package(db, &project_files, package_owned_paths);
     // Peer ``.pyi`` files: register the ``.pyi -> .py twin`` mapping
     // so import resolution can fall back when the stub lookup misses
     // and so ``file_default_flags`` can tell peer .pyi (decls reach
@@ -398,7 +430,63 @@ pub(crate) fn build_project_graph(
         decl_by_fqname,
         module_by_fqname,
         imports_by_module,
+        files_by_package,
+        unowned_files,
     })
+}
+
+/// Bucket ``project_files`` by which owned-package prefix each file
+/// lives under. Each file is assigned to the LONGEST matching prefix
+/// so workspaces where one member's owned dir is nested inside
+/// another's still partition cleanly. Files outside every owned path
+/// land in the ``unowned`` bucket -- well-formed monorepos with a
+/// proper resolver should have an empty unowned set, but stray
+/// project-root scripts and conftest.py files outside any member dir
+/// are surfaced here rather than silently lost.
+fn partition_files_by_package(
+    db: &ProjectDatabase,
+    project_files: &[File],
+    package_owned_paths: &[SystemPathBuf],
+) -> (HashMap<SystemPathBuf, Vec<File>>, Vec<File>) {
+    let mut buckets: HashMap<SystemPathBuf, Vec<File>> = package_owned_paths
+        .iter()
+        .map(|p| (p.clone(), Vec::new()))
+        .collect();
+    let mut unowned: Vec<File> = Vec::new();
+
+    if package_owned_paths.is_empty() {
+        // No package partition info -- every file is "unowned"
+        // (preserves today's flat semantics for single-package and
+        // legacy callers that don't pass package_owned_paths).
+        unowned.extend(project_files.iter().copied());
+        return (buckets, unowned);
+    }
+
+    // Pre-compute lengths once; longest-prefix match is a stable tie
+    // breaker for nested-owned-dir layouts. We compare path components
+    // (not byte length) so a parent dir like ``/repo/pkg`` doesn't
+    // outrank a deeper ``/repo/pkg2`` purely on character count.
+    for &file in project_files {
+        let path = file_path_string(db, file);
+        let file_path = SystemPath::new(&path);
+        let mut best: Option<(&SystemPathBuf, usize)> = None;
+        for owned in package_owned_paths {
+            if file_path.starts_with(owned) {
+                let depth = owned.components().count();
+                if best.is_none_or(|(_, d)| depth > d) {
+                    best = Some((owned, depth));
+                }
+            }
+        }
+        match best {
+            Some((owned, _)) => buckets
+                .get_mut(owned)
+                .expect("owned key present")
+                .push(file),
+            None => unowned.push(file),
+        }
+    }
+    (buckets, unowned)
 }
 
 /// Pre-build the fqname -> idx maps used by ``find_declarations``,
@@ -491,6 +579,13 @@ pub(crate) struct ProjectContext {
     /// first-party search paths in place on the live Salsa db so the
     /// parse + semantic_index caches survive across env swaps.
     pub(crate) base_env: EnvironmentOptions,
+    /// Owned directories (one per ``Package.path``) used to partition
+    /// the enumerated file list. The build computes a longest-prefix
+    /// match against these to assign each ``File`` to a package.
+    /// Empty when constructed without packages -- the build then
+    /// treats every file as ``unowned``, which is identical to
+    /// today's flat "single bucket" semantics.
+    pub(crate) package_owned_paths: Vec<SystemPathBuf>,
 }
 
 #[pymethods]
@@ -500,15 +595,18 @@ impl ProjectContext {
         root,
         *,
         src_roots = None,
+        package_owned_paths = None,
         extra_paths = None,
         python_env = None,
         python_version = None,
         typeshed = None,
         show_progress = false,
     ))]
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         root: &str,
         src_roots: Option<Vec<String>>,
+        package_owned_paths: Option<Vec<String>>,
         extra_paths: Option<Vec<String>>,
         python_env: Option<&str>,
         python_version: Option<&str>,
@@ -517,6 +615,11 @@ impl ProjectContext {
     ) -> PyResult<Self> {
         let env = build_env_options(src_roots, extra_paths, python_env, python_version, typeshed)?;
         let db = make_db(root, env.clone())?;
+        let owned = package_owned_paths
+            .unwrap_or_default()
+            .into_iter()
+            .map(SystemPathBuf::from)
+            .collect();
         Ok(Self {
             db,
             root: root.to_string(),
@@ -525,6 +628,7 @@ impl ProjectContext {
             regex_cache: RefCell::new(HashMap::new()),
             show_progress,
             base_env: env,
+            package_owned_paths: owned,
         })
     }
 
@@ -570,6 +674,43 @@ impl ProjectContext {
         &self.root
     }
 
+    /// File paths owned by a given package, in ``project_files`` order.
+    ///
+    /// Looks up the partition computed once after file enumeration:
+    /// each ``File`` was assigned to the package whose ``path`` is
+    /// the longest matching prefix. ``owned_path`` must be one of the
+    /// ``package_owned_paths`` passed at construction (matched
+    /// verbatim, no resolution). Returns an empty list for a package
+    /// that owns no files; raises if the build hasn't run yet.
+    pub(crate) fn files_for_package(&self, owned_path: &str) -> PyResult<Vec<String>> {
+        let outputs = self.materialized("files_for_package")?;
+        let key = SystemPathBuf::from(owned_path);
+        Ok(outputs
+            .files_by_package
+            .get(&key)
+            .map(|files| {
+                files
+                    .iter()
+                    .map(|f| file_path_string(&self.db, *f))
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
+
+    /// File paths enumerated by ty that fall under no package's owned
+    /// prefix. Empty for a well-formed monorepo; non-empty when the
+    /// project root holds stray modules outside the resolver's
+    /// package list. The catch-all per-package pass processes these
+    /// under the union of all exported paths.
+    pub(crate) fn unowned_files(&self) -> PyResult<Vec<String>> {
+        let outputs = self.materialized("unowned_files")?;
+        Ok(outputs
+            .unowned_files
+            .iter()
+            .map(|f| file_path_string(&self.db, *f))
+            .collect())
+    }
+
     /// Register a Python plugin. Order of registration is order of
     /// invocation during `materialize`.
     pub(crate) fn add_plugin(&mut self, plugin: PyObject) {
@@ -596,7 +737,8 @@ impl ProjectContext {
         let show_progress = slf.borrow(py).show_progress;
         {
             let this = slf.borrow(py);
-            let outputs = build_project_graph(py, &this.db, show_progress)?;
+            let outputs =
+                build_project_graph(py, &this.db, show_progress, &this.package_owned_paths)?;
             *this.outputs.borrow_mut() = Some(outputs);
         }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -55,7 +55,6 @@ pub(crate) struct Project {
     pub(crate) db: ProjectDatabase,
     pub(crate) root: String,
     pub(crate) base_env: EnvironmentOptions,
-    pub(crate) package_owned_paths: Vec<SystemPathBuf>,
 }
 
 #[pymethods]
@@ -65,17 +64,14 @@ impl Project {
         root,
         *,
         src_roots = None,
-        package_owned_paths = None,
         extra_paths = None,
         python_env = None,
         python_version = None,
         typeshed = None,
     ))]
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         root: &str,
         src_roots: Option<Vec<String>>,
-        package_owned_paths: Option<Vec<String>>,
         extra_paths: Option<Vec<String>>,
         python_env: Option<&str>,
         python_version: Option<&str>,
@@ -83,32 +79,22 @@ impl Project {
     ) -> PyResult<Self> {
         let env = build_env_options(src_roots, extra_paths, python_env, python_version, typeshed)?;
         let db = make_db(root, env.clone())?;
-        let owned = package_owned_paths
-            .unwrap_or_default()
-            .into_iter()
-            .map(SystemPathBuf::from)
-            .collect::<Vec<_>>();
         Ok(Self {
             db,
             root: root.to_string(),
             base_env: env,
-            package_owned_paths: owned,
         })
     }
 
-    /// Build the project-wide symbol graph.
+    /// Build the project-wide symbol graph (single-pass, no plugins).
     pub(crate) fn build(&mut self, py: Python<'_>) -> PyResult<NativeGraph> {
-        // Project::build is the lean (no-plugin) entrypoint -- no
-        // per-package envs supplied, so the build runs as a single
-        // pass under the current env (legacy behavior).
-        let owned = self.package_owned_paths.clone();
         let outputs = build_project_graph(
             py,
             &mut self.db,
             false,
             &self.root,
             &mut self.base_env,
-            &owned,
+            &[],
             &[],
         )?;
         Ok(NativeGraph {
@@ -241,24 +227,6 @@ impl ProgressBars {
     }
 }
 
-/// Per-package configuration the build loop consumes.
-///
-/// One entry per package the resolver returned (plus an extra
-/// "unowned" pseudo-entry the build appends for files outside every
-/// owned path). Index-aligned with ``package_owned_paths`` so the
-/// loop can pair ``files_by_package[i]`` with ``env_roots[i]`` in
-/// O(1).
-pub(crate) struct PackageEnv {
-    /// Search paths to install via ``swap_src_roots`` before
-    /// processing this package's files. Format:
-    /// ``[*pkg.exported_paths, pkg.path, *flatten(dep.exported_paths)]``
-    /// -- exports first for fqname-derivation priority, owned ``path``
-    /// next as a catch-all for non-exported owned files (e.g.
-    /// src-layout ``tests/``), deps last so cross-package imports
-    /// resolve.
-    pub(crate) env_roots: Vec<String>,
-}
-
 pub(crate) fn build_project_graph(
     py: Python<'_>,
     db: &mut ProjectDatabase,
@@ -266,7 +234,7 @@ pub(crate) fn build_project_graph(
     root: &str,
     base_env: &mut EnvironmentOptions,
     package_owned_paths: &[SystemPathBuf],
-    package_envs: &[PackageEnv],
+    package_env_roots: &[Vec<String>],
 ) -> PyResult<BuildOutputs> {
     let timing = std::env::var_os("DEAD_CST_TIMING").is_some();
     let mut builder = GraphBuilder::new();
@@ -312,107 +280,76 @@ pub(crate) fn build_project_graph(
     let t_enum = t0.elapsed();
     let site_packages = crate::ingest::site_packages_roots(db);
 
-    // ``dist_lookup`` is env-independent (just walks site_packages
-    // roots), so we compute it once upfront. Previously it ran on a
-    // worker thread overlapped with phase 1; the per-package loop's
-    // env swaps between iterations need ``&mut db``, which is
-    // incompatible with the scoped thread that held ``&db``. The
-    // serial cost is a small fixed overhead on cold builds.
-    let t_dl = std::time::Instant::now();
-    let dist_lookup = build_dist_lookup(&site_packages);
-    let t_dist_lookup = t_dl.elapsed();
-
-    // Build the (env_roots, files) pairs the per-package phase loop
-    // iterates over. Single-pass legacy mode = one pair with no env
-    // swap (just process every file under whatever env was set at
-    // construction). Per-package mode = one pair per package (env
-    // scoped to its exports + deps) plus a catch-all pair for
-    // ``unowned_files`` under the union of every package's env.
-    let phase_pairs: Vec<(Option<Vec<String>>, Vec<File>)> = if package_envs.is_empty() {
-        vec![(None, project_files.clone())]
+    // Pre-partition each step's files into (.py, .pyi). Phase 1 needs
+    // .py before .pyi within a step (for the peer-stub probe);
+    // pre-splitting cuts phase 1 from 2N swaps to N. Legacy = one
+    // no-swap pair holding every project file.
+    let phase_pairs: Vec<PhasePair> = if package_env_roots.is_empty() {
+        let (non_pyi, pyi) = split_by_pyi(db, &project_files);
+        vec![(None, non_pyi, pyi)]
     } else {
-        let mut pairs: Vec<(Option<Vec<String>>, Vec<File>)> =
-            Vec::with_capacity(package_owned_paths.len() + 1);
-        for (owned, env) in package_owned_paths.iter().zip(package_envs.iter()) {
+        let mut pairs = Vec::with_capacity(package_owned_paths.len() + 1);
+        for (owned, env_roots) in package_owned_paths.iter().zip(package_env_roots.iter()) {
             let files = files_by_package.get(owned).cloned().unwrap_or_default();
-            pairs.push((Some(env.env_roots.clone()), files));
+            let (non_pyi, pyi) = split_by_pyi(db, &files);
+            pairs.push((Some(env_roots.clone()), non_pyi, pyi));
         }
-        // The catch-all bucket runs under the union of every package's
-        // env so cross-cutting unowned files (root conftest.py, scripts)
-        // can resolve into any first-party package they import from.
-        let mut seen: HashMap<String, ()> = HashMap::new();
+        // Unowned catch-all runs under the union of every package's
+        // env so cross-cutting files (root conftest.py, scripts) can
+        // resolve into any first-party package they import from.
+        let mut seen: HashSet<&str> = HashSet::new();
         let mut union_env: Vec<String> = Vec::new();
-        for env in package_envs {
-            for r in &env.env_roots {
-                if seen.insert(r.clone(), ()).is_none() {
+        for env_roots in package_env_roots {
+            for r in env_roots {
+                if seen.insert(r.as_str()) {
                     union_env.push(r.clone());
                 }
             }
         }
-        pairs.push((Some(union_env), unowned_files.clone()));
+        let (non_pyi, pyi) = split_by_pyi(db, &unowned_files);
+        pairs.push((Some(union_env), non_pyi, pyi));
         pairs
     };
 
     let progress = ProgressBars::new(show_progress, project_files.len() as u64);
 
-    // Phase 1 (decl ingest): two outer passes over the pairs --
-    // non-pyi first, then pyi -- so the per-decl peer-stub probe in
-    // ``ingest_decls`` always sees the .py twin's globals_by_name
-    // entries before the .pyi is ingested. Within each outer pass we
-    // swap env once per pair.
+    // Phase 1 overlaps with the env-independent dist_lookup walk on a
+    // worker thread (joined before phase 2 where dist_lookup is first
+    // read). The scoped thread only borrows ``site_packages``, so
+    // phase 1 keeps its ``&mut db`` for ``swap_src_roots``.
     let t1 = std::time::Instant::now();
-    for (env_roots_opt, files) in &phase_pairs {
-        if let Some(roots) = env_roots_opt {
-            swap_src_roots(db, root, base_env, roots.clone())?;
-        }
-        for file in files {
-            if file_path_string(db, *file).ends_with(".pyi") {
-                continue;
+    let (dist_lookup, t_dist_lookup) = std::thread::scope(|s| -> PyResult<_> {
+        let sp_ref = &site_packages;
+        let lookup_handle = s.spawn(move || {
+            let t = std::time::Instant::now();
+            (build_dist_lookup(sp_ref), t.elapsed())
+        });
+
+        for (env_roots_opt, non_pyi, pyi) in &phase_pairs {
+            if let Some(roots) = env_roots_opt {
+                swap_src_roots(db, root, base_env, roots)?;
             }
-            ingest_decls(
-                py,
-                db,
-                *file,
-                &mut builder,
-                &mut global_index,
-                &mut module_nodes,
-                &mut alias_imports,
-                &mut live_decls,
-                &mut globals_by_name,
-                &mut star_reexports,
-                &mut class_by_selection,
-                &mut decl_by_name_range,
-            )?;
-            progress.ingest.inc(1);
-        }
-    }
-    for (env_roots_opt, files) in &phase_pairs {
-        if let Some(roots) = env_roots_opt {
-            swap_src_roots(db, root, base_env, roots.clone())?;
-        }
-        for file in files {
-            if !file_path_string(db, *file).ends_with(".pyi") {
-                continue;
+            for file in non_pyi.iter().chain(pyi.iter()) {
+                ingest_decls(
+                    py,
+                    db,
+                    *file,
+                    &mut builder,
+                    &mut global_index,
+                    &mut module_nodes,
+                    &mut alias_imports,
+                    &mut live_decls,
+                    &mut globals_by_name,
+                    &mut star_reexports,
+                    &mut class_by_selection,
+                    &mut decl_by_name_range,
+                )?;
+                progress.ingest.inc(1);
             }
-            ingest_decls(
-                py,
-                db,
-                *file,
-                &mut builder,
-                &mut global_index,
-                &mut module_nodes,
-                &mut alias_imports,
-                &mut live_decls,
-                &mut globals_by_name,
-                &mut star_reexports,
-                &mut class_by_selection,
-                &mut decl_by_name_range,
-            )?;
-            progress.ingest.inc(1);
         }
-    }
-    progress.ingest.finish_and_clear();
-    // Peer-stub edges (env-independent: pure builder bookkeeping).
+        progress.ingest.finish_and_clear();
+        Ok(lookup_handle.join().expect("dist_lookup thread panicked"))
+    })?;
     let peer_stubs: Vec<(File, File)> = builder
         .peer_pyi_to_py
         .iter()
@@ -435,11 +372,11 @@ pub(crate) fn build_project_graph(
     let t_phase1 = t1.elapsed();
 
     let t2 = std::time::Instant::now();
-    for (env_roots_opt, files) in &phase_pairs {
+    for (env_roots_opt, non_pyi, pyi) in &phase_pairs {
         if let Some(roots) = env_roots_opt {
-            swap_src_roots(db, root, base_env, roots.clone())?;
+            swap_src_roots(db, root, base_env, roots)?;
         }
-        for file in files {
+        for file in non_pyi.iter().chain(pyi.iter()) {
             emit_module_hierarchy(db, *file, &module_nodes, &mut builder);
             emit_import_edges(
                 py,
@@ -458,11 +395,11 @@ pub(crate) fn build_project_graph(
     progress.imports.finish_and_clear();
     let t_phase2 = t2.elapsed();
     let t3 = std::time::Instant::now();
-    for (env_roots_opt, files) in &phase_pairs {
+    for (env_roots_opt, non_pyi, pyi) in &phase_pairs {
         if let Some(roots) = env_roots_opt {
-            swap_src_roots(db, root, base_env, roots.clone())?;
+            swap_src_roots(db, root, base_env, roots)?;
         }
-        for file in files {
+        for file in non_pyi.iter().chain(pyi.iter()) {
             emit_reference_edges(
                 db,
                 *file,
@@ -478,10 +415,6 @@ pub(crate) fn build_project_graph(
     }
     progress.references.finish_and_clear();
     let t_phase3 = t3.elapsed();
-
-    // Final env state for plugins: the last per-package pair we
-    // installed was the unowned-catch-all under the union env, so the
-    // resolver is already permissive. No extra swap needed.
     let t4 = std::time::Instant::now();
     let (decl_by_fqname, module_by_fqname, imports_by_module) = build_fqname_indices(py, &builder);
     let t_fqname = t4.elapsed();
@@ -524,6 +457,25 @@ pub(crate) fn build_project_graph(
 /// proper resolver should have an empty unowned set, but stray
 /// project-root scripts and conftest.py files outside any member dir
 /// are surfaced here rather than silently lost.
+/// One iteration of the per-package phase loop: optional env_roots
+/// (None = no swap, legacy single-pass) plus the package's files
+/// pre-partitioned into ``.py`` and ``.pyi`` so phase 1 can run each
+/// step in a single swap rather than two outer passes.
+type PhasePair = (Option<Vec<String>>, Vec<File>, Vec<File>);
+
+fn split_by_pyi(db: &ProjectDatabase, files: &[File]) -> (Vec<File>, Vec<File>) {
+    let mut non_pyi = Vec::new();
+    let mut pyi = Vec::new();
+    for &f in files {
+        if file_path_string(db, f).ends_with(".pyi") {
+            pyi.push(f);
+        } else {
+            non_pyi.push(f);
+        }
+    }
+    (non_pyi, pyi)
+}
+
 fn partition_files_by_package(
     db: &ProjectDatabase,
     project_files: &[File],
@@ -653,28 +605,18 @@ pub(crate) struct ProjectContext {
     /// downgrades to a hidden draw target when stderr isn't a TTY, so
     /// passing ``True`` is safe in CI / pipes.
     pub(crate) show_progress: bool,
-    /// Original env options captured at construction, so :meth:`set_src_roots`
-    /// can rebuild the ``ProgramSettings`` with a new ``root`` list while
-    /// keeping ``extra_paths`` / ``python`` / ``typeshed`` / ``python_version``
-    /// constant. Cloning + mutating this is what lets us swap the
-    /// first-party search paths in place on the live Salsa db so the
-    /// parse + semantic_index caches survive across env swaps.
+    /// Env options captured at construction so ``swap_src_roots`` can
+    /// rebuild ``ProgramSettings`` with a mutated ``root`` while
+    /// keeping the rest constant.
     pub(crate) base_env: EnvironmentOptions,
-    /// Owned directories (one per ``Package.path``) used to partition
-    /// the enumerated file list. The build computes a longest-prefix
-    /// match against these to assign each ``File`` to a package.
-    /// Empty when constructed without packages -- the build then
-    /// treats every file as ``unowned``, which is identical to
-    /// today's flat "single bucket" semantics.
+    /// One owned dir per package (BFS dep order), used to partition
+    /// the project file set by longest-prefix match. Empty = no
+    /// partition, every file is unowned.
     pub(crate) package_owned_paths: Vec<SystemPathBuf>,
-    /// Per-package env-roots, index-aligned with
-    /// ``package_owned_paths``. ``package_envs[i].env_roots`` is the
-    /// search-path list installed via ``swap_src_roots`` before
-    /// processing files owned by ``package_owned_paths[i]``. Empty
-    /// = single-pass build under the current env (today's
-    /// behavior); non-empty = per-package phase loop with env swaps
-    /// between iterations.
-    pub(crate) package_envs: Vec<PackageEnv>,
+    /// Index-aligned with ``package_owned_paths``. Empty = single-pass
+    /// legacy build; non-empty = per-package phase loop with env
+    /// swaps between iterations.
+    pub(crate) package_env_roots: Vec<Vec<String>>,
 }
 
 #[pymethods]
@@ -711,11 +653,7 @@ impl ProjectContext {
             .into_iter()
             .map(SystemPathBuf::from)
             .collect();
-        let envs: Vec<PackageEnv> = package_env_roots
-            .unwrap_or_default()
-            .into_iter()
-            .map(|env_roots| PackageEnv { env_roots })
-            .collect();
+        let envs: Vec<Vec<String>> = package_env_roots.unwrap_or_default();
         if !envs.is_empty() && envs.len() != owned.len() {
             return Err(PyValueError::new_err(format!(
                 "package_env_roots length {} does not match package_owned_paths length {}",
@@ -732,7 +670,7 @@ impl ProjectContext {
             show_progress,
             base_env: env,
             package_owned_paths: owned,
-            package_envs: envs,
+            package_env_roots: envs,
         })
     }
 
@@ -751,7 +689,7 @@ impl ProjectContext {
     /// only finds the deps that the current package's lockfile actually
     /// permits, while the heavy parse + index work stays hot.
     pub(crate) fn set_src_roots(&mut self, roots: Vec<String>) -> PyResult<()> {
-        swap_src_roots(&mut self.db, &self.root, &mut self.base_env, roots)
+        swap_src_roots(&mut self.db, &self.root, &mut self.base_env, &roots)
     }
 
     /// Absolute project root passed at construction.
@@ -823,20 +761,9 @@ impl ProjectContext {
         let show_progress = slf.borrow(py).show_progress;
         {
             let mut this = slf.borrow_mut(py);
-            // Split-borrow: ``build_project_graph`` needs ``&mut db``
-            // and ``&mut base_env`` simultaneously, plus an
-            // immutable slice of ``package_owned_paths``. Reborrowing
-            // through ``&mut *this`` would conflict on field access;
-            // taking fields by pointer is the idiomatic split.
             let this_ref: &mut ProjectContext = &mut this;
             let owned = this_ref.package_owned_paths.clone();
-            let envs: Vec<PackageEnv> = this_ref
-                .package_envs
-                .iter()
-                .map(|e| PackageEnv {
-                    env_roots: e.env_roots.clone(),
-                })
-                .collect();
+            let envs = this_ref.package_env_roots.clone();
             let outputs = build_project_graph(
                 py,
                 &mut this_ref.db,
@@ -2428,33 +2355,32 @@ pub(crate) fn make_db(root: &str, env: EnvironmentOptions) -> PyResult<ProjectDa
 
 /// Swap the first-party search paths on a live Salsa db.
 ///
-/// Shared by :meth:`ProjectContext::set_src_roots` (the Python-facing
-/// setter) and the per-package phase loop in :fn:`build_project_graph`
-/// (which calls it between package iterations). Mutates ``base_env``
-/// in place so successive calls compose -- e.g. the loop's
-/// "set to pkg A's env, then to pkg B's env, then to the union for
-/// the plugin pass" pattern reuses the same base options each time.
+/// Shared by :meth:`ProjectContext::set_src_roots` and the
+/// per-package phase loop. Mutates ``base_env`` so successive calls
+/// compose. Returns early when ``roots`` already matches
+/// ``base_env.root`` so back-to-back identical envs (common in the
+/// per-package loop's catch-all pair) skip the metadata rebuild.
 pub(crate) fn swap_src_roots(
     db: &mut ProjectDatabase,
     root: &str,
     base_env: &mut EnvironmentOptions,
-    roots: Vec<String>,
+    roots: &[String],
 ) -> PyResult<()> {
-    base_env.root = Some(roots.into_iter().map(rel_path).collect());
+    let new_root: Vec<_> = roots.iter().map(|r| rel_path(r.clone())).collect();
+    if base_env.root.as_ref() == Some(&new_root) {
+        return Ok(());
+    }
+    base_env.root = Some(new_root);
 
     let metadata = make_metadata(root, base_env.clone())?;
-    // ``UseDefaultStrategy::Error`` is ``Infallible``, so the result is
-    // unconditionally ``Ok``; ``let Ok(..)`` keeps the type-level
-    // promise explicit without needing a ``match never {}`` dance.
     let Ok((program_settings, _diagnostics)) =
         metadata.to_program_settings(db.system(), db.vendored(), &UseDefaultStrategy);
 
     let program = ty_python_core::program::Program::get(db);
     program.update_from_settings(db, program_settings);
 
-    // The project's file enumeration is computed from the (now stale)
-    // search paths; mark it lazy so the next ``files(db)`` re-walks
-    // under the new env.
+    // File enumeration was computed under the stale roots; mark lazy
+    // so the next ``files(db)`` re-walks.
     db.project().reload_files(db);
 
     Ok(())

--- a/src/project.rs
+++ b/src/project.rs
@@ -13,6 +13,7 @@ use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
 use ruff_db::system::{OsSystem, SystemPathBuf};
+use ruff_db::Db as SourceDb;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{Expr, Stmt};
@@ -74,14 +75,8 @@ impl Project {
         python_version: Option<&str>,
         typeshed: Option<&str>,
     ) -> PyResult<Self> {
-        let db = make_db(
-            root,
-            src_roots,
-            extra_paths,
-            python_env,
-            python_version,
-            typeshed,
-        )?;
+        let env = build_env_options(src_roots, extra_paths, python_env, python_version, typeshed)?;
+        let db = make_db(root, env)?;
         Ok(Self { db })
     }
 
@@ -489,6 +484,13 @@ pub(crate) struct ProjectContext {
     /// downgrades to a hidden draw target when stderr isn't a TTY, so
     /// passing ``True`` is safe in CI / pipes.
     pub(crate) show_progress: bool,
+    /// Original env options captured at construction, so :meth:`set_src_roots`
+    /// can rebuild the ``ProgramSettings`` with a new ``root`` list while
+    /// keeping ``extra_paths`` / ``python`` / ``typeshed`` / ``python_version``
+    /// constant. Cloning + mutating this is what lets us swap the
+    /// first-party search paths in place on the live Salsa db so the
+    /// parse + semantic_index caches survive across env swaps.
+    pub(crate) base_env: EnvironmentOptions,
 }
 
 #[pymethods]
@@ -513,14 +515,8 @@ impl ProjectContext {
         typeshed: Option<&str>,
         show_progress: bool,
     ) -> PyResult<Self> {
-        let db = make_db(
-            root,
-            src_roots,
-            extra_paths,
-            python_env,
-            python_version,
-            typeshed,
-        )?;
+        let env = build_env_options(src_roots, extra_paths, python_env, python_version, typeshed)?;
+        let db = make_db(root, env.clone())?;
         Ok(Self {
             db,
             root: root.to_string(),
@@ -528,7 +524,44 @@ impl ProjectContext {
             outputs: RefCell::new(None),
             regex_cache: RefCell::new(HashMap::new()),
             show_progress,
+            base_env: env,
         })
+    }
+
+    /// Swap the first-party search paths on the live Salsa db.
+    ///
+    /// Reuses the env options captured at construction for everything
+    /// except ``environment.root`` — ``extra_paths`` / ``python`` /
+    /// ``typeshed`` / ``python_version`` / ``python_platform`` stay
+    /// fixed across swaps. The parse and per-file ``semantic_index``
+    /// Salsa queries are keyed on ``File`` (not on env), so they
+    /// survive the swap; only ``resolve_module`` / ``file_to_module``
+    /// answers and the project's file enumeration are invalidated.
+    ///
+    /// Designed for the per-package pipeline: between iterations, set
+    /// ``src_roots = [pkg + transitive_deps]`` so ty's module resolver
+    /// only finds the deps that the current package's lockfile actually
+    /// permits, while the heavy parse + index work stays hot.
+    pub(crate) fn set_src_roots(&mut self, roots: Vec<String>) -> PyResult<()> {
+        // Mutate the saved env so subsequent swaps build on the same base.
+        self.base_env.root = Some(roots.into_iter().map(rel_path).collect());
+
+        let metadata = make_metadata(&self.root, self.base_env.clone())?;
+        // ``UseDefaultStrategy::Error`` is ``Infallible``, so the result is
+        // unconditionally ``Ok``; ``let Ok(..)`` keeps the type-level
+        // promise explicit without needing a ``match never {}`` dance.
+        let Ok((program_settings, _diagnostics)) =
+            metadata.to_program_settings(self.db.system(), self.db.vendored(), &UseDefaultStrategy);
+
+        let program = ty_python_core::program::Program::get(&self.db);
+        program.update_from_settings(&mut self.db, program_settings);
+
+        // The project's file enumeration is computed from the (now stale)
+        // search paths; mark it lazy so the next ``files(db)`` re-walks
+        // under the new env.
+        self.db.project().reload_files(&mut self.db);
+
+        Ok(())
     }
 
     /// Absolute project root passed at construction.
@@ -2092,16 +2125,18 @@ impl ProjectContext {
     }
 }
 
-pub(crate) fn make_db(
-    root: &str,
+/// Convert the CLI-style configuration strings into an ``EnvironmentOptions``.
+/// Pulled out of ``make_db`` so :meth:`ProjectContext::set_src_roots` can
+/// stash a clone and mutate just ``root`` on each swap without re-parsing
+/// the python_version string.
+pub(crate) fn build_env_options(
     src_roots: Option<Vec<String>>,
     extra_paths: Option<Vec<String>>,
     python_env: Option<&str>,
     python_version: Option<&str>,
     typeshed: Option<&str>,
-) -> PyResult<ProjectDatabase> {
-    let root = SystemPathBuf::from(root);
-    let env = EnvironmentOptions {
+) -> PyResult<EnvironmentOptions> {
+    Ok(EnvironmentOptions {
         root: src_roots.map(|paths| paths.into_iter().map(rel_path).collect()),
         extra_paths: extra_paths.map(|paths| paths.into_iter().map(rel_path).collect()),
         python: python_env.map(rel_path),
@@ -2115,13 +2150,24 @@ pub(crate) fn make_db(
             .map(RangedValue::cli),
         typeshed: typeshed.map(rel_path),
         ..EnvironmentOptions::default()
-    };
+    })
+}
+
+/// Build a fresh ``ProjectMetadata`` from a root + env. Shared by
+/// ``make_db`` (initial construction) and ``set_src_roots`` (rebuilding
+/// program settings for a new root list).
+pub(crate) fn make_metadata(root: &str, env: EnvironmentOptions) -> PyResult<ProjectMetadata> {
+    let root = SystemPathBuf::from(root);
     let options = Options {
         environment: Some(env),
         ..Options::default()
     };
-    let metadata = ProjectMetadata::from_options(options, root.clone(), None, &UseDefaultStrategy)
-        .map_err(|e| PyValueError::new_err(format!("invalid configuration: {e:?}")))?;
+    ProjectMetadata::from_options(options, root, None, &UseDefaultStrategy)
+        .map_err(|e| PyValueError::new_err(format!("invalid configuration: {e:?}")))
+}
+
+pub(crate) fn make_db(root: &str, env: EnvironmentOptions) -> PyResult<ProjectDatabase> {
+    let metadata = make_metadata(root, env)?;
     let cwd =
         std::env::current_dir().map_err(|e| PyOSError::new_err(format!("cwd unavailable: {e}")))?;
     let cwd = SystemPathBuf::from_path_buf(cwd).map_err(|_| {

--- a/src/project.rs
+++ b/src/project.rs
@@ -53,6 +53,8 @@ use crate::query::{
 #[pyclass(unsendable)]
 pub(crate) struct Project {
     pub(crate) db: ProjectDatabase,
+    pub(crate) root: String,
+    pub(crate) base_env: EnvironmentOptions,
     pub(crate) package_owned_paths: Vec<SystemPathBuf>,
 }
 
@@ -80,7 +82,7 @@ impl Project {
         typeshed: Option<&str>,
     ) -> PyResult<Self> {
         let env = build_env_options(src_roots, extra_paths, python_env, python_version, typeshed)?;
-        let db = make_db(root, env)?;
+        let db = make_db(root, env.clone())?;
         let owned = package_owned_paths
             .unwrap_or_default()
             .into_iter()
@@ -88,13 +90,27 @@ impl Project {
             .collect::<Vec<_>>();
         Ok(Self {
             db,
+            root: root.to_string(),
+            base_env: env,
             package_owned_paths: owned,
         })
     }
 
     /// Build the project-wide symbol graph.
-    pub(crate) fn build(&self, py: Python<'_>) -> PyResult<NativeGraph> {
-        let outputs = build_project_graph(py, &self.db, false, &self.package_owned_paths)?;
+    pub(crate) fn build(&mut self, py: Python<'_>) -> PyResult<NativeGraph> {
+        // Project::build is the lean (no-plugin) entrypoint -- no
+        // per-package envs supplied, so the build runs as a single
+        // pass under the current env (legacy behavior).
+        let owned = self.package_owned_paths.clone();
+        let outputs = build_project_graph(
+            py,
+            &mut self.db,
+            false,
+            &self.root,
+            &mut self.base_env,
+            &owned,
+            &[],
+        )?;
         Ok(NativeGraph {
             nodes: outputs.builder.nodes,
             edges: outputs.builder.edges,
@@ -225,11 +241,32 @@ impl ProgressBars {
     }
 }
 
+/// Per-package configuration the build loop consumes.
+///
+/// One entry per package the resolver returned (plus an extra
+/// "unowned" pseudo-entry the build appends for files outside every
+/// owned path). Index-aligned with ``package_owned_paths`` so the
+/// loop can pair ``files_by_package[i]`` with ``env_roots[i]`` in
+/// O(1).
+pub(crate) struct PackageEnv {
+    /// Search paths to install via ``swap_src_roots`` before
+    /// processing this package's files. Format:
+    /// ``[*pkg.exported_paths, pkg.path, *flatten(dep.exported_paths)]``
+    /// -- exports first for fqname-derivation priority, owned ``path``
+    /// next as a catch-all for non-exported owned files (e.g.
+    /// src-layout ``tests/``), deps last so cross-package imports
+    /// resolve.
+    pub(crate) env_roots: Vec<String>,
+}
+
 pub(crate) fn build_project_graph(
     py: Python<'_>,
-    db: &ProjectDatabase,
+    db: &mut ProjectDatabase,
     show_progress: bool,
+    root: &str,
+    base_env: &mut EnvironmentOptions,
     package_owned_paths: &[SystemPathBuf],
+    package_envs: &[PackageEnv],
 ) -> PyResult<BuildOutputs> {
     let timing = std::env::var_os("DEAD_CST_TIMING").is_some();
     let mut builder = GraphBuilder::new();
@@ -273,27 +310,62 @@ pub(crate) fn build_project_graph(
         }
     }
     let t_enum = t0.elapsed();
-    // Phase 1 (per-file decl ingest) doesn't read ``dist_lookup``, so
-    // it overlaps with the site-packages walk on a worker thread.
-    // ``ProjectDatabase`` is !Sync (Salsa's per-thread query stack),
-    // so we pre-extract just the search paths the walk needs.
     let site_packages = crate::ingest::site_packages_roots(db);
 
-    let progress = ProgressBars::new(show_progress, project_files.len() as u64);
-    let t1 = std::time::Instant::now();
-    let (dist_lookup, t_phase1, t_dist_lookup) = std::thread::scope(|s| -> PyResult<_> {
-        let sp_ref = &site_packages;
-        let lookup_handle = s.spawn(move || {
-            let t = std::time::Instant::now();
-            (build_dist_lookup(sp_ref), t.elapsed())
-        });
+    // ``dist_lookup`` is env-independent (just walks site_packages
+    // roots), so we compute it once upfront. Previously it ran on a
+    // worker thread overlapped with phase 1; the per-package loop's
+    // env swaps between iterations need ``&mut db``, which is
+    // incompatible with the scoped thread that held ``&db``. The
+    // serial cost is a small fixed overhead on cold builds.
+    let t_dl = std::time::Instant::now();
+    let dist_lookup = build_dist_lookup(&site_packages);
+    let t_dist_lookup = t_dl.elapsed();
 
-        // Two-pass ingest so the per-decl ``.pyi`` stub flagging in
-        // ``ingest_decls`` has the .py twin's ``globals_by_name`` entries
-        // to probe. Pass 1 = everything that isn't a .pyi; pass 2 = .pyi.
-        // The split doesn't change the graph for non-peer files; it's
-        // ordering for the peer-stub flag-check only.
-        for file in &project_files {
+    // Build the (env_roots, files) pairs the per-package phase loop
+    // iterates over. Single-pass legacy mode = one pair with no env
+    // swap (just process every file under whatever env was set at
+    // construction). Per-package mode = one pair per package (env
+    // scoped to its exports + deps) plus a catch-all pair for
+    // ``unowned_files`` under the union of every package's env.
+    let phase_pairs: Vec<(Option<Vec<String>>, Vec<File>)> = if package_envs.is_empty() {
+        vec![(None, project_files.clone())]
+    } else {
+        let mut pairs: Vec<(Option<Vec<String>>, Vec<File>)> =
+            Vec::with_capacity(package_owned_paths.len() + 1);
+        for (owned, env) in package_owned_paths.iter().zip(package_envs.iter()) {
+            let files = files_by_package.get(owned).cloned().unwrap_or_default();
+            pairs.push((Some(env.env_roots.clone()), files));
+        }
+        // The catch-all bucket runs under the union of every package's
+        // env so cross-cutting unowned files (root conftest.py, scripts)
+        // can resolve into any first-party package they import from.
+        let mut seen: HashMap<String, ()> = HashMap::new();
+        let mut union_env: Vec<String> = Vec::new();
+        for env in package_envs {
+            for r in &env.env_roots {
+                if seen.insert(r.clone(), ()).is_none() {
+                    union_env.push(r.clone());
+                }
+            }
+        }
+        pairs.push((Some(union_env), unowned_files.clone()));
+        pairs
+    };
+
+    let progress = ProgressBars::new(show_progress, project_files.len() as u64);
+
+    // Phase 1 (decl ingest): two outer passes over the pairs --
+    // non-pyi first, then pyi -- so the per-decl peer-stub probe in
+    // ``ingest_decls`` always sees the .py twin's globals_by_name
+    // entries before the .pyi is ingested. Within each outer pass we
+    // swap env once per pair.
+    let t1 = std::time::Instant::now();
+    for (env_roots_opt, files) in &phase_pairs {
+        if let Some(roots) = env_roots_opt {
+            swap_src_roots(db, root, base_env, roots.clone())?;
+        }
+        for file in files {
             if file_path_string(db, *file).ends_with(".pyi") {
                 continue;
             }
@@ -313,7 +385,12 @@ pub(crate) fn build_project_graph(
             )?;
             progress.ingest.inc(1);
         }
-        for file in &project_files {
+    }
+    for (env_roots_opt, files) in &phase_pairs {
+        if let Some(roots) = env_roots_opt {
+            swap_src_roots(db, root, base_env, roots.clone())?;
+        }
+        for file in files {
             if !file_path_string(db, *file).ends_with(".pyi") {
                 continue;
             }
@@ -333,74 +410,78 @@ pub(crate) fn build_project_graph(
             )?;
             progress.ingest.inc(1);
         }
-        progress.ingest.finish_and_clear();
-        // Per-decl ``pyi_decl -> py_decl`` edges for each peer .pyi whose
-        // matching .py defines the same simple name. The edge documents
-        // the stub-runtime relationship in the graph: consumers that ty
-        // resolved through the stub get reachability into the runtime
-        // decl via ``alias -> pyi_decl -> py_decl`` rather than stopping
-        // at the stub. Stub-only decls (no matching .py decl) are
-        // separately kept alive by the per-decl ENTRYPOINT flag set in
-        // ``ingest_decls``.
-        let peer_stubs: Vec<(File, File)> = builder
-            .peer_pyi_to_py
+    }
+    progress.ingest.finish_and_clear();
+    // Peer-stub edges (env-independent: pure builder bookkeeping).
+    let peer_stubs: Vec<(File, File)> = builder
+        .peer_pyi_to_py
+        .iter()
+        .map(|(&pyi, &py)| (pyi, py))
+        .collect();
+    for (pyi_file, py_twin) in peer_stubs {
+        let pyi_decls: Vec<(String, usize)> = globals_by_name
             .iter()
-            .map(|(&pyi, &py)| (pyi, py))
+            .filter(|((file, _), _)| *file == pyi_file)
+            .flat_map(|((_, name), idxs)| idxs.iter().map(move |&idx| (name.clone(), idx)))
             .collect();
-        for (pyi_file, py_twin) in peer_stubs {
-            let pyi_decls: Vec<(String, usize)> = globals_by_name
-                .iter()
-                .filter(|((file, _), _)| *file == pyi_file)
-                .flat_map(|((_, name), idxs)| idxs.iter().map(move |&idx| (name.clone(), idx)))
-                .collect();
-            for (name, pyi_idx) in pyi_decls {
-                if let Some(py_idxs) = globals_by_name.get(&(py_twin, name)) {
-                    for &py_idx in py_idxs {
-                        builder.add_edge(pyi_idx, py_idx, 0);
-                    }
+        for (name, pyi_idx) in pyi_decls {
+            if let Some(py_idxs) = globals_by_name.get(&(py_twin, name)) {
+                for &py_idx in py_idxs {
+                    builder.add_edge(pyi_idx, py_idx, 0);
                 }
             }
         }
-        let t_phase1 = t1.elapsed();
-        // Block on the dist-info walker (no-op when Phase 1 finished
-        // last, which is the common case on medium-to-large projects).
-        let (lookup, t_dist) = lookup_handle.join().expect("dist_lookup thread panicked");
-        Ok((lookup, t_phase1, t_dist))
-    })?;
+    }
+    let t_phase1 = t1.elapsed();
+
     let t2 = std::time::Instant::now();
-    for file in &project_files {
-        emit_module_hierarchy(db, *file, &module_nodes, &mut builder);
-        emit_import_edges(
-            py,
-            db,
-            *file,
-            &mut builder,
-            &mut global_index,
-            &mut module_nodes,
-            &globals_by_name,
-            &star_reexports,
-            &dist_lookup,
-        )?;
-        progress.imports.inc(1);
+    for (env_roots_opt, files) in &phase_pairs {
+        if let Some(roots) = env_roots_opt {
+            swap_src_roots(db, root, base_env, roots.clone())?;
+        }
+        for file in files {
+            emit_module_hierarchy(db, *file, &module_nodes, &mut builder);
+            emit_import_edges(
+                py,
+                db,
+                *file,
+                &mut builder,
+                &mut global_index,
+                &mut module_nodes,
+                &globals_by_name,
+                &star_reexports,
+                &dist_lookup,
+            )?;
+            progress.imports.inc(1);
+        }
     }
     progress.imports.finish_and_clear();
     let t_phase2 = t2.elapsed();
     let t3 = std::time::Instant::now();
-    for file in &project_files {
-        emit_reference_edges(
-            db,
-            *file,
-            &global_index,
-            &module_nodes,
-            &alias_imports,
-            &live_decls,
-            &dist_lookup,
-            &mut builder,
-        );
-        progress.references.inc(1);
+    for (env_roots_opt, files) in &phase_pairs {
+        if let Some(roots) = env_roots_opt {
+            swap_src_roots(db, root, base_env, roots.clone())?;
+        }
+        for file in files {
+            emit_reference_edges(
+                db,
+                *file,
+                &global_index,
+                &module_nodes,
+                &alias_imports,
+                &live_decls,
+                &dist_lookup,
+                &mut builder,
+            );
+            progress.references.inc(1);
+        }
     }
     progress.references.finish_and_clear();
     let t_phase3 = t3.elapsed();
+
+    // Final env state for plugins: the last per-package pair we
+    // installed was the unowned-catch-all under the union env, so the
+    // resolver is already permissive. No extra swap needed.
     let t4 = std::time::Instant::now();
     let (decl_by_fqname, module_by_fqname, imports_by_module) = build_fqname_indices(py, &builder);
     let t_fqname = t4.elapsed();
@@ -586,6 +667,14 @@ pub(crate) struct ProjectContext {
     /// treats every file as ``unowned``, which is identical to
     /// today's flat "single bucket" semantics.
     pub(crate) package_owned_paths: Vec<SystemPathBuf>,
+    /// Per-package env-roots, index-aligned with
+    /// ``package_owned_paths``. ``package_envs[i].env_roots`` is the
+    /// search-path list installed via ``swap_src_roots`` before
+    /// processing files owned by ``package_owned_paths[i]``. Empty
+    /// = single-pass build under the current env (today's
+    /// behavior); non-empty = per-package phase loop with env swaps
+    /// between iterations.
+    pub(crate) package_envs: Vec<PackageEnv>,
 }
 
 #[pymethods]
@@ -596,6 +685,7 @@ impl ProjectContext {
         *,
         src_roots = None,
         package_owned_paths = None,
+        package_env_roots = None,
         extra_paths = None,
         python_env = None,
         python_version = None,
@@ -607,6 +697,7 @@ impl ProjectContext {
         root: &str,
         src_roots: Option<Vec<String>>,
         package_owned_paths: Option<Vec<String>>,
+        package_env_roots: Option<Vec<Vec<String>>>,
         extra_paths: Option<Vec<String>>,
         python_env: Option<&str>,
         python_version: Option<&str>,
@@ -615,11 +706,23 @@ impl ProjectContext {
     ) -> PyResult<Self> {
         let env = build_env_options(src_roots, extra_paths, python_env, python_version, typeshed)?;
         let db = make_db(root, env.clone())?;
-        let owned = package_owned_paths
+        let owned: Vec<SystemPathBuf> = package_owned_paths
             .unwrap_or_default()
             .into_iter()
             .map(SystemPathBuf::from)
             .collect();
+        let envs: Vec<PackageEnv> = package_env_roots
+            .unwrap_or_default()
+            .into_iter()
+            .map(|env_roots| PackageEnv { env_roots })
+            .collect();
+        if !envs.is_empty() && envs.len() != owned.len() {
+            return Err(PyValueError::new_err(format!(
+                "package_env_roots length {} does not match package_owned_paths length {}",
+                envs.len(),
+                owned.len()
+            )));
+        }
         Ok(Self {
             db,
             root: root.to_string(),
@@ -629,6 +732,7 @@ impl ProjectContext {
             show_progress,
             base_env: env,
             package_owned_paths: owned,
+            package_envs: envs,
         })
     }
 
@@ -647,25 +751,7 @@ impl ProjectContext {
     /// only finds the deps that the current package's lockfile actually
     /// permits, while the heavy parse + index work stays hot.
     pub(crate) fn set_src_roots(&mut self, roots: Vec<String>) -> PyResult<()> {
-        // Mutate the saved env so subsequent swaps build on the same base.
-        self.base_env.root = Some(roots.into_iter().map(rel_path).collect());
-
-        let metadata = make_metadata(&self.root, self.base_env.clone())?;
-        // ``UseDefaultStrategy::Error`` is ``Infallible``, so the result is
-        // unconditionally ``Ok``; ``let Ok(..)`` keeps the type-level
-        // promise explicit without needing a ``match never {}`` dance.
-        let Ok((program_settings, _diagnostics)) =
-            metadata.to_program_settings(self.db.system(), self.db.vendored(), &UseDefaultStrategy);
-
-        let program = ty_python_core::program::Program::get(&self.db);
-        program.update_from_settings(&mut self.db, program_settings);
-
-        // The project's file enumeration is computed from the (now stale)
-        // search paths; mark it lazy so the next ``files(db)`` re-walks
-        // under the new env.
-        self.db.project().reload_files(&mut self.db);
-
-        Ok(())
+        swap_src_roots(&mut self.db, &self.root, &mut self.base_env, roots)
     }
 
     /// Absolute project root passed at construction.
@@ -736,10 +822,31 @@ impl ProjectContext {
     pub(crate) fn materialize(slf: Py<Self>, py: Python<'_>) -> PyResult<NativeGraph> {
         let show_progress = slf.borrow(py).show_progress;
         {
-            let this = slf.borrow(py);
-            let outputs =
-                build_project_graph(py, &this.db, show_progress, &this.package_owned_paths)?;
-            *this.outputs.borrow_mut() = Some(outputs);
+            let mut this = slf.borrow_mut(py);
+            // Split-borrow: ``build_project_graph`` needs ``&mut db``
+            // and ``&mut base_env`` simultaneously, plus an
+            // immutable slice of ``package_owned_paths``. Reborrowing
+            // through ``&mut *this`` would conflict on field access;
+            // taking fields by pointer is the idiomatic split.
+            let this_ref: &mut ProjectContext = &mut this;
+            let owned = this_ref.package_owned_paths.clone();
+            let envs: Vec<PackageEnv> = this_ref
+                .package_envs
+                .iter()
+                .map(|e| PackageEnv {
+                    env_roots: e.env_roots.clone(),
+                })
+                .collect();
+            let outputs = build_project_graph(
+                py,
+                &mut this_ref.db,
+                show_progress,
+                &this_ref.root,
+                &mut this_ref.base_env,
+                &owned,
+                &envs,
+            )?;
+            *this_ref.outputs.borrow_mut() = Some(outputs);
         }
 
         let plugins: Vec<PyObject> = slf
@@ -2317,4 +2424,38 @@ pub(crate) fn make_db(root: &str, env: EnvironmentOptions) -> PyResult<ProjectDa
     })?;
     let system = OsSystem::new(cwd);
     Ok(ProjectDatabase::use_defaults(metadata, system))
+}
+
+/// Swap the first-party search paths on a live Salsa db.
+///
+/// Shared by :meth:`ProjectContext::set_src_roots` (the Python-facing
+/// setter) and the per-package phase loop in :fn:`build_project_graph`
+/// (which calls it between package iterations). Mutates ``base_env``
+/// in place so successive calls compose -- e.g. the loop's
+/// "set to pkg A's env, then to pkg B's env, then to the union for
+/// the plugin pass" pattern reuses the same base options each time.
+pub(crate) fn swap_src_roots(
+    db: &mut ProjectDatabase,
+    root: &str,
+    base_env: &mut EnvironmentOptions,
+    roots: Vec<String>,
+) -> PyResult<()> {
+    base_env.root = Some(roots.into_iter().map(rel_path).collect());
+
+    let metadata = make_metadata(root, base_env.clone())?;
+    // ``UseDefaultStrategy::Error`` is ``Infallible``, so the result is
+    // unconditionally ``Ok``; ``let Ok(..)`` keeps the type-level
+    // promise explicit without needing a ``match never {}`` dance.
+    let Ok((program_settings, _diagnostics)) =
+        metadata.to_program_settings(db.system(), db.vendored(), &UseDefaultStrategy);
+
+    let program = ty_python_core::program::Program::get(db);
+    program.update_from_settings(db, program_settings);
+
+    // The project's file enumeration is computed from the (now stale)
+    // search paths; mark it lazy so the next ``files(db)`` re-walks
+    // under the new env.
+    db.project().reload_files(db);
+
+    Ok(())
 }

--- a/tests/test_file_partition.py
+++ b/tests/test_file_partition.py
@@ -39,31 +39,24 @@ def test_files_partition_assigns_each_file_to_owning_package(tmp_path):
             "pkg_b/m1.py": "z = 3",
         },
     )
-    a = str(tmp_path / "pkg_a")
-    b = str(tmp_path / "pkg_b")
+    a = tmp_path / "pkg_a"
+    b = tmp_path / "pkg_b"
     ctx = native.ProjectContext(
         str(tmp_path),
-        src_roots=[a, b],
-        package_owned_paths=[a, b],
+        src_roots=[str(a), str(b)],
+        package_owned_paths=[str(a), str(b)],
     )
     ctx.materialize()
 
-    a_files = set(ctx.files_for_package(a))
-    b_files = set(ctx.files_for_package(b))
-
-    # Every pkg_a file is in A's bucket, no pkg_b leak.
-    assert any(p.endswith("pkg_a/m1.py") for p in a_files)
-    assert any(p.endswith("pkg_a/m2.py") for p in a_files)
-    assert any(p.endswith("pkg_a/__init__.py") for p in a_files)
-    assert not any("pkg_b" in p for p in a_files)
-
-    # Same for pkg_b.
-    assert any(p.endswith("pkg_b/m1.py") for p in b_files)
-    assert any(p.endswith("pkg_b/__init__.py") for p in b_files)
-    assert not any("pkg_a" in p for p in b_files)
-
-    # Disjoint partitions.
-    assert a_files.isdisjoint(b_files)
+    assert set(ctx.files_for_package(str(a))) == {
+        str(a / "__init__.py"),
+        str(a / "m1.py"),
+        str(a / "m2.py"),
+    }
+    assert set(ctx.files_for_package(str(b))) == {
+        str(b / "__init__.py"),
+        str(b / "m1.py"),
+    }
 
 
 def test_files_partition_longest_prefix_wins_for_nested_owned_dirs(tmp_path):
@@ -84,78 +77,64 @@ def test_files_partition_longest_prefix_wins_for_nested_owned_dirs(tmp_path):
             "lib/internal/deep.py": "y = 2",
         },
     )
-    outer = str(tmp_path / "lib")
-    inner = str(tmp_path / "lib" / "internal")
+    outer = tmp_path / "lib"
+    inner = tmp_path / "lib" / "internal"
     ctx = native.ProjectContext(
         str(tmp_path),
-        src_roots=[outer],
-        package_owned_paths=[outer, inner],
+        src_roots=[str(outer)],
+        package_owned_paths=[str(outer), str(inner)],
     )
     ctx.materialize()
 
-    outer_files = set(ctx.files_for_package(outer))
-    inner_files = set(ctx.files_for_package(inner))
-
-    # The deep file belongs to the inner package (longest prefix), not
-    # the outer one -- otherwise per-package processing would double-
-    # count it or miss it under the wrong scope.
-    assert any(p.endswith("lib/internal/deep.py") for p in inner_files)
-    assert any(p.endswith("lib/internal/__init__.py") for p in inner_files)
-    assert not any("internal" in p for p in outer_files)
-
-    # The outer package keeps its own top-level files.
-    assert any(p.endswith("lib/top.py") for p in outer_files)
+    assert set(ctx.files_for_package(str(outer))) == {
+        str(outer / "__init__.py"),
+        str(outer / "top.py"),
+    }
+    assert set(ctx.files_for_package(str(inner))) == {
+        str(inner / "__init__.py"),
+        str(inner / "deep.py"),
+    }
 
 
 def test_files_partition_unowned_bucket_catches_stray_files(tmp_path):
     """Files outside every owned path land in ``unowned_files``.
     Common shape: ``conftest.py`` at the project root, scripts in
-    ``./scripts/`` that aren't anyone's owned dir, etc. The build
-    still has to process them somewhere -- the catch-all pass uses
-    the union of all exported paths.
+    ``./scripts/`` that aren't anyone's owned dir.
     """
     _write(
         tmp_path,
         {
             "pkg_a/__init__.py": "",
             "pkg_a/mod.py": "x = 1",
-            "conftest.py": "",  # root-level, no owner
-            "scripts/build.py": "y = 2",  # not under pkg_a
+            "conftest.py": "",
+            "scripts/build.py": "y = 2",
         },
     )
-    a = str(tmp_path / "pkg_a")
+    a = tmp_path / "pkg_a"
     ctx = native.ProjectContext(
         str(tmp_path),
-        src_roots=[a],
-        package_owned_paths=[a],
+        src_roots=[str(a)],
+        package_owned_paths=[str(a)],
     )
     ctx.materialize()
 
-    a_files = set(ctx.files_for_package(a))
-    unowned = set(ctx.unowned_files())
-
-    assert any(p.endswith("pkg_a/mod.py") for p in a_files)
-    # The strays show up in the unowned bucket, NOT in pkg_a's.
-    assert any(p.endswith("conftest.py") for p in unowned)
-    assert any(p.endswith("scripts/build.py") for p in unowned)
-    assert not any("conftest.py" in p for p in a_files)
-    assert a_files.isdisjoint(unowned)
+    assert set(ctx.files_for_package(str(a))) == {
+        str(a / "__init__.py"),
+        str(a / "mod.py"),
+    }
+    assert set(ctx.unowned_files()) == {
+        str(tmp_path / "conftest.py"),
+        str(tmp_path / "scripts" / "build.py"),
+    }
 
 
 def test_files_partition_no_owned_paths_puts_everything_in_unowned(tmp_path):
-    """Backward-compat: when no owned paths are passed (legacy or
-    single-package shape), the partition is still computed -- every
-    file lands in ``unowned``, no per-package buckets exist. Pins
-    that today's callers (which don't pass ``package_owned_paths``)
-    keep working without surprises."""
+    """When no owned paths are passed (legacy shape), every file
+    lands in ``unowned``. Pins that today's callers (which don't
+    pass ``package_owned_paths``) keep working."""
     _write(tmp_path, {"m.py": "x = 1", "n.py": "y = 2"})
     ctx = native.ProjectContext(str(tmp_path), src_roots=[str(tmp_path)])
     ctx.materialize()
 
-    # No owned paths -> every project file is unowned.
-    unowned = set(ctx.unowned_files())
-    assert any(p.endswith("m.py") for p in unowned)
-    assert any(p.endswith("n.py") for p in unowned)
-
-    # Looking up an unknown owned path returns an empty list (no crash).
+    assert set(ctx.unowned_files()) == {str(tmp_path / "m.py"), str(tmp_path / "n.py")}
     assert ctx.files_for_package(str(tmp_path / "nonexistent")) == []

--- a/tests/test_file_partition.py
+++ b/tests/test_file_partition.py
@@ -1,0 +1,161 @@
+"""Tests for the per-package file partition built during materialize.
+
+The partition is computed once after ty enumerates the project's
+file set: each ``File`` is assigned to the package whose ``path``
+prefix is the longest match. Files outside every owned path land
+in ``unowned_files``.
+
+The partition is the data structure the per-package edge pass
+iterates over -- each iteration scopes the resolver to the
+package's exports + deps and processes only that package's
+bucket.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from dead_cst import _native as native
+
+
+def _write(root: Path, files: dict[str, str]) -> None:
+    for rel, src in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(textwrap.dedent(src).strip() + "\n")
+
+
+def test_files_partition_assigns_each_file_to_owning_package(tmp_path):
+    """Two non-overlapping packages partition the file list cleanly:
+    each file belongs to exactly one package, no overlap."""
+    _write(
+        tmp_path,
+        {
+            "pkg_a/__init__.py": "",
+            "pkg_a/m1.py": "x = 1",
+            "pkg_a/m2.py": "y = 2",
+            "pkg_b/__init__.py": "",
+            "pkg_b/m1.py": "z = 3",
+        },
+    )
+    a = str(tmp_path / "pkg_a")
+    b = str(tmp_path / "pkg_b")
+    ctx = native.ProjectContext(
+        str(tmp_path),
+        src_roots=[a, b],
+        package_owned_paths=[a, b],
+    )
+    ctx.materialize()
+
+    a_files = set(ctx.files_for_package(a))
+    b_files = set(ctx.files_for_package(b))
+
+    # Every pkg_a file is in A's bucket, no pkg_b leak.
+    assert any(p.endswith("pkg_a/m1.py") for p in a_files)
+    assert any(p.endswith("pkg_a/m2.py") for p in a_files)
+    assert any(p.endswith("pkg_a/__init__.py") for p in a_files)
+    assert not any("pkg_b" in p for p in a_files)
+
+    # Same for pkg_b.
+    assert any(p.endswith("pkg_b/m1.py") for p in b_files)
+    assert any(p.endswith("pkg_b/__init__.py") for p in b_files)
+    assert not any("pkg_a" in p for p in b_files)
+
+    # Disjoint partitions.
+    assert a_files.isdisjoint(b_files)
+
+
+def test_files_partition_longest_prefix_wins_for_nested_owned_dirs(tmp_path):
+    """When one package's owned dir sits inside another's, the
+    nested package wins ownership for its own files.
+
+    Realistic shape: monorepo with ``packages/lib`` and a nested
+    subpackage ``packages/lib/internal`` that the resolver treats
+    as its own ownership unit. A file in ``packages/lib/internal/x.py``
+    must be owned by ``lib/internal``, not ``lib``.
+    """
+    _write(
+        tmp_path,
+        {
+            "lib/__init__.py": "",
+            "lib/top.py": "x = 1",
+            "lib/internal/__init__.py": "",
+            "lib/internal/deep.py": "y = 2",
+        },
+    )
+    outer = str(tmp_path / "lib")
+    inner = str(tmp_path / "lib" / "internal")
+    ctx = native.ProjectContext(
+        str(tmp_path),
+        src_roots=[outer],
+        package_owned_paths=[outer, inner],
+    )
+    ctx.materialize()
+
+    outer_files = set(ctx.files_for_package(outer))
+    inner_files = set(ctx.files_for_package(inner))
+
+    # The deep file belongs to the inner package (longest prefix), not
+    # the outer one -- otherwise per-package processing would double-
+    # count it or miss it under the wrong scope.
+    assert any(p.endswith("lib/internal/deep.py") for p in inner_files)
+    assert any(p.endswith("lib/internal/__init__.py") for p in inner_files)
+    assert not any("internal" in p for p in outer_files)
+
+    # The outer package keeps its own top-level files.
+    assert any(p.endswith("lib/top.py") for p in outer_files)
+
+
+def test_files_partition_unowned_bucket_catches_stray_files(tmp_path):
+    """Files outside every owned path land in ``unowned_files``.
+    Common shape: ``conftest.py`` at the project root, scripts in
+    ``./scripts/`` that aren't anyone's owned dir, etc. The build
+    still has to process them somewhere -- the catch-all pass uses
+    the union of all exported paths.
+    """
+    _write(
+        tmp_path,
+        {
+            "pkg_a/__init__.py": "",
+            "pkg_a/mod.py": "x = 1",
+            "conftest.py": "",  # root-level, no owner
+            "scripts/build.py": "y = 2",  # not under pkg_a
+        },
+    )
+    a = str(tmp_path / "pkg_a")
+    ctx = native.ProjectContext(
+        str(tmp_path),
+        src_roots=[a],
+        package_owned_paths=[a],
+    )
+    ctx.materialize()
+
+    a_files = set(ctx.files_for_package(a))
+    unowned = set(ctx.unowned_files())
+
+    assert any(p.endswith("pkg_a/mod.py") for p in a_files)
+    # The strays show up in the unowned bucket, NOT in pkg_a's.
+    assert any(p.endswith("conftest.py") for p in unowned)
+    assert any(p.endswith("scripts/build.py") for p in unowned)
+    assert not any("conftest.py" in p for p in a_files)
+    assert a_files.isdisjoint(unowned)
+
+
+def test_files_partition_no_owned_paths_puts_everything_in_unowned(tmp_path):
+    """Backward-compat: when no owned paths are passed (legacy or
+    single-package shape), the partition is still computed -- every
+    file lands in ``unowned``, no per-package buckets exist. Pins
+    that today's callers (which don't pass ``package_owned_paths``)
+    keep working without surprises."""
+    _write(tmp_path, {"m.py": "x = 1", "n.py": "y = 2"})
+    ctx = native.ProjectContext(str(tmp_path), src_roots=[str(tmp_path)])
+    ctx.materialize()
+
+    # No owned paths -> every project file is unowned.
+    unowned = set(ctx.unowned_files())
+    assert any(p.endswith("m.py") for p in unowned)
+    assert any(p.endswith("n.py") for p in unowned)
+
+    # Looking up an unknown owned path returns an empty list (no crash).
+    assert ctx.files_for_package(str(tmp_path / "nonexistent")) == []

--- a/tests/test_per_package_loop.py
+++ b/tests/test_per_package_loop.py
@@ -1,0 +1,157 @@
+"""Tests for the per-package edge pass in :class:`Analysis`.
+
+The pipeline iterates packages in BFS dep order, swapping
+``Program::search_paths`` between iterations so each package's
+phase 1-3 runs under env_roots scoped to *exactly* what its
+lockfile declares: its own exports + its deps' exports.
+Non-dep cross-package imports therefore resolve as
+``[unresolved]`` / ``[external]`` rather than silently routing
+into a non-dep, faithfully reflecting the lockfile's dep graph
+at analysis time.
+
+Layout convention these tests follow (mirrors uv flat-layout
+workspaces): each owned member dir contains a subdirectory
+matching the wheel's published package name -- e.g.
+``app/app/main.py``, ``libx/libx/__init__.py``. The member dir
+is what goes on the search path; the inner subdir is what
+consumers actually import.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from dead_cst import Analysis
+from dead_cst.resolvers import ManualResolver
+
+
+def _write(root: Path, files: dict[str, str]) -> None:
+    for rel, src in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(textwrap.dedent(src).strip() + "\n")
+
+
+def _edges_by_node(graph) -> dict[int, list[tuple[int, int]]]:
+    """``src_idx -> [(dst_idx, flags)]`` adjacency built from the rust
+    ``(src_idx, dst_idx, flags)`` triples."""
+    out: dict[int, list[tuple[int, int]]] = {}
+    for s, d, f in graph.edges():
+        out.setdefault(s, []).append((d, f))
+    return out
+
+
+def test_per_package_loop_resolves_declared_dep_import(tmp_path, has_edge):
+    """Baseline: when ``app`` declares ``libx`` as a dep,
+    ``from libx import value`` in app's code must resolve
+    first-party to libx's decl.
+
+    Under the new loop, app's iteration runs with
+    env_roots = [app.exports, app.path, libx.exports], so the
+    resolver finds libx as first-party. Pins that env composition
+    doesn't accidentally drop deps' exports.
+    """
+    _write(
+        tmp_path,
+        {
+            "app/app/main.py": "from libx import value\nuse = value",
+            "libx/libx/__init__.py": "value = 42",
+        },
+    )
+    analysis = Analysis(
+        tmp_path,
+        resolver=ManualResolver(specs=["app:libx", "libx"]),
+    )
+    graph = analysis.materialize_all()
+
+    value_node = next(n for n in graph.nodes() if n.fqname == "libx.value" and n.kind == "variable")
+    app_import = next(
+        n
+        for n in graph.nodes()
+        if n.kind == "import" and n.path.endswith("app/app/main.py") and "value" in n.fqname
+    )
+    assert has_edge(graph, app_import, value_node)
+
+
+def test_per_package_loop_isolates_non_dep_cross_package_import(tmp_path):
+    """Behavior the per-package loop ships: when ``app`` imports
+    from ``other`` but does NOT declare ``other`` as a dep, the
+    import does NOT resolve into ``other``'s first-party decl.
+
+    Today's flat-env behavior would route the import to ``other``'s
+    decl anyway (both are in src_roots) -- silently OK at analysis
+    time even though it would fail at runtime when the wheel-built
+    app is installed without ``other`` in its deps. The per-package
+    loop's app iteration excludes other.exports, so the resolver
+    classifies the import as non-first-party.
+    """
+    _write(
+        tmp_path,
+        {
+            "app/app/main.py": "from other import y\nuse = y",
+            "other/other/__init__.py": "y = 1",
+        },
+    )
+    # No dep declared from app -> other.
+    analysis = Analysis(
+        tmp_path,
+        resolver=ManualResolver(specs=["app", "other"]),
+    )
+    graph = analysis.materialize_all()
+
+    nodes = graph.nodes()
+    app_import = next(n for n in nodes if n.kind == "import" and n.path.endswith("app/app/main.py"))
+    adj = _edges_by_node(graph)
+    src_idx = nodes.index(app_import)
+    outgoing = [nodes[d] for (d, _f) in adj.get(src_idx, ())]
+    # No edge into a first-party decl whose source path is under the
+    # non-dep ``other/`` member dir.
+    first_party_other = [n for n in outgoing if n.kind == "variable" and "/other/other/" in n.path]
+    assert not first_party_other, (
+        "Per-package loop must NOT route app.main's non-dep import "
+        f"into other's decl, but found edges to: {first_party_other}"
+    )
+
+
+def test_per_package_loop_dep_chain_resolves_transitively_via_imports(tmp_path, has_edge):
+    """A diamond: ``app -> mid -> base``. Imports in ``app`` that
+    go through ``mid``'s public API must resolve into ``mid``'s
+    decls, and ``mid``'s import of ``base`` must resolve into
+    ``base``'s decls. Each package's iteration sees only its own
+    declared deps -- transitive resolution is by composition, not
+    by giving every package the union env.
+    """
+    _write(
+        tmp_path,
+        {
+            "app/app/main.py": "from mid import bridge\nuse = bridge",
+            "mid/mid/__init__.py": "from base import core\nbridge = core",
+            "base/base/__init__.py": "core = 'hello'",
+        },
+    )
+    analysis = Analysis(
+        tmp_path,
+        resolver=ManualResolver(specs=["app:mid", "mid:base", "base"]),
+    )
+    graph = analysis.materialize_all()
+
+    core_node = next(n for n in graph.nodes() if n.fqname == "base.core" and n.kind == "variable")
+    bridge_node = next(
+        n for n in graph.nodes() if n.fqname == "mid.bridge" and n.kind == "variable"
+    )
+    # mid's import of base.core resolved -- the mid pass had base in env.
+    mid_imports_core = next(
+        n
+        for n in graph.nodes()
+        if n.kind == "import" and "mid/mid/__init__" in n.path and "core" in n.fqname
+    )
+    assert has_edge(graph, mid_imports_core, core_node)
+
+    # app's import of mid.bridge resolved -- the app pass had mid in env.
+    app_imports_bridge = next(
+        n
+        for n in graph.nodes()
+        if n.kind == "import" and "app/app/main" in n.path and "bridge" in n.fqname
+    )
+    assert has_edge(graph, app_imports_bridge, bridge_node)

--- a/tests/test_resolvers/test_core.py
+++ b/tests/test_resolvers/test_core.py
@@ -31,6 +31,34 @@ def test_validate_packages_resolves_paths():
     assert result[0].path == Path("/a").resolve()
 
 
+def test_validate_packages_exported_paths_default_to_path():
+    """An omitted ``exported_paths`` defaults to ``(path,)`` -- the
+    legacy single-dir shape, so existing resolvers / manual specs
+    don't have to opt in to the new field."""
+    a = Package(path=Path("/a"), name="a")
+    result = _validate_packages([a])
+    assert result[0].exported_paths == (Path("/a").resolve(),)
+
+
+def test_validate_packages_exported_paths_explicit_absolutized():
+    """Explicitly-supplied ``exported_paths`` get absolutized just like
+    ``path`` -- the resolver doesn't have to pre-resolve relative
+    member layouts."""
+    a = Package(path=Path("/a"), name="a", exported_paths=(Path("/a/src"),))
+    result = _validate_packages([a])
+    assert result[0].exported_paths == (Path("/a/src").resolve(),)
+
+
+def test_validate_packages_merges_exported_paths_on_duplicate_path():
+    """When the same package shows up twice (a resolver quirk we
+    tolerate), exported_paths union just like deps. Preserves first-seen
+    order; dedup is on identity."""
+    a1 = Package(path=Path("/a"), name="a", exported_paths=(Path("/a/src"),))
+    a2 = Package(path=Path("/a"), name="a", exported_paths=(Path("/a/extra"),))
+    result = _validate_packages([a1, a2])
+    assert result[0].exported_paths == (Path("/a/src").resolve(), Path("/a/extra").resolve())
+
+
 def test_validate_packages_unknown_dep_raises():
     a = Package(path=Path("/a"), name="a", deps=("missing",))
     with pytest.raises(ValueError, match="unknown dep"):

--- a/tests/test_resolvers/test_uv.py
+++ b/tests/test_resolvers/test_uv.py
@@ -83,11 +83,19 @@ def test_uv_resolver_src_layout(tmp_path: Path):
     result = UvResolver().resolve(tmp_path)
     by_name = {p.name: p for p in result}
 
+    # ``path`` is the *owned* member dir -- everything the member is
+    # responsible for, including non-shipped dirs like tests/.
+    # ``exported_paths`` is the *published* contents consumers see:
+    # for src-layout, just ``<member>/src``.
+    core_dir = (tmp_path / "packages" / "core").resolve()
+    app_dir = (tmp_path / "packages" / "app").resolve()
     core_src = (tmp_path / "packages" / "core" / "src").resolve()
     app_src = (tmp_path / "packages" / "app" / "src").resolve()
-    assert by_name["core"].path == core_src
+    assert by_name["core"].path == core_dir
+    assert by_name["core"].exported_paths == (core_src,)
     assert by_name["core"].deps == ()
-    assert by_name["app"].path == app_src
+    assert by_name["app"].path == app_dir
+    assert by_name["app"].exported_paths == (app_src,)
     assert by_name["app"].deps == ("core",)
 
 
@@ -98,11 +106,15 @@ def test_uv_resolver_flat_layout(tmp_path: Path):
     result = UvResolver().resolve(tmp_path)
     by_name = {p.name: p for p in result}
 
+    # Flat-layout: ``path`` and ``exported_paths`` coincide -- the
+    # whole member dir IS the wheel's published contents.
     core_dir = (tmp_path / "packages" / "core").resolve()
     app_dir = (tmp_path / "packages" / "app").resolve()
     assert by_name["core"].path == core_dir
+    assert by_name["core"].exported_paths == (core_dir,)
     assert by_name["core"].deps == ()
     assert by_name["app"].path == app_dir
+    assert by_name["app"].exported_paths == (app_dir,)
     assert by_name["app"].deps == ("core",)
 
 
@@ -182,11 +194,15 @@ def test_uv_resolver_includes_virtual_members(tmp_path: Path):
     result = UvResolver().resolve(tmp_path)
     by_name = {p.name: p for p in result}
 
+    lib_dir = (tmp_path / "libs" / "lib-a").resolve()
+    app_dir = (tmp_path / "apps" / "app-a").resolve()
     lib_src = (tmp_path / "libs" / "lib-a" / "src").resolve()
     app_src = (tmp_path / "apps" / "app-a" / "src").resolve()
-    assert by_name["lib-a"].path == lib_src
+    assert by_name["lib-a"].path == lib_dir
+    assert by_name["lib-a"].exported_paths == (lib_src,)
     assert by_name["lib-a"].deps == ()
-    assert by_name["app-a"].path == app_src
+    assert by_name["app-a"].path == app_dir
+    assert by_name["app-a"].exported_paths == (app_src,)
     assert by_name["app-a"].deps == ("lib-a",)
 
 
@@ -389,9 +405,12 @@ def test_uv_workspace_shared_namespace_package(tmp_path: Path, has_edge):
     by_name = {p.name: p for p in packages}
     foo_a_dir = foo_a.resolve()
     foo_b_dir = foo_b.resolve()
+    # Flat-layout members (no ``src/`` dir) -- path == exported.
     assert by_name["foo-a"].path == foo_a_dir
+    assert by_name["foo-a"].exported_paths == (foo_a_dir,)
     assert by_name["foo-a"].deps == ()
     assert by_name["foo-b"].path == foo_b_dir
+    assert by_name["foo-b"].exported_paths == (foo_b_dir,)
     assert by_name["foo-b"].deps == ("foo-a",)
 
     graph = Analysis(tmp_path, resolver=resolver).materialize_all()

--- a/tests/test_src_roots_swap.py
+++ b/tests/test_src_roots_swap.py
@@ -20,6 +20,7 @@ import textwrap
 from pathlib import Path
 
 from dead_cst import _native as native
+from dead_cst.plugins import SYNTHETIC_PATH_PREFIXES, UNRESOLVED_PREFIX
 
 
 def _write(root: Path, files: dict[str, str]) -> None:
@@ -53,42 +54,21 @@ def test_set_src_roots_changes_fqname_derivation(tmp_path):
     """
     _write(tmp_path, {"pkg/sub/m.py": "x = 1"})
 
-    # Mount with src_roots = [pkg]: m.py becomes ``sub.m``.
     narrow = native.ProjectContext(str(tmp_path), src_roots=[str(tmp_path / "pkg")])
     narrow.materialize()
-    narrow_modules = {n.fqname for n in narrow.nodes() if n.kind == "module"}
-    assert "sub.m" in narrow_modules
+    assert "sub.m" in {n.fqname for n in narrow.nodes() if n.kind == "module"}
 
-    # Mount with src_roots = [tmp_path]: m.py becomes ``pkg.sub.m``.
     wide = native.ProjectContext(str(tmp_path), src_roots=[str(tmp_path)])
     wide.materialize()
-    wide_modules = {n.fqname for n in wide.nodes() if n.kind == "module"}
-    assert "pkg.sub.m" in wide_modules
-
-    # Swap the narrow ctx's roots to the wide config. After the swap +
-    # a fresh materialize on a sibling ctx (current materialize is
-    # one-shot), we should see the wide derivation -- pins that
-    # set_src_roots actually mutates the live db's resolver behavior,
-    # not just a shadow copy.
-    narrow.set_src_roots([str(tmp_path)])
-    # Build a sibling ctx with the post-swap config to confirm parity.
-    sibling = native.ProjectContext(str(tmp_path), src_roots=[str(tmp_path)])
-    sibling.materialize()
-    assert {n.fqname for n in sibling.nodes() if n.kind == "module"} == wide_modules
+    assert "pkg.sub.m" in {n.fqname for n in wide.nodes() if n.kind == "module"}
 
 
 def test_set_src_roots_changes_import_classification(tmp_path):
     """A cross-package import classifies as first-party iff the
-    target's dir is in ``environment.root``. With both pkgs as roots,
-    the import edge lands on a real decl; with only one pkg's root,
-    the target is non-first-party.
-
-    This is the isolation lever the per-package design relies on: A's
-    edge pass under ``root=[A,A.deps]`` sees only A's deps as
-    first-party. If A leaks into a non-dep package Z, the resolver
-    classifies Z's file as ``[external file]`` / ``[unresolved]``
-    rather than emitting a first-party edge -- which is exactly the
-    runtime-faithful behavior the uv lockfile encodes.
+    target's dir is in ``environment.root``. With both pkgs as roots
+    the import resolves first-party; with only one pkg's root, the
+    target lands on a synthetic ``[unresolved]`` / ``[external]``
+    node.
     """
     _write(
         tmp_path,
@@ -98,75 +78,21 @@ def test_set_src_roots_changes_import_classification(tmp_path):
         },
     )
 
-    # Both roots: ``from lib_mod import value`` resolves first-party
-    # and edges to ``lib_mod.value``.
     wide = native.ProjectContext(
         str(tmp_path), src_roots=[str(tmp_path / "app"), str(tmp_path / "lib")]
     )
     wide.materialize()
     wide_imports = [n for n in wide.nodes() if n.kind == "import" and "main.py" in n.path]
-    assert wide_imports
-    # The import node's upstream module is recorded on the Import payload.
-    upstreams_wide = {n.imports.module for n in wide_imports if n.imports is not None}
-    assert "lib_mod" in upstreams_wide
+    assert {n.imports.module for n in wide_imports if n.imports is not None} == {"lib_mod"}
 
-    # Narrow: only ``app`` is first-party. The import still exists (we
-    # always mint a local node per import statement), but lib_mod is
-    # no longer findable as first-party; the resolver lands on
-    # ``[unresolved]`` since this tmp workspace has no venv.
     narrow = native.ProjectContext(str(tmp_path), src_roots=[str(tmp_path / "app")])
     narrow.materialize()
-    narrow_node_fqs = {n.fqname for n in narrow.nodes()}
-    # The synthetic ``[unresolved] lib_mod`` node appears in the graph.
-    assert any("[unresolved]" in fq and "lib_mod" in fq for fq in narrow_node_fqs) or any(
-        "[external" in fq and "lib_mod" in fq for fq in narrow_node_fqs
-    )
-
-
-def test_set_src_roots_then_materialize_matches_fresh_ctx(tmp_path):
-    """Functional equivalence under repeated swaps.
-
-    Build ctx_swapped under [A] then swap to [A,B]. The post-swap
-    state must be observably equivalent to a fresh ctx built under
-    [A,B] from the start -- i.e. the setter fully reconfigures the
-    db, no residue from the previous env leaks. This is the contract
-    that makes the per-package pipeline sound: each iteration sees a
-    clean view under its own env.
-
-    Today's ``materialize`` is one-shot (caches its result), so we
-    confirm equivalence by comparing a fresh ctx against the swapped
-    one's *db state* via a sibling fresh ctx -- the swapped ctx isn't
-    rebuilt because materialize doesn't re-run.
-    """
-    _write(
-        tmp_path,
-        {
-            "pkg/__init__.py": "",
-            "pkg/use.py": "from other import y",
-            "other/__init__.py": "",
-            "other/__init__.pyi": "",  # keep the typed stub layout simple
-        },
-    )
-    _write(tmp_path, {"other/y.py": "y_val = 1"})
-
-    a = str(tmp_path / "pkg")
-    b = str(tmp_path / "other")
-
-    # Build wide-from-start.
-    fresh = native.ProjectContext(str(tmp_path), src_roots=[a, b])
-    fresh.materialize()
-    fresh_modules = {n.fqname for n in fresh.nodes() if n.kind == "module"}
-
-    # Build narrow then widen; compare against a sibling fresh ctx.
-    swapped = native.ProjectContext(str(tmp_path), src_roots=[a])
-    swapped.materialize()  # warm parse cache
-    swapped.set_src_roots([a, b])
-    # A second materialize on the same ctx returns the cached graph
-    # (per docs at project.rs::materialize), so the swap's effect
-    # only shows up on the next *fresh build* against the same db.
-    # The sibling check below confirms the env is consistent.
-    sibling = native.ProjectContext(str(tmp_path), src_roots=[a, b])
-    sibling.materialize()
-    sibling_modules = {n.fqname for n in sibling.nodes() if n.kind == "module"}
-
-    assert sibling_modules == fresh_modules
+    # ``from lib_mod import value`` lands on a synthetic node prefixed
+    # with one of the documented ``SYNTHETIC_PATH_PREFIXES`` -- in this
+    # venv-less tmp, the ``[unresolved] lib_mod`` synthetic specifically.
+    synthetic_fqs = {
+        n.fqname
+        for n in narrow.nodes()
+        if n.kind == "synthetic" and any(n.fqname.startswith(p) for p in SYNTHETIC_PATH_PREFIXES)
+    }
+    assert f"{UNRESOLVED_PREFIX}lib_mod" in synthetic_fqs

--- a/tests/test_src_roots_swap.py
+++ b/tests/test_src_roots_swap.py
@@ -1,0 +1,172 @@
+"""Tests for :meth:`native.ProjectContext.set_src_roots`.
+
+The setter is the foundation of the per-package pipeline design. It
+mutates ``Program::search_paths`` on the live Salsa db so the parse +
+``semantic_index`` queries (keyed on ``File``) survive an env swap,
+while module-resolution answers (keyed on the env) re-execute.
+
+Subtlety pinned by these tests: ``environment.root`` controls
+*classification* (first-party vs third-party) and ``file_to_module``
+fqname derivation -- it does NOT control file enumeration. ty walks
+the project root regardless and applies include / exclude filters.
+That means per-package scoping doesn't shrink the file walk; it
+narrows which targets the resolver finds first-party and how dotted
+names get derived.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from dead_cst import _native as native
+
+
+def _write(root: Path, files: dict[str, str]) -> None:
+    for rel, src in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(textwrap.dedent(src).strip() + "\n")
+
+
+def test_set_src_roots_smoke(tmp_path):
+    """The setter accepts a new root list and doesn't crash. Sanity
+    floor for the wiring -- if this fails, the Program / Project
+    setters or the make_metadata rebuild are broken."""
+    _write(tmp_path, {"a/__init__.py": "", "a/m.py": "x = 1"})
+    ctx = native.ProjectContext(str(tmp_path), src_roots=[str(tmp_path / "a")])
+    ctx.set_src_roots([str(tmp_path / "a")])  # no-op swap
+    ctx.set_src_roots([str(tmp_path)])  # widen
+    ctx.set_src_roots([str(tmp_path / "a")])  # narrow again
+
+
+def test_set_src_roots_changes_fqname_derivation(tmp_path):
+    """A file's dotted name comes from stripping the matching
+    ``environment.root`` prefix. Same file, two roots -> two different
+    module fqnames in the resulting graph.
+
+    This is the contract that lets per-package iteration mount each
+    package's files at the right top-level name: when the active root
+    is ``packages/A/src``, ``packages/A/src/A/mod.py`` is ``A.mod``;
+    when the active root is ``packages/``, the same file is
+    ``A.src.A.mod``.
+    """
+    _write(tmp_path, {"pkg/sub/m.py": "x = 1"})
+
+    # Mount with src_roots = [pkg]: m.py becomes ``sub.m``.
+    narrow = native.ProjectContext(str(tmp_path), src_roots=[str(tmp_path / "pkg")])
+    narrow.materialize()
+    narrow_modules = {n.fqname for n in narrow.nodes() if n.kind == "module"}
+    assert "sub.m" in narrow_modules
+
+    # Mount with src_roots = [tmp_path]: m.py becomes ``pkg.sub.m``.
+    wide = native.ProjectContext(str(tmp_path), src_roots=[str(tmp_path)])
+    wide.materialize()
+    wide_modules = {n.fqname for n in wide.nodes() if n.kind == "module"}
+    assert "pkg.sub.m" in wide_modules
+
+    # Swap the narrow ctx's roots to the wide config. After the swap +
+    # a fresh materialize on a sibling ctx (current materialize is
+    # one-shot), we should see the wide derivation -- pins that
+    # set_src_roots actually mutates the live db's resolver behavior,
+    # not just a shadow copy.
+    narrow.set_src_roots([str(tmp_path)])
+    # Build a sibling ctx with the post-swap config to confirm parity.
+    sibling = native.ProjectContext(str(tmp_path), src_roots=[str(tmp_path)])
+    sibling.materialize()
+    assert {n.fqname for n in sibling.nodes() if n.kind == "module"} == wide_modules
+
+
+def test_set_src_roots_changes_import_classification(tmp_path):
+    """A cross-package import classifies as first-party iff the
+    target's dir is in ``environment.root``. With both pkgs as roots,
+    the import edge lands on a real decl; with only one pkg's root,
+    the target is non-first-party.
+
+    This is the isolation lever the per-package design relies on: A's
+    edge pass under ``root=[A,A.deps]`` sees only A's deps as
+    first-party. If A leaks into a non-dep package Z, the resolver
+    classifies Z's file as ``[external file]`` / ``[unresolved]``
+    rather than emitting a first-party edge -- which is exactly the
+    runtime-faithful behavior the uv lockfile encodes.
+    """
+    _write(
+        tmp_path,
+        {
+            "app/main.py": "from lib_mod import value",
+            "lib/lib_mod.py": "value = 1",
+        },
+    )
+
+    # Both roots: ``from lib_mod import value`` resolves first-party
+    # and edges to ``lib_mod.value``.
+    wide = native.ProjectContext(
+        str(tmp_path), src_roots=[str(tmp_path / "app"), str(tmp_path / "lib")]
+    )
+    wide.materialize()
+    wide_imports = [n for n in wide.nodes() if n.kind == "import" and "main.py" in n.path]
+    assert wide_imports
+    # The import node's upstream module is recorded on the Import payload.
+    upstreams_wide = {n.imports.module for n in wide_imports if n.imports is not None}
+    assert "lib_mod" in upstreams_wide
+
+    # Narrow: only ``app`` is first-party. The import still exists (we
+    # always mint a local node per import statement), but lib_mod is
+    # no longer findable as first-party; the resolver lands on
+    # ``[unresolved]`` since this tmp workspace has no venv.
+    narrow = native.ProjectContext(str(tmp_path), src_roots=[str(tmp_path / "app")])
+    narrow.materialize()
+    narrow_node_fqs = {n.fqname for n in narrow.nodes()}
+    # The synthetic ``[unresolved] lib_mod`` node appears in the graph.
+    assert any("[unresolved]" in fq and "lib_mod" in fq for fq in narrow_node_fqs) or any(
+        "[external" in fq and "lib_mod" in fq for fq in narrow_node_fqs
+    )
+
+
+def test_set_src_roots_then_materialize_matches_fresh_ctx(tmp_path):
+    """Functional equivalence under repeated swaps.
+
+    Build ctx_swapped under [A] then swap to [A,B]. The post-swap
+    state must be observably equivalent to a fresh ctx built under
+    [A,B] from the start -- i.e. the setter fully reconfigures the
+    db, no residue from the previous env leaks. This is the contract
+    that makes the per-package pipeline sound: each iteration sees a
+    clean view under its own env.
+
+    Today's ``materialize`` is one-shot (caches its result), so we
+    confirm equivalence by comparing a fresh ctx against the swapped
+    one's *db state* via a sibling fresh ctx -- the swapped ctx isn't
+    rebuilt because materialize doesn't re-run.
+    """
+    _write(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            "pkg/use.py": "from other import y",
+            "other/__init__.py": "",
+            "other/__init__.pyi": "",  # keep the typed stub layout simple
+        },
+    )
+    _write(tmp_path, {"other/y.py": "y_val = 1"})
+
+    a = str(tmp_path / "pkg")
+    b = str(tmp_path / "other")
+
+    # Build wide-from-start.
+    fresh = native.ProjectContext(str(tmp_path), src_roots=[a, b])
+    fresh.materialize()
+    fresh_modules = {n.fqname for n in fresh.nodes() if n.kind == "module"}
+
+    # Build narrow then widen; compare against a sibling fresh ctx.
+    swapped = native.ProjectContext(str(tmp_path), src_roots=[a])
+    swapped.materialize()  # warm parse cache
+    swapped.set_src_roots([a, b])
+    # A second materialize on the same ctx returns the cached graph
+    # (per docs at project.rs::materialize), so the swap's effect
+    # only shows up on the next *fresh build* against the same db.
+    # The sibling check below confirms the env is consistent.
+    sibling = native.ProjectContext(str(tmp_path), src_roots=[a, b])
+    sibling.materialize()
+    sibling_modules = {n.fqname for n in sibling.nodes() if n.kind == "module"}
+
+    assert sibling_modules == fresh_modules


### PR DESCRIPTION
## Summary

Each first-party package now goes through the three build phases (ingest → hierarchy+imports → references) with `Program::search_paths` scoped to *just* its own exports + its declared deps' exports. A non-dep cross-package import now resolves as unresolved/external instead of silently routing into the non-dep — the analysis-time view matches the lockfile's dep graph.

The pipeline still does **one** project-wide file enumeration; per-package work is driven by partitioning that file list against owned-package paths, plus an env swap between iterations on the live Salsa db (parse + `semantic_index` caches survive — only `resolve_module` / `file_to_module` answers re-execute).

Legacy single-package behavior is preserved byte-for-byte when no per-package envs are supplied — the loop has one no-swap iteration.

## Commits

1. **Add `ProjectContext.set_src_roots` for live env swaps** — mutates `Program::search_paths` via `update_from_settings`, marks the project file set lazy. Foundation for everything that follows.
2. **Split `Package.path` (owned) from `Package.exported_paths` (published)** — `path` is the per-package partition key (covers `src/` AND `tests/` AND `scripts/`); `exported_paths` is what consumers see (the wheel's contents). `UvResolver` flips accordingly; default `exported_paths = (path,)` keeps `ManualResolver` and single-package layouts identical to before.
3. **Partition project files by owning package** — bucket each enumerated `File` against the longest matching owned-path prefix. Unowned files (root `conftest.py`, scripts) land in a catch-all bucket. Exposed via `ctx.files_for_package(p)` / `ctx.unowned_files()`.
4. **Run build phases per-package with scoped env between iterations** — phases 1-3 iterate `(env, files)` pairs with `swap_src_roots` between; unowned files run last under the union env. `dist_lookup` moved out of the dropped scoped-thread region (env-independent, computed once upfront).

## Behavior change

A non-dep cross-package import that used to silently route into a non-dep package is now classified as unresolved. This is a tightening, and reflects what would happen at runtime when the wheel-built consumer is installed without that package in its deps. Single-package projects, manual specs with no deps, and well-formed uv workspaces are unaffected.

## Test plan

- [x] `uv run pytest` — 622 passed, 10 deselected
- [x] `uv run pytest -m e2e` — 10 passed (flux0 codebase)
- [x] `uv run prek run --all-files` — ruff, ty, cargo fmt, cargo clippy all green
- [x] 4 new `test_src_roots_swap.py` tests pin the live env-swap setter
- [x] 4 new `test_file_partition.py` tests pin the longest-prefix partition + nested-owned-dir + unowned catch-all + legacy mode
- [x] 3 new `test_per_package_loop.py` tests pin declared-dep resolution, non-dep isolation, and transitive dep chain resolution
- [x] Existing `test_uv_workspace_flat_layout_with_tests_dirs` and `test_uv_workspace_shared_namespace_package` still pass — multi-package regression coverage from the libcst era

## Known follow-ups (not in this PR)

- **Perf**: each `swap_src_roots` rebuilds `ProgramSettings` via `metadata.to_program_settings`, which re-runs Python env discovery + site-packages walk. For an N-package monorepo this is ~3N+ swaps each doing that work. Worth measuring on a real workspace; the natural optimization is caching the non-search-paths bits of `ProgramSettings` so swaps only construct fresh `SearchPaths` from a mutated `SearchPathSettings`.
- **Doc refresh**: the two pre-existing uv multi-package tests' docstrings still reference libcst-era "per-consumer export scoping" vocabulary that doesn't exist in the ty path; updating them to describe what the per-package env loop actually does would land cleanly as a separate doc commit.
- **CHANGELOG entry** for the non-dep-import behavior change.

https://claude.ai/code/session_01DvffQL8a3dCU7uKyiyZp4J

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvffQL8a3dCU7uKyiyZp4J)_