### PR TITLE
vendor: point ruff submodule at lpetre/ruff fork @ 18448938c8

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/ruff"]
 	path = vendor/ruff
-	url = https://github.com/astral-sh/ruff.git
+	url = https://github.com/lpetre/ruff.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ two versions.
 
 ## [Unreleased]
 
+### Changed
+- Bumped vendored `ruff` (ty) submodule to `18448938c8` and switched
+  the upstream URL to the `lpetre/ruff` fork. Picks up 159 ty commits
+  including a search-path cache keyed by top-level module-name
+  component, plus a long tail of upstream ty resolution fixes
+  (enum/class-decorator handling, TypedDict union fallbacks,
+  fall-through narrowing, cycle-recovery panics).
+
 ### Fixed
 - `Analysis(..., venv=...)` no longer drops `project_root` from ty's
   static search paths when a venv is given. The previous suppression

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,11 +2223,13 @@ name = "ty_project"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bitvec",
  "camino",
  "colored",
  "crossbeam",
  "get-size2",
  "globset",
+ "ignore",
  "notify",
  "ordermap",
  "pep440_rs",

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,12 +3,12 @@
 //! plugin-facing graph ops (`AddNode`/`AddEdge`/`AddEntrypoint`), the
 //! generic BFS walker, and the `apply_graph_op` apply pass.
 
-use std::collections::{HashMap, HashSet};
 use std::sync::OnceLock;
 
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use ruff_db::files::File;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::graph::{intern_kind, SymbolNode};
 use crate::helpers::NODE_FLAG_ENTRYPOINT;
