### PR TITLE
rust: opt-in stack-size override for populate phase (no default)

### DIFF
--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -307,16 +307,23 @@ class ProjectContext:
         show_progress: bool = ...,
     ) -> None: ...
     @property
-    def stack_size(self) -> int:
-        """Rayon worker stack size (bytes) for the populate phase.
-        Defaults to 32 MiB; override via :meth:`set_stack_size`."""
+    def stack_size(self) -> int | None:
+        """Rayon worker stack size override (bytes) for the populate
+        phase, or ``None`` if no override is set (in which case the
+        populate phase runs on rayon's global pool with rayon's own
+        default stack — 2 MiB unless ``RAYON_STACK_SIZE`` /
+        ``RUST_MIN_STACK`` are set process-wide)."""
 
     def set_stack_size(self, bytes_: int) -> None:
         """Override the rayon worker stack size (bytes) used by the
         populate phase. Call BEFORE :meth:`materialize`; calls after
         the graph is materialized have no effect on the already-
         built graph. Raises :class:`ValueError` if ``bytes_`` is
-        not positive."""
+        not positive.
+
+        Set this on projects with deeply-nested generated code
+        (protobuf modules, ML-generated ASTs, big literal dicts)
+        that overflow rayon's default 2 MiB stack."""
 
     def add_plugin(self, plugin: _ProjectPluginLike | Any) -> None:
         """Register a plugin. Order of registration is order of

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -306,6 +306,18 @@ class ProjectContext:
         typeshed: str | None = ...,
         show_progress: bool = ...,
     ) -> None: ...
+    @property
+    def stack_size(self) -> int:
+        """Rayon worker stack size (bytes) for the populate phase.
+        Defaults to 32 MiB; override via :meth:`set_stack_size`."""
+
+    def set_stack_size(self, bytes_: int) -> None:
+        """Override the rayon worker stack size (bytes) used by the
+        populate phase. Call BEFORE :meth:`materialize`; calls after
+        the graph is materialized have no effect on the already-
+        built graph. Raises :class:`ValueError` if ``bytes_`` is
+        not positive."""
+
     def add_plugin(self, plugin: _ProjectPluginLike | Any) -> None:
         """Register a plugin. Order of registration is order of
         invocation during :meth:`materialize`."""

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -62,9 +62,8 @@ class Analysis:
         self._plugins: tuple[Plugin, ...] = tuple(plugins)
         self._show_progress: bool = show_progress
         # Buffered until ``materialize_all`` constructs the ctx.
-        # ``None`` means "use the rust-side default" (32 MiB at the
-        # time of writing — see ``DEFAULT_RAYON_STACK_SIZE`` in the
-        # rust crate).
+        # ``None`` means "no override" — the rust side uses rayon's
+        # global pool with rayon's own default stack.
         self._stack_size: int | None = None
         # Held past ``materialize_all`` so the rust BFS queries
         # (:meth:`reachable`, :meth:`dead`, :meth:`descendants`,
@@ -78,10 +77,13 @@ class Analysis:
         after the graph is materialized have no effect on the
         already-built graph.
 
-        Defaults to 32 MiB on the rust side, which is generous for
-        typical Python code. Raise this if you see a stack overflow
-        on deeply-nested generated code (e.g. protobuf modules,
-        ML-generated ASTs, or large nested literal dicts) — the
+        With no override set, the populate phase uses rayon's global
+        pool with rayon's own default stack (2 MiB unless
+        ``RAYON_STACK_SIZE`` / ``RUST_MIN_STACK`` are set
+        process-wide), which is sufficient for typical Python code.
+        Call this on projects with deeply-nested generated code
+        (e.g. protobuf modules, ML-generated ASTs, or large nested
+        literal dicts) that stack-overflow at the default — the
         declared size is virtual address space on Linux, so going
         much higher costs no resident memory unless actually used.
         """

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -61,11 +61,33 @@ class Analysis:
         self._venv: Path | None = venv
         self._plugins: tuple[Plugin, ...] = tuple(plugins)
         self._show_progress: bool = show_progress
