### PR TITLE
release: 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ two versions.
 
 ## [Unreleased]
 
-## [0.11.1] - 2026-05-24
+## [0.12.0] - 2026-05-24
 
 ### Changed
 - Bumped vendored `ruff` (ty) submodule to `18448938c8` and switched
@@ -1583,8 +1583,8 @@ versions until the first stable release.
 - `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, and `ROADMAP.md` with a
   stack-ranked plan from alpha to 1.0.
 
-[Unreleased]: https://github.com/lpetre/dead-cst/compare/v0.11.1...HEAD
-[0.11.1]: https://github.com/lpetre/dead-cst/compare/v0.11.0...v0.11.1
+[Unreleased]: https://github.com/lpetre/dead-cst/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/lpetre/dead-cst/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/lpetre/dead-cst/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/lpetre/dead-cst/compare/v0.9.4...v0.10.0
 [0.9.4]: https://github.com/lpetre/dead-cst/compare/v0.9.3...v0.9.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ two versions.
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-05-24
+
 ### Changed
 - Bumped vendored `ruff` (ty) submodule to `18448938c8` and switched
   the upstream URL to the `lpetre/ruff` fork. Picks up 159 ty commits
@@ -1581,7 +1583,8 @@ versions until the first stable release.
 - `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, and `ROADMAP.md` with a
   stack-ranked plan from alpha to 1.0.
 
-[Unreleased]: https://github.com/lpetre/dead-cst/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/lpetre/dead-cst/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/lpetre/dead-cst/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/lpetre/dead-cst/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/lpetre/dead-cst/compare/v0.9.4...v0.10.0
 [0.9.4]: https://github.com/lpetre/dead-cst/compare/v0.9.3...v0.9.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "dead-cst-native"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bincode",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "dead-cst-native"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dead-cst-native"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 publish = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dead-cst-native"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
Bumps Cargo.toml + Cargo.lock + CHANGELOG to 0.12.0.

### What's in 0.12.0
- **Fixed** `Analysis(..., venv=...)` dropping `project_root` from ty's static search paths (the `FastAPIPlugin` symptom from #222 — every cross-file first-party import resolved to `[unresolved]` on setuptools' default PEP 660 editable install).
- **Fixed** `build_scope_table` livelock on scopes that rebind an inherited name to a flipped version of itself.
- **Changed** vendored `ruff` (ty) submodule bumped to `18448938c8`, upstream URL switched to the `lpetre/ruff` fork. Picks up 159 ty commits (search-path cache by top-level component, plus upstream resolution fixes).

## Release procedure
After merge, tag `v0.12.0` via `gh release create v0.12.0` to trigger the PyPI publish workflow.

## Test plan
- [x] `uv run pytest` — 582 passed
- [x] `cargo test --no-default-features` — 131 passed
- [ ] CI green on the PR
- [ ] After merge: `gh release create v0.12.0` triggers \`publish-pypi\`

Note: branch is named \`release-0.11.1\` from an earlier draft; contents are 0.12.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)