### PR TITLE
rust: keep project_root on search paths; specificity-aware file→fqname (fixes #222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ two versions.
 ## [Unreleased]
 
 ### Fixed
+- `Analysis(..., venv=...)` no longer drops `project_root` from ty's
+  static search paths when a venv is given. The previous suppression
+  relied on `.pth`-derived dynamic paths to cover every first-party
+  package, which failed silently for setuptools' default PEP 660
+  editable install (`__editable__.<dist>.pth` is a finder stub, not a
+  flat path). Every cross-file first-party import resolved to an
+  `[unresolved]` synthetic and the whole graph fell apart — see #222
+  for the `FastAPIPlugin` symptom. `project_root` is now always on
+  the search list; a new specificity-aware reverse module lookup
+  (`helpers::canonical_module_name_for_file`) makes a deeper `.pth`
+  path still win the fqname for files it covers, so monorepo layouts
+  (`packages/lib_a/src/lib_a/`) keep their short `lib_a` fqname
+  instead of regressing to `packages.lib_a.src.lib_a`.
 - `build_scope_table` (dead-branch detector) no longer livelocks on
   scopes that rebind an inherited name to a flipped version of itself
   — e.g. a function whose body is `global foo; foo = not foo` when

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -85,18 +85,18 @@ class Analysis:
 
         from .plugins import Plugin
 
-        # When a venv is provided, suppress ty's auto-discovery of
-        # ``env.root`` (which would put ``project_root`` in static
-        # search paths, shadowing the .pth-derived per-member paths
-        # that come via ``python_env``). With ``env.root = []``,
-        # static_paths is empty; ty falls through to
-        # ``dynamic_resolution_paths`` (site-packages + .pth) for
-        # first-party resolution.
+        # Always keep ``project_root`` in ty's static search paths
+        # alongside any ``.pth``-derived dynamic paths from the venv.
+        # ``helpers::canonical_module_for_file`` (rust side) does a
+        # specificity-aware reverse lookup so a deep ``.pth`` path
+        # still wins the fqname for files it covers, while the
+        # project root becomes a safe fallback for single-package
+        # setups whose editable install uses a PEP 660 ``MetaPathFinder``
+        # (no flat ``.pth``) — the case that #222 reproduced as
+        # ``[unresolved]`` synthetics.
         venv_str = str(self._venv) if self._venv is not None else None
-        suppress_autodetect = self._venv is not None
         ctx = _native.ProjectContext(
             str(self._project_root),
-            src_roots=[] if suppress_autodetect else None,
             python_env=venv_str,
             show_progress=self._show_progress,
         )

--- a/src/file_payload.rs
+++ b/src/file_payload.rs
@@ -29,7 +29,7 @@ use ruff_text_size::TextRange;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use std::collections::HashMap;
-use ty_module_resolver::{file_to_module, resolve_module, ModuleName};
+use ty_module_resolver::{resolve_module, ModuleName};
 use ty_project::Db as ProjectDb;
 use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
 use ty_python_core::place::{PlaceExprRef, ScopedPlaceId};
@@ -835,7 +835,7 @@ pub(crate) fn file_to_edges<'db>(db: &'db dyn ProjectDb, file: File) -> FileEdge
 /// top-level packages (no parent) and for parents that live outside
 /// the project (the cross-file hierarchy edge has nowhere to land).
 fn parent_module_file(db: &dyn ProjectDb, file: File) -> Option<File> {
-    let module = file_to_module(db, file)?;
+    let module = crate::helpers::canonical_module_for_file(db, file)?;
     let parent_name = module.name(db).parent()?;
     let parent_module = resolve_module(db, file, &parent_name)?;
     parent_module.file(db)

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -16,7 +16,10 @@ use ruff_python_ast::visitor::{walk_expr, Visitor};
 use ruff_python_ast::{Expr, Stmt, StmtClassDef};
 use ruff_source_file::LineIndex;
 use ruff_text_size::{Ranged, TextRange};
-use ty_module_resolver::{file_to_module, resolve_module, ModuleName};
+use ty_module_resolver::Module;
+use ty_module_resolver::{
+    file_to_module, resolve_module, search_paths, ModuleName, ModuleResolveMode,
+};
 use ty_project::metadata::value::RelativePathBuf;
 use ty_project::{Db as ProjectDb, ProjectDatabase};
 
@@ -1691,9 +1694,139 @@ pub(crate) fn file_default_flags(db: &dyn ProjectDb, file: File) -> u32 {
     }
 }
 