+        # Buffered until ``materialize_all`` constructs the ctx.
+        # ``None`` means "use the rust-side default" (32 MiB at the
+        # time of writing — see ``DEFAULT_RAYON_STACK_SIZE`` in the
+        # rust crate).
+        self._stack_size: int | None = None
         # Held past ``materialize_all`` so the rust BFS queries
         # (:meth:`reachable`, :meth:`dead`, :meth:`descendants`,
         # :meth:`ancestors`) and node/edge enumeration can run against
         # the live context without re-building the project graph.
         self._ctx: native.ProjectContext | None = None
+
+    def set_stack_size(self, bytes_: int) -> None:
+        """Override the rayon worker stack size (bytes) used by the
+        populate phase. Call BEFORE :meth:`materialize_all`; calls
+        after the graph is materialized have no effect on the
+        already-built graph.
+
+        Defaults to 32 MiB on the rust side, which is generous for
+        typical Python code. Raise this if you see a stack overflow
+        on deeply-nested generated code (e.g. protobuf modules,
+        ML-generated ASTs, or large nested literal dicts) — the
+        declared size is virtual address space on Linux, so going
+        much higher costs no resident memory unless actually used.
+        """
+        if bytes_ <= 0:
+            raise ValueError(f"stack_size must be > 0, got {bytes_}")
+        self._stack_size = bytes_
 
     @property
     def project_root(self) -> Path:
@@ -100,6 +122,8 @@ class Analysis:
             python_env=venv_str,
             show_progress=self._show_progress,
         )
+        if self._stack_size is not None:
+            ctx.set_stack_size(self._stack_size)
         for plugin in self._plugins:
             # Catch ``Pluign()`` typos and bare dicts before the rust
             # side silently drops them.

