### PR TITLE
tests: convert edge-focused test_imports cases to assert_edges

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -525,16 +525,46 @@ STAR_REEXPORT_EDGES = frozenset(
             {"p.x -> p.functions"},
             id="dunder-import-keyword-level-resolves-relative-rust",
         ),
-    ],
-)
-def test_imports(build_decl_graph, assert_edges, src, expected_extra_edges):
-    graph = build_decl_graph({**IMPORT_TEST_FILES, "p/x.py": src})
-    assert_edges(graph, IMPORT_BASE_EDGES | expected_extra_edges)
-
-
-@pytest.mark.parametrize(
-    "src, expected_extra_edges",
-    [
+        # ------------------------------------------------------------------
+        # ``__import__`` fromlist: rust emits one edge per explicit symbol
+        # the call mentions (base module plus each literal fromlist entry
+        # that resolves as a submodule or global-scope decl), all tagged
+        # ``EdgeFlags.DYNAMIC_IMPORT``. Attribute-style entries that don't
+        # resolve drop silently — no warning.
+        # ------------------------------------------------------------------
+        pytest.param(
+            "__import__('p', None, None, ['functions'])",
+            {
+                "p.x -> p",
+                "p.x -> p.functions",
+            },
+            id="dunder-import-fromlist-positional-resolves-submodule",
+        ),
+        pytest.param(
+            "__import__('p', fromlist=['functions'])",
+            {
+                "p.x -> p",
+                "p.x -> p.functions",
+            },
+            id="dunder-import-fromlist-keyword-resolves-submodule",
+        ),
+        pytest.param(
+            # Mixed: ``f`` resolves as a global-scope decl in p.functions
+            # (one edge, no fan-out to ``g``); the empty string entry
+            # drops silently with no warning.
+            "__import__('p.functions', fromlist=['f', ''])",
+            {
+                "p.x -> p.functions",
+                "p.x -> p.functions.f",
+            },
+            id="dunder-import-fromlist-attribute-entries-silent",
+        ),
+        # ------------------------------------------------------------------
+        # ``__all__`` is followed when assigned a list/tuple of string
+        # literals; each named entry becomes an outgoing edge from the
+        # ``__all__`` synthetic node to the local decl (or import alias).
+        # Unknown names are ignored silently.
+        # ------------------------------------------------------------------
         pytest.param(
             'from p.functions import f\n__all__ = ["f"]',
             {
@@ -597,49 +627,9 @@ def test_imports(build_decl_graph, assert_edges, src, expected_extra_edges):
         ),
     ],
 )
-def test_dunder_all_edges(build_decl_graph, assert_edges, src, expected_extra_edges):
+def test_imports(build_decl_graph, assert_edges, src, expected_extra_edges):
     graph = build_decl_graph({**IMPORT_TEST_FILES, "p/x.py": src})
     assert_edges(graph, IMPORT_BASE_EDGES | expected_extra_edges)
-
-
-@pytest.mark.parametrize(
-    "src",
-    [
-        pytest.param("__import__('p', None, None, ['functions'])", id="fromlist-positional"),
-        pytest.param("__import__('p', fromlist=['functions'])", id="fromlist-keyword"),
-    ],
-)
-def test_dunder_import_fromlist_resolves_submodules_rust(build_decl_graph, assert_edges, src):
-    """Rust emits one edge per explicit symbol the call mentions: the
-    base module plus each literal fromlist entry that resolves as a
-    submodule, all tagged ``EdgeFlags.DYNAMIC_IMPORT``."""
-    graph = build_decl_graph({**IMPORT_TEST_FILES, "p/x.py": src})
-    assert_edges(
-        graph,
-        IMPORT_BASE_EDGES
-        | {
-            "p.x -> p",
-            "p.x -> p.functions",
-        },
-    )
-
-
-def test_dunder_import_fromlist_attribute_entries_silent_rust(build_decl_graph, assert_edges):
-    """The rust backend looks each entry up as a global-scope decl in
-    the base module and emits an edge if found (no fan-out to g),
-    otherwise drops silently — and never warns on attribute-style
-    entries."""
-    graph = build_decl_graph(
-        {**IMPORT_TEST_FILES, "p/x.py": "__import__('p.functions', fromlist=['f', ''])"}
-    )
-    assert_edges(
-        graph,
-        IMPORT_BASE_EDGES
-        | {
-            "p.x -> p.functions",
-            "p.x -> p.functions.f",
-        },
-    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -751,13 +751,27 @@ def test_module_runtime_dunder_access_is_module_dep(build_decl_graph, assert_edg
     assert [r.getMessage() for r in caplog.records] == []
     # No synthetic was minted for the missing-dunder lookup.
     assert not [n.fqname for n in graph.nodes() if n.fqname.endswith(".__file__")]
-    # The module-level dependency edges remain intact for each user of a dunder.
-    edge_strs = {
-        f"{graph.nodes()[u].fqname} -> {graph.nodes()[v].fqname}" for u, v, _ in graph.edges()
-    }
-    assert "pkg.config.FILE_PATH -> pkg" in edge_strs
-    assert "pkg.config.NAME -> pkg" in edge_strs
-    assert "pkg.config.SPEC -> pkg" in edge_strs
+    # The module-level dependency edges remain intact for each user of a dunder
+    # (FILE_PATH / NAME / SPEC all edge to ``pkg`` directly).
+    assert_edges(
+        graph,
+        {
+            "pkg.config -> pkg",
+            "pkg.config.FILE_PATH -> pkg",
+            "pkg.config.FILE_PATH -> pkg.config",
+            "pkg.config.FILE_PATH -> pkg.config.Path",
+            "pkg.config.FILE_PATH -> pkg.config.pkg_alias",
+            "pkg.config.NAME -> pkg",
+            "pkg.config.NAME -> pkg.config",
+            "pkg.config.NAME -> pkg.config.pkg_alias",
+            "pkg.config.Path -> pkg.config",
+            "pkg.config.SPEC -> pkg",
+            "pkg.config.SPEC -> pkg.config",
+            "pkg.config.SPEC -> pkg.config.pkg_alias",
+            "pkg.config.pkg_alias -> pkg",
+            "pkg.config.pkg_alias -> pkg.config",
+        },
+    )
 
 
 def test_dunder_on_imported_symbol_strips_dunder_tail(build_decl_graph, assert_edges):
@@ -774,11 +788,25 @@ def test_dunder_on_imported_symbol_strips_dunder_tail(build_decl_graph, assert_e
             "pkg/uses.py": ("from pkg.lib import Cls\nWHO = Cls.__name__\nDOCSTR = Cls.__doc__\n"),
         }
     )
-    edge_strs = {
-        f"{graph.nodes()[u].fqname} -> {graph.nodes()[v].fqname}" for u, v, _ in graph.edges()
-    }
-    assert "pkg.uses.WHO -> pkg.lib.Cls" in edge_strs
-    assert "pkg.uses.DOCSTR -> pkg.lib.Cls" in edge_strs
+    assert_edges(
+        graph,
+        {
+            "pkg.lib -> pkg",
+            "pkg.lib.Cls -> pkg.lib",
+            "pkg.uses -> pkg",
+            "pkg.uses.Cls -> pkg.lib",
+            "pkg.uses.Cls -> pkg.lib.Cls",
+            "pkg.uses.Cls -> pkg.uses",
+            "pkg.uses.DOCSTR -> pkg.lib",
+            "pkg.uses.DOCSTR -> pkg.lib.Cls",
+            "pkg.uses.DOCSTR -> pkg.uses",
+            "pkg.uses.DOCSTR -> pkg.uses.Cls",
+            "pkg.uses.WHO -> pkg.lib",
+            "pkg.uses.WHO -> pkg.lib.Cls",
+            "pkg.uses.WHO -> pkg.uses",
+            "pkg.uses.WHO -> pkg.uses.Cls",
+        },
+    )
 
 
 def test_cyclic_reexport_terminates_rust(build_decl_graph, assert_edges):
@@ -827,7 +855,9 @@ def test_import_resolves_through_star_reexport_rust(build_decl_graph, assert_edg
     ``from pkg._internal import *`` statement rather than a per-name
     ``pkg.g`` alias; ty resolves ``from pkg import g`` straight to
     ``pkg._internal.g``, so the consumer alias edges directly to the
-    upstream decl (no intermediate ``pkg.g``).
+    upstream decl (no intermediate ``pkg.g``). The absence of any
+    ``consumer.g -> pkg.g`` edge from the full set below is the codified
+    "no per-name alias is minted" invariant.
     """
     graph = build_decl_graph(
         {
@@ -836,14 +866,23 @@ def test_import_resolves_through_star_reexport_rust(build_decl_graph, assert_edg
             "consumer.py": "from pkg import g\ng()\n",
         }
     )
-    edge_strs = {
-        f"{graph.nodes()[u].fqname} -> {graph.nodes()[v].fqname}" for u, v, _ in graph.edges()
-    }
-    assert "consumer.g -> pkg._internal.g" in edge_strs
-    assert "consumer.g -> pkg" in edge_strs
-    # No `pkg.g` alias is minted; the star node carries the reexport.
-    assert "consumer.g -> pkg.g" not in edge_strs
     assert any(n.fqname == "pkg.*pkg._internal" for n in graph.nodes())
+    assert_edges(
+        graph,
+        {
+            "consumer -> consumer.g",
+            "consumer -> pkg",
+            "consumer -> pkg.*pkg._internal",
+            "consumer.g -> consumer",
+            "consumer.g -> pkg",
+            "consumer.g -> pkg._internal.g",
+            "pkg.*pkg._internal -> pkg",
+            "pkg.*pkg._internal -> pkg._internal",
+            "pkg._internal -> pkg",
+            "pkg._internal -> pkg._internal",
+            "pkg._internal.g -> pkg._internal",
+        },
+    )
 
 
 def test_import_resolves_through_chained_star_reexports(build_decl_graph, assert_edges):
@@ -856,10 +895,22 @@ def test_import_resolves_through_chained_star_reexports(build_decl_graph, assert
             "consumer.py": "from A import g\ng()\n",
         }
     )
-    edge_strs = {
-        f"{graph.nodes()[u].fqname} -> {graph.nodes()[v].fqname}" for u, v, _ in graph.edges()
-    }
-    assert "consumer.g -> C.g" in edge_strs
+    assert_edges(
+        graph,
+        {
+            "A.*B -> A",
+            "A.*B -> B",
+            "B.*C -> B",
+            "B.*C -> C",
+            "C.g -> C",
+            "consumer -> A",
+            "consumer -> A.*B",
+            "consumer -> consumer.g",
+            "consumer.g -> A",
+            "consumer.g -> C.g",
+            "consumer.g -> consumer",
+        },
+    )
 
 
 def test_star_reexport_cycle_terminates(build_decl_graph, assert_edges):
@@ -871,14 +922,29 @@ def test_star_reexport_cycle_terminates(build_decl_graph, assert_edges):
             "consumer.py": "from A import b\n",
         }
     )
-    edge_strs = {
-        f"{graph.nodes()[u].fqname} -> {graph.nodes()[v].fqname}" for u, v, _ in graph.edges()
-    }
-    assert "consumer.b -> B.b" in edge_strs
+    assert_edges(
+        graph,
+        {
+            "A.*B -> A",
+            "A.*B -> B",
+            "A.a -> A",
+            "B.*A -> A",
+            "B.*A -> B",
+            "B.b -> B",
+            "consumer.b -> A",
+            "consumer.b -> B.b",
+            "consumer.b -> consumer",
+        },
+    )
 
 
 def test_star_reexport_shadowed_by_real_decl(build_decl_graph, assert_edges):
-    """A real decl in the importing module wins over a star re-export of the same name."""
+    """A real decl in the importing module wins over a star re-export of the same name.
+
+    The absence of ``consumer.g -> other.g`` from the full edge set
+    below codifies that the consumer's ``g`` resolves to ``mod.g``
+    (not through the star re-export to ``other.g``).
+    """
     graph = build_decl_graph(
         {
             "other.py": "def g(): pass\n",
@@ -886,11 +952,21 @@ def test_star_reexport_shadowed_by_real_decl(build_decl_graph, assert_edges):
             "consumer.py": "from mod import g\ng()\n",
         }
     )
-    edge_strs = {
-        f"{graph.nodes()[u].fqname} -> {graph.nodes()[v].fqname}" for u, v, _ in graph.edges()
-    }
-    assert "consumer.g -> mod.g" in edge_strs
-    assert "consumer.g -> other.g" not in edge_strs
+    assert_edges(
+        graph,
+        {
+            "consumer -> consumer.g",
+            "consumer -> mod",
+            "consumer -> mod.g",
+            "consumer.g -> consumer",
+            "consumer.g -> mod",
+            "consumer.g -> mod.g",
+            "mod.*other -> mod",
+            "mod.*other -> other",
+            "mod.g -> mod",
+            "other.g -> other",
+        },
+    )
 
 
 def test_from_import_prefers_namespace_binding_over_submodule(build_decl_graph):
@@ -1008,9 +1084,7 @@ def _find_node(graph, *, fqname, kind, path_substring):
     return matches[0]
 
 
-def test_from_relative_import_in_init_keeps_submodule_alias_alive(
-    build_decl_graph, predecessors_of, successors_of
-):
+def test_from_relative_import_in_init_keeps_submodule_alias_alive(build_decl_graph, assert_edges):
     """``from .sub import X`` inside an ``__init__.py`` mints both a
     normal ``ImportFrom`` alias for ``X`` and an
     ``ImportFromSubmodule`` alias for the side-effect attribute
@@ -1020,6 +1094,13 @@ def test_from_relative_import_in_init_keeps_submodule_alias_alive(
     submodule alias alive whenever any sibling alias is — otherwise
     the analyzer would falsely flag the submodule attribute as dead
     every time it's not also referenced by name in the same file.
+
+    The ``pkg.X -> pkg.sub`` and ``pkg.Y -> pkg.sub`` edges in the full
+    set below are the sibling-rescue edges that drag the submodule
+    attribute alias alive whenever ``X`` or ``Y`` is reached. (Both the
+    submodule attribute alias and the module itself share the fqname
+    ``pkg.sub`` — the duplicate ``pkg.sub -> pkg.sub`` edge is the
+    attribute alias edging to the module it shadows.)
     """
     graph = build_decl_graph(
         {
@@ -1027,14 +1108,21 @@ def test_from_relative_import_in_init_keeps_submodule_alias_alive(
             "pkg/sub.py": "class X: pass\nclass Y: pass\n",
         }
     )
-    sub_alias = _find_node(graph, fqname="pkg.sub", kind="import", path_substring="pkg/__init__.py")
-    x_alias = _find_node(graph, fqname="pkg.X", kind="import", path_substring="pkg/__init__.py")
-    y_alias = _find_node(graph, fqname="pkg.Y", kind="import", path_substring="pkg/__init__.py")
-
-    preds = set(predecessors_of(graph, sub_alias))
-    # Sibling aliases drag the submodule attribute alias alive.
-    assert x_alias in preds
-    assert y_alias in preds
+    assert_edges(
+        graph,
+        {
+            "pkg.X -> pkg",
+            "pkg.X -> pkg.sub",
+            "pkg.X -> pkg.sub.X",
+            "pkg.Y -> pkg",
+            "pkg.Y -> pkg.sub",
+            "pkg.Y -> pkg.sub.Y",
+            "pkg.sub -> pkg",
+            "pkg.sub -> pkg.sub",
+            "pkg.sub.X -> pkg.sub",
+            "pkg.sub.Y -> pkg.sub",
+        },
+    )
 
 
 def test_submodule_alias_dies_when_all_siblings_dead(build_decl_graph):
@@ -1094,7 +1182,12 @@ def test_submodule_alias_not_minted_in_non_init_file(build_decl_graph):
 # ---------------------------------------------------------------------------
 
 
-def test_type_checking_import_used_only_in_string_annotation(build_decl_graph, predecessors_of):
+def test_type_checking_import_used_only_in_string_annotation(build_decl_graph, assert_edges):
+    """``f`` (the only top-level decl using ``Helper`` via a string
+    annotation) appears as ``mod.f -> mod.Helper`` in the full edge set
+    — string annotations are uses even when the import lives under a
+    dead ``if TYPE_CHECKING:`` branch.
+    """
     graph = build_decl_graph(
         {
             "mod.py": (
@@ -1108,8 +1201,19 @@ def test_type_checking_import_used_only_in_string_annotation(build_decl_graph, p
             "helpers.py": "class Helper: pass\n",
         }
     )
-    helper_alias = next(n for n in graph.nodes() if n.fqname == "mod.Helper" and n.kind == "import")
-    # ``f`` (the only top-level decl using Helper via a string annotation)
-    # should be in the import alias's in-edges.
-    preds = {n.fqname for n in predecessors_of(graph, helper_alias)}
-    assert "mod.f" in preds
+    assert_edges(
+        graph,
+        {
+            "helpers.Helper -> helpers",
+            "mod -> mod.TYPE_CHECKING",
+            "mod.Helper -> helpers",
+            "mod.Helper -> helpers.Helper",
+            "mod.Helper -> mod",
+            "mod.TYPE_CHECKING -> mod",
+            "mod.annotations -> mod",
+            "mod.f -> helpers",
+            "mod.f -> helpers.Helper",
+            "mod.f -> mod",
+            "mod.f -> mod.Helper",
+        },
+    )

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -642,6 +642,249 @@ def test_dunder_import_fromlist_attribute_entries_silent_rust(build_decl_graph, 
     )
 
 
+@pytest.mark.parametrize(
+    "files, expected_edges",
+    [
+        pytest.param(
+            # Regression guard for the visitor-level dunder strip:
+            # ``Cls.__name__`` / ``Cls.__doc__`` drop the dunder and
+            # everything after it, so an access through an imported
+            # symbol still resolves to that symbol (not past it).
+            {
+                "pkg/__init__.py": "",
+                "pkg/lib.py": "class Cls:\n    pass\n",
+                "pkg/uses.py": "from pkg.lib import Cls\nWHO = Cls.__name__\nDOCSTR = Cls.__doc__\n",
+            },
+            {
+                "pkg.lib -> pkg",
+                "pkg.lib.Cls -> pkg.lib",
+                "pkg.uses -> pkg",
+                "pkg.uses.Cls -> pkg.lib",
+                "pkg.uses.Cls -> pkg.lib.Cls",
+                "pkg.uses.Cls -> pkg.uses",
+                "pkg.uses.DOCSTR -> pkg.lib",
+                "pkg.uses.DOCSTR -> pkg.lib.Cls",
+                "pkg.uses.DOCSTR -> pkg.uses",
+                "pkg.uses.DOCSTR -> pkg.uses.Cls",
+                "pkg.uses.WHO -> pkg.lib",
+                "pkg.uses.WHO -> pkg.lib.Cls",
+                "pkg.uses.WHO -> pkg.uses",
+                "pkg.uses.WHO -> pkg.uses.Cls",
+            },
+            id="dunder-on-imported-symbol-strips-tail",
+        ),
+        pytest.param(
+            # Re-export cycle terminates without spinning. The rust
+            # backend resolves each alias once and stops — no
+            # reexport-chain self-edges (``A.x -> A.x``), no transitive
+            # walk through the cycle (no ``main -> B.x``). The cycle
+            # itself is still represented (``A.x -> B.x``,
+            # ``B.x -> A.x``) so reachability from ``main`` can walk
+            # it. The use-site emits the standard Principle 2
+            # parallel-upstream edge to ``A.x`` (the decl in A's
+            # namespace that the import resolved to) — same shape as
+            # ``main -> A`` for the upstream module.
+            {
+                "A.py": "from B import x",
+                "B.py": "from A import x",
+                "main.py": "from A import x\nx()",
+            },
+            {
+                "A.x -> A",
+                "A.x -> B",
+                "A.x -> B.x",
+                "B.x -> A",
+                "B.x -> A.x",
+                "B.x -> B",
+                "main -> A",
+                "main -> A.x",
+                "main -> main.x",
+                "main.x -> A",
+                "main.x -> A.x",
+                "main.x -> main",
+            },
+            id="cyclic-reexport-terminates",
+        ),
+        pytest.param(
+            # ``from pkg import g`` resolves through the star node to
+            # ``pkg._internal.g``. The rust backend mints one
+            # ``*pkg._internal`` node per ``from pkg._internal import *``
+            # statement rather than a per-name ``pkg.g`` alias; ty
+            # resolves ``from pkg import g`` straight to
+            # ``pkg._internal.g``, so the consumer alias edges directly
+            # to the upstream decl. The absence of any
+            # ``consumer.g -> pkg.g`` edge from the set below codifies
+            # the "no per-name alias is minted" invariant.
+            {
+                "pkg/__init__.py": "from pkg._internal import *\n",
+                "pkg/_internal.py": "def g(): pass\n",
+                "consumer.py": "from pkg import g\ng()\n",
+            },
+            {
+                "consumer -> consumer.g",
+                "consumer -> pkg",
+                "consumer -> pkg.*pkg._internal",
+                "consumer.g -> consumer",
+                "consumer.g -> pkg",
+                "consumer.g -> pkg._internal.g",
+                "pkg.*pkg._internal -> pkg",
+                "pkg.*pkg._internal -> pkg._internal",
+                "pkg._internal -> pkg",
+                "pkg._internal -> pkg._internal",
+                "pkg._internal.g -> pkg._internal",
+            },
+            id="import-resolves-through-star-reexport",
+        ),
+        pytest.param(
+            # ``from A import g`` follows the ``A -> B -> C`` star
+            # chain to ``C.g``.
+            {
+                "A.py": "from B import *\n",
+                "B.py": "from C import *\n",
+                "C.py": "def g(): pass\n",
+                "consumer.py": "from A import g\ng()\n",
+            },
+            {
+                "A.*B -> A",
+                "A.*B -> B",
+                "B.*C -> B",
+                "B.*C -> C",
+                "C.g -> C",
+                "consumer -> A",
+                "consumer -> A.*B",
+                "consumer -> consumer.g",
+                "consumer.g -> A",
+                "consumer.g -> C.g",
+                "consumer.g -> consumer",
+            },
+            id="import-resolves-through-chained-star-reexports",
+        ),
+        pytest.param(
+            # Mutual ``from B import *`` / ``from A import *``
+            # terminates without spinning; consumer's ``b`` still
+            # resolves to ``B.b``.
+            {
+                "A.py": "from B import *\ndef a(): pass\n",
+                "B.py": "from A import *\ndef b(): pass\n",
+                "consumer.py": "from A import b\n",
+            },
+            {
+                "A.*B -> A",
+                "A.*B -> B",
+                "A.a -> A",
+                "B.*A -> A",
+                "B.*A -> B",
+                "B.b -> B",
+                "consumer.b -> A",
+                "consumer.b -> B.b",
+                "consumer.b -> consumer",
+            },
+            id="star-reexport-cycle-terminates",
+        ),
+        pytest.param(
+            # A real decl in the importing module wins over a star
+            # re-export of the same name. The absence of
+            # ``consumer.g -> other.g`` from the set below codifies
+            # that the consumer's ``g`` resolves to ``mod.g`` (not
+            # through the star re-export to ``other.g``).
+            {
+                "other.py": "def g(): pass\n",
+                "mod.py": "from other import *\ndef g(): return 1\n",
+                "consumer.py": "from mod import g\ng()\n",
+            },
+            {
+                "consumer -> consumer.g",
+                "consumer -> mod",
+                "consumer -> mod.g",
+                "consumer.g -> consumer",
+                "consumer.g -> mod",
+                "consumer.g -> mod.g",
+                "mod.*other -> mod",
+                "mod.*other -> other",
+                "mod.g -> mod",
+                "other.g -> other",
+            },
+            id="star-reexport-shadowed-by-real-decl",
+        ),
+        pytest.param(
+            # ``from .sub import X, Y`` inside an ``__init__.py`` mints
+            # both a normal ``ImportFrom`` alias for each name and an
+            # ``ImportFromSubmodule`` alias for the side-effect
+            # attribute ``sub`` on the current package — Python rebinds
+            # ``pkg.sub`` to the submodule whenever the statement runs.
+            # The two are one inseparable syntactic unit, so
+            # reachability must drag the submodule alias alive whenever
+            # any sibling alias is — the ``pkg.X -> pkg.sub`` and
+            # ``pkg.Y -> pkg.sub`` edges below are those sibling-rescue
+            # edges. (Both the submodule attribute alias and the module
+            # itself share the fqname ``pkg.sub`` — the
+            # ``pkg.sub -> pkg.sub`` edge is the attribute alias edging
+            # to the module it shadows.)
+            {
+                "pkg/__init__.py": "from .sub import X, Y\n",
+                "pkg/sub.py": "class X: pass\nclass Y: pass\n",
+            },
+            {
+                "pkg.X -> pkg",
+                "pkg.X -> pkg.sub",
+                "pkg.X -> pkg.sub.X",
+                "pkg.Y -> pkg",
+                "pkg.Y -> pkg.sub",
+                "pkg.Y -> pkg.sub.Y",
+                "pkg.sub -> pkg",
+                "pkg.sub -> pkg.sub",
+                "pkg.sub.X -> pkg.sub",
+                "pkg.sub.Y -> pkg.sub",
+            },
+            id="from-relative-import-in-init-keeps-submodule-alias-alive",
+        ),
+        pytest.param(
+            # Composition test: an import that lives under a dead
+            # ``if TYPE_CHECKING:`` branch *and* is referenced only
+            # from a quoted annotation in live code must still pick up
+            # the use edge. ``mod.f -> mod.Helper`` below is that use
+            # edge. The basic mechanics (string annotations are uses;
+            # regular string literals are not) are pinned by
+            # ``test_imports`` cases above.
+            {
+                "mod.py": (
+                    "from __future__ import annotations\n"
+                    "from typing import TYPE_CHECKING\n"
+                    "if TYPE_CHECKING:\n"
+                    "    from helpers import Helper\n"
+                    "def f(x: 'Helper') -> 'Helper':\n"
+                    "    return x\n"
+                ),
+                "helpers.py": "class Helper: pass\n",
+            },
+            {
+                "helpers.Helper -> helpers",
+                "mod -> mod.TYPE_CHECKING",
+                "mod.Helper -> helpers",
+                "mod.Helper -> helpers.Helper",
+                "mod.Helper -> mod",
+                "mod.TYPE_CHECKING -> mod",
+                "mod.annotations -> mod",
+                "mod.f -> helpers",
+                "mod.f -> helpers.Helper",
+                "mod.f -> mod",
+                "mod.f -> mod.Helper",
+            },
+            id="type-checking-import-used-only-in-string-annotation",
+        ),
+    ],
+)
+def test_full_graph_edges(build_decl_graph, assert_edges, files, expected_edges):
+    """Bespoke-scaffold edge tests. Each case provides a complete
+    ``{filename: contents}`` mapping (rather than overlaying onto
+    :data:`IMPORT_TEST_FILES` like :func:`test_imports` does) and the
+    full edge set the graph produces. The case IDs document what each
+    scenario proves.
+    """
+    graph = build_decl_graph(files)
+    assert_edges(graph, expected_edges)
+
+
 def test_third_party_import_creates_synthetic_node(build_decl_graph):
     graph = build_decl_graph(
         {
@@ -774,201 +1017,6 @@ def test_module_runtime_dunder_access_is_module_dep(build_decl_graph, assert_edg
     )
 
 
-def test_dunder_on_imported_symbol_strips_dunder_tail(build_decl_graph, assert_edges):
-    """``from pkg import Cls; Cls.__name__`` -> edge to ``Cls``, not ``Cls.__name__``.
-
-    Regression guard for the visitor-level dunder strip: the truncation
-    drops the dunder *and everything after it*, so an access through an
-    imported symbol still resolves to that symbol (not past it).
-    """
-    graph = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/lib.py": "class Cls:\n    pass\n",
-            "pkg/uses.py": ("from pkg.lib import Cls\nWHO = Cls.__name__\nDOCSTR = Cls.__doc__\n"),
-        }
-    )
-    assert_edges(
-        graph,
-        {
-            "pkg.lib -> pkg",
-            "pkg.lib.Cls -> pkg.lib",
-            "pkg.uses -> pkg",
-            "pkg.uses.Cls -> pkg.lib",
-            "pkg.uses.Cls -> pkg.lib.Cls",
-            "pkg.uses.Cls -> pkg.uses",
-            "pkg.uses.DOCSTR -> pkg.lib",
-            "pkg.uses.DOCSTR -> pkg.lib.Cls",
-            "pkg.uses.DOCSTR -> pkg.uses",
-            "pkg.uses.DOCSTR -> pkg.uses.Cls",
-            "pkg.uses.WHO -> pkg.lib",
-            "pkg.uses.WHO -> pkg.lib.Cls",
-            "pkg.uses.WHO -> pkg.uses",
-            "pkg.uses.WHO -> pkg.uses.Cls",
-        },
-    )
-
-
-def test_cyclic_reexport_terminates_rust(build_decl_graph, assert_edges):
-    """Re-export cycle terminates without spinning (rust behavior).
-
-    The rust backend resolves each alias once and stops — no
-    reexport-chain self-edges (``A.x -> A.x``), no transitive walk
-    through the cycle (no ``main -> B.x``). The cycle itself is still
-    represented (``A.x -> B.x``, ``B.x -> A.x``) so reachability from
-    `main` can still walk it. The use-site does emit the standard
-    Principle 2 parallel-upstream edge to ``A.x`` (the decl in A's
-    namespace that the import resolved to) — same shape as
-    ``main -> A`` for the upstream module.
-    """
-    graph = build_decl_graph(
-        {
-            "A.py": "from B import x",
-            "B.py": "from A import x",
-            "main.py": "from A import x\nx()",
-        }
-    )
-
-    assert_edges(
-        graph,
-        {
-            "A.x -> A",
-            "A.x -> B",
-            "A.x -> B.x",
-            "B.x -> A",
-            "B.x -> A.x",
-            "B.x -> B",
-            "main -> A",
-            "main -> A.x",
-            "main -> main.x",
-            "main.x -> A",
-            "main.x -> A.x",
-            "main.x -> main",
-        },
-    )
-
-
-def test_import_resolves_through_star_reexport_rust(build_decl_graph, assert_edges):
-    """``from pkg import g`` resolves through the star node to ``pkg._internal.g``.
-
-    The rust backend mints one ``*pkg._internal`` node per
-    ``from pkg._internal import *`` statement rather than a per-name
-    ``pkg.g`` alias; ty resolves ``from pkg import g`` straight to
-    ``pkg._internal.g``, so the consumer alias edges directly to the
-    upstream decl (no intermediate ``pkg.g``). The absence of any
-    ``consumer.g -> pkg.g`` edge from the full set below is the codified
-    "no per-name alias is minted" invariant.
-    """
-    graph = build_decl_graph(
-        {
-            "pkg/__init__.py": "from pkg._internal import *\n",
-            "pkg/_internal.py": "def g(): pass\n",
-            "consumer.py": "from pkg import g\ng()\n",
-        }
-    )
-    assert any(n.fqname == "pkg.*pkg._internal" for n in graph.nodes())
-    assert_edges(
-        graph,
-        {
-            "consumer -> consumer.g",
-            "consumer -> pkg",
-            "consumer -> pkg.*pkg._internal",
-            "consumer.g -> consumer",
-            "consumer.g -> pkg",
-            "consumer.g -> pkg._internal.g",
-            "pkg.*pkg._internal -> pkg",
-            "pkg.*pkg._internal -> pkg._internal",
-            "pkg._internal -> pkg",
-            "pkg._internal -> pkg._internal",
-            "pkg._internal.g -> pkg._internal",
-        },
-    )
-
-
-def test_import_resolves_through_chained_star_reexports(build_decl_graph, assert_edges):
-    """``from A import g`` follows ``A -> B -> C`` star chain to ``C.g``."""
-    graph = build_decl_graph(
-        {
-            "A.py": "from B import *\n",
-            "B.py": "from C import *\n",
-            "C.py": "def g(): pass\n",
-            "consumer.py": "from A import g\ng()\n",
-        }
-    )
-    assert_edges(
-        graph,
-        {
-            "A.*B -> A",
-            "A.*B -> B",
-            "B.*C -> B",
-            "B.*C -> C",
-            "C.g -> C",
-            "consumer -> A",
-            "consumer -> A.*B",
-            "consumer -> consumer.g",
-            "consumer.g -> A",
-            "consumer.g -> C.g",
-            "consumer.g -> consumer",
-        },
-    )
-
-
-def test_star_reexport_cycle_terminates(build_decl_graph, assert_edges):
-    """Mutual ``from B import *`` / ``from A import *`` terminates without spinning."""
-    graph = build_decl_graph(
-        {
-            "A.py": "from B import *\ndef a(): pass\n",
-            "B.py": "from A import *\ndef b(): pass\n",
-            "consumer.py": "from A import b\n",
-        }
-    )
-    assert_edges(
-        graph,
-        {
-            "A.*B -> A",
-            "A.*B -> B",
-            "A.a -> A",
-            "B.*A -> A",
-            "B.*A -> B",
-            "B.b -> B",
-            "consumer.b -> A",
-            "consumer.b -> B.b",
-            "consumer.b -> consumer",
-        },
-    )
-
-
-def test_star_reexport_shadowed_by_real_decl(build_decl_graph, assert_edges):
-    """A real decl in the importing module wins over a star re-export of the same name.
-
-    The absence of ``consumer.g -> other.g`` from the full edge set
-    below codifies that the consumer's ``g`` resolves to ``mod.g``
-    (not through the star re-export to ``other.g``).
-    """
-    graph = build_decl_graph(
-        {
-            "other.py": "def g(): pass\n",
-            "mod.py": "from other import *\ndef g(): return 1\n",
-            "consumer.py": "from mod import g\ng()\n",
-        }
-    )
-    assert_edges(
-        graph,
-        {
-            "consumer -> consumer.g",
-            "consumer -> mod",
-            "consumer -> mod.g",
-            "consumer.g -> consumer",
-            "consumer.g -> mod",
-            "consumer.g -> mod.g",
-            "mod.*other -> mod",
-            "mod.*other -> other",
-            "mod.g -> mod",
-            "other.g -> other",
-        },
-    )
-
-
 def test_from_import_prefers_namespace_binding_over_submodule(build_decl_graph):
     """``from p import q`` where ``p/__init__.py`` binds ``q`` (e.g. to an
     int) and ``p/q.py`` *also* exists: CPython's ``_handle_fromlist``
@@ -1084,47 +1132,6 @@ def _find_node(graph, *, fqname, kind, path_substring):
     return matches[0]
 
 
-def test_from_relative_import_in_init_keeps_submodule_alias_alive(build_decl_graph, assert_edges):
-    """``from .sub import X`` inside an ``__init__.py`` mints both a
-    normal ``ImportFrom`` alias for ``X`` and an
-    ``ImportFromSubmodule`` alias for the side-effect attribute
-    ``sub`` on the current package — Python rebinds ``pkg.sub`` to
-    the submodule whenever the statement runs. The two are one
-    inseparable syntactic unit, so reachability must drag the
-    submodule alias alive whenever any sibling alias is — otherwise
-    the analyzer would falsely flag the submodule attribute as dead
-    every time it's not also referenced by name in the same file.
-
-    The ``pkg.X -> pkg.sub`` and ``pkg.Y -> pkg.sub`` edges in the full
-    set below are the sibling-rescue edges that drag the submodule
-    attribute alias alive whenever ``X`` or ``Y`` is reached. (Both the
-    submodule attribute alias and the module itself share the fqname
-    ``pkg.sub`` — the duplicate ``pkg.sub -> pkg.sub`` edge is the
-    attribute alias edging to the module it shadows.)
-    """
-    graph = build_decl_graph(
-        {
-            "pkg/__init__.py": "from .sub import X, Y\n",
-            "pkg/sub.py": "class X: pass\nclass Y: pass\n",
-        }
-    )
-    assert_edges(
-        graph,
-        {
-            "pkg.X -> pkg",
-            "pkg.X -> pkg.sub",
-            "pkg.X -> pkg.sub.X",
-            "pkg.Y -> pkg",
-            "pkg.Y -> pkg.sub",
-            "pkg.Y -> pkg.sub.Y",
-            "pkg.sub -> pkg",
-            "pkg.sub -> pkg.sub",
-            "pkg.sub.X -> pkg.sub",
-            "pkg.sub.Y -> pkg.sub",
-        },
-    )
-
-
 def test_submodule_alias_dies_when_all_siblings_dead(build_decl_graph):
     """When every sibling alias from a ``from .sub import X`` statement
     is dead, the submodule-attribute alias dies too — there's no
@@ -1169,51 +1176,3 @@ def test_submodule_alias_not_minted_in_non_init_file(build_decl_graph):
     ]
     fqnames = {n.fqname for n in consumer_aliases}
     assert fqnames == {"pkg.consumer.X"}
-
-
-# ---------------------------------------------------------------------------
-# TYPE_CHECKING-guarded import referenced from a string annotation.
-#
-# The basic mechanics (string annotations are uses; regular string
-# literals are not) are pinned by parametrized ``test_imports`` cases
-# above. This composition test covers the practical motivator: an
-# import that lives under a dead branch *and* is referenced only from
-# a quoted annotation in live code must still pick up the use edge.
-# ---------------------------------------------------------------------------
-
-
-def test_type_checking_import_used_only_in_string_annotation(build_decl_graph, assert_edges):
-    """``f`` (the only top-level decl using ``Helper`` via a string
-    annotation) appears as ``mod.f -> mod.Helper`` in the full edge set
-    — string annotations are uses even when the import lives under a
-    dead ``if TYPE_CHECKING:`` branch.
-    """
-    graph = build_decl_graph(
-        {
-            "mod.py": (
-                "from __future__ import annotations\n"
-                "from typing import TYPE_CHECKING\n"
-                "if TYPE_CHECKING:\n"
-                "    from helpers import Helper\n"
-                "def f(x: 'Helper') -> 'Helper':\n"
-                "    return x\n"
-            ),
-            "helpers.py": "class Helper: pass\n",
-        }
-    )
-    assert_edges(
-        graph,
-        {
-            "helpers.Helper -> helpers",
-            "mod -> mod.TYPE_CHECKING",
-            "mod.Helper -> helpers",
-            "mod.Helper -> helpers.Helper",
-            "mod.Helper -> mod",
-            "mod.TYPE_CHECKING -> mod",
-            "mod.annotations -> mod",
-            "mod.f -> helpers",
-            "mod.f -> helpers.Helper",
-            "mod.f -> mod",
-            "mod.f -> mod.Helper",
-        },
-    )


### PR DESCRIPTION
## Summary
- Replaces `edge_strs` subset / `predecessors_of` checks in eight edge-focused tests in `tests/test_imports.py` with full `assert_edges` calls, so the complete edge set each case produces is visible in the test source (matching the parametrized cases above).
- Negative assertions ("X edge not in") become absence from the full expected set; non-edge invariants kept alongside (e.g. `caplog` for `test_module_runtime_dunder_access_is_module_dep`, the `*pkg._internal` node existence check for `test_import_resolves_through_star_reexport_rust`).
- Tests left as-is: cases not fundamentally about edges — synthetic-node existence / canonical-name / no-warning / node-disambiguation / reachability / node-attribute.

Converted tests:
- `test_module_runtime_dunder_access_is_module_dep`
- `test_dunder_on_imported_symbol_strips_dunder_tail`
- `test_import_resolves_through_star_reexport_rust`
- `test_import_resolves_through_chained_star_reexports`
- `test_star_reexport_cycle_terminates`
- `test_star_reexport_shadowed_by_real_decl`
- `test_from_relative_import_in_init_keeps_submodule_alias_alive` (dropped unused `predecessors_of` / `successors_of` fixtures; `_find_node` still used by the sibling-dead test)
- `test_type_checking_import_used_only_in_string_annotation`

## Test plan
- [x] `uv run pytest tests/test_imports.py` — 63 passed
- [x] `uv run prek run --files tests/test_imports.py` — clean

https://claude.ai/code/session_01PxCJNutkCEzV3s6BTeLiob

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxCJNutkCEzV3s6BTeLiob)_