### PR TITLE
rust: prewarm delete + string-annotation manual parse + rayon work-stealing populate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ name = "dead-cst-native"
 version = "0.11.0"
 dependencies = [
  "bincode",
+ "crossbeam-channel",
  "get-size2",
  "indicatif",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ rustc-hash = "2.0"
 smallvec = { version = "1.13", features = ["union", "const_generics", "const_new"] }
 indicatif = "0.17"
 rayon = "1.10"
+crossbeam-channel = "0.5"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 bincode = "1.3"

--- a/src/file_ref_edges.rs
+++ b/src/file_ref_edges.rs
@@ -261,8 +261,23 @@ impl<'a, 'db> RefWalker<'a, 'db> {
     ///   aren't entered yet.
     fn find_local_bindings(&self, name: &ExprName) -> Vec<Resolution<'db>> {
         let db = self.model.db();
-        let Some(file_scope) = self.model.scope(name.into()) else {
-            return Vec::new();
+        // For names from a string-annotation sub-AST, ty doesn't know
+        // their scope (we parsed them ourselves rather than going
+        // through enter_string_annotation). Fall back to the file's
+        // global scope — typing references inside annotations almost
+        // always resolve via global-scope imports, and the
+        // ancestor-scope walk below still climbs from global to find
+        // them. Loses precision for "T defined inside def f, used in
+        // f's annotation as string" which is rare.
+        let file_scope = if self.in_string_annotation {
+            self.model
+                .scope(name.into())
+                .unwrap_or(FileScopeId::global())
+        } else {
+            let Some(s) = self.model.scope(name.into()) else {
+                return Vec::new();
+            };
+            s
         };
         let mut first = true;
         for (scope_id, _scope) in self.index.visible_ancestor_scopes(file_scope) {
@@ -470,39 +485,37 @@ impl<'a, 'db> RefWalker<'a, 'db> {
         self.in_annotation -= 1;
     }
 
-    /// Parse a string-typed annotation via ty's
-    /// `enter_string_annotation` and walk the parsed sub-AST for
-    /// name uses. The sub-walker shares `&mut edges` / `&mut warnings`
-    /// indirectly via local Vecs that get merged back; this keeps the
-    /// borrow checker happy and matches today's pipeline's
-    /// AND-of-flags merge with set-semantics dedup at the outer level.
+    /// Parse a string-typed annotation as a Python expression and
+    /// walk it for name uses.
+    ///
+    /// Uses `ruff_python_parser::parse_expression` directly instead
+    /// of `SemanticModel::enter_string_annotation`. The latter calls
+    /// `infer_complete_scope_types`, which triggers ty's full type
+    /// inference for the enclosing scope — that fault-loads typeshed
+    /// (`typing.pyi`, `builtins.pyi`, …) and on typing-heavy
+    /// codebases adds tens of GB of `parsed_module` storage to
+    /// salsa's cache at 200k-file scale.
+    ///
+    /// Trade-off: we lose ty's `is_string_annotation` syntactic
+    /// gate (which would distinguish a typing-relevant string from
+    /// e.g. a `Callable[["unused param doc"], int]` shape). Names
+    /// inside the parsed sub-AST resolve via `in_string_annotation`'s
+    /// global-scope fallback in `find_local_bindings`; sub-AST
+    /// nodes aren't in the file's `uses_map`, so the
+    /// position-sensitive `scoped_use_id` path is skipped and
+    /// resolution falls through to `end_of_scope_symbol_bindings`.
     fn walk_string_annotation(&mut self, string_expr: &ExprStringLiteral) {
-        let Some((parsed_expr, sub_model)) = self.model.enter_string_annotation(string_expr) else {
+        let Some(string_literal) = string_expr.as_single_part_string() else {
             return;
         };
-        let mut sub_edges: FxHashSet<(NodeRef<'db>, NodeRef<'db>, u32)> = FxHashSet::default();
-        let mut sub_warnings: Vec<String> = Vec::new();
-        {
-            let mut sub = RefWalker {
-                owner: self.owner,
-                file: self.file,
-                db: self.db,
-                parsed: self.parsed,
-                index: self.index,
-                self_nodes: self.self_nodes,
-                model: &sub_model,
-                dead_ranges: self.dead_ranges,
-                edges: &mut sub_edges,
-                warnings: &mut sub_warnings,
-                nested_context: self.nested_context,
-                current_flags: 0,
-                in_annotation: self.in_annotation,
-                in_string_annotation: true,
-            };
-            sub.visit_expr(parsed_expr.expr());
-        }
-        self.edges.extend(sub_edges);
-        self.warnings.append(&mut sub_warnings);
+        let parsed = match ruff_python_parser::parse_expression(string_literal.as_str()) {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        let prev = self.in_string_annotation;
+        self.in_string_annotation = true;
+        self.visit_expr(parsed.expr());
+        self.in_string_annotation = prev;
     }
 
     /// Recognize and emit edges for a dynamic-import call. Returns

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -4,8 +4,6 @@
 //! of pure-function helpers the per-file salsa-tracked queries in
 //! `file_payload.rs` and `file_ref_edges.rs` call into:
 //!
-//! * `prewarm_file` — parallel salsa cache fill for `parsed_module` +
-//!   `semantic_index` before the per-file workers run.
 //! * `decl_kind_str`, `from_module_string` — small classifiers used
 //!   when building per-file node payloads.
 //! * `stmt_creates_top_level_definition`, `target_is_dunder_all`,
@@ -27,39 +25,12 @@ use std::path::{Path, PathBuf};
 
 use pyo3::prelude::*;
 use ruff_db::files::{File, FilePath};
-use ruff_db::parsed::parsed_module;
 use ruff_python_ast::{Expr, ExprName, Stmt};
 use ruff_text_size::Ranged;
 use ty_module_resolver::{
     file_to_module, resolve_module, search_paths, ModuleName, ModuleResolveMode,
 };
 use ty_python_core::definition::DefinitionKind;
-use ty_python_core::semantic_index;
-
-// ---------------------------------------------------------------------------
-// Phase 1: decl enumeration via ty's SemanticIndex
-// ---------------------------------------------------------------------------
-
-/// Salsa-tracked per-file "pre-warm" -- forces ``parsed_module`` +
-/// ``semantic_index`` to be cached for ``file`` so subsequent
-/// serial reads in ``ingest_decls`` hit the cache instead of
-/// blocking on a fill. Returns the body length only to keep salsa's
-/// signature non-trivial; the body's side effect (cache fill) is
-/// what matters.
-///
-/// Calling this in parallel via ``rayon::scope`` lets salsa's
-/// tracked-function machinery handle the lock-free coordination
-/// between workers, instead of the parking_lot lock contention
-/// plain-Rust callers hit. Experiment to confirm whether the
-/// tracked-function path actually scales for this codebase before
-/// committing to the larger ``extract_decls``-returning-NodeData
-/// refactor for phase 1.
-#[salsa::tracked]
-pub(crate) fn prewarm_file(db: &dyn ty_project::Db, file: File) -> usize {
-    let parsed = parsed_module(db, file).load(db);
-    let _ = semantic_index(db, file);
-    parsed.syntax().body.len()
-}
 
 pub(crate) fn decl_kind_str(kind: &DefinitionKind<'_>) -> Option<&'static str> {
     if kind.is_import() {

--- a/src/project.rs
+++ b/src/project.rs
@@ -242,47 +242,73 @@ pub(crate) fn build_project_graph(
     // Parallel pre-populate: run file_to_nodes, file_to_edges, and
     // file_to_ref_edges as #[salsa::tracked] queries across all
     // project files. Workers are pure-rust (GIL released via
-    // py.allow_threads). Each chunk attaches a cloned db so salsa's
-    // tracked-fn machinery can do lock-free coordination — same
-    // pattern as prewarm above. The salsa cache is populated for the
-    // serial assembly pass below; nothing here directly mutates the
-    // graph builder.
+    // py.allow_threads). Each file's three queries are attached on
+    // whatever rayon worker thread picks them up — work-stealing
+    // distributes load across cores; salsa-tracked machinery owns
+    // the lock-free coordination between workers. The salsa cache
+    // is populated for the serial assembly pass below; nothing here
+    // directly mutates the graph builder.
     //
-    // project_dist_lookup is also populated here on its own thread.
-    // The old pipeline overlapped build_dist_lookup with phase 1; we
-    // do the same so the first per-file worker that needs it (for
-    // PEP 503 canonical [external dist] X classification) hits a
-    // warm salsa cache instead of paying the ~100ms walk inline.
+    // project_dist_lookup runs in parallel with the file work via
+    // rayon::join. The old pipeline overlapped build_dist_lookup
+    // with phase 1; we keep the same shape so the first per-file
+    // worker that needs it (for PEP 503 canonical [external dist] X
+    // classification) hits a warm salsa cache instead of paying
+    // the ~100ms walk inline.
     let t_populate = std::time::Instant::now();
     {
-        let parent_db: ProjectDatabase = db.clone();
-        let dist_db: ProjectDatabase = db.clone();
-        let files_ref: &[File] = &project_files;
+        // Compute dist_lookup BEFORE the rayon::scope below. Two
+        // reasons it can't overlap on rayon:
+        //   (a) project_dist_lookup is a salsa-tracked query whose
+        //       body calls build_dist_lookup, which uses
+        //       rayon::par_extend internally. If we ran dist_lookup
+        //       on a rayon worker (or on a std::thread that submits
+        //       to the global rayon pool), its par_extend sub-tasks
+        //       would land on workers already running file_to_*
+        //       calls with a *different* db attached — salsa panics
+        //       with "Cannot change database mid-query".
+        //   (b) Once dist_lookup is cached, the per-file
+        //       file_to_edges call hits salsa's cache cheaply; no
+        //       cost penalty for serializing it first.
+        // The dist_lookup walk is ~100ms cold on a typical venv;
+        // file-work parallelism more than makes up for it on
+        // anything beyond a tiny corpus.
+        {
+            use salsa::Database as _;
+            let dist_db: ProjectDatabase = db.clone();
+            py.allow_threads(move || {
+                dist_db.attach(|local_db| {
+                    let _ = crate::file_payload::project_dist_lookup(local_db);
+                });
+            });
+        }
+        // Per-file work-stealing on rayon: pre-clone N salsa
+        // snapshots into a bounded MPMC channel; each task pulls a
+        // snapshot, processes ONE file, returns it. ProjectDatabase
+        // is Send-but-not-Sync so a shared db can't cross task
+        // boundaries — channel transfer is the closest match.
         let num_workers = std::thread::available_parallelism()
             .map(std::num::NonZeroUsize::get)
             .unwrap_or(4);
-        let chunk_size = files_ref.len().div_ceil(num_workers).max(1);
+        let (db_tx, db_rx) = crossbeam_channel::bounded::<ProjectDatabase>(num_workers);
+        for _ in 0..num_workers {
+            db_tx.send(db.clone()).expect("channel open");
+        }
+        let files_ref: &[File] = &project_files;
         py.allow_threads(move || {
-            std::thread::scope(|s| {
-                // dist_lookup on its own thread — overlapped with
-                // the file_to_* work below.
-                s.spawn(move || {
-                    use salsa::Database as _;
-                    dist_db.attach(|local_db| {
-                        let _ = crate::file_payload::project_dist_lookup(local_db);
-                    });
-                });
-                for chunk in files_ref.chunks(chunk_size) {
-                    let local_db = parent_db.clone();
-                    s.spawn(move || {
+            rayon::scope(|s| {
+                for &file in files_ref {
+                    let db_tx = db_tx.clone();
+                    let db_rx = db_rx.clone();
+                    s.spawn(move |_| {
                         use salsa::Database as _;
+                        let local_db = db_rx.recv().expect("snapshot available");
                         local_db.attach(|local_db| {
-                            for &file in chunk {
-                                let _ = file_to_nodes(local_db, file);
-                                let _ = file_to_edges(local_db, file);
-                                let _ = file_to_ref_edges(local_db, file);
-                            }
+                            let _ = file_to_nodes(local_db, file);
+                            let _ = file_to_edges(local_db, file);
+                            let _ = file_to_ref_edges(local_db, file);
                         });
+                        db_tx.send(local_db).expect("channel open");
                     });
                 }
             });

--- a/src/project.rs
+++ b/src/project.rs
@@ -232,44 +232,12 @@ pub(crate) fn build_project_graph(
 
     let progress = ProgressBars::new(show_progress, project_files.len() as u64);
 
-    // Pre-warm: in parallel, force salsa's ``parsed_module`` and
-    // ``semantic_index`` queries to fill for every project file.
-    // The body is a ``#[salsa::tracked]`` function, so salsa owns
-    // the parallel coordination (lock-free fast paths, not the
-    // parking_lot contention plain-Rust callers hit). After this,
-    // phase 1's serial ``ingest_decls`` loop hits warm caches.
-    //
-    // DEAD_CST_SKIP_PREWARM=1 disables this so the per-file populate
-    // workers below fault parsed_module + semantic_index in
-    // themselves. Used for the "does prewarm still buy us anything?"
-    // A/B experiment; the populate phase is already parallel, so the
-    // hypothesis is that prewarm is now redundant.
-    let t_warm = std::time::Instant::now();
-    let skip_prewarm = std::env::var_os("DEAD_CST_SKIP_PREWARM").is_some();
-    if !skip_prewarm {
-        let parent_db: ProjectDatabase = db.clone();
-        let files_ref: &[File] = &project_files;
-        let num_workers = std::thread::available_parallelism()
-            .map(std::num::NonZeroUsize::get)
-            .unwrap_or(4);
-        let chunk_size = files_ref.len().div_ceil(num_workers).max(1);
-        py.allow_threads(move || {
-            std::thread::scope(|s| {
-                for chunk in files_ref.chunks(chunk_size) {
-                    let local_db = parent_db.clone();
-                    s.spawn(move || {
-                        use salsa::Database as _;
-                        local_db.attach(|local_db| {
-                            for &file in chunk {
-                                crate::ingest::prewarm_file(local_db, file);
-                            }
-                        });
-                    });
-                }
-            });
-        });
-    }
-    let t_prewarm = t_warm.elapsed();
+    // (prewarm phase deleted — confirmed redundant after the
+    // fan-out refactor. The populate phase below already
+    // parallelises parsed_module + semantic_index loading inside
+    // its own attach-per-thread scope; pre-warming them in a
+    // separate parallel pass was a no-op at every corpus size we
+    // measured. See PR #226 follow-up for the A/B data.)
 
     // Parallel pre-populate: run file_to_nodes, file_to_edges, and
     // file_to_ref_edges as #[salsa::tracked] queries across all
@@ -346,12 +314,11 @@ pub(crate) fn build_project_graph(
     let t_fqname = t4.elapsed();
     if timing {
         eprintln!(
-            "[dead-cst-timing] files={} nodes={} edges={} enum={:?} prewarm={:?} populate={:?} assemble={:?} fqname={:?} total={:?} rss={}MB",
+            "[dead-cst-timing] files={} nodes={} edges={} enum={:?} populate={:?} assemble={:?} fqname={:?} total={:?} rss={}MB",
             project_files.len(),
             builder.nodes.len(),
             builder.edges.len(),
             t_enum,
-            t_prewarm,
             t_populate_elapsed,
             t_assemble_elapsed,
             t_fqname,

--- a/src/project.rs
+++ b/src/project.rs
@@ -238,8 +238,15 @@ pub(crate) fn build_project_graph(
     // the parallel coordination (lock-free fast paths, not the
     // parking_lot contention plain-Rust callers hit). After this,
     // phase 1's serial ``ingest_decls`` loop hits warm caches.
+    //
+    // DEAD_CST_SKIP_PREWARM=1 disables this so the per-file populate
+    // workers below fault parsed_module + semantic_index in
+    // themselves. Used for the "does prewarm still buy us anything?"
+    // A/B experiment; the populate phase is already parallel, so the
+    // hypothesis is that prewarm is now redundant.
     let t_warm = std::time::Instant::now();
-    {
+    let skip_prewarm = std::env::var_os("DEAD_CST_SKIP_PREWARM").is_some();
+    if !skip_prewarm {
         let parent_db: ProjectDatabase = db.clone();
         let files_ref: &[File] = &project_files;
         let num_workers = std::thread::available_parallelism()
@@ -339,7 +346,7 @@ pub(crate) fn build_project_graph(
     let t_fqname = t4.elapsed();
     if timing {
         eprintln!(
-            "[dead-cst-timing] files={} nodes={} edges={} enum={:?} prewarm={:?} populate={:?} assemble={:?} fqname={:?} total={:?}",
+            "[dead-cst-timing] files={} nodes={} edges={} enum={:?} prewarm={:?} populate={:?} assemble={:?} fqname={:?} total={:?} rss={}MB",
             project_files.len(),
             builder.nodes.len(),
             builder.edges.len(),
@@ -349,7 +356,16 @@ pub(crate) fn build_project_graph(
             t_assemble_elapsed,
             t_fqname,
             t0.elapsed(),
+            current_rss_mb(),
         );
+    }
+    if let Some(mode) = std::env::var_os("DEAD_CST_DUMP_HEAP") {
+        let dump = db.salsa_memory_dump();
+        if mode == "full" {
+            eprintln!("{}", dump.display_full());
+        } else {
+            eprintln!("{}", dump.display_short());
+        }
     }
     builder.peer_pyi_to_py = peer_pyi_to_py;
     Ok(BuildOutputs {
@@ -364,6 +380,23 @@ pub(crate) fn build_project_graph(
         module_by_fqname,
         imports_by_module,
     })
+}
+
+/// Read VmRSS from /proc/self/status. Returns 0 on non-Linux or on
+/// parse failure. Used by the timing dump for a cheap "what's the
+/// resident set after the build" signal without needing
+/// /usr/bin/time or external sampling.
+fn current_rss_mb() -> usize {
+    std::fs::read_to_string("/proc/self/status")
+        .ok()
+        .and_then(|s| {
+            s.lines()
+                .find(|l| l.starts_with("VmRSS:"))
+                .and_then(|l| l.split_whitespace().nth(1))
+                .and_then(|n| n.parse::<usize>().ok())
+        })
+        .map(|kb| kb / 1024)
+        .unwrap_or(0)
 }
 
 /// Output of the [`assemble_graph`] pass. The fields are exactly the


### PR DESCRIPTION
## Summary

Three wins from a perf/memory deep dive on top of #226:

1. **Delete prewarm.** Confirmed redundant after the fan-out refactor — populate already parallelises the same `parsed_module` + `semantic_index` work.
2. **Replace `SemanticModel::enter_string_annotation` with manual `parse_expression`.** Stops fault-loading typeshed for every string annotation — **2.9× faster, 5.6× less salsa memory** on typing-heavy code.
3. **`rayon::scope` + per-file work-stealing for populate.** Pre-clones N salsa snapshots into a crossbeam-channel, each rayon task pulls one, processes a file, returns it. **~30% faster than the chunked dispatch** even on a homogeneous corpus, and resilient to slow files dominating a chunk on heterogeneous projects.

Plus instrumentation (`DEAD_CST_DUMP_HEAP=1/full`, RSS in the timing line) for future investigations.

## Numbers

Typing-heavy 30-file `python/` tree (dead-cst itself):

| | before all 3 | after all 3 | delta |
|--|--|--|--|
| total wall time | 195ms | **~50ms** | ~3.9× faster |
| RSS | 88MB | 55MB | 1.6× smaller |
| salsa total | 30MB | **5.3MB** | 5.6× smaller |
| `parsed_module` entries | 67 (37 typeshed faults) | 30 (project files only) | -37 |
| `infer_*` queries | ~750 entries | **0** | gone |

338-file pygments corpus (no string annotations of consequence — isolates the rayon win):

| | before | after rayon | delta |
|--|--|--|--|
| total wall time | 350ms | **~220ms** | ~1.6× faster |
| populate phase | 290ms | 200ms | ~30% faster |
| RSS | 144MB | 144MB | — |
| salsa total | 83MB | 83MB | — |

Even pygments (homogeneous workload) saw a 30% populate-phase win once the chunking went away.

## Why string annotations dominated

`enter_string_annotation` does:

```rust
if !infer_complete_scope_types(self.db, scope).is_string_annotation(expr) {
    return None;
}
```

That's ty's full type inference engine running for the enclosing scope. To decide "is this string an annotation," ty has to type-check the whole scope, which faults in typeshed (`typing.pyi`, `builtins.pyi`, …). Triggered once per string annotation per file. On typing-heavy code that's the dominant cost — both wall time and salsa cache.

Manual `ruff_python_parser::parse_expression` on the string body skips that chain entirely. We lose ty's `is_string_annotation` syntactic gate, but `in_annotation > 0` (already required to even reach this code path) is a sufficient filter — parser failure silently drops, no false positives.

For names from the parsed sub-AST, `find_local_bindings` falls back to `FileScopeId::global()` when `model.scope(name)` returns None (sub-AST names aren't in ty's expression_scope_id map). Loses precision for "T defined inside `def f`, referenced in f's annotation as a string" (rare); names that resolve via global-scope imports (the typical typing references) work unchanged.

## Why prewarm is redundant

Originally added in commit `9669144` to feed the OLD serial Phase 1's `ingest_decls` with warm caches. After #226 the populate phase parallelises that same `parsed_module` + `semantic_index` work inside its own attach-per-thread scope — prewarming them in a separate pass is a no-op.

A/B with the temporary `DEAD_CST_SKIP_PREWARM` knob (from the instrumentation commit, removed in the delete commit):

| corpus | with prewarm | skip prewarm |
|--|--|--|
| 338-file pygments | 350ms median | 344ms median |
| 30-file project | 199ms median | 207ms median |

No-op at every scale measured.

## Why rayon + per-file work-stealing wins (and why dist_lookup had to move)

The new shape:

```rust
let (db_tx, db_rx) = crossbeam_channel::bounded(num_workers);
for _ in 0..num_workers { db_tx.send(db.clone())?; }
rayon::scope(|s| {
    for &file in files_ref {
        let db_tx = db_tx.clone();
        let db_rx = db_rx.clone();
        s.spawn(move |_| {
            let local_db = db_rx.recv()?;
            local_db.attach(|local_db| {
                let _ = file_to_nodes(local_db, file);
                let _ = file_to_edges(local_db, file);
                let _ = file_to_ref_edges(local_db, file);
            });
            db_tx.send(local_db)?;
        });
    }
});
```

`ProjectDatabase` is `Send` but not `Sync`, so a shared parent + clone-inside-task pattern (`par_iter().for_each(|f| db.clone()...)`) doesn't typecheck. The channel ferries N pre-cloned snapshots between rayon workers — each task pulls one, processes a single file, returns it. At most `num_workers` files are in flight at once, matching what the chunked version allowed, but rayon's work-stealing means a slow file doesn't tie down a contiguous chunk while peers idle.

**`project_dist_lookup` now runs to completion BEFORE the rayon::scope** (used to overlap on a separate thread). Subtle hazard:

> `build_dist_lookup` uses `rayon::par_extend` internally. If `project_dist_lookup` runs as a rayon-pool task in parallel with the file work, its `par_extend` sub-tasks land on rayon workers that already have a different `ProjectDatabase` attached, and salsa panics with "Cannot change database mid-query."

Pre-computing dist_lookup serializes ~80ms of work but eliminates that hazard AND removes inter-task contention. The total time still went DOWN (350 → 220ms on pygments) because the overlap was actually hurting on shared workers.

## Instrumentation kept

- `DEAD_CST_TIMING=1` line now includes `rss=NNMb` (read from `/proc/self/status`).
- `DEAD_CST_DUMP_HEAP=1` prints salsa's `display_short` (totals by struct/memo metadata + fields).
- `DEAD_CST_DUMP_HEAP=full` prints the per-ingredient breakdown (which query holds how much, count).

These are how the numbers in the tables above were measured; useful for future digs.

## Test plan

- [x] `cargo check --no-default-features` — clean
- [x] `cargo clippy --all-targets --locked -- -D warnings` — clean
- [x] `uv run pytest -q` — **579 passed, 10 deselected**
- [x] `uv run pytest -m e2e -v` × 5 — **10 passed each run**, no flakiness (rayon attach hazard fixed by dist_lookup serialization above)
- [ ] Re-run on the 200k-file real corpus to confirm the typing-heavy win scales as expected and that per-file work-stealing helps on a heterogeneous file-size distribution

## Commits

1. `44c4099` add `DEAD_CST_DUMP_HEAP` + RSS to timing dump; `DEAD_CST_SKIP_PREWARM` A/B knob
2. `87b6d1d` delete prewarm — redundant after fan-out refactor
3. `a4be509` replace `SemanticModel::enter_string_annotation` with manual parse
4. `dac6fb8` `rayon::scope` + per-file work-stealing for populate phase

https://claude.ai/code/session_01SbHeJrqUdjZJVc5CPbVNr5