--- a/src/project.rs
+++ b/src/project.rs
@@ -257,60 +257,61 @@ pub(crate) fn build_project_graph(
     // the ~100ms walk inline.
     let t_populate = std::time::Instant::now();
     {
-        // Compute dist_lookup BEFORE the rayon::scope below. Two
-        // reasons it can't overlap on rayon:
-        //   (a) project_dist_lookup is a salsa-tracked query whose
-        //       body calls build_dist_lookup, which uses
-        //       rayon::par_extend internally. If we ran dist_lookup
-        //       on a rayon worker (or on a std::thread that submits
-        //       to the global rayon pool), its par_extend sub-tasks
-        //       would land on workers already running file_to_*
-        //       calls with a *different* db attached — salsa panics
-        //       with "Cannot change database mid-query".
-        //   (b) Once dist_lookup is cached, the per-file
-        //       file_to_edges call hits salsa's cache cheaply; no
-        //       cost penalty for serializing it first.
-        // The dist_lookup walk is ~100ms cold on a typical venv;
-        // file-work parallelism more than makes up for it on
-        // anything beyond a tiny corpus.
-        {
-            use salsa::Database as _;
-            let dist_db: ProjectDatabase = db.clone();
-            py.allow_threads(move || {
-                dist_db.attach(|local_db| {
-                    let _ = crate::file_payload::project_dist_lookup(local_db);
-                });
-            });
-        }
         // Per-file work-stealing on rayon: pre-clone N salsa
         // snapshots into a bounded MPMC channel; each task pulls a
         // snapshot, processes ONE file, returns it. ProjectDatabase
         // is Send-but-not-Sync so a shared db can't cross task
         // boundaries — channel transfer is the closest match.
+        //
+        // Custom rayon pool with a larger stack: the default 2MB
+        // overflows on deeply-nested generated code (protobuf
+        // modules, big literal dicts, long star-reexport chains).
+        // RUST_MIN_STACK overrides if set — same env var name rayon
+        // / std::thread already honour, so users who've sized it up
+        // for one tool's deep recursion get the same setting here.
+        // 8MB matches rustc's own thread stack default for compiler
+        // recursion and is conservative for our workload.
         let num_workers = std::thread::available_parallelism()
             .map(std::num::NonZeroUsize::get)
             .unwrap_or(4);
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(num_workers)
+            .stack_size(rayon_worker_stack_size())
+            .build()
+            .expect("build rayon thread pool");
         let (db_tx, db_rx) = crossbeam_channel::bounded::<ProjectDatabase>(num_workers);
         for _ in 0..num_workers {
             db_tx.send(db.clone()).expect("channel open");
         }
+        // dist_lookup ALSO runs inside pool.install so its
+        // par_extend sub-tasks land on the custom-stack workers
+        // (otherwise they'd hit rayon's global pool with the
+        // default stack). Serialized before the rayon::scope below
+        // to avoid the "Cannot change database mid-query" salsa
+        // panic — see the prior commit's message for the hazard.
+        let dist_db: ProjectDatabase = db.clone();
         let files_ref: &[File] = &project_files;
         py.allow_threads(move || {
-            rayon::scope(|s| {
-                for &file in files_ref {
-                    let db_tx = db_tx.clone();
-                    let db_rx = db_rx.clone();
-                    s.spawn(move |_| {
-                        use salsa::Database as _;
-                        let local_db = db_rx.recv().expect("snapshot available");
-                        local_db.attach(|local_db| {
-                            let _ = file_to_nodes(local_db, file);
-                            let _ = file_to_edges(local_db, file);
-                            let _ = file_to_ref_edges(local_db, file);
+            pool.install(move || {
+                use salsa::Database as _;
+                dist_db.attach(|local_db| {
+                    let _ = crate::file_payload::project_dist_lookup(local_db);
+                });
+                rayon::scope(|s| {
+                    for &file in files_ref {
+                        let db_tx = db_tx.clone();
+                        let db_rx = db_rx.clone();
+                        s.spawn(move |_| {
+                            let local_db = db_rx.recv().expect("snapshot available");
+                            local_db.attach(|local_db| {
+                                let _ = file_to_nodes(local_db, file);
+                                let _ = file_to_edges(local_db, file);
+                                let _ = file_to_ref_edges(local_db, file);
+                            });
+                            db_tx.send(local_db).expect("channel open");
                         });
-                        db_tx.send(local_db).expect("channel open");
-                    });
-                }
+                    }
+                });
             });
         });
     }
@@ -373,6 +374,23 @@ pub(crate) fn build_project_graph(
         module_by_fqname,
         imports_by_module,
     })
+}
+
+/// Stack size for rayon worker threads in the populate-phase pool.
+/// Honours `RUST_MIN_STACK` (same env var rayon / `std::thread`
+/// already read) so users who've sized it up for one tool's deep
+/// recursion get the same setting here. Defaults to 8 MiB —
+/// generous headroom for deeply-nested generated code (protobuf
+/// modules, big literal dicts) and long star-reexport chains
+/// where rayon's default 2 MiB stack has been observed to
+/// overflow on large repos.
+fn rayon_worker_stack_size() -> usize {
+    const DEFAULT: usize = 8 * 1024 * 1024;
+    std::env::var("RUST_MIN_STACK")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .map(|n| n.max(DEFAULT))
+        .unwrap_or(DEFAULT)
 }
 
 /// Read VmRSS from /proc/self/status. Returns 0 on non-Linux or on

--- a/src/project.rs
+++ b/src/project.rs
@@ -266,11 +266,12 @@ pub(crate) fn build_project_graph(
         // Custom rayon pool with a larger stack: the default 2MB
         // overflows on deeply-nested generated code (protobuf
         // modules, big literal dicts, long star-reexport chains).
-        // RUST_MIN_STACK overrides if set — same env var name rayon
-        // / std::thread already honour, so users who've sized it up
-        // for one tool's deep recursion get the same setting here.
-        // 8MB matches rustc's own thread stack default for compiler
-        // recursion and is conservative for our workload.
+        // See `rayon_worker_stack_size` for the resolution order
+        // (DEAD_CST_STACK_SIZE > RUST_MIN_STACK > 32MB default).
+        // The declared size is virtual address space — Linux
+        // commits stack pages lazily, so 32MB × N workers costs no
+        // resident memory until a worker actually recurses into
+        // those pages.
         let num_workers = std::thread::available_parallelism()
             .map(std::num::NonZeroUsize::get)
             .unwrap_or(4);
@@ -376,20 +377,37 @@ pub(crate) fn build_project_graph(
     })
 }
 
-/// Stack size for rayon worker threads in the populate-phase pool.
-/// Honours `RUST_MIN_STACK` (same env var rayon / `std::thread`
-/// already read) so users who've sized it up for one tool's deep
-/// recursion get the same setting here. Defaults to 8 MiB —
-/// generous headroom for deeply-nested generated code (protobuf
-/// modules, big literal dicts) and long star-reexport chains
-/// where rayon's default 2 MiB stack has been observed to
-/// overflow on large repos.
+/// Stack size (bytes) for rayon worker threads in the populate-phase
+/// pool. Resolution order:
+///
+/// 1. `DEAD_CST_STACK_SIZE`, if set and parseable as a non-zero
+///    `usize`. Lets users override our default without touching the
+///    process-wide `RUST_MIN_STACK` (which rayon / `std::thread`
+///    also honour, so it can have ripple effects on other code).
+/// 2. `RUST_MIN_STACK`, if set and parseable. Same env var rayon /
+///    `std::thread` already read — picked up so users who've sized
+///    it up for one tool's deep recursion don't get silently capped
+///    by our default.
+/// 3. 32 MiB default.
+///
+/// 32 MiB covers ~32k recursive frames at ~1 KB/frame — well past
+/// any AST CPython can parse (default recursion limit is 1000) and
+/// generous headroom for auto-generated protobuf, ML-generated
+/// code, etc. Linux commits stack pages lazily, so the declared
+/// size is virtual address space, not resident memory.
 fn rayon_worker_stack_size() -> usize {
-    const DEFAULT: usize = 8 * 1024 * 1024;
+    const DEFAULT: usize = 32 * 1024 * 1024;
+    if let Some(n) = std::env::var("DEAD_CST_STACK_SIZE")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+    {
+        return n;
+    }
     std::env::var("RUST_MIN_STACK")
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
-        .map(|n| n.max(DEFAULT))
+        .filter(|&n| n > 0)
         .unwrap_or(DEFAULT)
 }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -79,7 +79,7 @@ impl Project {
 
     /// Build the project-wide symbol graph (single-pass, no plugins).
     pub(crate) fn build(&mut self, py: Python<'_>) -> PyResult<NativeGraph> {
-        let outputs = build_project_graph(py, &mut self.db, false, DEFAULT_RAYON_STACK_SIZE)?;
+        let outputs = build_project_graph(py, &mut self.db, false, None)?;
         Ok(NativeGraph {
             nodes: outputs.builder.nodes,
             edges: outputs.builder.edges,
@@ -197,7 +197,7 @@ pub(crate) fn build_project_graph(
     py: Python<'_>,
     db: &mut ProjectDatabase,
     show_progress: bool,
-    stack_size: usize,
+    stack_size: Option<usize>,
 ) -> PyResult<BuildOutputs> {
     let timing = std::env::var_os("DEAD_CST_TIMING").is_some();
 
@@ -264,57 +264,60 @@ pub(crate) fn build_project_graph(
         // is Send-but-not-Sync so a shared db can't cross task
         // boundaries — channel transfer is the closest match.
         //
-        // Custom rayon pool with a larger stack: the default 2MB
-        // overflows on deeply-nested generated code (protobuf
-        // modules, big literal dicts, long star-reexport chains).
-        // See `rayon_worker_stack_size` for the resolution order
-        // (DEAD_CST_STACK_SIZE > RUST_MIN_STACK > 32MB default).
-        // The declared size is virtual address space — Linux
-        // commits stack pages lazily, so 32MB × N workers costs no
-        // resident memory until a worker actually recurses into
-        // those pages.
+        // When `stack_size` is `Some`, build a local rayon pool
+        // with that stack size and run the work inside `install`.
+        // Otherwise use the global rayon pool — rayon's default
+        // stack (2 MiB) is sufficient for typical Python code;
+        // callers with deeply-nested generated code call
+        // `ProjectContext.set_stack_size` to opt in to a bigger
+        // stack. Linux commits stack pages lazily, so the declared
+        // size is virtual address space, not resident memory.
         let num_workers = std::thread::available_parallelism()
             .map(std::num::NonZeroUsize::get)
             .unwrap_or(4);
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(num_workers)
-            .stack_size(stack_size)
-            .build()
-            .expect("build rayon thread pool");
         let (db_tx, db_rx) = crossbeam_channel::bounded::<ProjectDatabase>(num_workers);
         for _ in 0..num_workers {
             db_tx.send(db.clone()).expect("channel open");
         }
-        // dist_lookup ALSO runs inside pool.install so its
-        // par_extend sub-tasks land on the custom-stack workers
-        // (otherwise they'd hit rayon's global pool with the
-        // default stack). Serialized before the rayon::scope below
-        // to avoid the "Cannot change database mid-query" salsa
-        // panic — see the prior commit's message for the hazard.
+        // dist_lookup runs inside the same pool (custom or global)
+        // so its par_extend sub-tasks share that pool's workers,
+        // not stray onto unrelated rayon usage. Serialized before
+        // the rayon::scope below to avoid the "Cannot change
+        // database mid-query" salsa panic — see the prior PR's
+        // commit message for the hazard.
         let dist_db: ProjectDatabase = db.clone();
         let files_ref: &[File] = &project_files;
-        py.allow_threads(move || {
-            pool.install(move || {
-                use salsa::Database as _;
-                dist_db.attach(|local_db| {
-                    let _ = crate::file_payload::project_dist_lookup(local_db);
-                });
-                rayon::scope(|s| {
-                    for &file in files_ref {
-                        let db_tx = db_tx.clone();
-                        let db_rx = db_rx.clone();
-                        s.spawn(move |_| {
-                            let local_db = db_rx.recv().expect("snapshot available");
-                            local_db.attach(|local_db| {
-                                let _ = file_to_nodes(local_db, file);
-                                let _ = file_to_edges(local_db, file);
-                                let _ = file_to_ref_edges(local_db, file);
-                            });
-                            db_tx.send(local_db).expect("channel open");
-                        });
-                    }
-                });
+        let run_populate = move || {
+            use salsa::Database as _;
+            dist_db.attach(|local_db| {
+                let _ = crate::file_payload::project_dist_lookup(local_db);
             });
+            rayon::scope(|s| {
+                for &file in files_ref {
+                    let db_tx = db_tx.clone();
+                    let db_rx = db_rx.clone();
+                    s.spawn(move |_| {
+                        let local_db = db_rx.recv().expect("snapshot available");
+                        local_db.attach(|local_db| {
+                            let _ = file_to_nodes(local_db, file);
+                            let _ = file_to_edges(local_db, file);
+                            let _ = file_to_ref_edges(local_db, file);
+                        });
+                        db_tx.send(local_db).expect("channel open");
+                    });
+                }
+            });
+        };
+        py.allow_threads(move || match stack_size {
+            Some(n) => {
+                let pool = rayon::ThreadPoolBuilder::new()
+                    .num_threads(num_workers)
+                    .stack_size(n)
+                    .build()
+                    .expect("build rayon thread pool");
+                pool.install(run_populate);
+            }
+            None => run_populate(),
         });
     }
     let t_populate_elapsed = t_populate.elapsed();
@@ -377,16 +380,6 @@ pub(crate) fn build_project_graph(
         imports_by_module,
     })
 }
-
-/// Default rayon worker stack size for the populate phase, in bytes.
-/// 32 MiB covers ~32k recursive frames at ~1 KB/frame — well past
-/// any AST CPython can parse (default recursion limit is 1000) and
-/// generous headroom for auto-generated protobuf, ML-generated
-/// code, etc. Linux commits stack pages lazily, so the declared
-/// size is virtual address space, not resident memory.
-///
-/// Override per-build via [`ProjectContext::set_stack_size`].
-pub(crate) const DEFAULT_RAYON_STACK_SIZE: usize = 32 * 1024 * 1024;
 
 /// Read VmRSS from /proc/self/status. Returns 0 on non-Linux or on
 /// parse failure. Used by the timing dump for a cheap "what's the
@@ -726,14 +719,15 @@ pub(crate) struct ProjectContext {
     /// When true, ``materialize`` and ``build_project_graph`` draw
     /// indicatif progress bars to stderr.
     pub(crate) show_progress: bool,
-    /// Stack size (bytes) for the rayon workers that run the
-    /// per-file populate phase. Defaults to
-    /// [`DEFAULT_RAYON_STACK_SIZE`] (32 MiB); override via
-    /// [`Self::set_stack_size`] before calling `materialize`.
-    /// Sized for deeply-nested generated code (protobuf modules,
-    /// long star-reexport chains) where rayon's default 2 MiB
-    /// stack has been observed to overflow on large repos.
-    pub(crate) stack_size: usize,
+    /// Optional override for the rayon worker stack size (bytes)
+    /// used by the populate phase. `None` (the default) uses the
+    /// global rayon pool, which honours rayon's own size (2 MiB
+    /// unless `RAYON_STACK_SIZE` / `RUST_MIN_STACK` are set in the
+    /// process env). `Some(n)` builds a local pool with stack_size
+    /// `n`. Set via [`Self::set_stack_size`] for projects with
+    /// deeply-nested generated code (protobuf modules, long
+    /// star-reexport chains) that overflow the default.
+    pub(crate) stack_size: Option<usize>,
 }
 
 #[pymethods]
@@ -767,7 +761,7 @@ impl ProjectContext {
             outputs: RefCell::new(None),
             regex_cache: RefCell::new(HashMap::new()),
             show_progress,
-            stack_size: DEFAULT_RAYON_STACK_SIZE,
+            stack_size: None,
         })
     }
 
@@ -779,26 +773,27 @@ impl ProjectContext {
 
     /// Override the rayon worker stack size (bytes) used by the
     /// populate phase. Call BEFORE `materialize`; later calls don't
-    /// affect a build already in progress. Useful for projects with
+    /// affect a build already in progress. By default no override
+    /// is set — populate runs on rayon's global pool with rayon's
+    /// own default stack (2 MiB). Set this on projects with
     /// deeply-nested generated code (protobuf modules, ML-generated
-    /// asts) where rayon's default 2 MiB stack — or our 32 MiB
-    /// default — isn't enough. Passing 0 is invalid and raises
-    /// ValueError.
+    /// ASTs, big literal dicts) that overflow the default. Passing
+    /// 0 is invalid and raises ValueError.
     pub(crate) fn set_stack_size(&mut self, bytes: usize) -> PyResult<()> {
         if bytes == 0 {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "stack_size must be > 0",
             ));
         }
-        self.stack_size = bytes;
+        self.stack_size = Some(bytes);
         Ok(())
     }
 
-    /// Current rayon worker stack size (bytes). Defaults to 32 MiB
-    /// (see [`DEFAULT_RAYON_STACK_SIZE`]); can be raised or lowered
-    /// via [`Self::set_stack_size`].
+    /// Current rayon worker stack size override in bytes, or `None`
+    /// if no override is set (in which case the populate phase uses
+    /// rayon's global pool with its own default stack).
     #[getter]
-    pub(crate) fn stack_size(&self) -> usize {
+    pub(crate) fn stack_size(&self) -> Option<usize> {
         self.stack_size
     }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -79,7 +79,7 @@ impl Project {
 
     /// Build the project-wide symbol graph (single-pass, no plugins).
     pub(crate) fn build(&mut self, py: Python<'_>) -> PyResult<NativeGraph> {
-        let outputs = build_project_graph(py, &mut self.db, false)?;
+        let outputs = build_project_graph(py, &mut self.db, false, DEFAULT_RAYON_STACK_SIZE)?;
         Ok(NativeGraph {
             nodes: outputs.builder.nodes,
             edges: outputs.builder.edges,
@@ -197,6 +197,7 @@ pub(crate) fn build_project_graph(
     py: Python<'_>,
     db: &mut ProjectDatabase,
     show_progress: bool,
+    stack_size: usize,
 ) -> PyResult<BuildOutputs> {
     let timing = std::env::var_os("DEAD_CST_TIMING").is_some();
 
@@ -277,7 +278,7 @@ pub(crate) fn build_project_graph(
             .unwrap_or(4);
         let pool = rayon::ThreadPoolBuilder::new()
             .num_threads(num_workers)
-            .stack_size(rayon_worker_stack_size())
+            .stack_size(stack_size)
             .build()
             .expect("build rayon thread pool");
         let (db_tx, db_rx) = crossbeam_channel::bounded::<ProjectDatabase>(num_workers);
@@ -377,39 +378,15 @@ pub(crate) fn build_project_graph(
     })
 }
 
-/// Stack size (bytes) for rayon worker threads in the populate-phase
-/// pool. Resolution order:
-///
-/// 1. `DEAD_CST_STACK_SIZE`, if set and parseable as a non-zero
-///    `usize`. Lets users override our default without touching the
-///    process-wide `RUST_MIN_STACK` (which rayon / `std::thread`
-///    also honour, so it can have ripple effects on other code).
-/// 2. `RUST_MIN_STACK`, if set and parseable. Same env var rayon /
-///    `std::thread` already read — picked up so users who've sized
-///    it up for one tool's deep recursion don't get silently capped
-///    by our default.
-/// 3. 32 MiB default.
-///
+/// Default rayon worker stack size for the populate phase, in bytes.
 /// 32 MiB covers ~32k recursive frames at ~1 KB/frame — well past
 /// any AST CPython can parse (default recursion limit is 1000) and
 /// generous headroom for auto-generated protobuf, ML-generated
 /// code, etc. Linux commits stack pages lazily, so the declared
 /// size is virtual address space, not resident memory.
-fn rayon_worker_stack_size() -> usize {
-    const DEFAULT: usize = 32 * 1024 * 1024;
-    if let Some(n) = std::env::var("DEAD_CST_STACK_SIZE")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .filter(|&n| n > 0)
-    {
-        return n;
-    }
-    std::env::var("RUST_MIN_STACK")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .filter(|&n| n > 0)
-        .unwrap_or(DEFAULT)
-}
+///
+/// Override per-build via [`ProjectContext::set_stack_size`].
+pub(crate) const DEFAULT_RAYON_STACK_SIZE: usize = 32 * 1024 * 1024;
 
 /// Read VmRSS from /proc/self/status. Returns 0 on non-Linux or on
 /// parse failure. Used by the timing dump for a cheap "what's the
@@ -749,6 +726,14 @@ pub(crate) struct ProjectContext {
     /// When true, ``materialize`` and ``build_project_graph`` draw
     /// indicatif progress bars to stderr.
     pub(crate) show_progress: bool,
+    /// Stack size (bytes) for the rayon workers that run the
+    /// per-file populate phase. Defaults to
+    /// [`DEFAULT_RAYON_STACK_SIZE`] (32 MiB); override via
+    /// [`Self::set_stack_size`] before calling `materialize`.
+    /// Sized for deeply-nested generated code (protobuf modules,
+    /// long star-reexport chains) where rayon's default 2 MiB
+    /// stack has been observed to overflow on large repos.
+    pub(crate) stack_size: usize,
 }
 
 #[pymethods]
@@ -782,6 +767,7 @@ impl ProjectContext {
             outputs: RefCell::new(None),
             regex_cache: RefCell::new(HashMap::new()),
             show_progress,
+            stack_size: DEFAULT_RAYON_STACK_SIZE,
         })
     }
 
@@ -789,6 +775,31 @@ impl ProjectContext {
     #[getter]
     pub(crate) fn project_root(&self) -> &str {
         &self.root
+    }
+
+    /// Override the rayon worker stack size (bytes) used by the
+    /// populate phase. Call BEFORE `materialize`; later calls don't
+    /// affect a build already in progress. Useful for projects with
+    /// deeply-nested generated code (protobuf modules, ML-generated
+    /// asts) where rayon's default 2 MiB stack — or our 32 MiB
+    /// default — isn't enough. Passing 0 is invalid and raises
+    /// ValueError.
+    pub(crate) fn set_stack_size(&mut self, bytes: usize) -> PyResult<()> {
+        if bytes == 0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "stack_size must be > 0",
+            ));
+        }
+        self.stack_size = bytes;
+        Ok(())
+    }
+
+    /// Current rayon worker stack size (bytes). Defaults to 32 MiB
+    /// (see [`DEFAULT_RAYON_STACK_SIZE`]); can be raised or lowered
+    /// via [`Self::set_stack_size`].
+    #[getter]
+    pub(crate) fn stack_size(&self) -> usize {
+        self.stack_size
     }
 
     /// Register a Python plugin. Order of registration is order of
@@ -815,9 +826,10 @@ impl ProjectContext {
     /// re-enter queries through the same ctx without aliasing violations.
     pub(crate) fn materialize(slf: Py<Self>, py: Python<'_>) -> PyResult<NativeGraph> {
         let show_progress = slf.borrow(py).show_progress;
+        let stack_size = slf.borrow(py).stack_size;
         {
             let mut this = slf.borrow_mut(py);
-            let outputs = build_project_graph(py, &mut this.db, show_progress)?;
+            let outputs = build_project_graph(py, &mut this.db, show_progress, stack_size)?;
             *this.outputs.borrow_mut() = Some(outputs);
         }
 


### PR DESCRIPTION
## Summary

Opt-in stack-size override for the populate phase, no implicit default.

By default the populate phase runs on rayon's global pool with rayon's own default stack (2 MiB unless `RAYON_STACK_SIZE` / `RUST_MIN_STACK` are set process-wide). When `set_stack_size(bytes)` is called before `materialize`, the populate phase builds a local rayon pool with the requested stack size.

## API

```python
from dead_cst import Analysis

# Default: no override, uses rayon's global pool
a = Analysis(project_root)
graph = a.materialize_all()

# Override for projects with deeply-nested generated code
a = Analysis(project_root)
a.set_stack_size(64 * 1024 * 1024)   # 64 MiB
graph = a.materialize_all()

# Same on the rust ctx directly:
ctx = _native.ProjectContext(root, ...)
ctx.set_stack_size(64 * 1024 * 1024)
ctx.materialize()
```

- `ProjectContext.set_stack_size(bytes_)` — pymethod, ValueError on non-positive.
- `ProjectContext.stack_size` — getter, returns `int | None`.
- `Analysis.set_stack_size(bytes_)` — Python method, buffers until `materialize_all`.
- `.pyi` stubs for both.

## Why opt-in

- No surprise per-build cost for users on small/typical projects.
- Doesn't preempt users who've set `RAYON_STACK_SIZE` / `RUST_MIN_STACK` process-wide for other tools.
- Authors who hit a real stack-overflow can configure it explicitly with a number they reason about for their corpus.

## When to call it

The populate phase recurses through:
- `visit_stmt` / `visit_expr` AST walks
- `walk_owned` recursion into function/class bodies
- `find_local_bindings` ancestor-scope walks
- `walk_exports_chain` (star reexports)
- `emit_upstream` submodule chain walks

Depth is bounded by **individual file structure**, not project file count. Set a larger stack if you hit a stack overflow on:
- Auto-generated protobuf with deeply nested message defs
- ML-generated code with deep call chains
- Big literal dicts / lookup tables
- Long star-reexport chains (>20 levels)

Linux commits stack pages lazily — declared stack size is virtual address space, not resident memory. Going from 2 MiB to 64 MiB costs zero resident memory until a worker actually recurses into those pages.

## Implementation

`ProjectContext.stack_size: Option<usize>`. `build_project_graph` matches:

```rust
match stack_size {
    Some(n) => {
        let pool = rayon::ThreadPoolBuilder::new()
            .num_threads(num_workers)
            .stack_size(n)
            .build()?;
        pool.install(run_populate);
    }
    None => run_populate(),
}
```

`run_populate` is the same closure either way (per-file work-stealing on rayon via crossbeam-channel db snapshots, dist_lookup serialized first to avoid the salsa "Cannot change database mid-query" hazard).

## Test plan

- [x] `cargo check --no-default-features` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --locked -- -D warnings` — clean
- [x] `uv run pytest -q` — **579 passed, 10 deselected**
- [x] `uv run pytest -m e2e` × 3 — **10 passed each run**
- [x] Smoke test: `Analysis()` → `ctx.stack_size is None`; `Analysis().set_stack_size(64 MiB)` → `ctx.stack_size == 67108864`; `set_stack_size(0)` raises `ValueError`

## Commits

1. `688d188` rust: custom rayon pool with stack-size knob (initial: 8 MiB)
2. `d488832` rust: bump default to 32 MiB (now removed)
3. `30d9c1f` ci: re-trigger after concurrency cancel
4. `00365b0` rust: env vars → `set_stack_size` method
5. `356b354` rust: drop default — opt-in only via `set_stack_size`

https://claude.ai/code/session_01SbHeJrqUdjZJVc5CPbVNr5