@@ -32,9 +32,9 @@ pub(crate) struct NodeKey {
 
 pub(crate) struct GraphBuilder {
     pub(crate) nodes: Vec<Py<SymbolNode>>,
-    pub(crate) node_index: HashMap<NodeKey, usize>,
+    pub(crate) node_index: FxHashMap<NodeKey, usize>,
     pub(crate) edges: Vec<(usize, usize, u32)>,
-    pub(crate) edge_set: HashSet<(usize, usize, u32)>,
+    pub(crate) edge_set: FxHashSet<(usize, usize, u32)>,
     /// Per-node forward / reverse adjacency lists kept in sync with
     /// ``edges``. ``bfs`` reads these so traversals are O(deg(i)) per
     /// pop instead of O(|edges|).
@@ -56,27 +56,27 @@ pub(crate) struct GraphBuilder {
     ///   stub-only ``.pyi`` (no .py twin -> flagged ``ENTRYPOINT``
     ///   so native-extension / protobuf-style stubs stay alive
     ///   artificially even when no consumer references them).
-    pub(crate) peer_pyi_to_py: HashMap<File, File>,
+    pub(crate) peer_pyi_to_py: FxHashMap<File, File>,
     /// `{ synthetic_fqname -> node idx }` for ``[external dist] X`` and
     /// ``[unresolved] X`` synthetics. Synthetics are deduplicated by
     /// fqname project-wide: every site that imports ``rustworkx``
     /// resolves to the same ``[external dist] rustworkx`` node, so
     /// reachability and the codemod's "this import has no
     /// dependents" query both work on a single anchor.
-    pub(crate) synthetic_nodes: HashMap<String, usize>,
+    pub(crate) synthetic_nodes: FxHashMap<String, usize>,
 }
 
 impl GraphBuilder {
     pub(crate) fn new() -> Self {
         Self {
             nodes: Vec::new(),
-            node_index: HashMap::new(),
+            node_index: FxHashMap::default(),
             edges: Vec::new(),
-            edge_set: HashSet::new(),
+            edge_set: FxHashSet::default(),
             forward_adj: Vec::new(),
             reverse_adj: Vec::new(),
-            peer_pyi_to_py: HashMap::new(),
-            synthetic_nodes: HashMap::new(),
+            peer_pyi_to_py: FxHashMap::default(),
+            synthetic_nodes: FxHashMap::default(),
         }
     }
 
@@ -251,8 +251,8 @@ pub(crate) fn bfs(
     seeds: impl IntoIterator<Item = usize>,
     direction: Direction,
     skip_flags: u32,
-) -> HashSet<usize> {
-    let mut visited: HashSet<usize> = HashSet::new();
+) -> FxHashSet<usize> {
+    let mut visited: FxHashSet<usize> = FxHashSet::default();
     let mut stack: Vec<usize> = seeds.into_iter().collect();
     while let Some(i) = stack.pop() {
         if !visited.insert(i) {
@@ -535,7 +535,7 @@ mod tests {
         add_edge_manual(&mut b, 1, 2, 0);
         add_edge_manual(&mut b, 0, 3, 0);
         let reachable = bfs(&b, [0], Direction::Forward, 0);
-        let expected: HashSet<usize> = [0, 1, 2, 3].into_iter().collect();
+        let expected: FxHashSet<usize> = [0, 1, 2, 3].into_iter().collect();
         assert_eq!(reachable, expected);
     }
 
@@ -546,7 +546,7 @@ mod tests {
         add_edge_manual(&mut b, 1, 2, 0);
         add_edge_manual(&mut b, 3, 2, 0);
         let ancestors = bfs(&b, [2], Direction::Reverse, 0);
-        let expected: HashSet<usize> = [0, 1, 2, 3].into_iter().collect();
+        let expected: FxHashSet<usize> = [0, 1, 2, 3].into_iter().collect();
         assert_eq!(ancestors, expected);
     }
 
@@ -558,12 +558,12 @@ mod tests {
         add_edge_manual(&mut b, 0, 2, 0);
         // With skip_flags = 1, the 0 -> 1 edge is filtered out.
         let reachable = bfs(&b, [0], Direction::Forward, 1);
-        let expected: HashSet<usize> = [0, 2].into_iter().collect();
+        let expected: FxHashSet<usize> = [0, 2].into_iter().collect();
         assert_eq!(reachable, expected);
 
         // skip_flags = 0 keeps every edge.
         let reachable_all = bfs(&b, [0], Direction::Forward, 0);
-        let expected_all: HashSet<usize> = [0, 1, 2].into_iter().collect();
+        let expected_all: FxHashSet<usize> = [0, 1, 2].into_iter().collect();
         assert_eq!(reachable_all, expected_all);
     }
 
@@ -576,13 +576,13 @@ mod tests {
             let r = bfs(&b, [0], Direction::Forward, mask);
             assert_eq!(
                 r,
-                [0].into_iter().collect::<HashSet<_>>(),
+                [0].into_iter().collect::<FxHashSet<_>>(),
                 "skip_flags=0b{mask:b} should drop the edge"
             );
         }
         // mask=0b100 doesn't intersect — edge survives.
         let r = bfs(&b, [0], Direction::Forward, 0b100);
-        assert_eq!(r, [0, 1].into_iter().collect::<HashSet<_>>());
+        assert_eq!(r, [0, 1].into_iter().collect::<FxHashSet<_>>());
     }
 
     #[test]
@@ -592,7 +592,7 @@ mod tests {
         add_edge_manual(&mut b, 1, 2, 0);
         add_edge_manual(&mut b, 2, 0, 0);
         let reachable = bfs(&b, [0], Direction::Forward, 0);
-        let expected: HashSet<usize> = [0, 1, 2].into_iter().collect();
+        let expected: FxHashSet<usize> = [0, 1, 2].into_iter().collect();
         assert_eq!(reachable, expected);
     }
 
@@ -607,7 +607,7 @@ mod tests {
     fn bfs_isolated_seed_returns_just_itself() {
         let b = empty_builder_with_n_slots(3);
         let r = bfs(&b, [2], Direction::Forward, 0);
-        assert_eq!(r, [2].into_iter().collect::<HashSet<_>>());
+        assert_eq!(r, [2].into_iter().collect::<FxHashSet<_>>());
     }
 
     #[test]
@@ -616,7 +616,7 @@ mod tests {
         add_edge_manual(&mut b, 0, 1, 0);
         add_edge_manual(&mut b, 2, 3, 0);
         let r = bfs(&b, [0, 2], Direction::Forward, 0);
-        let expected: HashSet<usize> = [0, 1, 2, 3].into_iter().collect();
+        let expected: FxHashSet<usize> = [0, 1, 2, 3].into_iter().collect();
         assert_eq!(r, expected);
     }
 
@@ -635,7 +635,7 @@ mod tests {
         add_edge_manual(&mut b, 0, 2, 1);
         add_edge_manual(&mut b, 1, 2, 0);
         let r = bfs(&b, [2], Direction::Reverse, 1);
-        let expected: HashSet<usize> = [1, 2].into_iter().collect();
+        let expected: FxHashSet<usize> = [1, 2].into_iter().collect();
         assert_eq!(r, expected);
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -5,13 +5,13 @@
 //! See `src/CLAUDE.md` for the architectural rules these types follow.
 
 use std::collections::hash_map::DefaultHasher;
-use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::OnceLock;
 
 use pyo3::prelude::*;
 use pyo3::types::PyAnyMethods;
 use ruff_db::files::File;
+use rustc_hash::FxHashMap;
 use ty_python_core::place::ScopedPlaceId;
 
 /// Raw record of one cross-file import reference, attached to a
@@ -252,7 +252,7 @@ impl NativeGraph {
 /// distinct target ranges.
 pub(crate) type DeclKey = (File, ScopedPlaceId, (u32, u32));
 
-pub(crate) type DeclIndex = HashMap<DeclKey, usize>;
+pub(crate) type DeclIndex = FxHashMap<DeclKey, usize>;
 
 /// Return type of `ProjectContext.find_main_blocks`: one entry per
 /// file with a top-level ``if __name__ == "__main__":`` block, paired

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -6,7 +6,6 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use ruff_db::files::{File, FilePath};
-use rustc_hash::{FxHashMap, FxHashSet};
 use ruff_db::parsed::{parsed_module, ParsedModuleRef};
 use ruff_db::source::{line_index, source_text};
 use ruff_db::system::SystemPath;
@@ -15,6 +14,7 @@ use ruff_python_ast::visitor::{walk_expr, Visitor};
 use ruff_python_ast::{Expr, Stmt, StmtClassDef};
 use ruff_source_file::LineIndex;
 use ruff_text_size::{Ranged, TextRange};
+use rustc_hash::{FxHashMap, FxHashSet};
 use ty_module_resolver::Module;
 use ty_module_resolver::{
     file_to_module, resolve_module, search_paths, ModuleName, ModuleResolveMode,
@@ -1506,7 +1506,10 @@ pub(crate) fn collect_scope_bindings<'a>(
 
 /// Scan `expr` for walrus (`:=`) targets that bind names in the
 /// enclosing scope.
-pub(crate) fn collect_walrus_in_expr<'a>(expr: &'a Expr, out: &mut FxHashMap<String, Vec<&'a Expr>>) {
+pub(crate) fn collect_walrus_in_expr<'a>(
+    expr: &'a Expr,
+    out: &mut FxHashMap<String, Vec<&'a Expr>>,
+) {
     match expr {
         Expr::Named(named) => {
             if let Expr::Name(target) = &*named.target {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -3,11 +3,10 @@
 //! dead-region detection, noqa scanning, position/file helpers, and the
 //! shared `NodeFlags`/`EdgeFlags` constant aliases.
 
-use std::collections::{HashMap, HashSet};
-
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use ruff_db::files::{File, FilePath};
+use rustc_hash::{FxHashMap, FxHashSet};
 use ruff_db::parsed::{parsed_module, ParsedModuleRef};
 use ruff_db::source::{line_index, source_text};
 use ruff_db::system::SystemPath;
@@ -62,8 +61,8 @@ pub(crate) fn class_body_defines_method(class_def: &StmtClassDef, method_name: &
 ///   (covers ``import module`` and ``import module as alias``).
 pub(crate) fn decorators_match_imports<'ast>(
     decorators: &'ast [ruff_python_ast::Decorator],
-    imports: &HashMap<String, String>,
-    names: &HashSet<&str>,
+    imports: &FxHashMap<String, String>,
+    names: &FxHashSet<&str>,
 ) -> Option<Option<&'ast ruff_python_ast::ExprCall>> {
     for dec in decorators {
         let (root_expr, call_form) = match &dec.expression {
@@ -114,7 +113,7 @@ pub(crate) fn iter_top_level_classes(
 /// two top-level classes can't share a source line.
 pub(crate) fn locate_class_def(
     db: &ProjectDatabase,
-    path_to_file: &HashMap<String, File>,
+    path_to_file: &FxHashMap<String, File>,
     path: &str,
     class_node: &SymbolNode,
 ) -> Option<(File, TextRange)> {
@@ -220,8 +219,8 @@ pub(crate) fn find_subclass_indices_via_refs(
     seed_name_range: TextRange,
     transitive: bool,
 ) -> Vec<usize> {
-    let mut out_idx: HashSet<usize> = HashSet::new();
-    let mut visited_seeds: HashSet<(File, (u32, u32))> = HashSet::new();
+    let mut out_idx: FxHashSet<usize> = FxHashSet::default();
+    let mut visited_seeds: FxHashSet<(File, (u32, u32))> = FxHashSet::default();
     let mut queue: Vec<(File, TextRange)> = vec![(seed_file, seed_name_range)];
 
     while let Some((cur_file, cur_range)) = queue.pop() {
@@ -304,7 +303,7 @@ pub(crate) fn locate_class_seed(
     let anchor = *outputs.project_files.first()?;
     let module = resolve_module(db, anchor, &module_name)?;
     let module_file = module.file(db)?;
-    let mut visited: HashSet<File> = HashSet::new();
+    let mut visited: FxHashSet<File> = FxHashSet::default();
     follow_class_through_module(db, module_file, class_name, &mut visited)
 }
 
@@ -318,7 +317,7 @@ pub(crate) fn follow_class_through_module(
     db: &ProjectDatabase,
     start_file: File,
     class_name: &str,
-    visited: &mut HashSet<File>,
+    visited: &mut FxHashSet<File>,
 ) -> Option<(File, TextRange)> {
     if !visited.insert(start_file) {
         return None;
@@ -428,8 +427,8 @@ pub(crate) fn is_string_literal(expr: &Expr, value: &str) -> bool {
 /// * ``import foo.bar`` → ``"foo" -> "foo"`` (Python binds the
 ///   leftmost segment; the runtime module ``foo`` is what the name
 ///   resolves to).
-pub(crate) fn collect_all_imports_local(parsed: &ParsedModuleRef) -> HashMap<String, String> {
-    let mut out: HashMap<String, String> = HashMap::new();
+pub(crate) fn collect_all_imports_local(parsed: &ParsedModuleRef) -> FxHashMap<String, String> {
+    let mut out: FxHashMap<String, String> = FxHashMap::default();
     for stmt in &parsed.syntax().body {
         match stmt {
             Stmt::ImportFrom(im) => {
@@ -479,13 +478,13 @@ pub(crate) fn collect_all_imports_local(parsed: &ParsedModuleRef) -> HashMap<Str
 pub(crate) fn collect_module_imports_local(
     parsed: &ParsedModuleRef,
     module: &str,
-    allowed: &HashSet<&str>,
-) -> HashMap<String, String> {
+    allowed: &FxHashSet<&str>,
+) -> FxHashMap<String, String> {
     // Submodule binding: ``from <parent> import <last_seg>`` makes
     // ``last_seg`` a local alias for the queried module (e.g.
     // ``from unittest import mock`` for module ``unittest.mock``).
     let parent_last = module.rsplit_once('.');
-    let mut out = HashMap::new();
+    let mut out = FxHashMap::default();
     for stmt in &parsed.syntax().body {
         match stmt {
             Stmt::ImportFrom(im) => {
@@ -540,9 +539,9 @@ pub(crate) fn collect_module_imports_local(
 /// Returns the matched upstream name (``"Flask"``) on hit, else ``None``.
 pub(crate) fn matched_call_target(
     call: &ruff_python_ast::ExprCall,
-    imports: &HashMap<String, String>,
+    imports: &FxHashMap<String, String>,
     module: &str,
-    allowed: &HashSet<&str>,
+    allowed: &FxHashSet<&str>,
 ) -> Option<String> {
     match call.func.as_ref() {
         Expr::Name(name) => {
@@ -602,10 +601,10 @@ pub(crate) fn top_level_assign_to_name(stmt: &Stmt) -> Option<(TextRange, &Expr)
 /// Recursive visitor: walk a function / class body collecting the set
 /// of constructor names called anywhere inside it.
 pub(crate) struct FactoryCallFinder<'a> {
-    pub(crate) imports: &'a HashMap<String, String>,
+    pub(crate) imports: &'a FxHashMap<String, String>,
     pub(crate) module: &'a str,
-    pub(crate) allowed: &'a HashSet<&'a str>,
-    pub(crate) kinds: HashSet<String>,
+    pub(crate) allowed: &'a FxHashSet<&'a str>,
+    pub(crate) kinds: FxHashSet<String>,
 }
 
 impl<'ast, 'a> Visitor<'ast> for FactoryCallFinder<'a> {
@@ -629,8 +628,8 @@ impl<'ast, 'a> Visitor<'ast> for FactoryCallFinder<'a> {
 /// ``!Sync`` — these maps are ``Sync`` on their own, which lets the
 /// callers borrow them across rayon thread boundaries.
 pub(crate) fn owner_idx_for_stmt_with(
-    decl_by_name_range: &HashMap<(File, (u32, u32)), usize>,
-    module_nodes_by_file: &HashMap<File, usize>,
+    decl_by_name_range: &FxHashMap<(File, (u32, u32)), usize>,
+    module_nodes_by_file: &FxHashMap<File, usize>,
     file: File,
     stmt: &Stmt,
 ) -> Option<usize> {
@@ -688,7 +687,7 @@ pub(crate) enum ArgValue {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct CallArgs {
     pub(crate) args: Vec<ArgValue>,
-    pub(crate) kwargs: HashMap<String, ArgValue>,
+    pub(crate) kwargs: FxHashMap<String, ArgValue>,
 }
 
 /// Resolve a dotted Name / Attribute chain to a project decl index
@@ -700,8 +699,8 @@ pub(crate) struct CallArgs {
 pub(crate) fn resolve_dotted_name_to_decl(
     root: &str,
     segs: &[&str],
-    file_imports: &HashMap<String, String>,
-    decl_by_fqname: &HashMap<String, Vec<usize>>,
+    file_imports: &FxHashMap<String, String>,
+    decl_by_fqname: &FxHashMap<String, Vec<usize>>,
 ) -> Option<usize> {
     let upstream = file_imports.get(root)?;
     let mut fqn =
@@ -718,8 +717,8 @@ pub(crate) fn resolve_dotted_name_to_decl(
 /// Convert one AST argument expression to an ``ArgValue``.
 pub(crate) fn extract_arg_value(
     expr: &Expr,
-    file_imports: &HashMap<String, String>,
-    decl_by_fqname: &HashMap<String, Vec<usize>>,
+    file_imports: &FxHashMap<String, String>,
+    decl_by_fqname: &FxHashMap<String, Vec<usize>>,
 ) -> ArgValue {
     match expr {
         Expr::NoneLiteral(_) => ArgValue::None,
@@ -774,8 +773,8 @@ pub(crate) fn extract_arg_value(
 /// Extract positional + keyword arguments from a call.
 pub(crate) fn extract_call_args_kwargs(
     call: &ruff_python_ast::ExprCall,
-    file_imports: &HashMap<String, String>,
-    decl_by_fqname: &HashMap<String, Vec<usize>>,
+    file_imports: &FxHashMap<String, String>,
+    decl_by_fqname: &FxHashMap<String, Vec<usize>>,
 ) -> CallArgs {
     let args: Vec<ArgValue> = call
         .arguments
@@ -783,7 +782,7 @@ pub(crate) fn extract_call_args_kwargs(
         .iter()
         .map(|a| extract_arg_value(a, file_imports, decl_by_fqname))
         .collect();
-    let mut kwargs: HashMap<String, ArgValue> = HashMap::new();
+    let mut kwargs: FxHashMap<String, ArgValue> = FxHashMap::default();
     for kw in &call.arguments.keywords {
         let Some(name) = kw.arg.as_ref() else {
             continue;
@@ -837,12 +836,12 @@ pub(crate) fn args_to_py_vec(
     args.iter().map(|v| arg_value_to_py(py, v, nodes)).collect()
 }
 
-/// Convert a kwargs map to ``HashMap<String, Py<PyAny>>``.
+/// Convert a kwargs map to ``FxHashMap<String, Py<PyAny>>``.
 pub(crate) fn kwargs_to_py_map(
     py: Python<'_>,
-    kwargs: &HashMap<String, ArgValue>,
+    kwargs: &FxHashMap<String, ArgValue>,
     nodes: &[Py<SymbolNode>],
-) -> HashMap<String, Py<PyAny>> {
+) -> FxHashMap<String, Py<PyAny>> {
     kwargs
         .iter()
         .map(|(k, v)| (k.clone(), arg_value_to_py(py, v, nodes)))
@@ -1004,8 +1003,8 @@ where
 {
     pub(crate) predicate: F,
     pub(crate) arg_index: usize,
-    pub(crate) file_imports: &'a HashMap<String, String>,
-    pub(crate) decl_by_fqname: &'a HashMap<String, Vec<usize>>,
+    pub(crate) file_imports: &'a FxHashMap<String, String>,
+    pub(crate) decl_by_fqname: &'a FxHashMap<String, Vec<usize>>,
     pub(crate) results: Vec<(String, CallArgs)>,
 }
 
@@ -1038,8 +1037,8 @@ where
 pub(crate) struct AttrCallFinder<'a> {
     pub(crate) attr: &'a str,
     pub(crate) arg_index: usize,
-    pub(crate) file_imports: &'a HashMap<String, String>,
-    pub(crate) decl_by_fqname: &'a HashMap<String, Vec<usize>>,
+    pub(crate) file_imports: &'a FxHashMap<String, String>,
+    pub(crate) decl_by_fqname: &'a FxHashMap<String, Vec<usize>>,
     pub(crate) results: Vec<(String, CallArgs)>,
 }
 
@@ -1144,11 +1143,11 @@ pub(crate) const EDGE_FLAG_DYNAMIC_IMPORT: u32 = EdgeFlags::DYNAMIC_IMPORT;
 /// `build_scope_table` from the scope's literal assignments,
 /// annotated assignments, and walrus expressions. Function and class
 /// bodies inherit and override their enclosing scope's table.
-pub(crate) type NameTable = HashMap<String, bool>;
+pub(crate) type NameTable = FxHashMap<String, bool>;
 
 pub(crate) fn detect_dead_ranges(parsed: &ParsedModuleRef) -> Vec<TextRange> {
     let mut dead = Vec::new();
-    let empty: NameTable = HashMap::new();
+    let empty: NameTable = FxHashMap::default();
     let module_table = build_scope_table(&parsed.syntax().body, &empty);
     walk_suite_for_dead(&parsed.syntax().body, &module_table, &mut dead);
     dead
@@ -1408,10 +1407,10 @@ pub(crate) fn evaluate_truthiness(expr: &Expr, table: &NameTable) -> Option<bool
 /// refuse to re-fold it for the rest of this scope.
 pub(crate) fn build_scope_table(stmts: &[Stmt], enclosing: &NameTable) -> NameTable {
     let mut table = enclosing.clone();
-    let mut bindings: HashMap<String, Vec<&Expr>> = HashMap::new();
+    let mut bindings: FxHashMap<String, Vec<&Expr>> = FxHashMap::default();
     collect_scope_bindings(stmts, &mut bindings);
 
-    let mut poisoned: HashSet<String> = HashSet::new();
+    let mut poisoned: FxHashSet<String> = FxHashSet::default();
     let mut changed = true;
     while changed {
         changed = false;
@@ -1460,7 +1459,7 @@ pub(crate) fn build_scope_table(stmts: &[Stmt], enclosing: &NameTable) -> NameTa
 /// scopes with their own tables.
 pub(crate) fn collect_scope_bindings<'a>(
     stmts: &'a [Stmt],
-    out: &mut HashMap<String, Vec<&'a Expr>>,
+    out: &mut FxHashMap<String, Vec<&'a Expr>>,
 ) {
     for stmt in stmts {
         match stmt {
@@ -1507,7 +1506,7 @@ pub(crate) fn collect_scope_bindings<'a>(
 
 /// Scan `expr` for walrus (`:=`) targets that bind names in the
 /// enclosing scope.
-pub(crate) fn collect_walrus_in_expr<'a>(expr: &'a Expr, out: &mut HashMap<String, Vec<&'a Expr>>) {
+pub(crate) fn collect_walrus_in_expr<'a>(expr: &'a Expr, out: &mut FxHashMap<String, Vec<&'a Expr>>) {
     match expr {
         Expr::Named(named) => {
             if let Expr::Name(target) = &*named.target {
@@ -1629,9 +1628,9 @@ pub(crate) fn scan_noqa_directives(
     parsed: &ParsedModuleRef,
     source: &str,
     line_index: &LineIndex,
-) -> (bool, HashSet<usize>) {
+) -> (bool, FxHashSet<usize>) {
     let mut file_pinned = false;
-    let mut per_line_pins: HashSet<usize> = HashSet::new();
+    let mut per_line_pins: FxHashSet<usize> = FxHashSet::default();
     for token in parsed.tokens().iter() {
         if token.kind() != TokenKind::Comment {
             continue;
@@ -2196,7 +2195,7 @@ mod tests {
 
     #[test]
     fn evaluate_truthiness_literals() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         assert_eq!(evaluate_truthiness(&parse_expr("True"), &empty), Some(true));
         assert_eq!(
             evaluate_truthiness(&parse_expr("False"), &empty),
@@ -2226,7 +2225,7 @@ mod tests {
 
     #[test]
     fn evaluate_truthiness_names_via_table() {
-        let mut table: NameTable = HashMap::new();
+        let mut table: NameTable = FxHashMap::default();
         table.insert("DEBUG".into(), true);
         table.insert("RELEASE".into(), false);
         assert_eq!(
@@ -2242,7 +2241,7 @@ mod tests {
 
     #[test]
     fn evaluate_truthiness_unary_not() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         assert_eq!(
             evaluate_truthiness(&parse_expr("not True"), &empty),
             Some(false)
@@ -2261,7 +2260,7 @@ mod tests {
 
     #[test]
     fn evaluate_truthiness_bool_ops_short_circuit_or() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         assert_eq!(
             evaluate_truthiness(&parse_expr("True or unknown"), &empty),
             Some(true)
@@ -2278,7 +2277,7 @@ mod tests {
 
     #[test]
     fn evaluate_truthiness_bool_ops_short_circuit_and() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         assert_eq!(
             evaluate_truthiness(&parse_expr("False and unknown"), &empty),
             Some(false)
@@ -2295,7 +2294,7 @@ mod tests {
 
     #[test]
     fn evaluate_truthiness_returns_none_for_unsupported() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         assert_eq!(evaluate_truthiness(&parse_expr("f()"), &empty), None);
         assert_eq!(evaluate_truthiness(&parse_expr("a.b"), &empty), None);
         assert_eq!(evaluate_truthiness(&parse_expr("a == b"), &empty), None);
@@ -2303,7 +2302,7 @@ mod tests {
 
     #[test]
     fn evaluate_truthiness_walrus_unwraps_value() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         // ``(x := True)`` should fold to True (the walrus's value).
         assert_eq!(
             evaluate_truthiness(&parse_expr("(x := True)"), &empty),
@@ -2315,7 +2314,7 @@ mod tests {
 
     #[test]
     fn stmt_is_terminator_basic_terminators() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("def f():\n    return 1\n");
         let body = match &stmts[0] {
             Stmt::FunctionDef(f) => &f.body,
@@ -2333,7 +2332,7 @@ mod tests {
 
     #[test]
     fn stmt_is_terminator_break_continue_inside_loop() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("for _ in []:\n    break\n");
         let body = match &stmts[0] {
             Stmt::For(f) => &f.body,
@@ -2351,7 +2350,7 @@ mod tests {
 
     #[test]
     fn stmt_is_terminator_assert_falsy() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         // `assert False` is a terminator; `assert True` is not.
         let stmts = parse_stmts("assert False\n");
         assert!(stmt_is_terminator(&stmts[0], &empty));
@@ -2365,14 +2364,14 @@ mod tests {
 
     #[test]
     fn stmt_is_terminator_if_constant_truthy_body_terminates() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("if True:\n    return\n");
         assert!(stmt_is_terminator(&stmts[0], &empty));
     }
 
     #[test]
     fn stmt_is_terminator_if_without_else_not_terminator() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         // No else clause + a non-constant test means the if might be
         // skipped — not a terminator.
         let stmts = parse_stmts("if cond:\n    return\n");
@@ -2381,21 +2380,21 @@ mod tests {
 
     #[test]
     fn stmt_is_terminator_if_else_both_terminate() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("if cond:\n    return\nelse:\n    raise X\n");
         assert!(stmt_is_terminator(&stmts[0], &empty));
     }
 
     #[test]
     fn stmt_is_terminator_if_else_one_falls_through() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("if cond:\n    return\nelse:\n    pass\n");
         assert!(!stmt_is_terminator(&stmts[0], &empty));
     }
 
     #[test]
     fn stmt_is_terminator_try_finally_terminates() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts =
             parse_stmts("try:\n    x = 1\nexcept Exception:\n    pass\nfinally:\n    return\n");
         assert!(stmt_is_terminator(&stmts[0], &empty));
@@ -2403,21 +2402,21 @@ mod tests {
 
     #[test]
     fn stmt_is_terminator_try_body_and_all_handlers_terminate() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("try:\n    return\nexcept Exception:\n    raise\n");
         assert!(stmt_is_terminator(&stmts[0], &empty));
     }
 
     #[test]
     fn stmt_is_terminator_try_handler_falls_through_not_terminator() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("try:\n    return\nexcept Exception:\n    pass\n");
         assert!(!stmt_is_terminator(&stmts[0], &empty));
     }
 
     #[test]
     fn stmt_is_terminator_with_body_terminates() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("with cm as c:\n    return\n");
         assert!(stmt_is_terminator(&stmts[0], &empty));
         let stmts = parse_stmts("with cm as c:\n    pass\n");
@@ -2426,14 +2425,14 @@ mod tests {
 
     #[test]
     fn stmt_is_terminator_pass_is_not() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("pass\n");
         assert!(!stmt_is_terminator(&stmts[0], &empty));
     }
 
     #[test]
     fn suite_terminates_finds_any_terminator() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("def f():\n    x = 1\n    return 2\n    y = 3\n");
         let body = match &stmts[0] {
             Stmt::FunctionDef(f) => &f.body,
@@ -2453,7 +2452,7 @@ mod tests {
 
     #[test]
     fn walk_suite_for_dead_marks_post_terminator_statements() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("def f():\n    return 1\n    x = 2\n    y = 3\n");
         let body = match &stmts[0] {
             Stmt::FunctionDef(f) => f.body.clone(),
@@ -2467,7 +2466,7 @@ mod tests {
 
     #[test]
     fn walk_suite_for_dead_handles_if_false() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("if False:\n    x = 1\n    y = 2\n");
         let mut dead = Vec::new();
         walk_suite_for_dead(&stmts, &empty, &mut dead);
@@ -2477,7 +2476,7 @@ mod tests {
 
     #[test]
     fn walk_suite_for_dead_handles_if_true_drops_else() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("if True:\n    x = 1\nelse:\n    y = 2\n");
         let mut dead = Vec::new();
         walk_suite_for_dead(&stmts, &empty, &mut dead);
@@ -2487,7 +2486,7 @@ mod tests {
 
     #[test]
     fn walk_suite_for_dead_recurses_into_function_body() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("def outer():\n    return\n    nested = 1\n");
         let mut dead = Vec::new();
         walk_suite_for_dead(&stmts, &empty, &mut dead);
@@ -2496,7 +2495,7 @@ mod tests {
 
     #[test]
     fn walk_suite_for_dead_empty_input_yields_nothing() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let mut dead = Vec::new();
         walk_suite_for_dead(&[], &empty, &mut dead);
         assert!(dead.is_empty());
@@ -2506,7 +2505,7 @@ mod tests {
 
     #[test]
     fn build_scope_table_folds_simple_constant() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("DEBUG = True\nX = False\n");
         let table = build_scope_table(&stmts, &empty);
         assert_eq!(table.get("DEBUG"), Some(&true));
@@ -2515,7 +2514,7 @@ mod tests {
 
     #[test]
     fn build_scope_table_handles_chained_constants() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("A = False\nB = A or False\nC = B\n");
         let table = build_scope_table(&stmts, &empty);
         assert_eq!(table.get("A"), Some(&false));
@@ -2525,7 +2524,7 @@ mod tests {
 
     #[test]
     fn build_scope_table_drops_conflicting_bindings() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("X = True\nX = False\n");
         let table = build_scope_table(&stmts, &empty);
         assert!(!table.contains_key("X"));
@@ -2533,7 +2532,7 @@ mod tests {
 
     #[test]
     fn build_scope_table_inherits_enclosing_table() {
-        let mut enclosing: NameTable = HashMap::new();
+        let mut enclosing: NameTable = FxHashMap::default();
         enclosing.insert("OUTER".into(), true);
         let stmts = parse_stmts("INNER = False\n");
         let table = build_scope_table(&stmts, &enclosing);
@@ -2546,7 +2545,7 @@ mod tests {
         // Inheriting ``foo`` from the enclosing scope and then evaluating
         // ``foo = not foo`` would oscillate the table between true/false
         // forever before the poison set was added.
-        let mut enclosing: NameTable = HashMap::new();
+        let mut enclosing: NameTable = FxHashMap::default();
         enclosing.insert("foo".into(), false);
         let stmts = parse_stmts("foo = not foo\n");
         let table = build_scope_table(&stmts, &enclosing);
@@ -2563,7 +2562,7 @@ mod tests {
             "foo = False\ndef flip():\n    global foo\n    foo = not foo\n",
         )
         .unwrap();
-        let mut bindings: HashMap<String, Vec<&Expr>> = HashMap::new();
+        let mut bindings: FxHashMap<String, Vec<&Expr>> = FxHashMap::default();
         let body = parsed.syntax().body.clone();
         collect_scope_bindings(&body, &mut bindings);
         // Sanity: module sees ``foo = False`` only, not the in-function rebind.
@@ -2571,7 +2570,7 @@ mod tests {
 
         // The inner ``flip`` body inherits ``foo = false``; building its
         // table must terminate and drop ``foo`` rather than fold it.
-        let mut enclosing: NameTable = HashMap::new();
+        let mut enclosing: NameTable = FxHashMap::default();
         enclosing.insert("foo".into(), false);
         if let Stmt::FunctionDef(f) = &body[1] {
             let nested = build_scope_table(&f.body, &enclosing);
@@ -2583,7 +2582,7 @@ mod tests {
 
     #[test]
     fn build_scope_table_ignores_nested_function_bindings() {
-        let empty: NameTable = HashMap::new();
+        let empty: NameTable = FxHashMap::default();
         let stmts = parse_stmts("def f():\n    X = True\n");
         let table = build_scope_table(&stmts, &empty);
         // ``X`` is defined inside ``f`` — separate scope.
@@ -2595,7 +2594,7 @@ mod tests {
     #[test]
     fn collect_walrus_in_expr_picks_up_assignment_target() {
         let expr = parse_expr("(x := 5)");
-        let mut out: HashMap<String, Vec<&Expr>> = HashMap::new();
+        let mut out: FxHashMap<String, Vec<&Expr>> = FxHashMap::default();
         collect_walrus_in_expr(&expr, &mut out);
         assert!(out.contains_key("x"));
     }
@@ -2603,7 +2602,7 @@ mod tests {
     #[test]
     fn collect_walrus_in_expr_descends_compound_exprs() {
         let expr = parse_expr("(a := 1) or (b := 2) and (c := 3)");
-        let mut out: HashMap<String, Vec<&Expr>> = HashMap::new();
+        let mut out: FxHashMap<String, Vec<&Expr>> = FxHashMap::default();
         collect_walrus_in_expr(&expr, &mut out);
         assert!(out.contains_key("a"));
         assert!(out.contains_key("b"));
@@ -2613,7 +2612,7 @@ mod tests {
     #[test]
     fn collect_walrus_in_expr_no_walrus_yields_empty() {
         let expr = parse_expr("a + b");
-        let mut out: HashMap<String, Vec<&Expr>> = HashMap::new();
+        let mut out: FxHashMap<String, Vec<&Expr>> = FxHashMap::default();
         collect_walrus_in_expr(&expr, &mut out);
         assert!(out.is_empty());
     }
@@ -2702,9 +2701,9 @@ mod tests {
             Stmt::FunctionDef(f) => &f.decorator_list,
             _ => unreachable!(),
         };
-        let mut imports: HashMap<String, String> = HashMap::new();
+        let mut imports: FxHashMap<String, String> = FxHashMap::default();
         imports.insert("register".into(), "register".into());
-        let mut allowed: HashSet<&str> = HashSet::new();
+        let mut allowed: FxHashSet<&str> = FxHashSet::default();
         allowed.insert("register");
         let got = decorators_match_imports(decorators, &imports, &allowed);
         assert!(got.is_some());
@@ -2717,9 +2716,9 @@ mod tests {
             Stmt::FunctionDef(f) => &f.decorator_list,
             _ => unreachable!(),
         };
-        let mut imports: HashMap<String, String> = HashMap::new();
+        let mut imports: FxHashMap<String, String> = FxHashMap::default();
         imports.insert("flask".into(), MODULE_ALIAS_MARKER.into());
-        let mut allowed: HashSet<&str> = HashSet::new();
+        let mut allowed: FxHashSet<&str> = FxHashSet::default();
         allowed.insert("route");
         let got = decorators_match_imports(decorators, &imports, &allowed);
         // Has a call form.
@@ -2733,9 +2732,9 @@ mod tests {
             Stmt::FunctionDef(f) => &f.decorator_list,
             _ => unreachable!(),
         };
-        let mut imports: HashMap<String, String> = HashMap::new();
+        let mut imports: FxHashMap<String, String> = FxHashMap::default();
         imports.insert("app".into(), MODULE_ALIAS_MARKER.into());
-        let mut allowed: HashSet<&str> = HashSet::new();
+        let mut allowed: FxHashSet<&str> = FxHashSet::default();
         allowed.insert("task");
         let got = decorators_match_imports(decorators, &imports, &allowed);
         // Bare (no call) — outer Some, inner None.
@@ -2749,8 +2748,8 @@ mod tests {
             Stmt::FunctionDef(f) => &f.decorator_list,
             _ => unreachable!(),
         };
-        let imports: HashMap<String, String> = HashMap::new();
-        let allowed: HashSet<&str> = HashSet::new();
+        let imports: FxHashMap<String, String> = FxHashMap::default();
+        let allowed: FxHashSet<&str> = FxHashSet::default();
         assert!(decorators_match_imports(decorators, &imports, &allowed).is_none());
     }
 
@@ -2759,9 +2758,9 @@ mod tests {
     #[test]
     fn matched_call_target_via_local_name() {
         let call = first_call("Flask(__name__)");
-        let mut imports: HashMap<String, String> = HashMap::new();
+        let mut imports: FxHashMap<String, String> = FxHashMap::default();
         imports.insert("Flask".into(), "Flask".into());
-        let mut allowed: HashSet<&str> = HashSet::new();
+        let mut allowed: FxHashSet<&str> = FxHashSet::default();
         allowed.insert("Flask");
         assert_eq!(
             matched_call_target(&call, &imports, "flask", &allowed),
@@ -2772,9 +2771,9 @@ mod tests {
     #[test]
     fn matched_call_target_via_module_alias_attr() {
         let call = first_call("flask.Flask(__name__)");
-        let mut imports: HashMap<String, String> = HashMap::new();
+        let mut imports: FxHashMap<String, String> = FxHashMap::default();
         imports.insert("flask".into(), MODULE_ALIAS_MARKER.into());
-        let mut allowed: HashSet<&str> = HashSet::new();
+        let mut allowed: FxHashSet<&str> = FxHashSet::default();
         allowed.insert("Flask");
         assert_eq!(
             matched_call_target(&call, &imports, "flask", &allowed),
@@ -2787,8 +2786,8 @@ mod tests {
         let call = first_call("unittest.mock.patch('x')");
         // No file imports entry for the leftmost name — fallback to the
         // literal dotted match against ``module``.
-        let imports: HashMap<String, String> = HashMap::new();
-        let mut allowed: HashSet<&str> = HashSet::new();
+        let imports: FxHashMap<String, String> = FxHashMap::default();
+        let mut allowed: FxHashSet<&str> = FxHashSet::default();
         allowed.insert("patch");
         assert_eq!(
             matched_call_target(&call, &imports, "unittest.mock", &allowed),
@@ -2799,18 +2798,18 @@ mod tests {
     #[test]
     fn matched_call_target_rejects_unknown_name() {
         let call = first_call("unrelated()");
-        let imports: HashMap<String, String> = HashMap::new();
-        let allowed: HashSet<&str> = HashSet::new();
+        let imports: FxHashMap<String, String> = FxHashMap::default();
+        let allowed: FxHashSet<&str> = FxHashSet::default();
         assert!(matched_call_target(&call, &imports, "x", &allowed).is_none());
     }
 
     #[test]
     fn matched_call_target_rejects_disallowed_name() {
         let call = first_call("Flask()");
-        let mut imports: HashMap<String, String> = HashMap::new();
+        let mut imports: FxHashMap<String, String> = FxHashMap::default();
         imports.insert("Flask".into(), "Flask".into());
         // Empty allowed set: target is present but not allowed.
-        let allowed: HashSet<&str> = HashSet::new();
+        let allowed: FxHashSet<&str> = FxHashSet::default();
         assert!(matched_call_target(&call, &imports, "flask", &allowed).is_none());
     }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -3,7 +3,6 @@
 //! Salsa-backed analysis context that the rest of the crate operates on.
 
 use std::cell::{Ref, RefCell};
-use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
@@ -43,7 +42,7 @@ use crate::query::{
     _compile_path_regex, _contains_any_identifier, _contains_identifier, par_scan_files,
     QueryBuilder,
 };
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::OnceLock as StdOnceLock;
 
 /// A ty-backed analysis project with explicitly-injected configuration.
@@ -98,33 +97,33 @@ pub(crate) struct BuildOutputs {
     pub(crate) global_index: DeclIndex,
     /// `file_path_string(file) -> File` so seed lookups don't have to
     /// linear-scan `project_files`. Populated alongside ingest.
-    pub(crate) path_to_file: HashMap<String, File>,
+    pub(crate) path_to_file: FxHashMap<String, File>,
     /// `(file, class_target_range_key) -> class node idx`. Lets
     /// `find_subclasses_of` map ty's `TypeHierarchyClass.selection_range`
     /// back to a graph node in O(1).
-    pub(crate) class_by_selection: HashMap<(File, (u32, u32)), usize>,
+    pub(crate) class_by_selection: FxHashMap<(File, (u32, u32)), usize>,
     /// `file -> module node idx`. Lets `find_main_blocks` reach the
     /// file's module node without a linear scan over `builder.nodes`.
-    pub(crate) module_nodes_by_file: HashMap<File, usize>,
+    pub(crate) module_nodes_by_file: FxHashMap<File, usize>,
     /// `(file, target_range_key) -> node idx`. Sister of
     /// ``class_by_selection`` but for every top-level decl ingest minted
     /// (function / class / variable / import). Lets ``find_decorated_decls``
     /// and the dispatch-app queries map an AST node's target range to a
     /// graph node in O(1) instead of scanning the full ``global_index``.
-    pub(crate) decl_by_name_range: HashMap<(File, (u32, u32)), usize>,
+    pub(crate) decl_by_name_range: FxHashMap<(File, (u32, u32)), usize>,
     /// `decl_fqname -> [node idx]`. Lets ``find_declarations`` answer
     /// in O(parts) instead of O(parts × all_nodes). Multiple entries
     /// per fqname arise from try/except rebinds and conditional
     /// re-imports.
-    pub(crate) decl_by_fqname: HashMap<String, Vec<usize>>,
+    pub(crate) decl_by_fqname: FxHashMap<String, Vec<usize>>,
     /// `module_fqname -> node idx`. Lets ``find_module`` answer in
     /// O(1) instead of scanning all nodes.
-    pub(crate) module_by_fqname: HashMap<String, usize>,
+    pub(crate) module_by_fqname: FxHashMap<String, usize>,
     /// `Import.module -> [import node idx]`. Lets ``find_imports_of``
     /// answer in O(1) lookup + O(matches) walk instead of scanning all
     /// nodes — and a cheap ``imports_of_exists`` short-circuit for
     /// plugins that just need a per-module presence check.
-    pub(crate) imports_by_module: HashMap<String, Vec<usize>>,
+    pub(crate) imports_by_module: FxHashMap<String, Vec<usize>>,
 }
 
 /// Run the three build phases (ingest → hierarchy+imports → references)
@@ -203,7 +202,8 @@ pub(crate) fn build_project_graph(
 
     let t0 = std::time::Instant::now();
     let project_files: Vec<File> = (&db.project().files(db)).into_iter().collect();
-    let mut path_to_file: HashMap<String, File> = HashMap::with_capacity(project_files.len());
+    let mut path_to_file: FxHashMap<String, File> =
+        FxHashMap::with_capacity_and_hasher(project_files.len(), Default::default());
     for &file in &project_files {
         path_to_file.insert(file_path_string(db, file), file);
     }
@@ -212,7 +212,7 @@ pub(crate) fn build_project_graph(
     // ENTRYPOINT flag fixup (.pyi decls without a runtime twin need
     // ENTRYPOINT so native-extension / protobuf-style stubs stay
     // alive even with no consumer reference).
-    let py_files_by_stem: HashMap<String, File> = project_files
+    let py_files_by_stem: FxHashMap<String, File> = project_files
         .iter()
         .filter_map(|&f| {
             file_path_string(db, f)
@@ -220,7 +220,7 @@ pub(crate) fn build_project_graph(
                 .map(|stem| (stem.to_string(), f))
         })
         .collect();
-    let mut peer_pyi_to_py: HashMap<File, File> = HashMap::new();
+    let mut peer_pyi_to_py: FxHashMap<File, File> = FxHashMap::default();
     for &f in &project_files {
         let path = file_path_string(db, f);
         if let Some(stem) = path.strip_suffix(".pyi") {
@@ -405,9 +405,9 @@ fn current_rss_mb() -> usize {
 struct AssembledGraph {
     builder: GraphBuilder,
     global_index: DeclIndex,
-    module_nodes_by_file: HashMap<File, usize>,
-    class_by_selection: HashMap<(File, (u32, u32)), usize>,
-    decl_by_name_range: HashMap<(File, (u32, u32)), usize>,
+    module_nodes_by_file: FxHashMap<File, usize>,
+    class_by_selection: FxHashMap<(File, (u32, u32)), usize>,
+    decl_by_name_range: FxHashMap<(File, (u32, u32)), usize>,
 }
 
 /// Serial pass that converts the salsa-tracked per-file payloads
@@ -442,13 +442,13 @@ fn assemble_graph<'db>(
     py: Python<'_>,
     db: &'db ProjectDatabase,
     project_files: &[File],
-    peer_pyi_to_py: &HashMap<File, File>,
+    peer_pyi_to_py: &FxHashMap<File, File>,
 ) -> PyResult<AssembledGraph> {
     let mut builder = GraphBuilder::new();
-    let mut global_index: DeclIndex = HashMap::new();
-    let mut module_nodes_by_file: HashMap<File, usize> = HashMap::new();
-    let mut class_by_selection: HashMap<(File, (u32, u32)), usize> = HashMap::new();
-    let mut decl_by_name_range: HashMap<(File, (u32, u32)), usize> = HashMap::new();
+    let mut global_index: DeclIndex = FxHashMap::default();
+    let mut module_nodes_by_file: FxHashMap<File, usize> = FxHashMap::default();
+    let mut class_by_selection: FxHashMap<(File, (u32, u32)), usize> = FxHashMap::default();
+    let mut decl_by_name_range: FxHashMap<(File, (u32, u32)), usize> = FxHashMap::default();
     let mut ref_to_global: FxHashMap<NodeRef<'db>, usize> = FxHashMap::default();
     let mut all_warnings: Vec<String> = Vec::new();
 
@@ -652,13 +652,13 @@ pub(crate) fn build_fqname_indices(
     py: Python<'_>,
     builder: &GraphBuilder,
 ) -> (
-    HashMap<String, Vec<usize>>,
-    HashMap<String, usize>,
-    HashMap<String, Vec<usize>>,
+    FxHashMap<String, Vec<usize>>,
+    FxHashMap<String, usize>,
+    FxHashMap<String, Vec<usize>>,
 ) {
-    let mut decls: HashMap<String, Vec<usize>> = HashMap::new();
-    let mut modules: HashMap<String, usize> = HashMap::new();
-    let mut imports_by_module: HashMap<String, Vec<usize>> = HashMap::new();
+    let mut decls: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+    let mut modules: FxHashMap<String, usize> = FxHashMap::default();
+    let mut imports_by_module: FxHashMap<String, Vec<usize>> = FxHashMap::default();
     for (idx, node_py) in builder.nodes.iter().enumerate() {
         let node = node_py.borrow(py);
         match node.kind {
@@ -715,7 +715,7 @@ pub(crate) struct ProjectContext {
     /// :meth:`decls_matching_name` / :meth:`find_comment_patterns`
     /// repeatedly across files with the same pattern, so caching keeps
     /// us off the regex compiler in the hot path.
-    pub(crate) regex_cache: RefCell<HashMap<String, regex::Regex>>,
+    pub(crate) regex_cache: RefCell<FxHashMap<String, regex::Regex>>,
     /// When true, ``materialize`` and ``build_project_graph`` draw
     /// indicatif progress bars to stderr.
     pub(crate) show_progress: bool,
@@ -759,7 +759,7 @@ impl ProjectContext {
             root: root.to_string(),
             plugins: Vec::new(),
             outputs: RefCell::new(None),
-            regex_cache: RefCell::new(HashMap::new()),
+            regex_cache: RefCell::new(FxHashMap::default()),
             show_progress,
             stack_size: None,
         })
@@ -963,10 +963,8 @@ impl ProjectContext {
                     .map_err(|e| PyValueError::new_err(format!("invalid regex {p:?}: {e}")))
             })
             .collect::<PyResult<_>>()?;
-        let str_set: std::collections::HashSet<&str> =
-            str_specs.iter().map(String::as_str).collect();
-        let abs_set: std::collections::HashSet<&str> =
-            abs_paths.iter().map(String::as_str).collect();
+        let str_set: FxHashSet<&str> = str_specs.iter().map(String::as_str).collect();
+        let abs_set: FxHashSet<&str> = abs_paths.iter().map(String::as_str).collect();
 
         let outputs = self.materialized("find_nodes_matching_specs")?;
         let mut out = Vec::new();
@@ -1493,7 +1491,7 @@ impl ProjectContext {
     ) -> PyResult<Vec<(Py<SymbolNode>, CallArgs)>> {
         let outputs = self.materialized("find_decorated_decls")?;
         let path_re = _compile_path_regex(path_regex)?;
-        let names: HashSet<&str> = decorator_names.iter().map(String::as_str).collect();
+        let names: FxHashSet<&str> = decorator_names.iter().map(String::as_str).collect();
         let needle_strs: Vec<&str> = decorator_names.iter().map(String::as_str).collect();
         let decl_by_name_range = &outputs.decl_by_name_range;
         let decl_by_fqname = &outputs.decl_by_fqname;
@@ -1571,7 +1569,7 @@ impl ProjectContext {
     ) -> PyResult<Vec<(Py<SymbolNode>, String, CallArgs)>> {
         let outputs = self.materialized("find_instance_constructions")?;
         let path_re = _compile_path_regex(path_regex)?;
-        let allowed: HashSet<&str> = ctor_names.iter().map(String::as_str).collect();
+        let allowed: FxHashSet<&str> = ctor_names.iter().map(String::as_str).collect();
         let needle_strs: Vec<&str> = ctor_names.iter().map(String::as_str).collect();
         let decl_by_name_range = &outputs.decl_by_name_range;
         let decl_by_fqname = &outputs.decl_by_fqname;
@@ -1638,7 +1636,7 @@ impl ProjectContext {
     ) -> PyResult<Vec<(String, Py<SymbolNode>, CallArgs)>> {
         let outputs = self.materialized("find_handler_decorators")?;
         let path_re = _compile_path_regex(path_regex)?;
-        let attrs: HashSet<&str> = decorator_attrs.iter().map(String::as_str).collect();
+        let attrs: FxHashSet<&str> = decorator_attrs.iter().map(String::as_str).collect();
         let needle_strs: Vec<&str> = decorator_attrs.iter().map(String::as_str).collect();
         let decl_by_name_range = &outputs.decl_by_name_range;
         let decl_by_fqname = &outputs.decl_by_fqname;
@@ -1660,7 +1658,7 @@ impl ProjectContext {
                     let Stmt::FunctionDef(func) = stmt else {
                         continue;
                     };
-                    let mut seen_owners: HashSet<String> = HashSet::new();
+                    let mut seen_owners: FxHashSet<String> = FxHashSet::default();
                     for dec in &func.decorator_list {
                         let (root_expr, call_form): (&Expr, Option<&ruff_python_ast::ExprCall>) =
                             match &dec.expression {
@@ -1715,7 +1713,7 @@ impl ProjectContext {
     ) -> PyResult<Vec<(String, Py<SymbolNode>, CallArgs)>> {
         let outputs = self.materialized("find_handler_decorators_via")?;
         let path_re = _compile_path_regex(path_regex)?;
-        let attrs: HashSet<&str> = decorator_attrs.iter().map(String::as_str).collect();
+        let attrs: FxHashSet<&str> = decorator_attrs.iter().map(String::as_str).collect();
         let decl_by_name_range = &outputs.decl_by_name_range;
         let decl_by_fqname = &outputs.decl_by_fqname;
         let project_files: &[File] = &outputs.project_files;
@@ -1737,7 +1735,7 @@ impl ProjectContext {
                     let Stmt::FunctionDef(func) = stmt else {
                         continue;
                     };
-                    let mut seen_owners: HashSet<String> = HashSet::new();
+                    let mut seen_owners: FxHashSet<String> = FxHashSet::default();
                     for dec in &func.decorator_list {
                         let (root_expr, call_form): (&Expr, Option<&ruff_python_ast::ExprCall>) =
                             match &dec.expression {
@@ -1869,7 +1867,7 @@ impl ProjectContext {
         ctor_names: Vec<String>,
     ) -> PyResult<Vec<(Py<SymbolNode>, Vec<String>)>> {
         let outputs = self.materialized("find_factory_decls")?;
-        let allowed: HashSet<&str> = ctor_names.iter().map(String::as_str).collect();
+        let allowed: FxHashSet<&str> = ctor_names.iter().map(String::as_str).collect();
         let needle_strs: Vec<&str> = ctor_names.iter().map(String::as_str).collect();
         let decl_by_name_range = &outputs.decl_by_name_range;
         let project_files: &[File] = &outputs.project_files;
@@ -1898,7 +1896,7 @@ impl ProjectContext {
                         imports: &imports,
                         module,
                         allowed: allowed_ref,
-                        kinds: HashSet::new(),
+                        kinds: FxHashSet::default(),
                     };
                     for inner in body {
                         finder.visit_stmt(inner);
@@ -1942,7 +1940,7 @@ impl ProjectContext {
     ) -> PyResult<Vec<(Py<SymbolNode>, String, CallArgs)>> {
         let outputs = self.materialized("find_calls_to_imported")?;
         let path_re = _compile_path_regex(path_regex)?;
-        let allowed: HashSet<&str> = [name].into_iter().collect();
+        let allowed: FxHashSet<&str> = [name].into_iter().collect();
         let decl_by_name_range = &outputs.decl_by_name_range;
         let decl_by_fqname = &outputs.decl_by_fqname;
         let module_nodes_by_file = &outputs.module_nodes_by_file;

--- a/src/query.rs
+++ b/src/query.rs
@@ -2,12 +2,11 @@
 //! Result types (`DecoratorRef`/`ConstructionRef`/`CallRef`/`FactoryRef`),
 //! the `QueryBuilder` entry point, and the per-stream `Query` builders.
 
-use std::collections::HashMap;
-
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::PyClass;
 use ruff_db::files::File;
+use rustc_hash::FxHashMap;
 use ty_project::Db as ProjectDb;
 
 use crate::graph::SymbolNode;
@@ -38,7 +37,7 @@ pub(crate) struct DecoratorRef {
     pub(crate) args: Vec<Py<PyAny>>,
     /// Keyword arguments of the decorator's ``Call`` form. Same value
     /// shape as ``args``.
-    pub(crate) kwargs: HashMap<String, Py<PyAny>>,
+    pub(crate) kwargs: FxHashMap<String, Py<PyAny>>,
 }
 
 #[pymethods]
@@ -70,7 +69,7 @@ pub(crate) struct ConstructionRef {
     pub(crate) args: Vec<Py<PyAny>>,
     /// Keyword arguments of the constructor call. Same value shape as
     /// ``args``.
-    pub(crate) kwargs: HashMap<String, Py<PyAny>>,
+    pub(crate) kwargs: FxHashMap<String, Py<PyAny>>,
 }
 
 #[pymethods]
@@ -94,7 +93,7 @@ pub(crate) struct CallRef {
     pub(crate) args: Vec<Py<PyAny>>,
     /// Keyword arguments of the matched call. Same value shape as
     /// ``args``.
-    pub(crate) kwargs: HashMap<String, Py<PyAny>>,
+    pub(crate) kwargs: FxHashMap<String, Py<PyAny>>,
 }
 
 #[pymethods]


### PR DESCRIPTION
## Summary
- Switch `vendor/ruff` submodule URL from `astral-sh/ruff` to `lpetre/ruff` fork
- Update submodule to commit `18448938c8` ("Add module-resolution search-path scaling benchmark")

## Test plan
- [ ] `git submodule update --init` resolves cleanly from the fork URL
- [ ] `uv sync` rebuilds `_native` against the new ruff revision
- [ ] `uv run pytest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)