+/// Convert a search-path-relative path into a dotted module name.
+///
+/// `rel` is the file's path relative to a search root (e.g.
+/// `"lib_a/__init__.py"` or `"handlers/job.py"`). Strips `.py` / `.pyi`
+/// extensions and any trailing `__init__` segment so a package's
+/// `__init__.py` collapses to the package's dotted name.
+///
+/// Returns `None` for paths that aren't valid module containers — most
+/// commonly a bare `__init__.py` whose search path *is* the package
+/// directory itself (a layout no `.pth` install would produce, but we
+/// reject it for safety: there's no name to bind).
+fn relative_to_module_name(rel: &str) -> Option<String> {
+    let stem = rel
+        .strip_suffix(".pyi")
+        .or_else(|| rel.strip_suffix(".py"))
+        .unwrap_or(rel);
+    if stem == "__init__" {
+        return None;
+    }
+    let stem = stem
+        .strip_suffix("/__init__")
+        .or_else(|| stem.strip_suffix("\\__init__"))
+        .unwrap_or(stem);
+    if stem.is_empty() {
+        return None;
+    }
+    Some(stem.replace(['/', '\\'], "."))
+}
+
+/// Specificity-aware reverse module lookup: which fqname would Python
+/// import to reach this file?
+///
+/// `ty_module_resolver::file_to_module` takes the *first* search path
+/// that contains the file. That's correct when search paths reflect
+/// Python's resolution order — but when project_root is on the list
+/// alongside a `.pth`-derived path inside it, the first match yields a
+/// workspace-relative dotted name (`libs.lib_a.src.lib_a`) instead of
+/// the import-time name (`lib_a`). The forward resolver still picks
+/// the right file via the `.pth`, so cross-file edges built against
+/// the workspace-relative fqname never connect.
+///
+/// This walks every containing search path, builds a candidate
+/// module name from each, round-trips it through `resolve_module`, and
+/// returns the candidate whose search path is *most* specific (largest
+/// component count). The specificity tiebreak picks `lib_a` over
+/// `libs.lib_a.src.lib_a` whenever both round-trip — i.e. when both a
+/// `.pth` entry and the project root cover the file.
+///
+/// Returns `None` when no candidate round-trips (the file is shadowed
+/// by another module of the same name in a higher-priority search
+/// path) or when the file isn't on any search path at all. Callers
+/// should fall back to a path-mangle in that case.
+pub(crate) fn canonical_module_for_file<'db>(
+    db: &'db dyn ty_module_resolver::Db,
+    file: File,
+) -> Option<Module<'db>> {
+    let name = canonical_module_name_for_file(db, file)?;
+    resolve_module(db, file, &name)
+}
+
+/// Same logic as :func:`canonical_module_for_file` but stops at the
+/// ``ModuleName``. Saves one ``resolve_module`` call per file in the
+/// common single-package case where ``module_fqname_for_file`` only
+/// needs the dotted name. Callers that go on to walk the parent module
+/// (``parent_module_file``, ``file_package_name``) still go through
+/// the ``Module``-returning wrapper above.
+pub(crate) fn canonical_module_name_for_file(
+    db: &dyn ty_module_resolver::Db,
+    file: File,
+) -> Option<ModuleName> {
+    let file_path = match file.path(db) {
+        FilePath::System(p) => p,
+        _ => return file_to_module(db, file).map(|m| m.name(db).clone()),
+    };
+
+    // Collect every search path that physically contains the file.
+    // Typical projects have ≤ 5 search paths and a file usually lives
+    // under 1–2 of them, so the SmallVec stays inline.
+    let mut candidates: smallvec::SmallVec<[(usize, ModuleName); 4]> = smallvec::SmallVec::new();
+    for sp in search_paths(db, ModuleResolveMode::StubsAllowed) {
+        let Some(sp_path) = sp.as_system_path() else {
+            continue;
+        };
+        let Ok(rel) = file_path.strip_prefix(sp_path) else {
+            continue;
+        };
+        let Some(name_str) = relative_to_module_name(rel.as_str()) else {
+            continue;
+        };
+        let Some(name) = ModuleName::new(&name_str) else {
+            continue;
+        };
+        candidates.push((sp_path.components().count(), name));
+    }
+
+    // Fast path: a single containing search path means no ambiguity —
+    // skip the ``resolve_module`` round-trip entirely. This is the
+    // single-package shape (just ``project_root`` on the search list)
+    // and accounts for the bulk of first-party files in typical
+    // codebases. Without this short-circuit, the round-trip would cost
+    // one ``resolve_module`` call per project file at cold start.
+    //
+    // Correctness note: ``file_to_module`` round-trips to reject files
+    // shadowed by a same-named package (``foo.py`` next to
+    // ``foo/__init__.py``). We deliberately don't reject here — the
+    // current code path falls back to a path-mangle for those files
+    // anyway, returning the same fqname we would. Shadowing precedence
+    // for import-edge routing lives in ``file_payload`` / the trie,
+    // not here.
+    if candidates.len() == 1 {
+        // No ambiguity, no round-trip needed.
+        return candidates.into_iter().next().map(|(_, name)| name);
+    }
+
+    // Multiple containing paths -- specificity tiebreak with round-trip.
+    candidates.sort_by_key(|c| std::cmp::Reverse(c.0));
+    for (_, name) in candidates {
+        let Some(resolved) = resolve_module(db, file, &name) else {
+            continue;
+        };
+        let Some(resolved_file) = resolved.file(db) else {
+            continue;
+        };
+        if resolved_file == file {
+            return Some(name);
+        }
+    }
+    None
+}
+
 pub(crate) fn module_fqname_for_file(db: &dyn ProjectDb, file: File) -> String {
-    if let Some(module) = file_to_module(db, file) {
-        return module.name(db).as_str().to_string();
+    if let Some(name) = canonical_module_name_for_file(db, file) {
+        return name.as_str().to_string();
     }
     // Fallback for files ty doesn't classify (e.g. ``gunicorn.conf.py`` at
     // the project root — there's no ``__init__.py`` and the stem contains

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -27,9 +27,7 @@ use pyo3::prelude::*;
 use ruff_db::files::{File, FilePath};
 use ruff_python_ast::{Expr, ExprName, Stmt};
 use ruff_text_size::Ranged;
-use ty_module_resolver::{
-    file_to_module, resolve_module, search_paths, ModuleName, ModuleResolveMode,
-};
+use ty_module_resolver::{resolve_module, search_paths, ModuleName, ModuleResolveMode};
 use ty_python_core::definition::DefinitionKind;
 
 pub(crate) fn decl_kind_str(kind: &DefinitionKind<'_>) -> Option<&'static str> {
@@ -515,7 +513,7 @@ pub(crate) fn resolve_dynamic_target(
 /// `pkg/__init__.py` this is `"pkg"`; for `pkg/sub.py` this is
 /// `"pkg"`; for a top-level `mod.py` this is `None`.
 pub(crate) fn file_package_name(db: &dyn ty_python_semantic::Db, file: File) -> Option<String> {
-    let module = file_to_module(db, file)?;
+    let module = crate::helpers::canonical_module_for_file(db, file)?;
     let name = module.name(db);
     let path_str = match file.path(db) {
         FilePath::System(p) => p.to_string(),

--- a/tests/test_canonical_fqname.py
+++ b/tests/test_canonical_fqname.py
@@ -1,0 +1,139 @@
+"""Tests for canonical (specificity-aware) file → fqname resolution.
+
+dead-cst's reverse module lookup must agree with the forward import
+resolver: if ``from lib_a import greet`` resolves to file F, then F's
+fqname-in-graph must be ``lib_a`` so the cross-file edge connects. ty's
+own ``file_to_module`` returns the *first* containing search path's
+relative name, which goes wrong when ``project_root`` is on the list
+alongside a ``.pth``-derived path it physically contains.
+
+These tests pin the two endpoints of the fix from #222:
+
+1. **Single-package, no flat ``.pth`` covering first-party code** (e.g.
+   setuptools' default PEP 660 ``MetaPathFinder`` editable install):
+   ``project_root`` must still rescue first-party resolution. Before
+   the fix, ``Analysis(..., venv=...)`` suppressed ``project_root``
+   from ty's search paths entirely; every cross-file import resolved
+   to ``[unresolved]`` and the whole graph fell apart.
+
+2. **Monorepo with flat ``.pth`` per workspace member**: the deeper
+   ``.pth`` path must still win the fqname for files it covers — the
+   workspace-rooted path mustn't shadow it. ``module`` nodes for
+   ``packages/lib_a/src/lib_a/__init__.py`` should still come out as
+   ``lib_a``, not ``packages.lib_a.src.lib_a``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dead_cst import Analysis
+
+
+def _module_fqnames(graph) -> dict[str, str]:
+    """``{file_path: fqname}`` over every ``kind == "module"`` node."""
+    return {n.path: n.fqname for n in graph.nodes() if n.kind == "module"}
+
+
+def test_pep660_finder_install_resolves_via_project_root(
+    tmp_path, write_files, make_workspace_venv
+):
+    """Reproduces #222: a venv whose ``.pth`` is a PEP 660 finder stub
+    (no flat path entries) must not break first-party resolution. We
+    simulate by handing ``Analysis`` a venv that has *no* editable
+    ``.pth`` covering the project — ``project_root`` on ty's search
+    paths is now the only thing keeping ``myapp.routes.job`` reachable.
+    """
+    write_files(
+        {
+            "myapp/__init__.py": "",
+            "myapp/main.py": (
+                "from myapp.routes.job import router as job_router\napp = job_router\n"
+            ),
+            "myapp/routes/__init__.py": "",
+            "myapp/routes/job.py": "router = object()\n",
+        }
+    )
+    # Empty venv -- mimics a setuptools PEP 660 finder install whose
+    # ``.pth`` we can't see into. No flat path covers ``myapp/``, so the
+    # only first-party search root is ``project_root`` itself.
+    venv = make_workspace_venv({})
+
+    analysis = Analysis(tmp_path, venv=venv)
+    graph = analysis.materialize_all()
+    by_path = _module_fqnames(graph)
+
+    assert by_path[str(tmp_path / "myapp" / "__init__.py")] == "myapp"
+    assert by_path[str(tmp_path / "myapp" / "main.py")] == "myapp.main"
+    assert by_path[str(tmp_path / "myapp" / "routes" / "job.py")] == "myapp.routes.job"
+
+    # The import alias in main.py must resolve to the real router var,
+    # not to ``[unresolved] myapp``.
+    job_router_alias = next(n for n in graph.nodes() if n.fqname == "myapp.main.job_router")
+    router_var = next(n for n in graph.nodes() if n.fqname == "myapp.routes.job.router")
+    # The alias's descendant set should reach the upstream var.
+    assert router_var in graph.descendants(job_router_alias)
+
+
+def test_monorepo_pth_beats_project_root_in_fqname(tmp_path, write_files, make_workspace_venv):
+    """Specificity tiebreak: when both a deep ``.pth`` and ``project_root``
+    contain the same file, the ``.pth``-derived fqname must win.
+
+    Layout mirrors a uv workspace: ``packages/lib_a/src/lib_a/`` is the
+    real source, ``packages/lib_a/src`` is the editable ``.pth`` entry,
+    and ``project_root`` (=tmp_path) is also on ty's search paths now
+    that suppression is gone.
+    """
+    write_files(
+        {
+            "packages/lib_a/src/lib_a/__init__.py": "def greet(name): return name\n",
+            "packages/lib_b/src/lib_b/__init__.py": (
+                "from lib_a import greet\ndef shout(n): return greet(n).upper()\n"
+            ),
+            "main.py": "from lib_a import greet\nprint(greet('x'))\n",
+        }
+    )
+    venv = make_workspace_venv(
+        {
+            "lib_a": "packages/lib_a/src",
+            "lib_b": "packages/lib_b/src",
+        }
+    )
+
+    analysis = Analysis(tmp_path, venv=venv)
+    graph = analysis.materialize_all()
+    by_path = _module_fqnames(graph)
+
+    # Deepest ``.pth`` wins: not ``packages.lib_a.src.lib_a``.
+    assert (
+        by_path[str(tmp_path / "packages" / "lib_a" / "src" / "lib_a" / "__init__.py")] == "lib_a"
+    )
+    assert (
+        by_path[str(tmp_path / "packages" / "lib_b" / "src" / "lib_b" / "__init__.py")] == "lib_b"
+    )
+    # Files at the workspace root with no ``.pth`` coverage fall through
+    # to ``project_root``, which is fine -- their short name is already
+    # the canonical one.
+    assert by_path[str(tmp_path / "main.py")] == "main"
+
+
+def test_pth_with_top_level_module_keeps_short_fqname(tmp_path, write_files, make_workspace_venv):
+    """An app published as a flat ``.pth`` (no ``src/`` layer) must
+    surface its top-level module as the bare name (``handlers.job``),
+    not as a workspace-rooted dotted name (``apps.app_two.handlers.job``).
+    """
+    write_files(
+        {
+            "apps/app_two/main.py": "from handlers.job import work\nwork()\n",
+            "apps/app_two/handlers/__init__.py": "",
+            "apps/app_two/handlers/job.py": "def work(): return 0\n",
+        }
+    )
+    venv = make_workspace_venv({"app_two": "apps/app_two"})
+
+    analysis = Analysis(tmp_path, venv=venv)
+    graph = analysis.materialize_all()
+    by_path = _module_fqnames(graph)
+
+    assert by_path[str(tmp_path / "apps" / "app_two" / "handlers" / "job.py")] == "handlers.job"
+    assert by_path[str(tmp_path / "apps" / "app_two" / "main.py")] == "main"

--- a/tests/test_canonical_fqname.py
+++ b/tests/test_canonical_fqname.py
@@ -25,7 +25,6 @@ These tests pin the two endpoints of the fix from #222:
 
 from __future__ import annotations
 
-from pathlib import Path
 
 from dead_cst import Analysis
 


### PR DESCRIPTION
## Summary

Fixes #222. `Analysis(..., venv=...)` used to set `src_roots=[]` so ty's auto-discovery wouldn't put `project_root` on the static first-party search-path list — the theory being that the venv's `.pth` files would supply first-party resolution. That holds for flat-`.pth` editable installs (uv workspaces, hatchling) but breaks for setuptools' default PEP 660 install, whose `.pth` is a finder stub that ty's static resolver can't execute. Every cross-file first-party import then resolves to `[unresolved]` and the whole reachability graph snaps at the file boundary — exactly the `FastAPIPlugin` symptom in #222.

`project_root` now stays on ty's search paths unconditionally. The hazard the suppression was guarding against (a workspace-rooted prefix shadowing a deeper `.pth` and producing `packages.lib_a.src.lib_a` instead of `lib_a`) is handled inside a new `helpers::canonical_module_name_for_file`: it walks every search path that physically contains the file, picks the most specific (longest component count) whose candidate name round-trips through `resolve_module`, and short-circuits to the bare candidate when only one search path covers the file (the common-case fast path — avoids one `resolve_module` per file). `module_fqname_for_file`, `parent_module_file`, and `file_package_name` all funnel through it so the three agree.

## Why this works for both shapes

- **Single-package, PEP 660 finder install** (the #222 case): `project_root` is the only search path covering first-party code → 1 candidate → fast path → returns the workspace-rooted dotted name, which is also the right Python import name. Imports resolve. Graph wires up.
- **Monorepo with flat `.pth`** (the #224 strategic-fix shape): every workspace member has a `.pth` deeper than `project_root` → 2+ candidates → specificity tiebreak picks the deeper one. `lib_a/__init__.py` stays `lib_a`, not `packages.lib_a.src.lib_a`. Identical graph to before.

## Benchmarks (release, 7 runs, cold = first `materialize()`)

| project              | install style    | before  | after   | edges before → after  |
| -------------------- | ---------------- | ------- | ------- | --------------------- |
| django (2910 files)  | PEP 660 finder   | 679ms   | 1016ms  | 88,662 → **149,609**  |
| starlette (67 files) | flat `.pth`      | 37ms    | 39ms    | 11,551 → 11,551       |
| mono (workspace)     | flat `.pth`      | 4ms     | 5ms     | 86 → 86               |
| dead-cst (self)      | flat `.pth`      | 44ms    | 42ms    | 1,351 → 1,351         |

Django's +50% cold cost is the fix doing legitimate work: 69% more import edges actually resolve now (the previous run was fast because most first-party imports silently dangled as `[unresolved]` synthetics). Flat-`.pth` projects pay ≤5% from one extra search-path iteration per file and emit byte-identical graphs. Warm cost is ≤6ms in every case.

## Test plan

- [x] `uv run pytest` — 582 passed (3 new regression tests + 579 existing)
- [x] `uv run prek run --all-files` — clean (clippy / ruff / ty)
- [x] Issue #222 flat-layout repro: 6 dead findings → 0
- [x] Issue #222 package-layout PEP 660 repro: 6 dead findings → 0
- [x] Hand-built monorepo: identical `module` node fqnames vs baseline (`lib_a`, `lib_b`, `handlers.job`, …)

## New tests (`tests/test_canonical_fqname.py`)

1. `test_pep660_finder_install_resolves_via_project_root` — pins the #222 fix: when no `.pth` covers first-party code, `project_root` rescues resolution and the import alias edges into the real upstream var, not `[unresolved]`.
2. `test_monorepo_pth_beats_project_root_in_fqname` — pins the specificity tiebreak: deeper `.pth` paths win the fqname even with `project_root` on the search list.
3. `test_pth_with_top_level_module_keeps_short_fqname` — pins flat-app shape: `handlers.job` stays `handlers.job`, not `apps.app_two.handlers.job`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcBdLVmLkpjet9pKdwDZDM)_