### PR TITLE
vendor: point ruff submodule at lpetre/ruff @ 7ceb20f0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/ruff"]
 	path = vendor/ruff
-	url = https://github.com/astral-sh/ruff.git
+	url = https://github.com/lpetre/ruff.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,11 +2223,13 @@ name = "ty_project"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bitvec",
  "camino",
  "colored",
  "crossbeam",
  "get-size2",
  "globset",
+ "ignore",
  "notify",
  "ordermap",
  "pep440_rs",


### PR DESCRIPTION
## Summary
- Switch `vendor/ruff` submodule URL from `astral-sh/ruff` to `lpetre/ruff`
- Bump the gitlink from `ac6361d` to `7ceb20f009467d16ff35bce45f79f2044635f83e`

## Test plan
- [ ] `git submodule sync vendor/ruff && git submodule update --init vendor/ruff` resolves to `7ceb20f0`
- [ ] `uv sync` builds the rust extension against the new ruff checkout
- [ ] `uv run pytest` passes

https://claude.ai/code/session_01VVn8QhLQ5Rebgp9BqWThbu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVn8QhLQ5Rebgp9BqWThbu)_