### PR TITLE
release: 0.12.2 — class_bases / indices / parallel plugins / @overload regression / slack-bolt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ two versions.
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-05-25
+
 ### Added
 - `dead_cst.contrib.slack_bolt_plugin` keeps `slack_bolt.App` and
   `slack_bolt.async_app.AsyncApp` instances alive, treats every
@@ -1708,7 +1710,8 @@ versions until the first stable release.
 - `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, and `ROADMAP.md` with a
   stack-ranked plan from alpha to 1.0.
 
-[Unreleased]: https://github.com/lpetre/dead-cst/compare/v0.12.1...HEAD
+[Unreleased]: https://github.com/lpetre/dead-cst/compare/v0.12.2...HEAD
+[0.12.2]: https://github.com/lpetre/dead-cst/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/lpetre/dead-cst/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/lpetre/dead-cst/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/lpetre/dead-cst/compare/v0.10.0...v0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ two versions.
 
 ## [Unreleased]
 
+### Added
+- `dead_cst.contrib.slack_bolt_plugin` keeps `slack_bolt.App` and
+  `slack_bolt.async_app.AsyncApp` instances alive, treats every
+  `@app.event` / `@app.message` / `@app.command` / `@app.action` /
+  `@app.shortcut` / `@app.view` / `@app.options` / `@app.error` /
+  `@app.step` / `@app.function` handler as an entrypoint, and
+  follows factory-style construction. Registered under the
+  `slack_bolt` CLI plugin key.
+
 ## [0.12.1] - 2026-05-24
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "dead-cst-native"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "bincode",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
  "crossbeam-channel",
  "get-size2",
  "indicatif",
+ "parking_lot",
  "pyo3",
  "rayon",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dead-cst-native"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 publish = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,4 @@ crossbeam-channel = "0.5"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 bincode = "1.3"
+parking_lot = "0.12"

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -515,6 +515,20 @@ class ProjectContext:
         """
         ...
 
+    def module_surfaces(self, module_fqns: list[str]) -> dict[str, list[SymbolNode]]:
+        """Batched form of :meth:`module_surface`. Resolves every
+        fqname in ``module_fqns`` in a single scan of the internal
+        ``module_by_fqname`` and ``decl_by_fqname`` indices instead
+        of one scan per fqname.
+
+        Returns a dict keyed by input fqname; modules that don't
+        resolve map to empty lists. Duplicate inputs share the same
+        result list. Use when a plugin needs to resolve many module
+        surfaces in one shot (``LiteralListPlugin``'s ``__all__``
+        entries, ``DiscordPyPlugin``'s ``load_extensions`` args, …).
+        """
+        ...
+
     def find_module_top_level_decls(self, module_fqn: str) -> list[SymbolNode]:
         """``module_fqn``'s immediate top-level decls — every
         function / class / variable / import bound at its module scope.

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -185,6 +185,25 @@ class AddEdge:
 
     def __init__(self, src: SymbolNode, dst: SymbolNode, *, flags: int = 0) -> None: ...
 
+class AddEdgeByIdx:
+    """Index-keyed variant of :class:`AddEdge`. Accepts positional
+    indices into ``ctx.nodes()`` instead of ``SymbolNode`` references.
+
+    Lets plugins that already work in index space (paired with the
+    ``.indices()`` query terminals or
+    :meth:`ProjectContext.indices_where`) emit edges without ever
+    round-tripping through ``Py<SymbolNode>``. The apply pass treats
+    it identically to :class:`AddEdge` once the indices land in the
+    builder. Raises :class:`IndexError` at apply time when either
+    endpoint is out of range.
+    """
+
+    src_idx: int
+    dst_idx: int
+    flags: int
+
+    def __init__(self, src_idx: int, dst_idx: int, *, flags: int = 0) -> None: ...
+
 class AddEntrypoint:
     """Mark ``decl`` as an entrypoint.
 
@@ -235,7 +254,7 @@ class AddNode:
         edges_to: Iterable[SymbolNode] = ...,
     ) -> None: ...
 
-GraphOp = AddEdge | AddEntrypoint | AddNode
+GraphOp = AddEdge | AddEdgeByIdx | AddEntrypoint | AddNode
 
 class NativeGraph:
     """The project-wide graph snapshot returned by ``Project.build()``
@@ -584,6 +603,52 @@ class ProjectContext:
         """Forward closure from every node carrying any bit in
         ``seed_flags`` (defaults to :data:`NodeFlags.ENTRYPOINT`). The
         set of dead decls is the complement against :meth:`nodes`."""
+        ...
+
+    def reachable_indices(self, *, skip_flags: int = 0, seed_flags: int = ...) -> list[int]:
+        """Idx-only sibling of :meth:`reachable`. Same semantics, but
+        returns positional indices into :meth:`nodes` instead of
+        materialising ``SymbolNode`` clones. Use when you only need
+        set-membership / counting on the reached set — pair with
+        :meth:`nodes_at` to revive specific nodes on demand.
+        """
+        ...
+
+    def indices_where(
+        self,
+        *,
+        kind: str | None = None,
+        kinds: list[str] | None = None,
+        filename: str | None = None,
+        filenames: list[str] | None = None,
+        simple_name: str | None = None,
+        simple_names: list[str] | None = None,
+        paths: list[str] | None = None,
+        path_regex: str | None = None,
+        flags: int | None = None,
+        flags_any: int | None = None,
+        fqname_prefix: str | None = None,
+    ) -> list[int]:
+        """Flat-form predicate filter returning positional indices into
+        :meth:`nodes`. Mirrors the :class:`DeclQuery` predicate
+        vocabulary but skips the builder construction — useful when
+        you only have one filter step and just need a ``list[int]``.
+
+        Every parameter is keyword-only and optional; unset arguments
+        don't filter. ``kind`` / ``kinds`` (and similarly the
+        ``filename`` / ``simple_name`` pairs) are merged; pass either
+        form. All set predicates AND together. ``flags`` is the
+        all-bits-set form (``node.flags & mask == mask``);
+        ``flags_any`` is the any-bit form (``node.flags & mask != 0``).
+        """
+        ...
+
+    def nodes_at(self, indices: Sequence[int]) -> list[SymbolNode]:
+        """Inverse of the ``.indices()`` terminals: materialize
+        specific nodes by their positional indices into :meth:`nodes`.
+        Validates bounds and raises :class:`IndexError` when any index
+        is out of range.
+        """
         ...
 
     # ----- Pure scans over the in-progress graph ------------------------
@@ -953,6 +1018,13 @@ class SubclassQuery:
     def collect(self) -> list[SymbolNode]: ...
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[SymbolNode]: ...
+    def indices(self) -> list[int]:
+        """Index-returning terminal. Same lookup as :meth:`collect`,
+        but emits each subclass's positional index into
+        :meth:`ProjectContext.nodes` instead of allocating
+        ``SymbolNode`` clones.
+        """
+        ...
 
 class ImportQuery:
     """Enumerate the ``kind="import"`` nodes that bind a name from a
@@ -963,6 +1035,13 @@ class ImportQuery:
 
     def of(self, module: str) -> ImportQuery: ...
     def collect(self) -> list[SymbolNode]: ...
+    def indices(self) -> list[int]:
+        """Index-returning terminal. Reads positional indices straight
+        out of the pre-built ``imports_by_module`` index — no Python
+        allocation per row.
+        """
+        ...
+
     def count(self) -> int: ...
     def exists(self) -> bool:
         """O(1) presence probe — does any project file import the
@@ -986,6 +1065,13 @@ class ClassQuery:
     def collect(self) -> list[SymbolNode]: ...
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[SymbolNode]: ...
+    def indices(self) -> list[int]:
+        """Index-returning terminal. Same per-file parallel walk as
+        :meth:`collect`, but emits positional indices into
+        :meth:`ProjectContext.nodes` instead of allocating
+        ``SymbolNode`` clones.
+        """
+        ...
 
 class FactoryRef:
     """One result row from :class:`FactoryQuery`.
@@ -1064,6 +1150,18 @@ class EdgeQuery:
     def first(self) -> EdgeRef | None: ...
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[EdgeRef]: ...
+    def index_triples(self) -> list[tuple[int, int, int]]:
+        """Index-returning terminal for edges. Same per-edge predicate
+        pipeline as :meth:`collect`, but emits ``(src_idx, dst_idx,
+        flags)`` triples instead of materialising one :class:`EdgeRef`
+        (and two ``SymbolNode`` clones) per row.
+
+        Faster than :meth:`collect` when you only need set-membership
+        / counting over edge endpoints; pair with
+        :meth:`ProjectContext.nodes_at` to revive the surviving
+        endpoints on demand.
+        """
+        ...
 
 class DeclQuery:
     """Generic filter over every interned node in the in-progress graph.
@@ -1109,6 +1207,20 @@ class DeclQuery:
     def collect(self) -> list[SymbolNode]: ...
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[SymbolNode]: ...
+    def indices(self) -> list[int]:
+        """Index-returning terminal. Same predicate semantics as
+        :meth:`collect`, but emits each surviving node's positional
+        index into :meth:`ProjectContext.nodes` (a plain
+        ``list[int]``) instead of allocating one ``SymbolNode`` per
+        row.
+
+        Use when you only need set membership / counting on the
+        surviving nodes (or want to feed an index-keyed
+        :class:`AddEdgeByIdx`); call
+        :meth:`ProjectContext.nodes_at` to materialize back to
+        ``SymbolNode`` later.
+        """
+        ...
 
 # ---------- Graph persistence --------------------------------------------
 

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -599,6 +599,21 @@ class ProjectContext:
         """
         ...
 
+    def direct_predecessors(
+        self, node: SymbolNode, *, skip_flags: int = 0
+    ) -> list[SymbolNode]:
+        """One-hop reverse step: every node with an edge directly into
+        ``node``.
+
+        Unlike :meth:`ancestors`, this does *not* take the transitive
+        closure — it only returns the immediate predecessors. Dedups by
+        source node, so a pair of parallel edges with different
+        :class:`EdgeFlags` between the same two nodes only produces one
+        entry. ``skip_flags`` filters edges by intersecting flag mask —
+        same semantics as :meth:`ancestors`.
+        """
+        ...
+
     def reachable(self, *, skip_flags: int = 0, seed_flags: int = ...) -> list[SymbolNode]:
         """Forward closure from every node carrying any bit in
         ``seed_flags`` (defaults to :data:`NodeFlags.ENTRYPOINT`). The

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -360,6 +360,28 @@ class ProjectContext:
         """
         ...
 
+    def build_only(self) -> None:
+        """Run only the project-wide build pass, without invoking any
+        registered plugins. Used by :class:`dead_cst.Analysis` to
+        split build from the plugin pass so the latter can run on a
+        Python :class:`concurrent.futures.ThreadPoolExecutor`."""
+        ...
+
+    def run_plugin(self, plugin: _ProjectPluginLike | Any) -> None:
+        """Invoke ``plugin.run(ctx)`` once, applying every yielded
+        op to the graph as it comes off the iterator. Safe to call
+        concurrently from multiple Python threads — graph mutations
+        serialize on the rust-side lock while read-only queries on
+        the in-progress graph run in parallel."""
+        ...
+
+    def snapshot_graph(self) -> NativeGraph:
+        """Snapshot the current graph (post-:meth:`build_only` +
+        any :meth:`run_plugin` calls) as a :class:`NativeGraph`.
+        Used by :class:`dead_cst.Analysis` to return the final graph
+        without re-running :meth:`materialize`."""
+        ...
+
     def query(self) -> QueryBuilder:
         """Open a chainable query builder against this context.
 

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -381,34 +381,44 @@ class ProjectContext:
         """
         ...
 
-    def find_subclasses_via_bases(self, base_fqns: list[str]) -> list[SymbolNode]:
-        """Every project class that transitively inherits from any
-        fqname in ``base_fqns``, computed by walking the project's
-        ``ClassDef`` base lists directly instead of asking ty's
-        ``find_references`` to walk down from each base.
+    def subclasses_of_fqn(self, fqn: str, *, transitive: bool = True) -> list[SymbolNode]:
+        """Project classes that inherit from the class identified by
+        ``fqn``. ``fqn`` may name a project or external class.
 
-        Roughly equivalent to calling :meth:`find_subclasses` once per
-        ``base_fqn`` and unioning the results — but the framework
-        modules are never loaded out of the venv, so cold-cache cost
-        scales with project file count rather than venv parse cost.
-        Useful when the targets are external classes that ty would
-        otherwise force-load (``flask.Flask``, ``typer.Typer``, …).
+        Backed by a project-wide index built once at materialize time
+        from each file's per-class resolved base list, so external
+        seeds (``flask.Flask``, ``typer.Typer``) are answered without
+        loading the framework out of the venv. ``transitive=True``
+        (default) walks the full subclass closure; ``transitive=False``
+        returns only direct subclasses.
 
         Match shapes per base expression in a class header:
 
         * ``Name(X)`` where ``X`` is imported via
-          ``from <module> import X [as alias]`` resolves to
+          ``from <module> import X [as alias]`` matches
           ``<module>.X``;
         * ``Attribute(Name(M).N)`` where ``M`` is bound via
-          ``import <module> [as M]`` resolves to ``<module>.N``;
-        * dotted ``a.b.c.N`` rooted at an imported name resolves to
-          ``<a-upstream>.b.c.N``;
+          ``import <module> [as M]`` matches ``<module>.N``;
+        * dotted ``a.b.c.N`` rooted at an imported name matches the
+          flat ``<a-upstream>.b.c.N`` fqname;
         * a bare ``Name(X)`` referring to a class defined in the same
-          file (``class Sub(Local): ...``).
+          file participates in node-keyed walks.
 
         Generic parameterizations (``class C(Foo[T])``) and other
-        non-identifier base expressions are skipped — accept that
-        cost; it matches the libcst pipeline's behavior.
+        non-identifier base expressions are skipped — matches the
+        libcst pipeline's behavior.
+        """
+        ...
+
+    def subclasses_of_node(
+        self, class_node: SymbolNode, *, transitive: bool = True
+    ) -> list[SymbolNode]:
+        """Project classes that inherit from ``class_node``.
+
+        Sibling of :meth:`subclasses_of_fqn` for callers that already
+        hold the seed as a ``SymbolNode``. Returns an empty list when
+        ``class_node`` isn't of class kind or isn't found in the
+        project's class-by-selection index.
         """
         ...
 

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -528,6 +528,16 @@ class ProjectContext:
         """
         ...
 
+    def find_module_top_level_decls_indices(self, module_fqn: str) -> list[int]:
+        """Idx-only variant of :meth:`find_module_top_level_decls`.
+
+        Returns positional indices into :meth:`nodes` rather than
+        allocating ``SymbolNode`` clones — pair with
+        :class:`AddEdgeByIdx` to skip the ``SymbolNode -> idx``
+        round-trip when emitting edges to every export of a module.
+        """
+        ...
+
     def find_module_dunder_all_exports(self, module_fqn: str) -> list[SymbolNode] | None:
         """Decls listed in ``module_fqn``'s ``__all__``, or ``None``
         when the module doesn't declare ``__all__``.
@@ -540,6 +550,15 @@ class ProjectContext:
         matters: callers that want CPython's ``from X import *``
         semantics should fall back to the non-underscore decl list
         only in the ``None`` case.
+        """
+        ...
+
+    def find_module_dunder_all_exports_indices(self, module_fqn: str) -> list[int] | None:
+        """Idx-only variant of :meth:`find_module_dunder_all_exports`.
+
+        ``None`` still means "no ``__all__``"; ``[]`` means "empty /
+        unresolvable ``__all__``" — same semantics as the
+        ``SymbolNode``-returning version.
         """
         ...
 

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -1256,7 +1256,28 @@ class DeclQuery:
         """Restrict to nodes whose ``flags & mask != 0`` (any bit set)."""
         ...
 
-    def with_fqname_prefix(self, prefix: str) -> DeclQuery: ...
+    def with_fqname_prefix(self, prefix: str) -> DeclQuery:
+        """Restrict to nodes whose ``fqname`` starts with ``prefix`` —
+        a raw string prefix, not segment-bounded. ``prefix="foo"``
+        matches both ``foo.bar`` and ``foobar``. Use
+        :meth:`with_fqname_under` for the segment-bounded
+        "descendants of this fqname" predicate that walks the fqname
+        tree via the ``children_by_parent`` index.
+        """
+        ...
+
+    def with_fqname_under(self, parent_fqn: str) -> DeclQuery:
+        """Restrict to nodes whose ``fqname`` equals ``parent_fqn``
+        or is a transitive descendant of it in the fqname tree.
+
+        Segment-bounded: ``parent_fqn="pkg.foo"`` matches ``pkg.foo``,
+        ``pkg.foo.bar``, ``pkg.foo.bar.baz`` — but **not** ``pkg.foobar``.
+        Backed by the project's ``children_by_parent`` index, so this
+        is O(matches) instead of the O(all_nodes) scan
+        :meth:`with_fqname_prefix` performs.
+        """
+        ...
+
     def where_fqname(
         self,
         value: str | re.Pattern[str] | Sequence[str | re.Pattern[str]],

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -599,9 +599,7 @@ class ProjectContext:
         """
         ...
 
-    def direct_predecessors(
-        self, node: SymbolNode, *, skip_flags: int = 0
-    ) -> list[SymbolNode]:
+    def direct_predecessors(self, node: SymbolNode, *, skip_flags: int = 0) -> list[SymbolNode]:
         """One-hop reverse step: every node with an edge directly into
         ``node``.
 

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterator, Sequence
 
@@ -23,6 +25,36 @@ def _iter_dead(
             continue
         if n not in reachable:
             yield n
+
+
+def _serial_mode() -> bool:
+    """``True`` if ``DEAD_CST_PLUGINS_SERIAL=1`` is set in the env.
+
+    Kill switch for the concurrent plugin executor — falls back to
+    the rust-side serial loop. Useful for debugging plugin races,
+    flaky CI environments, or comparing serial vs parallel timings.
+    """
+    return os.environ.get("DEAD_CST_PLUGINS_SERIAL", "") == "1"
+
+
+def _plugin_worker_count(n_plugins: int) -> int:
+    """Worker count for the plugin :class:`ThreadPoolExecutor`.
+
+    Resolves to ``DEAD_CST_PLUGIN_WORKERS`` if set (clamped to
+    ``[1, n_plugins]``), otherwise ``min(n_plugins, cpu_count or 4)``.
+    Never returns more workers than plugins — extra workers just
+    idle.
+    """
+    raw = os.environ.get("DEAD_CST_PLUGIN_WORKERS", "")
+    if raw:
+        try:
+            requested = int(raw)
+        except ValueError as exc:
+            raise ValueError(f"DEAD_CST_PLUGIN_WORKERS must be an integer, got {raw!r}") from exc
+        if requested < 1:
+            raise ValueError(f"DEAD_CST_PLUGIN_WORKERS must be >= 1, got {requested}")
+        return min(requested, n_plugins)
+    return min(n_plugins, os.cpu_count() or 4)
 
 
 class Analysis:
@@ -140,9 +172,33 @@ class Analysis:
         )
         if self._stack_size is not None:
             ctx.set_stack_size(self._stack_size)
-        for plugin in self._plugins:
-            ctx.add_plugin(plugin)
-        ctx.materialize()
+
+        # ``DEAD_CST_PLUGINS_SERIAL=1`` (or no plugins / a single
+        # plugin) keeps the legacy rust-side loop. Otherwise we drive
+        # plugins from a ``ThreadPoolExecutor`` so any plugin time
+        # spent in GIL-releasing rust queries (``find_decorated_decls``,
+        # ``find_subclasses_of_class``, ``find_handler_decorators``, ...)
+        # overlaps across workers. Mutations to the graph still
+        # serialize behind the rust-side ``RwLock`` on ``outputs`` —
+        # only one ``apply_graph_op`` write runs at a time — but the
+        # read path is fully concurrent.
+        if _serial_mode() or len(self._plugins) <= 1:
+            for plugin in self._plugins:
+                ctx.add_plugin(plugin)
+            ctx.materialize()
+        else:
+            ctx.build_only()
+            workers = _plugin_worker_count(len(self._plugins))
+            # Plugins are scheduled in registration order; results
+            # ``.result()`` waits in the same order. Errors propagate
+            # via the future's ``.result()`` call.
+            with ThreadPoolExecutor(
+                max_workers=workers,
+                thread_name_prefix="dead-cst-plugin",
+            ) as pool:
+                futures = [pool.submit(ctx.run_plugin, p) for p in self._plugins]
+                for fut in futures:
+                    fut.result()
         self._ctx = ctx
         return ctx
 

--- a/python/dead_cst/cli.py
+++ b/python/dead_cst/cli.py
@@ -39,6 +39,7 @@ from .contrib.flask import flask_plugin
 from .contrib.mock_patch import MockPatchPlugin
 from .contrib.pytest import PytestPlugin
 from .contrib.server_config import ServerConfigPlugin
+from .contrib.slack_bolt import slack_bolt_plugin
 from .contrib.typer import typer_plugin
 from .contrib.unittest import UnittestPlugin
 from .graph import (
@@ -86,6 +87,7 @@ _BUILTIN_PLUGINS: dict[str, Plugin] = {
     "cyclopts": cyclopts_plugin(),
     "celery": CeleryPlugin(),
     "discordpy": DiscordPyPlugin(),
+    "slack_bolt": slack_bolt_plugin(),
     "init_subclass": InitSubclassPlugin(),
     "dynamic_import_fallback": DynamicImportFallbackPlugin(),
 }

--- a/python/dead_cst/contrib/__init__.py
+++ b/python/dead_cst/contrib/__init__.py
@@ -18,6 +18,7 @@ from .flask import flask_plugin
 from .mock_patch import MockPatchPlugin
 from .pytest import PytestPlugin
 from .server_config import ServerConfigPlugin
+from .slack_bolt import slack_bolt_plugin
 from .typer import typer_plugin
 from .unittest import UnittestPlugin
 
@@ -33,5 +34,6 @@ __all__ = [
     "fastapi_plugin",
     "fastmcp_plugin",
     "flask_plugin",
+    "slack_bolt_plugin",
     "typer_plugin",
 ]

--- a/python/dead_cst/contrib/discordpy.py
+++ b/python/dead_cst/contrib/discordpy.py
@@ -121,20 +121,28 @@ class DiscordPyPlugin(Plugin):
                 )
 
         # 5. load_extension / load_extensions string-literal targets.
+        # Collect the (owner_path, extension_fqname) pairs in order
+        # first so the module-surface lookup runs in a single batched
+        # scan instead of one scan per call site.
         seen_extensions: set[str] = set()
+        pending: list[tuple[str, str]] = []
         for attr in ("load_extension", "load_extensions"):
             for cref in native.query(ctx).calls().where_attr(attr).string_arg_at(0):
                 if cref.owner.path not in discord_paths:
                     continue
                 if cref.string_arg in seen_extensions:
                     continue
-                targets = list(ctx.module_surface(cref.string_arg))
+                seen_extensions.add(cref.string_arg)
+                pending.append((cref.owner.path, cref.string_arg))
+        if pending:
+            surfaces = ctx.module_surfaces([ext for _, ext in pending])
+            for owner_path, ext_fqname in pending:
+                targets = surfaces.get(ext_fqname, [])
                 if not targets:
                     continue
-                seen_extensions.add(cref.string_arg)
                 yield native.AddNode(
-                    fqname=f"{DISCORDPY_EXTENSION_PREFIX}{cref.string_arg}",
-                    path=cref.owner.path,
+                    fqname=f"{DISCORDPY_EXTENSION_PREFIX}{ext_fqname}",
+                    path=owner_path,
                     flags=int(NodeFlags.ENTRYPOINT),
                     edges_to=targets,
                 )

--- a/python/dead_cst/contrib/fastmcp.py
+++ b/python/dead_cst/contrib/fastmcp.py
@@ -26,13 +26,14 @@ def fastmcp_plugin() -> DispatchAppPlugin:
     module-prefixed (``import fastmcp; mcp = fastmcp.FastMCP(...)``),
     and factory-style (``mcp = create_server()``) construction.
 
-    Only the ``fastmcp`` import path is recognized. Users on the
-    Anthropic MCP SDK's compatibility layer
-    (``from mcp.server.fastmcp import FastMCP``) can keep their handlers
-    alive with explicit ``-e`` entrypoints or a project-local plugin.
+    Both import paths are recognized:
+
+    * ``fastmcp.FastMCP`` — the standalone ``fastmcp`` package.
+    * ``mcp.server.fastmcp.FastMCP`` — the Anthropic MCP SDK's
+      compatibility layer (``from mcp.server.fastmcp import FastMCP``).
     """
     return DispatchAppPlugin(
         marker_prefix="fastmcp",
-        app_classes=("fastmcp.FastMCP",),
+        app_classes=("fastmcp.FastMCP", "mcp.server.fastmcp.FastMCP"),
         registration_decorators=_REGISTRATION_DECORATORS,
     )

--- a/python/dead_cst/contrib/slack_bolt.py
+++ b/python/dead_cst/contrib/slack_bolt.py
@@ -1,0 +1,50 @@
+"""Plugin: keep Slack Bolt apps and their handlers alive."""
+
+from __future__ import annotations
+
+from ..plugins.decl_shapes import DispatchAppPlugin
+
+# Attribute names ``slack_bolt.App`` / ``slack_bolt.async_app.AsyncApp``
+# expose for registering a handler. Matched as the rightmost attribute
+# of ``@<instance>.<name>(...)`` -- both bare-decorator and
+# call-decorator forms are picked up by ``find_handlers``.
+#
+# Sourced from the public Slack Bolt for Python API
+# (https://github.com/slackapi/bolt-python). The sync ``App`` and async
+# ``AsyncApp`` classes expose the same decorator surface; both bases are
+# listed in ``app_classes`` below.
+_REGISTRATION_DECORATORS: frozenset[str] = frozenset(
+    {
+        "event",
+        "message",
+        "command",
+        "action",
+        "shortcut",
+        "view",
+        "options",
+        "error",
+        "step",
+        "function",
+    }
+)
+
+
+def slack_bolt_plugin() -> DispatchAppPlugin:
+    """Mark Slack Bolt apps as entrypoints and wire handlers through them.
+
+    Handles direct (``app = App(...)``), aliased
+    (``from slack_bolt import App as Bolt; app = Bolt(...)``),
+    module-prefixed (``import slack_bolt; app = slack_bolt.App(...)``),
+    and factory-style (``app = create_app()``) construction.
+
+    Both sync and async APIs are recognised:
+
+    * ``slack_bolt.App`` -- sync app.
+    * ``slack_bolt.async_app.AsyncApp`` -- async app (decorator forms
+      identical to the sync surface).
+    """
+    return DispatchAppPlugin(
+        marker_prefix="slack-bolt",
+        app_classes=("slack_bolt.App", "slack_bolt.async_app.AsyncApp"),
+        registration_decorators=_REGISTRATION_DECORATORS,
+    )

--- a/python/dead_cst/plugins/decl_shapes.py
+++ b/python/dead_cst/plugins/decl_shapes.py
@@ -156,10 +156,11 @@ class DispatchAppPlugin(Plugin):
             out.setdefault(module, set()).add(name)
         if not self.app_classes:
             return out
-        for sub in ctx.find_subclasses_via_bases(list(self.app_classes)):
-            sub_module, _, sub_name = sub.fqname.rpartition(".")
-            if sub_module and sub_name:
-                out.setdefault(sub_module, set()).add(sub_name)
+        for fqn in self.app_classes:
+            for sub in ctx.subclasses_of_fqn(fqn):
+                sub_module, _, sub_name = sub.fqname.rpartition(".")
+                if sub_module and sub_name:
+                    out.setdefault(sub_module, set()).add(sub_name)
         return out
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:

--- a/python/dead_cst/plugins/decl_shapes.py
+++ b/python/dead_cst/plugins/decl_shapes.py
@@ -336,13 +336,16 @@ class LiteralListPlugin(Plugin):
             return
 
         prefix = f"<{self.marker_prefix}>:"
+        # One batched scan of the module / decl index maps for every
+        # entry, instead of N independent scans. Each entry resolves
+        # as either a module fqname (revive the whole surface,
+        # mirroring ``importlib.import_module``) or a single decl
+        # fqname — try both; some entries may match both (e.g.
+        # ``pkg.foo`` where ``foo`` is also a re-exported decl in
+        # ``pkg/__init__.py``).
+        surfaces = ctx.module_surfaces(entries)
         for entry in entries:
-            # Each entry resolves as either a module fqname (revive the
-            # whole surface, mirroring ``importlib.import_module``) or a
-            # single decl fqname. Try both; some entries may match both
-            # (e.g. ``pkg.foo`` where ``foo`` is also a re-exported decl
-            # in ``pkg/__init__.py``).
-            targets: list[native.SymbolNode] = list(ctx.module_surface(entry))
+            targets: list[native.SymbolNode] = list(surfaces.get(entry, ()))
             targets.extend(ctx.find_declarations(entry))
             if not targets:
                 continue

--- a/python/dead_cst/plugins/decl_shapes.py
+++ b/python/dead_cst/plugins/decl_shapes.py
@@ -271,24 +271,23 @@ class DispatchAppPlugin(Plugin):
                 for var in direct_by_owner.get(key, []):
                     yield native.AddEdge(var, h.decorated)
 
-        # 6. Factory walk: vars that aren't directly constructed but
-        # whose descendant graph reaches a factory marker get
-        # entrypoint-promoted too. Skipped under seed_as_entrypoint=False.
+        # 6. Factory walk: vars whose *direct* successor is one of the
+        # factory decls get entrypoint-promoted. Skipped under
+        # seed_as_entrypoint=False.
         #
-        # Inverted from the naive ``ctx.descendants(var)`` per unclassified
-        # handler (O(handlers × graph_size)) to one reverse BFS per
-        # factory decl plus an O(1) set lookup per handler. The factory
-        # markers emitted in step 4 each have one incoming edge from
-        # their ``fref.decl`` — so a var that reaches the marker also
-        # reaches the decl, and ``ancestors(fref.decl)`` is the exact
-        # set of vars (and intermediate nodes) we care about. K factory
-        # decls is typically O(framework_count) and never large; handler
-        # count grows with project size.
+        # We invert the question: rather than walk each var's
+        # descendants looking for a factory marker, we collect the
+        # direct predecessors of every factory decl into a single set
+        # and check ``var in factory_reachers``. This rules out the
+        # over-promotion case ``wrapper = app; app = create_app()`` —
+        # ``wrapper -> app -> create_app`` is two hops, so ``wrapper``
+        # doesn't reach the factory directly and stays unclassified.
+        # Only ``app`` (whose direct successor *is* ``create_app``)
+        # promotes.
         if self.seed_as_entrypoint and factory_decls:
             factory_reachers: set[native.SymbolNode] = set()
             for fref, _kind in factory_decls:
-                factory_reachers.update(ctx.ancestors(fref.decl))
-                factory_reachers.add(fref.decl)
+                factory_reachers.update(ctx.direct_predecessors(fref.decl))
 
             classified: set[tuple[str, str]] = set()
             for h in handlers:

--- a/python/dead_cst/plugins/decl_shapes.py
+++ b/python/dead_cst/plugins/decl_shapes.py
@@ -273,28 +273,37 @@ class DispatchAppPlugin(Plugin):
         # 6. Factory walk: vars that aren't directly constructed but
         # whose descendant graph reaches a factory marker get
         # entrypoint-promoted too. Skipped under seed_as_entrypoint=False.
-        if self.seed_as_entrypoint:
+        #
+        # Inverted from the naive ``ctx.descendants(var)`` per unclassified
+        # handler (O(handlers × graph_size)) to one reverse BFS per
+        # factory decl plus an O(1) set lookup per handler. The factory
+        # markers emitted in step 4 each have one incoming edge from
+        # their ``fref.decl`` — so a var that reaches the marker also
+        # reaches the decl, and ``ancestors(fref.decl)`` is the exact
+        # set of vars (and intermediate nodes) we care about. K factory
+        # decls is typically O(framework_count) and never large; handler
+        # count grows with project size.
+        if self.seed_as_entrypoint and factory_decls:
+            factory_reachers: set[native.SymbolNode] = set()
+            for fref, _kind in factory_decls:
+                factory_reachers.update(ctx.ancestors(fref.decl))
+                factory_reachers.add(fref.decl)
+
             classified: set[tuple[str, str]] = set()
             for h in handlers:
                 key = (h.decorated.path, h.decorator_owner or "")
                 if key in direct_by_owner or key in classified:
                     continue
                 var = vars_by_file.get(key)
-                if var is None:
+                if var is None or var not in factory_reachers:
                     continue
-                for desc in ctx.descendants(var):
-                    if desc.kind != "synthetic":
-                        continue
-                    if not desc.fqname.startswith(factory_prefix):
-                        continue
-                    classified.add(key)
-                    yield native.AddNode(
-                        fqname=f"{app_prefix}{var.fqname}",
-                        path=var.path,
-                        flags=int(NodeFlags.ENTRYPOINT),
-                        edges_to=[var],
-                    )
-                    break
+                classified.add(key)
+                yield native.AddNode(
+                    fqname=f"{app_prefix}{var.fqname}",
+                    path=var.path,
+                    flags=int(NodeFlags.ENTRYPOINT),
+                    edges_to=[var],
+                )
 
 
 @dataclass(kw_only=True)

--- a/python/dead_cst/plugins/dynamic_import.py
+++ b/python/dead_cst/plugins/dynamic_import.py
@@ -42,48 +42,60 @@ class DynamicImportFallbackPlugin(Plugin):
     include_targets: tuple[str, ...] = ()
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
-        cache: dict[str, list] = {}
+        cache: dict[str, list[int]] = {}
         project_root = Path(ctx.project_root)
-        # Rust-side edge filter: ``with_flags`` masks edges whose
-        # flags don't intersect ``DYNAMIC_IMPORT`` and ``with_dst_kind``
-        # masks edges whose ``dst.kind`` isn't ``"module"``. We get
-        # endpoint ``SymbolNode``s pre-resolved, so the Python loop
-        # only sees rows it actually needs to act on — no per-edge
-        # Python ↔ rust FFI hops over the (typically large) full
-        # edge list.
-        edges = (
+        # Rust-side edge filter via ``with_flags`` (mask out edges whose
+        # flags don't intersect ``DYNAMIC_IMPORT``) + ``with_dst_kind``
+        # (drop edges whose ``dst.kind`` isn't ``"module"``).
+        # ``index_triples()`` returns ``(src_idx, dst_idx, flags)`` —
+        # cheaper than materialising ``EdgeRef`` rows with
+        # ``Py<SymbolNode>`` endpoints up-front. We batch-materialise
+        # only the (src, dst) pair we actually need for the
+        # path / fqname filter via ``ctx.nodes_at``.
+        triples = (
             native.query(ctx)
             .edges()
             .with_flags(_DYNAMIC_IMPORT_FLAG)
             .with_dst_kind("module")
-            .collect()
+            .index_triples()
         )
-        for edge in edges:
-            src = edge.src
-            dst = edge.dst
+        for src_idx, dst_idx, _flags in triples:
+            src, dst = ctx.nodes_at([src_idx, dst_idx])
             if not self._allowed(Path(src.path), project_root, dst.fqname):
                 continue
-            for export in self._exports_for(ctx, dst.fqname, cache):
-                yield native.AddEdge(src=src, dst=export)
+            # Exports are looked up as raw indices so the fan-out yields
+            # ``AddEdgeByIdx`` — skipping the ``Py<SymbolNode> -> idx``
+            # round-trip the rust apply pass would otherwise do for every
+            # edge.
+            for export_idx in self._exports_indices_for(ctx, dst.fqname, cache):
+                yield native.AddEdgeByIdx(src_idx=src_idx, dst_idx=export_idx)
 
-    def _exports_for(
+    def _exports_indices_for(
         self,
         ctx: native.ProjectContext,
         module_fqname: str,
-        cache: dict[str, list],
-    ) -> list:
+        cache: dict[str, list[int]],
+    ) -> list[int]:
         cached = cache.get(module_fqname)
         if cached is not None:
             return cached
-        exports = None
+        exports: list[int] | None = None
         if self.respect_dunder_all:
-            exports = ctx.find_module_dunder_all_exports(module_fqname)
+            exports = ctx.find_module_dunder_all_exports_indices(module_fqname)
         if exports is None:
-            decls = ctx.find_module_top_level_decls(module_fqname)
+            decls_idx = ctx.find_module_top_level_decls_indices(module_fqname)
             if self.include_underscore:
-                exports = decls
+                exports = decls_idx
             else:
-                exports = [d for d in decls if not d.fqname.rsplit(".", 1)[-1].startswith("_")]
+                # Per-export name check still needs to ask the node what
+                # its simple name is. Materialise the candidate decls
+                # once and keep the filtered indices.
+                decls = ctx.nodes_at(decls_idx)
+                exports = [
+                    idx
+                    for idx, decl in zip(decls_idx, decls)
+                    if not decl.fqname.rsplit(".", 1)[-1].startswith("_")
+                ]
         cache[module_fqname] = exports
         return exports
 

--- a/scripts/bench_heavy_plugins.py
+++ b/scripts/bench_heavy_plugins.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+"""Stress-test the parallel plugin executor with N synthetic
+"heavy" plugins that simulate the kind of workload an out-of-tree
+plugin might have (many find_subclasses / find_decorated_decls
+queries). Each plugin's ``run`` body issues a fixed number of
+queries; in parallel mode they should overlap on the GIL-releasing
+rust paths.
+
+Usage:
+    uv run python scripts/bench_heavy_plugins.py --plugins 8 --queries 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _bench_common import (  # noqa: E402
+    require_native,
+    stage_dead_cst,
+)
+
+from dead_cst import Analysis  # noqa: E402
+from dead_cst import _native as native  # noqa: E402
+from dead_cst.plugins import Plugin  # noqa: E402
+
+
+class _HeavyPlugin(Plugin):
+    """Synthetic plugin that issues a configurable number of subclass
+    queries — each one drops the GIL inside the rust query
+    (``find_subclasses_of_class``), so concurrent plugins overlap on
+    that work."""
+
+    def __init__(self, queries: int, seeds: list[str]) -> None:
+        self.queries = queries
+        self.seeds = seeds
+
+    def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
+        for _ in range(self.queries):
+            for seed in self.seeds:
+                ctx.find_subclasses(seed, transitive=True)
+        return ()
+
+
+def _one_run(target_root: Path, plugins: list) -> float:
+    start = time.perf_counter()
+    Analysis(target_root, plugins=plugins).materialize_all()
+    return time.perf_counter() - start
+
+
+def _measure(target_root: Path, plugins: list, repeats: int, mode: str) -> list[float]:
+    if mode == "serial":
+        os.environ["DEAD_CST_PLUGINS_SERIAL"] = "1"
+    else:
+        os.environ.pop("DEAD_CST_PLUGINS_SERIAL", None)
+    return [_one_run(target_root, plugins) for _ in range(repeats)]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repeats", type=int, default=4)
+    parser.add_argument(
+        "--plugins",
+        type=int,
+        default=8,
+        help="How many synthetic heavy plugins to run.",
+    )
+    parser.add_argument(
+        "--queries",
+        type=int,
+        default=20,
+        help="How many find_subclasses_of_class calls each plugin makes.",
+    )
+    args = parser.parse_args()
+
+    require_native()
+
+    target = stage_dead_cst()
+    # Pick seeds whose subclasses queries actually do work — these
+    # are imported by dead_cst plugins.
+    seeds = [
+        "dead_cst.plugins._base.Plugin",
+        "dead_cst.plugins.decl_shapes.DispatchAppPlugin",
+        "dead_cst.plugins.decl_shapes.DecoratedDeclPlugin",
+        "typer.Typer",
+        "click.Command",
+        "flask.Flask",
+    ]
+    plugins = [_HeavyPlugin(args.queries, seeds) for _ in range(args.plugins)]
+    print(
+        f"\n{args.plugins} plugins x {args.queries} queries x "
+        f"{len(seeds)} seeds = {args.plugins * args.queries * len(seeds)} "
+        "calls / run"
+    )
+
+    print(f"\n{'mode':<10} {'best (ms)':>11} {'median':>10} {'min/max ratio':>14}")
+    print("-" * 50)
+    for mode in ("serial", "parallel"):
+        timings = _measure(target, plugins, args.repeats, mode)
+        best = min(timings) * 1000.0
+        med = statistics.median(timings) * 1000.0
+        ratio = min(timings) / max(timings)
+        print(f"{mode:<10} {best:>11.1f} {med:>10.1f} {ratio:>14.2%}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_parallel_plugins.py
+++ b/scripts/bench_parallel_plugins.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+"""Serial vs parallel plugin pass — wall-clock comparison.
+
+Runs the full set of built-in plugins against each target
+(``dead_cst`` self, flux0_server, flux0_workspace) in both modes and
+prints best-of-N timings. Uses ``DEAD_CST_PLUGINS_SERIAL`` to flip
+between the rust-side serial loop and the Python
+:class:`concurrent.futures.ThreadPoolExecutor` driven path.
+
+Usage:
+    uv run python scripts/bench_parallel_plugins.py --repeats 6
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+# Sibling import; make the scripts dir importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _bench_common import (  # noqa: E402
+    add_common_target_args,
+    gather_flux0_targets,
+    require_native,
+    stage_dead_cst,
+    file_count,
+    TargetConfig,
+)
+
+from dead_cst import Analysis  # noqa: E402
+from dead_cst.cli import _BUILTIN_PLUGINS  # noqa: E402
+
+
+def _all_builtin_plugins() -> list:
+    """Return the CLI's default set of built-in plugins. Plugins are
+    stateless after construction so reusing one instance per
+    materialize call is safe."""
+    return list(_BUILTIN_PLUGINS.values())
+
+
+def _one_run(target: TargetConfig, plugins: list) -> float:
+    start = time.perf_counter()
+    Analysis(target.root, plugins=plugins).materialize_all()
+    return time.perf_counter() - start
+
+
+def _measure(target: TargetConfig, repeats: int, mode: str) -> list[float]:
+    """``repeats`` measurements of ``Analysis(...).materialize_all()``
+    with the all-plugin set, in the requested mode."""
+    env_before = os.environ.get("DEAD_CST_PLUGINS_SERIAL")
+    if mode == "serial":
+        os.environ["DEAD_CST_PLUGINS_SERIAL"] = "1"
+    else:
+        os.environ.pop("DEAD_CST_PLUGINS_SERIAL", None)
+    try:
+        return [_one_run(target, _all_builtin_plugins()) for _ in range(repeats)]
+    finally:
+        if env_before is None:
+            os.environ.pop("DEAD_CST_PLUGINS_SERIAL", None)
+        else:
+            os.environ["DEAD_CST_PLUGINS_SERIAL"] = env_before
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=6,
+        help="How many timed runs per (target, mode) pair (best-of-N).",
+    )
+    add_common_target_args(parser, default_targets=["dead_cst", "flux0_server", "flux0_workspace"])
+    args = parser.parse_args()
+
+    require_native()
+
+    targets: list[TargetConfig] = []
+    if "dead_cst" in args.targets:
+        targets.append(TargetConfig(name="dead_cst self", root=stage_dead_cst()))
+    if not args.no_flux0:
+        targets.extend(gather_flux0_targets(args.targets, args.cache_root))
+
+    print(f"\n{'target':<28} {'mode':<8} {'files':>7} {'best (ms)':>11} {'median':>10}")
+    print("-" * 70)
+    for target in targets:
+        files = file_count(target.root)
+        for mode in ("serial", "parallel"):
+            timings = _measure(target, args.repeats, mode)
+            best_ms = min(timings) * 1000.0
+            med_ms = statistics.median(timings) * 1000.0
+            print(
+                f"{target.name:<28} {mode:<8} {files:>7} {best_ms:>11.1f} {med_ms:>10.1f}"
+            )
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_parallel_plugins.py
+++ b/scripts/bench_parallel_plugins.py
@@ -92,9 +92,7 @@ def main() -> None:
             timings = _measure(target, args.repeats, mode)
             best_ms = min(timings) * 1000.0
             med_ms = statistics.median(timings) * 1000.0
-            print(
-                f"{target.name:<28} {mode:<8} {files:>7} {best_ms:>11.1f} {med_ms:>10.1f}"
-            )
+            print(f"{target.name:<28} {mode:<8} {files:>7} {best_ms:>11.1f} {med_ms:>10.1f}")
         print()
 
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -360,81 +360,193 @@ pub(crate) fn synthetic_node(
     }
 }
 
+/// A [`GraphOp`] prepared for application: every Python-owned field
+/// has been hoisted into pure-rust storage so that
+/// [`apply_graph_op`] can drop the GIL before contending for the
+/// write lock on ``outputs``. Edge endpoints are represented as
+/// [`NodeKey`]s (the positional identity used by the builder's
+/// index) plus the source ``decl.fqname`` for entrypoint markers.
+/// See [`apply_graph_op`] for the concurrency rationale.
+pub(crate) enum PreparedOp {
+    Edge {
+        src: NodeKey,
+        dst: NodeKey,
+        flags: u32,
+    },
+    EdgeByIdx {
+        src_idx: usize,
+        dst_idx: usize,
+        flags: u32,
+    },
+    Entrypoint {
+        decl: NodeKey,
+        decl_fqname: String,
+        decl_path: String,
+        marker: String,
+    },
+    Node {
+        fqname: String,
+        kind: &'static str,
+        path: String,
+        flags: u32,
+        edges_from: Vec<NodeKey>,
+        edges_to: Vec<NodeKey>,
+    },
+}
+
 pub(crate) fn apply_graph_op(
     ctx: &Py<ProjectContext>,
     py: Python<'_>,
     op: &Bound<'_, PyAny>,
 ) -> PyResult<()> {
-    let this = ctx.borrow(py);
-    let mut outputs = this.outputs.borrow_mut();
-    let outputs = outputs
-        .as_mut()
-        .ok_or_else(|| not_materialized("apply_graph_op"))?;
+    // GIL-required prep: extract everything we need from the
+    // (potentially Python-owned) op into pure-rust state before we
+    // touch the lock. Concurrent plugins running on a Python
+    // :class:`ThreadPoolExecutor` can hold the ``outputs`` read
+    // guard across :meth:`pyo3::Python::allow_threads`; if we
+    // acquired the write lock while still holding the GIL, a reader
+    // returning from ``allow_threads`` would block on
+    // :func:`take_gil`, and the write side would block on
+    // ``wait_for_readers`` — classic deadlock. Dropping the GIL
+    // before contending for the write lock breaks that cycle.
+    let prepared = if let Ok(add_edge) = op.extract::<PyRef<AddEdge>>() {
+        PreparedOp::Edge {
+            src: node_key_of(&add_edge.src.borrow(py)),
+            dst: node_key_of(&add_edge.dst.borrow(py)),
+            flags: add_edge.flags,
+        }
+    } else if let Ok(add_edge_idx) = op.extract::<PyRef<AddEdgeByIdx>>() {
+        PreparedOp::EdgeByIdx {
+            src_idx: add_edge_idx.src_idx,
+            dst_idx: add_edge_idx.dst_idx,
+            flags: add_edge_idx.flags,
+        }
+    } else if let Ok(add_ep) = op.extract::<PyRef<AddEntrypoint>>() {
+        let decl_ref = add_ep.decl.borrow(py);
+        PreparedOp::Entrypoint {
+            decl: node_key_of(&decl_ref),
+            decl_fqname: decl_ref.fqname.clone(),
+            decl_path: decl_ref.path.clone(),
+            marker: add_ep.marker.clone(),
+        }
+    } else if let Ok(add_node) = op.extract::<PyRef<AddNode>>() {
+        let edges_from: Vec<NodeKey> = add_node
+            .edges_from
+            .iter()
+            .map(|n| node_key_of(&n.borrow(py)))
+            .collect();
+        let edges_to: Vec<NodeKey> = add_node
+            .edges_to
+            .iter()
+            .map(|n| node_key_of(&n.borrow(py)))
+            .collect();
+        PreparedOp::Node {
+            fqname: add_node.fqname.clone(),
+            kind: add_node.kind,
+            path: add_node.path.clone(),
+            flags: add_node.flags,
+            edges_from,
+            edges_to,
+        }
+    } else {
+        return Err(PyValueError::new_err(format!(
+            "expected a GraphOp (AddEdge / AddEdgeByIdx / AddEntrypoint / AddNode), got {:?}",
+            op.get_type().name()?,
+        )));
+    };
 
-    if let Ok(add_edge) = op.extract::<PyRef<AddEdge>>() {
-        let src_idx = lookup_idx(&outputs.builder, &add_edge.src.borrow(py), "src")?;
-        let dst_idx = lookup_idx(&outputs.builder, &add_edge.dst.borrow(py), "dst")?;
-        outputs.builder.add_edge(src_idx, dst_idx, add_edge.flags);
-        return Ok(());
-    }
-    if let Ok(add_edge_idx) = op.extract::<PyRef<AddEdgeByIdx>>() {
-        let len = outputs.builder.nodes.len();
-        if add_edge_idx.src_idx >= len {
-            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                "AddEdgeByIdx: src_idx {} out of range (len={})",
-                add_edge_idx.src_idx, len
-            )));
+    // The ``write()`` MUST happen with the GIL released, then the
+    // GIL re-acquired *after* we own the write guard. Otherwise a
+    // concurrent reader returning from ``allow_threads`` and waiting
+    // on ``take_gil`` will deadlock against us — we'd be holding the
+    // GIL while blocked on ``wait_for_readers``, and the reader
+    // can't drop its read guard without first re-attaching the GIL.
+    //
+    // We grab an ``Arc<RwLock<Option<BuildOutputs>>>`` from the
+    // pyclass (which is the outputs handle itself) so we can move
+    // it across the ``allow_threads`` boundary — ``Arc`` is Send,
+    // ``PyRef`` is not.
+    let outputs_lock = ctx.borrow(py).outputs.clone();
+    py.allow_threads(move || -> PyResult<()> {
+        let mut outputs = outputs_lock.write();
+        let outputs = outputs
+            .as_mut()
+            .ok_or_else(|| not_materialized("apply_graph_op"))?;
+        // With the write guard owned, re-acquire the GIL only for
+        // the calls that genuinely need it (``Py::new`` for the new
+        // node, ``clone_ref(py)`` for refcounted edges).
+        Python::with_gil(|py| apply_prepared(outputs, py, prepared))
+    })
+}
+
+fn apply_prepared(
+    outputs: &mut crate::project::BuildOutputs,
+    py: Python<'_>,
+    prepared: PreparedOp,
+) -> PyResult<()> {
+    match prepared {
+        PreparedOp::Edge { src, dst, flags } => {
+            let src_idx = lookup_idx_by_key(&outputs.builder, &src, "src")?;
+            let dst_idx = lookup_idx_by_key(&outputs.builder, &dst, "dst")?;
+            outputs.builder.add_edge(src_idx, dst_idx, flags);
+            Ok(())
         }
-        if add_edge_idx.dst_idx >= len {
-            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                "AddEdgeByIdx: dst_idx {} out of range (len={})",
-                add_edge_idx.dst_idx, len
-            )));
+        PreparedOp::EdgeByIdx {
+            src_idx,
+            dst_idx,
+            flags,
+        } => {
+            let len = outputs.builder.nodes.len();
+            if src_idx >= len {
+                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                    "AddEdgeByIdx: src_idx {src_idx} out of range (len={len})"
+                )));
+            }
+            if dst_idx >= len {
+                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                    "AddEdgeByIdx: dst_idx {dst_idx} out of range (len={len})"
+                )));
+            }
+            outputs.builder.add_edge(src_idx, dst_idx, flags);
+            Ok(())
         }
-        outputs.builder.add_edge(
-            add_edge_idx.src_idx,
-            add_edge_idx.dst_idx,
-            add_edge_idx.flags,
-        );
-        return Ok(());
-    }
-    if let Ok(add_ep) = op.extract::<PyRef<AddEntrypoint>>() {
-        let decl = add_ep.decl.borrow(py);
-        let decl_idx = lookup_idx(&outputs.builder, &decl, "decl")?;
-        let marker_fqname = format!("{}:{}", add_ep.marker, decl.fqname);
-        let path = decl.path.clone();
-        drop(decl);
-        let marker_idx = outputs.builder.intern_node(
-            py,
-            synthetic_node(marker_fqname, "synthetic", path, NODE_FLAG_ENTRYPOINT),
-        )?;
-        outputs.builder.add_edge(marker_idx, decl_idx, 0);
-        return Ok(());
-    }
-    if let Ok(add_node) = op.extract::<PyRef<AddNode>>() {
-        let node_idx = outputs.builder.intern_node(
-            py,
-            synthetic_node(
-                add_node.fqname.clone(),
-                add_node.kind,
-                add_node.path.clone(),
-                add_node.flags,
-            ),
-        )?;
-        for src in &add_node.edges_from {
-            let src_idx = lookup_idx(&outputs.builder, &src.borrow(py), "edges_from")?;
-            outputs.builder.add_edge(src_idx, node_idx, 0);
+        PreparedOp::Entrypoint {
+            decl,
+            decl_fqname,
+            decl_path,
+            marker,
+        } => {
+            let decl_idx = lookup_idx_by_key(&outputs.builder, &decl, "decl")?;
+            let marker_fqname = format!("{marker}:{decl_fqname}");
+            let marker_idx = outputs.builder.intern_node(
+                py,
+                synthetic_node(marker_fqname, "synthetic", decl_path, NODE_FLAG_ENTRYPOINT),
+            )?;
+            outputs.builder.add_edge(marker_idx, decl_idx, 0);
+            Ok(())
         }
-        for dst in &add_node.edges_to {
-            let dst_idx = lookup_idx(&outputs.builder, &dst.borrow(py), "edges_to")?;
-            outputs.builder.add_edge(node_idx, dst_idx, 0);
+        PreparedOp::Node {
+            fqname,
+            kind,
+            path,
+            flags,
+            edges_from,
+            edges_to,
+        } => {
+            let node_idx = outputs
+                .builder
+                .intern_node(py, synthetic_node(fqname, kind, path, flags))?;
+            for src in &edges_from {
+                let src_idx = lookup_idx_by_key(&outputs.builder, src, "edges_from")?;
+                outputs.builder.add_edge(src_idx, node_idx, 0);
+            }
+            for dst in &edges_to {
+                let dst_idx = lookup_idx_by_key(&outputs.builder, dst, "edges_to")?;
+                outputs.builder.add_edge(node_idx, dst_idx, 0);
+            }
+            Ok(())
         }
-        return Ok(());
     }
-    Err(PyValueError::new_err(format!(
-        "expected a GraphOp (AddEdge / AddEdgeByIdx / AddEntrypoint / AddNode), got {:?}",
-        op.get_type().name()?,
-    )))
 }
 
 /// Resolve a `SymbolNode` reference to its builder-side index for an
@@ -451,6 +563,22 @@ pub(crate) fn lookup_idx(builder: &GraphBuilder, node: &SymbolNode, side: &str) 
                 node.fqname
             ))
         })
+}
+
+/// Variant of [`lookup_idx`] that takes a [`NodeKey`] directly so it
+/// can be called from [`apply_graph_op`]'s GIL-free post-prepare
+/// section — see [`PreparedOp`] for why the key is pre-extracted.
+pub(crate) fn lookup_idx_by_key(
+    builder: &GraphBuilder,
+    key: &NodeKey,
+    side: &str,
+) -> PyResult<usize> {
+    builder.node_index.get(key).copied().ok_or_else(|| {
+        PyValueError::new_err(format!(
+            "add_edge: {side} node {:?} is not interned in this ProjectContext",
+            key.fqname
+        ))
+    })
 }
 
 #[cfg(test)]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -174,6 +174,37 @@ impl AddEdge {
     }
 }
 
+/// Index-keyed variant of :class:`AddEdge`. Accepts positional
+/// indices into ``ctx.nodes()`` instead of ``SymbolNode`` references.
+///
+/// Lets plugins that already work in index space (e.g. paired with
+/// :meth:`DeclQuery.indices` or :meth:`ProjectContext.indices_where`)
+/// emit edges without ever round-tripping through ``Py<SymbolNode>``.
+/// The apply pass treats it identically to :class:`AddEdge` once the
+/// indices land in :meth:`GraphBuilder::add_edge`.
+///
+/// Raises :class:`IndexError` at apply time when either endpoint is
+/// out of range for the current graph snapshot.
+#[pyclass(frozen, get_all)]
+pub(crate) struct AddEdgeByIdx {
+    pub(crate) src_idx: usize,
+    pub(crate) dst_idx: usize,
+    pub(crate) flags: u32,
+}
+
+#[pymethods]
+impl AddEdgeByIdx {
+    #[new]
+    #[pyo3(signature = (src_idx, dst_idx, *, flags = 0))]
+    fn new(src_idx: usize, dst_idx: usize, flags: u32) -> Self {
+        Self {
+            src_idx,
+            dst_idx,
+            flags,
+        }
+    }
+}
+
 /// Mark ``decl`` as an entrypoint.
 ///
 /// ``marker`` is a self-documenting label (``"<celery-worker>"``,
@@ -346,6 +377,27 @@ pub(crate) fn apply_graph_op(
         outputs.builder.add_edge(src_idx, dst_idx, add_edge.flags);
         return Ok(());
     }
+    if let Ok(add_edge_idx) = op.extract::<PyRef<AddEdgeByIdx>>() {
+        let len = outputs.builder.nodes.len();
+        if add_edge_idx.src_idx >= len {
+            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                "AddEdgeByIdx: src_idx {} out of range (len={})",
+                add_edge_idx.src_idx, len
+            )));
+        }
+        if add_edge_idx.dst_idx >= len {
+            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                "AddEdgeByIdx: dst_idx {} out of range (len={})",
+                add_edge_idx.dst_idx, len
+            )));
+        }
+        outputs.builder.add_edge(
+            add_edge_idx.src_idx,
+            add_edge_idx.dst_idx,
+            add_edge_idx.flags,
+        );
+        return Ok(());
+    }
     if let Ok(add_ep) = op.extract::<PyRef<AddEntrypoint>>() {
         let decl = add_ep.decl.borrow(py);
         let decl_idx = lookup_idx(&outputs.builder, &decl, "decl")?;
@@ -380,7 +432,7 @@ pub(crate) fn apply_graph_op(
         return Ok(());
     }
     Err(PyValueError::new_err(format!(
-        "expected a GraphOp (AddEdge / AddEntrypoint / AddNode), got {:?}",
+        "expected a GraphOp (AddEdge / AddEdgeByIdx / AddEntrypoint / AddNode), got {:?}",
         op.get_type().name()?,
     )))
 }

--- a/src/file_payload.rs
+++ b/src/file_payload.rs
@@ -25,6 +25,7 @@
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_db::source::{line_index, source_text};
+use ruff_python_ast::Stmt;
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
@@ -36,6 +37,7 @@ use ty_python_core::place::{PlaceExprRef, ScopedPlaceId};
 use ty_python_core::scope::FileScopeId;
 use ty_python_core::semantic_index;
 
+use crate::graph::NodeFlags;
 use crate::helpers::{
     collect_all_imports_local, file_default_flags, file_path_string, iter_top_level_classes,
     module_fqname_for_file, position, range_key, resolve_base_fqn, scan_noqa_directives,
@@ -227,6 +229,13 @@ pub(crate) struct ImportPayload {
 ///   walk. Same-file `LocalSameFileClass(local_idx)` bases reference
 ///   the file's own `refs[local_idx]`; assemble translates them via
 ///   the same `NodeRef -> global_idx` map used for edges.
+/// * `overload_anchors` — `(impl_local_idx, stub_local_idx)` pairs for
+///   in-file `@typing.overload` groups. The assembly pass emits one
+///   `impl → stub` edge per pair so reachability propagates from a
+///   live impl to its stubs (and a dead impl drags its stubs along
+///   for the codemod). Stubs are also flagged `NodeFlags::OVERLOAD`
+///   in `nodes` and excluded from `exports_by_name` so cross-module
+///   `from mod import f` resolves to the impl only.
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct FileNodes<'db> {
     pub(crate) nodes: Box<[NodeData]>,
@@ -235,6 +244,7 @@ pub(crate) struct FileNodes<'db> {
     pub(crate) exports_by_name: FxHashMap<String, SmallVec<[u32; 2]>>,
     pub(crate) star_reexports: FxHashMap<String, String>,
     pub(crate) class_bases: Vec<ClassBaseEntry>,
+    pub(crate) overload_anchors: Box<[(u32, u32)]>,
 }
 
 /// `(name_range_key, resolved_bases)` pair stored in
@@ -323,6 +333,53 @@ pub(crate) fn ref_to_node<'db>(db: &'db dyn ProjectDb, r: NodeRef<'db>) -> NodeD
     }
 }
 
+/// Modules whose `.overload` attribute marks a function decl as a stub.
+const OVERLOAD_MODULES: &[&str] = &["typing", "typing_extensions"];
+
+/// Return `true` if `dec` references `typing.overload` /
+/// `typing_extensions.overload` in any of its bound forms:
+///
+/// * `@overload` / `@overload(...)` when `imports["overload"]` resolves
+///   to `typing.overload` (or `typing_extensions.overload`).
+/// * `@typing.overload` / `@typing.overload(...)` when `imports["typing"]`
+///   is bound as a module (the `<module>` marker used by
+///   `collect_all_imports_local` for plain `import typing`).
+/// * Aliased forms such as `from typing import overload as ovl` (the
+///   `imports` map already records `"ovl" -> "typing.overload"`).
+fn is_overload_decorator(
+    dec: &ruff_python_ast::Decorator,
+    imports: &rustc_hash::FxHashMap<String, String>,
+) -> bool {
+    // Unwrap call form (`@overload()`) so we look at the callee.
+    let mut expr = &dec.expression;
+    while let ruff_python_ast::Expr::Call(call) = expr {
+        expr = &call.func;
+    }
+    match expr {
+        ruff_python_ast::Expr::Name(n) => imports
+            .get(n.id.as_str())
+            .map(|target| {
+                OVERLOAD_MODULES
+                    .iter()
+                    .any(|m| target.as_str() == format!("{m}.overload"))
+            })
+            .unwrap_or(false),
+        ruff_python_ast::Expr::Attribute(attr) => {
+            if attr.attr.as_str() != "overload" {
+                return false;
+            }
+            let ruff_python_ast::Expr::Name(prefix) = attr.value.as_ref() else {
+                return false;
+            };
+            imports
+                .get(prefix.id.as_str())
+                .map(|target| OVERLOAD_MODULES.iter().any(|m| target == m))
+                .unwrap_or(false)
+        }
+        _ => false,
+    }
+}
+
 /// Build the per-file node payload. Salsa-tracked so it's memoized and
 /// safe to call concurrently from rayon workers; `returns(ref)` so
 /// callers get a borrow into salsa's storage instead of a clone.
@@ -380,6 +437,25 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
     let mut star_local_name_cache: HashMap<TextRange, String> = HashMap::new();
 
     let mut star_reexports: FxHashMap<String, String> = FxHashMap::default();
+
+    // Pre-scan top-level `Stmt::FunctionDef` decorator lists to identify
+    // `@typing.overload`-decorated function defs. The set is keyed on the
+    // function's name TextRange (which is what `DefinitionKind::Function`
+    // reports as its `target_range`), so we can flag the matching decl
+    // when ty enumerates it below.
+    let local_imports = collect_all_imports_local(&parsed);
+    let mut overload_decorated: FxHashSet<TextRange> = FxHashSet::default();
+    for stmt in &parsed.syntax().body {
+        if let Stmt::FunctionDef(func) = stmt {
+            if func
+                .decorator_list
+                .iter()
+                .any(|d| is_overload_decorator(d, &local_imports))
+            {
+                overload_decorated.insert(func.name.range());
+            }
+        }
+    }
 
     for (_def_id, state, _used) in use_def_map.all_definitions_with_usage() {
         let DefinitionState::Defined(def) = state else {
@@ -446,6 +522,13 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         {
             flags |= NODE_FLAGS_NOQA_PIN;
         }
+        // `@typing.overload`-decorated function defs: flag now so the
+        // post-pass can partition same-name groups into impl / stubs.
+        // The set is keyed on the function's name TextRange, which is
+        // exactly what `DefinitionKind::Function::target_range` returns.
+        if matches!(node_kind, NodeKind::Function) && overload_decorated.contains(&target_range) {
+            flags |= NodeFlags::OVERLOAD;
+        }
         // Stub-only ENTRYPOINT flagging is deferred to the assembly
         // pass; it needs the project-wide peer-stub map and the .py
         // twin's `exports_by_name`, which aren't visible to this
@@ -482,12 +565,58 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         }
     }
 
+    // Overload-anchor post-pass: for each same-name group of top-level
+    // function defs containing both `@overload`-decorated stubs AND a
+    // non-overload impl, pair each stub with the *last* non-overload
+    // decl (CPython's runtime semantics — the impl is the final one).
+    // Stubs that aren't anchored to an impl (e.g. a .pyi stub file
+    // where every `def f` is `@overload`) keep their OVERLOAD flag
+    // but emit no anchor; reachability falls back to the
+    // module-anchor edge.
+    let mut overload_anchors: Vec<(u32, u32)> = Vec::new();
+    let mut by_name: FxHashMap<String, Vec<u32>> = FxHashMap::default();
+    for (i, node) in nodes.iter().enumerate() {
+        if !matches!(node.kind, NodeKind::Function) {
+            continue;
+        }
+        let simple = node
+            .fqname
+            .rsplit_once('.')
+            .map(|p| p.1)
+            .unwrap_or(&node.fqname);
+        by_name
+            .entry(simple.to_string())
+            .or_default()
+            .push(i as u32);
+    }
+    for group in by_name.values() {
+        // Find the last non-overload entry — that's the impl. Groups
+        // without any non-overload decl emit no anchors (e.g. a .pyi
+        // stub file whose every `def f` is `@overload`).
+        let Some(&impl_idx) = group
+            .iter()
+            .rev()
+            .find(|&&i| nodes[i as usize].flags & NodeFlags::OVERLOAD == 0)
+        else {
+            continue;
+        };
+        for &i in group {
+            if nodes[i as usize].flags & NodeFlags::OVERLOAD != 0 {
+                overload_anchors.push((impl_idx, i));
+            }
+        }
+    }
+
     // Post-pass: populate `exports_by_name` from ty's end-of-scope
     // symbol bindings. This collapses sequential rebinds to the latest
     // while preserving branch-bound multi-binding cases (try/except,
     // if/else where each branch assigns). Mirrors `globals_by_name` in
     // today's pipeline. Values are indices into `nodes` (≥ 1, since
     // index 0 is the module node which can't be bound to a name).
+    // Overload-flagged decls are excluded so `from mod import f`
+    // resolves to the impl only — the impl `def f` shadows them via
+    // ty's end-of-scope binding anyway, but pyi stub files (every
+    // `def f` decorated `@overload`) need the explicit filter.
     let mut exports_by_name: FxHashMap<String, SmallVec<[u32; 2]>> = FxHashMap::default();
     for (symbol_id, bindings) in use_def_map.all_end_of_scope_symbol_bindings() {
         let PlaceExprRef::Symbol(sym) = place_table.place(ScopedPlaceId::Symbol(symbol_id)) else {
@@ -503,6 +632,9 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
                 continue;
             }
             if let Some(&local_idx) = ref_to_local.get(&NodeRef::Def(def)) {
+                if nodes[local_idx as usize].flags & NodeFlags::OVERLOAD != 0 {
+                    continue;
+                }
                 live.push(local_idx);
             }
         }
@@ -525,6 +657,7 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         exports_by_name,
         star_reexports,
         class_bases,
+        overload_anchors: overload_anchors.into_boxed_slice(),
     }
 }
 
@@ -796,6 +929,17 @@ pub(crate) fn file_to_edges<'db>(db: &'db dyn ProjectDb, file: File) -> FileEdge
     //    its decls. `refs[0]` is the module itself; skip it.
     for &node_ref in self_nodes.refs.iter().skip(1) {
         edges.insert((node_ref, module_ref, 0));
+    }
+
+    // 1a. `impl → stub` anchor edges for in-file `@typing.overload`
+    //     groups. Lets reachability propagate from a live impl to its
+    //     stubs and lets the codemod drop a dead impl's stubs in the
+    //     same pass. (`NodeFlags::OVERLOAD` on the stub additionally
+    //     excludes it from cross-module `from mod import f` lookups.)
+    for &(impl_local, stub_local) in self_nodes.overload_anchors.iter() {
+        let impl_ref = self_nodes.refs[impl_local as usize];
+        let stub_ref = self_nodes.refs[stub_local as usize];
+        edges.insert((impl_ref, stub_ref, 0));
     }
 
     // 2. Submodule → parent module hierarchy edge. Mirrors today's

--- a/src/file_payload.rs
+++ b/src/file_payload.rs
@@ -25,7 +25,7 @@
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_db::source::{line_index, source_text};
-use ruff_text_size::TextRange;
+use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use std::collections::HashMap;
@@ -37,7 +37,8 @@ use ty_python_core::scope::FileScopeId;
 use ty_python_core::semantic_index;
 
 use crate::helpers::{
-    file_default_flags, file_path_string, module_fqname_for_file, position, scan_noqa_directives,
+    collect_all_imports_local, file_default_flags, file_path_string, iter_top_level_classes,
+    module_fqname_for_file, position, range_key, resolve_base_fqn, scan_noqa_directives,
     NODE_FLAGS_NOQA_PIN,
 };
 use crate::ingest::{decl_kind_str, from_module_string};
@@ -217,6 +218,15 @@ pub(crate) struct ImportPayload {
 /// * `star_reexports` — per-name → upstream absolute module name when
 ///   `name` is bound in this file by `from <upstream> import *`. Lets
 ///   downstream chain walks hop through this file.
+/// * `class_bases` — per top-level class declaration, the resolved
+///   base list. Each entry is `(name_range_key, bases)` where
+///   `name_range_key` matches the `(start, end)` `u32` pair the
+///   assemble pass stores in `class_by_selection`, and `bases` is a
+///   small-vec of [`ResolvedBase`] entries. Drives the project-wide
+///   class-hierarchy fan-in at assemble time without a second AST
+///   walk. Same-file `LocalSameFileClass(local_idx)` bases reference
+///   the file's own `refs[local_idx]`; assemble translates them via
+///   the same `NodeRef -> global_idx` map used for edges.
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct FileNodes<'db> {
     pub(crate) nodes: Box<[NodeData]>,
@@ -224,6 +234,49 @@ pub(crate) struct FileNodes<'db> {
     pub(crate) ref_to_local: FxHashMap<NodeRef<'db>, u32>,
     pub(crate) exports_by_name: FxHashMap<String, SmallVec<[u32; 2]>>,
     pub(crate) star_reexports: FxHashMap<String, String>,
+    pub(crate) class_bases: Vec<ClassBaseEntry>,
+}
+
+/// `(name_range_key, resolved_bases)` pair stored in
+/// [`FileNodes::class_bases`]. The range key matches what the
+/// assemble pass writes into `class_by_selection`, so the project-wide
+/// fan-in is a hashmap probe.
+pub(crate) type ClassBaseEntry = ((u32, u32), SmallVec<[ResolvedBase; 2]>);
+
+/// One base-class expression resolved against a single file's
+/// imports + same-file class bindings. Computed purely from per-file
+/// state so it lives inside the salsa-tracked [`FileNodes`] payload —
+/// project-wide fan-in happens at assemble time.
+///
+/// Four shapes cover today's class headers:
+///
+/// * `LocalSameFileClass(local_idx)` — `class Sub(Base): ...` where
+///   `Base` is a top-level class earlier in the same file. The
+///   `local_idx` indexes into the per-file `refs`/`nodes` arrays;
+///   assemble translates it to a global graph index via the same
+///   `ref_to_global` map used for edges.
+/// * `ImportedFqn(fqn)` — `from <module> import Base` (or aliased)
+///   followed by `class Sub(Base): ...`. The fqn is fully qualified
+///   after relative-import resolution. Matches both project and
+///   external bases by string equality with no per-file state.
+/// * `Attribute { module_fqn, attr_name }` — `import <module> [as M];
+///   class Sub(M.Base): ...`. We resolve `M` to its absolute module
+///   name via the file's imports and keep `attr_name` separate so the
+///   assemble pass can probe the target module's `exports_by_name`
+///   (project-side) and synthesize the canonical `<module>.<attr>`
+///   fqn (external-side) without re-parsing.
+/// * `Unresolvable` — `Generic[T]`, dynamic constructions, any base
+///   shape outside the static-resolution contract. Kept as an entry
+///   so the parent class still appears in the index.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
+pub(crate) enum ResolvedBase {
+    LocalSameFileClass(u32),
+    ImportedFqn(String),
+    Attribute {
+        module_fqn: String,
+        attr_name: String,
+    },
+    Unresolvable,
 }
 
 /// Resolve a `NodeRef` to its `NodeData` payload.
@@ -458,13 +511,131 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         }
     }
 
+    // Build per-file `class_bases`: walk every top-level ClassDef and
+    // resolve each base expression against the file's imports + the
+    // same-file class name table. No project-wide state needed; the
+    // assemble pass turns these into the global `children_by_node` /
+    // `children_by_fqn` indices.
+    let class_bases = build_class_bases(&parsed, &exports_by_name, &nodes);
+
     FileNodes {
         nodes: nodes.into_boxed_slice(),
         refs: refs.into_boxed_slice(),
         ref_to_local,
         exports_by_name,
         star_reexports,
+        class_bases,
     }
+}
+
+/// Per-file class-hierarchy producer used by [`file_to_nodes`].
+///
+/// For each top-level `ClassDef`, locate its corresponding graph node
+/// (via `exports_by_name` + `nodes[..]` kind probe) and resolve each
+/// base expression to a [`ResolvedBase`]. The result is a flat list of
+/// `(local_class_idx, bases)` pairs the assemble pass folds into the
+/// project-wide hierarchy without re-parsing.
+///
+/// Resolution mirrors today's `build_class_children` + `resolve_base_fqn`
+/// helpers but reads everything from the per-file state:
+///
+/// * `Name(Foo)` where `Foo` is in `file_imports` → `ImportedFqn`.
+/// * `Name(Foo)` where `Foo` is a top-level class earlier in this
+///   file → `LocalSameFileClass(local_idx)`.
+/// * `Attribute(Name(M).N)` where `M` is in `file_imports` →
+///   `Attribute { module_fqn, attr_name: N }`.
+/// * Deeper `a.b.c.N` chains rooted at an import → flattened into
+///   `ImportedFqn("<a-upstream>.b.c.N")` (matches today's
+///   `resolve_base_fqn` behaviour for the `find_subclasses_via_bases`
+///   path).
+/// * Anything else → `ResolvedBase::Unresolvable`.
+fn build_class_bases(
+    parsed: &ruff_db::parsed::ParsedModuleRef,
+    exports_by_name: &FxHashMap<String, SmallVec<[u32; 2]>>,
+    nodes: &[NodeData],
+) -> Vec<ClassBaseEntry> {
+    use ruff_python_ast::Expr;
+    let file_imports = collect_all_imports_local(parsed);
+
+    // Build name → local class idx for same-file class references.
+    // Multiple top-level `class Foo` rebinds at the same name keep
+    // the *first* (matching the historical libcst behaviour where a
+    // syntactic base reference resolves to the lexically-earliest
+    // class with that name). The cross-module case is unaffected —
+    // `subclasses_of_fqn` indexes by fqname, so shadowed declarations
+    // resolve through the import path, not this map.
+    let mut same_file_classes: FxHashMap<&str, u32> = FxHashMap::default();
+    for (name, locals) in exports_by_name {
+        for &local_idx in locals {
+            if matches!(nodes[local_idx as usize].kind, NodeKind::Class) {
+                same_file_classes.entry(name.as_str()).or_insert(local_idx);
+                break;
+            }
+        }
+    }
+
+    let mut out: Vec<ClassBaseEntry> = Vec::new();
+    for cls in iter_top_level_classes(parsed) {
+        // Key on the class name's `(start, end)` byte range — same
+        // tuple the assemble pass uses to populate `class_by_selection`,
+        // so the assemble-side fan-in is an O(1) hashmap probe.
+        let cls_rk = range_key(cls.name.range());
+
+        let Some(args) = &cls.arguments else {
+            out.push((cls_rk, SmallVec::new()));
+            continue;
+        };
+        let mut bases: SmallVec<[ResolvedBase; 2]> = SmallVec::new();
+        for raw_base in &args.args {
+            // Unwrap `Foo[T]`, `Generic[T]`, `Protocol[T]`, etc.
+            // The original `build_class_children` matched these
+            // before the fqn-aware resolver ran; preserve that
+            // behaviour so subscripted generic bases still feed
+            // the class hierarchy.
+            let base = match raw_base {
+                Expr::Subscript(s) => s.value.as_ref(),
+                other => other,
+            };
+            // First-pass: try the fqn-aware resolver. It returns an
+            // upstream fqname for Name/Attribute chains rooted at an
+            // imported name. For a single Attribute(Name(M).N) we
+            // override to the `Attribute` variant so the assemble pass
+            // can probe the target module's `exports_by_name` for the
+            // project-side class lookup.
+            if let Some(fqn) = resolve_base_fqn(base, &file_imports) {
+                match base {
+                    Expr::Attribute(a) => {
+                        if let Expr::Name(root) = a.value.as_ref() {
+                            if let Some(module_fqn) = file_imports.get(root.id.as_str()) {
+                                bases.push(ResolvedBase::Attribute {
+                                    module_fqn: module_fqn.clone(),
+                                    attr_name: a.attr.as_str().to_string(),
+                                });
+                                continue;
+                            }
+                        }
+                        // Deeper chains: keep the flat fqn — used by
+                        // the fqn-keyed lookup.
+                        bases.push(ResolvedBase::ImportedFqn(fqn));
+                    }
+                    _ => {
+                        bases.push(ResolvedBase::ImportedFqn(fqn));
+                    }
+                }
+                continue;
+            }
+            // Fallback: same-file bare-name class reference.
+            if let Expr::Name(name) = base {
+                if let Some(&local_idx) = same_file_classes.get(name.id.as_str()) {
+                    bases.push(ResolvedBase::LocalSameFileClass(local_idx));
+                    continue;
+                }
+            }
+            bases.push(ResolvedBase::Unresolvable);
+        }
+        out.push((cls_rk, bases));
+    }
+    out
 }
 
 /// Pure-rust variant of `ingest::import_payload_for`. Returns the same

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ mod query;
 
 use pyo3::prelude::*;
 
-use crate::builder::{AddEdge, AddEntrypoint, AddNode};
+use crate::builder::{AddEdge, AddEdgeByIdx, AddEntrypoint, AddNode};
 use crate::graph::{EdgeFlags, Import, NativeGraph, NodeFlags, SymbolNode};
 use crate::io::{read_graph, write_graph, GraphMetadata};
 use crate::project::{Project, ProjectContext};
@@ -72,6 +72,7 @@ fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Project>()?;
     m.add_class::<ProjectContext>()?;
     m.add_class::<AddEdge>()?;
+    m.add_class::<AddEdgeByIdx>()?;
     m.add_class::<AddEntrypoint>()?;
     m.add_class::<AddNode>()?;
     m.add_class::<NodeFlags>()?;

--- a/src/project.rs
+++ b/src/project.rs
@@ -1652,12 +1652,27 @@ impl ProjectContext {
         py: Python<'_>,
         module_fqn: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
+        let indices = self.find_module_top_level_decls_indices(module_fqn)?;
         let outputs = self.materialized("find_module_top_level_decls")?;
+        Ok(indices
+            .into_iter()
+            .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
+            .collect())
+    }
+
+    /// Idx-only variant of :meth:`find_module_top_level_decls`. Same
+    /// scan, returns positional indices into ``ctx.nodes()`` rather
+    /// than allocating ``Py<SymbolNode>`` clones.
+    pub(crate) fn find_module_top_level_decls_indices(
+        &self,
+        module_fqn: &str,
+    ) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("find_module_top_level_decls_indices")?;
         if !outputs.module_by_fqname.contains_key(module_fqn) {
             return Ok(Vec::new());
         }
         let prefix = format!("{module_fqn}.");
-        let mut out = Vec::new();
+        let mut out: Vec<usize> = Vec::new();
         for (fqname, idxs) in &outputs.decl_by_fqname {
             let Some(rest) = fqname.strip_prefix(&prefix) else {
                 continue;
@@ -1666,9 +1681,7 @@ impl ProjectContext {
             if rest.contains('.') {
                 continue;
             }
-            for &idx in idxs {
-                out.push(outputs.builder.nodes[idx].clone_ref(py));
-            }
+            out.extend(idxs.iter().copied());
         }
         Ok(out)
     }
@@ -1693,18 +1706,39 @@ impl ProjectContext {
         py: Python<'_>,
         module_fqn: &str,
     ) -> PyResult<Option<Vec<Py<SymbolNode>>>> {
+        let Some(indices) = self.find_module_dunder_all_exports_indices(module_fqn)? else {
+            return Ok(None);
+        };
+        let outputs = self.materialized("find_module_dunder_all_exports")?;
+        Ok(Some(
+            indices
+                .into_iter()
+                .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
+                .collect(),
+        ))
+    }
+
+    /// Idx-only variant of :meth:`find_module_dunder_all_exports`.
+    /// Same lookup, returns positional indices into ``ctx.nodes()``
+    /// rather than allocating ``Py<SymbolNode>`` clones. ``None``
+    /// still means "no ``__all__``"; ``Some([])`` means "empty /
+    /// unresolvable ``__all__``" (callers wanting CPython's
+    /// ``from X import *`` semantics fall back to the non-underscore
+    /// decl list only in the ``None`` case).
+    pub(crate) fn find_module_dunder_all_exports_indices(
+        &self,
+        module_fqn: &str,
+    ) -> PyResult<Option<Vec<usize>>> {
         let all_fqn = format!("{module_fqn}.__all__");
         let Some(entries) = self.find_literal_list_entries(&all_fqn)? else {
             return Ok(None);
         };
-        let outputs = self.materialized("find_module_dunder_all_exports")?;
-        let mut out: Vec<Py<SymbolNode>> = Vec::new();
+        let outputs = self.materialized("find_module_dunder_all_exports_indices")?;
+        let mut out: Vec<usize> = Vec::new();
         for entry in entries {
             let entry_fqn = format!("{module_fqn}.{entry}");
             if let Some(idxs) = outputs.decl_by_fqname.get(&entry_fqn) {
-                for &idx in idxs {
-                    out.push(outputs.builder.nodes[idx].clone_ref(py));
-                }
+                out.extend(idxs.iter().copied());
             }
         }
         Ok(Some(out))

--- a/src/project.rs
+++ b/src/project.rs
@@ -34,7 +34,7 @@ use crate::helpers::{
     collect_modules_imports_local, decorators_match_imports, extract_call_args_kwargs,
     file_path_string, find_external_seed_direct_subclasses_par, find_main_block_range,
     find_subclass_indices_via_refs_with_queue, is_dunder_name, locate_class_def, locate_class_seed,
-    matched_call_target_any, owner_idx_for_stmt_with, range_key, rel_path, resolve_base_fqn,
+    matched_call_target_any, owner_idx_for_stmt_with, range_key, rel_path,
     top_level_assign_to_name, unwrap_subscripted_callee, AttrCallFinder, CallArgs,
     FactoryCallFinder, StringArgCallFinder, NODE_FLAG_ENTRYPOINT,
 };
@@ -125,11 +125,10 @@ pub(crate) struct BuildOutputs {
     /// nodes — and a cheap ``imports_of_exists`` short-circuit for
     /// plugins that just need a per-module presence check.
     pub(crate) imports_by_module: FxHashMap<String, Vec<usize>>,
-    /// PROTOTYPE: project-wide class hierarchy.
-    /// `class_idx -> [direct subclass class_idx]`. Built post-assembly
-    /// by walking each top-level class def's base list and resolving
-    /// each base Name expression via per-file `exports_by_name` and the
-    /// import-alias `forward_adj` chains.
+    /// Project-wide class hierarchy keyed by parent class graph idx.
+    /// `class_idx -> [direct subclass class_idx]`. Derived in
+    /// `assemble_graph` from each file's per-file `class_bases`
+    /// payload (see [`crate::file_payload::FileNodes::class_bases`]).
     ///
     /// Lets ``UnittestPlugin`` / ``InitSubclassPlugin`` do an O(N) BFS
     /// over this map instead of calling ``find_references`` per class.
@@ -137,7 +136,14 @@ pub(crate) struct BuildOutputs {
     /// ``find_subclass_indices_via_refs`` for the first hop into the
     /// project; once a project class is found, transitive walks use
     /// this map.
-    pub(crate) class_children: FxHashMap<usize, Vec<usize>>,
+    pub(crate) children_by_node: FxHashMap<usize, Vec<usize>>,
+    /// Project-wide class hierarchy keyed by parent fqname (project or
+    /// external). `base_fqn -> [direct subclass class_idx]`. Lets
+    /// ``subclasses_of_fqn`` answer the "any project classes extending
+    /// ``flask.Flask``?" question in O(1) without re-walking the AST
+    /// or re-resolving imports. Built alongside ``children_by_node``
+    /// from the per-file ``class_bases`` payload.
+    pub(crate) children_by_fqn: FxHashMap<String, Vec<usize>>,
 }
 
 /// Run the three build phases (ingest → hierarchy+imports → references)
@@ -356,23 +362,27 @@ pub(crate) fn build_project_graph(
     let decl_by_name_range = assembled.decl_by_name_range;
     let ref_to_global = assembled.ref_to_global;
 
-    // PROTOTYPE: build the project-wide class hierarchy index.
+    let t4 = std::time::Instant::now();
+    let (decl_by_fqname, module_by_fqname, imports_by_module) = build_fqname_indices(py, &builder);
+    let t_fqname = t4.elapsed();
+
+    // Class hierarchy fan-in: fold every file's per-file `class_bases`
+    // payload (see `file_payload::FileNodes::class_bases`) into two
+    // project-wide indices — node-keyed (intra-project subclass
+    // walks) and fqname-keyed (external seeds + the dispatch-plugin
+    // hot path). One pass over the per-file payloads + one pass per
+    // base; no AST re-walk.
     let t_hierarchy = std::time::Instant::now();
-    let class_children = build_class_children(
+    let (children_by_node, children_by_fqn) = build_class_hierarchy_indices(
         db,
         &project_files,
-        &path_to_file,
         &class_by_selection,
         &ref_to_global,
-        &builder.forward_adj,
+        &decl_by_fqname,
         py,
         &builder.nodes,
     );
     let t_hierarchy_elapsed = t_hierarchy.elapsed();
-
-    let t4 = std::time::Instant::now();
-    let (decl_by_fqname, module_by_fqname, imports_by_module) = build_fqname_indices(py, &builder);
-    let t_fqname = t4.elapsed();
     if timing {
         eprintln!(
             "[dead-cst-timing] files={} nodes={} edges={} enum={:?} populate={:?} assemble={:?} class_hier={:?} fqname={:?} total={:?} rss={}MB",
@@ -408,7 +418,8 @@ pub(crate) fn build_project_graph(
         decl_by_fqname,
         module_by_fqname,
         imports_by_module,
-        class_children,
+        children_by_node,
+        children_by_fqn,
     })
 }
 
@@ -793,165 +804,113 @@ fn assemble_graph<'db>(
     })
 }
 
-/// PROTOTYPE: build `class_idx -> [direct subclass class_idx]` map.
+/// Fold every file's per-file `class_bases` payload (see
+/// [`crate::file_payload::FileNodes::class_bases`]) into two
+/// project-wide indices used by the subclass queries:
 ///
-/// For each project file's top-level class definition, resolve each
-/// base expression's head Name to a graph node (via per-file
-/// `exports_by_name`), follow the resulting alias chain to a class
-/// node (via `builder.forward_adj`), and record the
-/// (class_idx, parent_class_idx) edge.
+/// * `children_by_node` — parent class graph idx → direct subclass
+///   graph idxs. Drives intra-project BFS for both project and
+///   external seeds (once the first hop lands a project class).
+/// * `children_by_fqn` — base fqname → direct subclass graph idxs.
+///   Lets external seeds (`unittest.TestCase`, `flask.Flask`) be
+///   answered without an AST re-walk and without ty's framework
+///   loader. The same map also serves project bases via the import
+///   path — `class C(Foo): ...` with `from m import Foo` lands as
+///   `ImportedFqn("m.Foo")`, which matches the project's own
+///   `m.Foo` class node when fqname lookup hits `decl_by_fqname`.
 ///
-/// Limitations of this prototype:
+/// Resolution rules per `ResolvedBase` variant:
 ///
-/// * Only handles `Name(...)` and `Attribute(...)` bases with a Name
-///   root. Complex bases like `Generic[T]` aren't walked beyond the
-///   head Name.
-/// * Local-binding resolution goes through `exports_by_name` which
-///   returns the end-of-scope binding(s); we don't honour
-///   per-statement use-def chains. For simple linear files this
-///   matches `SemanticModel::resolve_name`.
-/// * If a base resolves to an import alias, we walk the alias's
-///   `forward_adj` and keep the first class target found. Doesn't
-///   cover ``from a import C as D; class X(D): ...`` chains with more
-///   than one alias hop.
-#[allow(clippy::too_many_arguments)]
-fn build_class_children<'db>(
+/// * `LocalSameFileClass(local_idx)` — translate via the file's
+///   `refs[local_idx]` + `ref_to_global` to a parent class graph idx
+///   and emit a `children_by_node` entry.
+/// * `ImportedFqn(fqn)` — index in `children_by_fqn`. Additionally,
+///   when the fqn resolves in `decl_by_fqname` to a project class
+///   node, emit a `children_by_node` entry too (so a project base
+///   imported via `from m import C` participates in node-keyed
+///   walks).
+/// * `Attribute { module_fqn, attr_name }` — probe `module_fqname`
+///   via `module_by_fqname` (project-side) and resolve the attr in
+///   that module's `exports_by_name`. Project hits emit
+///   `children_by_node` entries; the fqname form
+///   `{module_fqn}.{attr_name}` also lands in `children_by_fqn` so
+///   external `M.N` references are answerable by string match.
+/// * `Unresolvable` — dropped.
+fn build_class_hierarchy_indices<'db>(
     db: &'db ProjectDatabase,
     project_files: &[File],
-    path_to_file: &FxHashMap<String, File>,
     class_by_selection: &FxHashMap<(File, (u32, u32)), usize>,
     ref_to_global: &FxHashMap<NodeRef<'db>, usize>,
-    forward_adj: &[Vec<(usize, u32)>],
+    decl_by_fqname: &FxHashMap<String, Vec<usize>>,
     py: Python<'_>,
     nodes: &[Py<SymbolNode>],
-) -> FxHashMap<usize, Vec<usize>> {
-    use crate::helpers::iter_top_level_classes;
-    let mut children: FxHashMap<usize, Vec<usize>> = FxHashMap::default();
+) -> (FxHashMap<usize, Vec<usize>>, FxHashMap<String, Vec<usize>>) {
+    use crate::file_payload::ResolvedBase;
+    let mut by_node: FxHashMap<usize, Vec<usize>> = FxHashMap::default();
+    let mut by_fqn: FxHashMap<String, Vec<usize>> = FxHashMap::default();
 
     for &file in project_files {
-        let parsed = parsed_module(db, file).load(db);
         let payload = file_to_nodes(db, file);
-
-        for cls in iter_top_level_classes(&parsed) {
-            let name_r = cls.name.range();
-            let rk = (name_r.start().to_u32(), name_r.end().to_u32());
-            let Some(&child_idx) = class_by_selection.get(&(file, rk)) else {
+        for (cls_rk, bases) in &payload.class_bases {
+            let Some(&child_idx) = class_by_selection.get(&(file, *cls_rk)) else {
                 continue;
             };
-
-            let Some(args) = &cls.arguments else {
-                continue;
-            };
-
-            for base in &args.args {
-                // Find the head Name + optional trailing attribute name
-                // for this base expression. Two shapes we handle:
-                //
-                // * `Cls` -> head=Cls, trailing=None
-                // * `module.Cls` -> head=module, trailing=Some("Cls")
-                // * `Generic[T]` / `Protocol[T]` -> head=Generic
-                let (head_name, trailing_attr): (Option<&str>, Option<&str>) = match base {
-                    Expr::Name(n) => (Some(n.id.as_str()), None),
-                    Expr::Attribute(a) => {
-                        if let Expr::Name(root) = a.value.as_ref() {
-                            (Some(root.id.as_str()), Some(a.attr.as_str()))
-                        } else {
-                            (None, None)
+            for base in bases {
+                match base {
+                    ResolvedBase::LocalSameFileClass(local_idx) => {
+                        let r = payload.refs[*local_idx as usize];
+                        if let Some(&parent_idx) = ref_to_global.get(&r) {
+                            if nodes[parent_idx].borrow(py).kind == "class" {
+                                by_node.entry(parent_idx).or_default().push(child_idx);
+                            }
                         }
                     }
-                    Expr::Subscript(s) => match s.value.as_ref() {
-                        Expr::Name(n) => (Some(n.id.as_str()), None),
-                        Expr::Attribute(a) => {
-                            if let Expr::Name(root) = a.value.as_ref() {
-                                (Some(root.id.as_str()), Some(a.attr.as_str()))
-                            } else {
-                                (None, None)
-                            }
-                        }
-                        _ => (None, None),
-                    },
-                    _ => (None, None),
-                };
-                let Some(head) = head_name else {
-                    continue;
-                };
-
-                // Resolve `head` in the file's global namespace.
-                let Some(locals) = payload.exports_by_name.get(head) else {
-                    continue;
-                };
-                for &local_idx in locals {
-                    let r = payload.refs[local_idx as usize];
-                    let Some(&parent_idx) = ref_to_global.get(&r) else {
-                        continue;
-                    };
-                    let parent_kind = nodes[parent_idx].borrow(py).kind;
-                    if parent_kind == "class" && trailing_attr.is_none() {
-                        children.entry(parent_idx).or_default().push(child_idx);
-                    } else if parent_kind == "import" {
-                        match trailing_attr {
-                            None => {
-                                // `Cls` resolved to an alias node;
-                                // follow alias's forward edges to a
-                                // class target.
-                                for &(adj_idx, _) in &forward_adj[parent_idx] {
-                                    if nodes[adj_idx].borrow(py).kind == "class" {
-                                        children.entry(adj_idx).or_default().push(child_idx);
-                                        break;
-                                    }
-                                }
-                            }
-                            Some(attr_name) => {
-                                // `module.Cls`: alias likely points at
-                                // a module node; look up `attr_name` in
-                                // that target module's
-                                // exports_by_name and follow.
-                                for &(adj_idx, _) in &forward_adj[parent_idx] {
-                                    let adj_node = nodes[adj_idx].borrow(py);
-                                    if adj_node.kind != "module" {
-                                        continue;
-                                    }
-                                    // Recover the target module's `File`
-                                    // via the project-wide `path_to_file`
-                                    // index (O(1) probe) instead of a
-                                    // linear scan over `project_files`.
-                                    let target_path = adj_node.path.clone();
-                                    drop(adj_node);
-                                    let Some(&target_file) = path_to_file.get(&target_path) else {
-                                        continue;
-                                    };
-                                    let target_payload = file_to_nodes(db, target_file);
-                                    let Some(attr_locals) =
-                                        target_payload.exports_by_name.get(attr_name)
-                                    else {
-                                        continue;
-                                    };
-                                    for &al in attr_locals {
-                                        let ar = target_payload.refs[al as usize];
-                                        let Some(&attr_idx) = ref_to_global.get(&ar) else {
-                                            continue;
-                                        };
-                                        if nodes[attr_idx].borrow(py).kind == "class" {
-                                            children.entry(attr_idx).or_default().push(child_idx);
-                                        }
-                                    }
-                                    break;
+                    ResolvedBase::ImportedFqn(fqn) => {
+                        by_fqn.entry(fqn.clone()).or_default().push(child_idx);
+                        if let Some(idxs) = decl_by_fqname.get(fqn) {
+                            for &parent_idx in idxs {
+                                if nodes[parent_idx].borrow(py).kind == "class" {
+                                    by_node.entry(parent_idx).or_default().push(child_idx);
                                 }
                             }
                         }
                     }
+                    ResolvedBase::Attribute {
+                        module_fqn,
+                        attr_name,
+                    } => {
+                        // Index by the synthesised fqname for
+                        // external bases + dispatch-plugin matches.
+                        let composed = format!("{module_fqn}.{attr_name}");
+                        by_fqn.entry(composed.clone()).or_default().push(child_idx);
+                        // Project-side: resolve `module_fqn.attr_name`
+                        // via `decl_by_fqname` (handles the common
+                        // case where the target module's class is in
+                        // the project) or via the target module's
+                        // `exports_by_name`.
+                        if let Some(idxs) = decl_by_fqname.get(&composed) {
+                            for &parent_idx in idxs {
+                                if nodes[parent_idx].borrow(py).kind == "class" {
+                                    by_node.entry(parent_idx).or_default().push(child_idx);
+                                }
+                            }
+                        }
+                    }
+                    ResolvedBase::Unresolvable => {}
                 }
             }
         }
     }
 
-    // Dedup each children vec — multiple bases or alias hops can
-    // produce the same edge.
-    for v in children.values_mut() {
+    for v in by_node.values_mut() {
         v.sort_unstable();
         v.dedup();
     }
-    children
+    for v in by_fqn.values_mut() {
+        v.sort_unstable();
+        v.dedup();
+    }
+    (by_node, by_fqn)
 }
 
 /// Serial pre-parallel Pass-2 helper: lookup-or-mint a `NodeRef` into
@@ -2555,7 +2514,7 @@ impl ProjectContext {
         ) {
             let rk = (seed_range.start().to_u32(), seed_range.end().to_u32());
             if let Some(&seed_idx) = outputs.class_by_selection.get(&(seed_file, rk)) {
-                let out_idx = transitive_subclasses_via_index(seed_idx, &outputs.class_children);
+                let out_idx = transitive_subclasses_via_index(seed_idx, &outputs.children_by_node);
                 return Ok(out_idx
                     .into_iter()
                     .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
@@ -2566,17 +2525,17 @@ impl ProjectContext {
     }
 }
 
-/// PROTOTYPE: BFS from `seed_idx` through `class_children`. Returns
-/// the transitive closure (excluding the seed itself).
+/// BFS from `seed_idx` through `children_by_node`. Returns the
+/// transitive closure (excluding the seed itself).
 fn transitive_subclasses_via_index(
     seed_idx: usize,
-    class_children: &FxHashMap<usize, Vec<usize>>,
+    children_by_node: &FxHashMap<usize, Vec<usize>>,
 ) -> Vec<usize> {
     let mut seen: FxHashSet<usize> = FxHashSet::default();
     let mut out: Vec<usize> = Vec::new();
     let mut stack: Vec<usize> = vec![seed_idx];
     while let Some(cur) = stack.pop() {
-        let Some(kids) = class_children.get(&cur) else {
+        let Some(kids) = children_by_node.get(&cur) else {
             continue;
         };
         for &k in kids {
@@ -2692,15 +2651,15 @@ impl ProjectContext {
         };
         // Project seeds: use the in-memory class-hierarchy index for
         // an O(deg) BFS. Built once at the end of ``assemble_graph``
-        // (see ``build_class_children``); short-circuits every
+        // (see ``build_class_hierarchy_indices``); short-circuits every
         // intra-project subclass query.
         let rk = (seed_range.start().to_u32(), seed_range.end().to_u32());
         if let Some(&seed_idx) = outputs.class_by_selection.get(&(seed_file, rk)) {
             let out_idx = if transitive {
-                transitive_subclasses_via_index(seed_idx, &outputs.class_children)
+                transitive_subclasses_via_index(seed_idx, &outputs.children_by_node)
             } else {
                 outputs
-                    .class_children
+                    .children_by_node
                     .get(&seed_idx)
                     .cloned()
                     .unwrap_or_default()
@@ -2726,7 +2685,7 @@ impl ProjectContext {
         // run without GIL contention, matching the pattern used by
         // ``find_decorated_decls``.
         let class_by_selection = &outputs.class_by_selection;
-        let class_children = &outputs.class_children;
+        let children_by_node = &outputs.children_by_node;
         let project_files: &[File] = &outputs.project_files;
         // ``base_fqn`` splits into ``(seed_module, seed_simple_name)``;
         // both halves are required for the fast path.
@@ -2789,7 +2748,7 @@ impl ProjectContext {
         let mut out_idx: FxHashSet<usize> = direct.iter().copied().collect();
         if transitive {
             for &d in &direct {
-                for idx in transitive_subclasses_via_index(d, class_children) {
+                for idx in transitive_subclasses_via_index(d, children_by_node) {
                     out_idx.insert(idx);
                 }
             }
@@ -2800,159 +2759,96 @@ impl ProjectContext {
             .collect())
     }
 
-    /// Find every project class that transitively inherits from any
-    /// fqname in ``base_fqns``, by inverting the search: instead of
-    /// asking ty's ``find_references`` to walk down from each base
-    /// (which has to load + parse the framework module out of the
-    /// venv), do a single parallel scan over project files, read each
-    /// top-level class's base list, resolve each base against the
-    /// file's imports, and check membership in the target set.
+    /// Project classes that inherit (directly or transitively) from
+    /// the class identified by ``fqn``. ``fqn`` may name a project
+    /// class (e.g. ``pkg.module.MyBase``) or an external one
+    /// (``flask.Flask``, ``typer.Typer``); the lookup is keyed against
+    /// the pre-built ``children_by_fqn`` index (populated at
+    /// materialize time from per-file `class_bases` payloads — see
+    /// `file_payload::ResolvedBase`), so the framework module is
+    /// never loaded out of the venv.
     ///
-    /// Returns project class nodes (transitive closure). External
-    /// targets are matched by fqname only — the framework module is
-    /// never loaded. This is the cold-path complement of
-    /// :meth:`find_subclasses` for the common "do any project classes
-    /// extend ``flask.Flask``?" question.
+    /// ``transitive=True`` (default) walks the subclass closure via
+    /// ``children_by_node``; ``transitive=False`` returns only direct
+    /// hits. Match shapes per base expression in the class header
+    /// follow the [`ResolvedBase`](crate::file_payload::ResolvedBase)
+    /// contract:
     ///
-    /// Match shapes per base expression in the class header:
     /// * ``Name(X)`` where ``X`` is imported via
-    ///   ``from <module> import X [as alias]`` resolving the import
-    ///   to ``<module>.X``;
+    ///   ``from <module> import X [as alias]`` → matches when
+    ///   ``<module>.X`` equals ``fqn``.
     /// * ``Attribute(Name(M).N)`` where ``M`` is bound via
-    ///   ``import <module> [as M]``, matching ``<module>.N``;
-    /// * Dotted-path ``a.b.c.N`` matching when the full path equals a
-    ///   target fqname (rare, but handles ``import flask;
-    ///   class X(flask.Flask): ...`` literally).
-    /// Generic parameterizations (``class X(Foo[T])``) are not
-    /// supported — matches a syntactic base name only.
-    pub(crate) fn find_subclasses_via_bases(
+    ///   ``import <module> [as M]`` → matches when ``<module>.N``
+    ///   equals ``fqn``.
+    /// * ``Name(X)`` referring to a class earlier in the same file →
+    ///   matches when the in-project resolution lands the parent's
+    ///   own fqname or graph idx.
+    ///
+    /// Generics (``class X(Foo[T])``) and other non-identifier
+    /// expressions are skipped — matches the libcst pipeline.
+    #[pyo3(signature = (fqn, *, transitive = true))]
+    pub(crate) fn subclasses_of_fqn(
         &self,
         py: Python<'_>,
-        base_fqns: Vec<String>,
+        fqn: &str,
+        transitive: bool,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.materialized("find_subclasses_via_bases")?;
-        // Build set of target fqnames and (module → {simple_names})
-        // for fast per-base resolution.
-        if base_fqns.is_empty() {
+        let outputs = self.materialized("subclasses_of_fqn")?;
+        let Some(direct) = outputs.children_by_fqn.get(fqn) else {
             return Ok(Vec::new());
-        }
-        // No text prefilter: a file containing a transitive subclass
-        // (``class GrandApp(MyApp): ...``) might not mention the
-        // framework's simple name at all. We need to parse every
-        // project file once and capture every ``ClassDef``'s base
-        // list — then the BFS over the collected (child, base_fqn)
-        // pairs handles transitive closure without re-scanning.
-        // Parsing is cheap (and already done during materialize), so
-        // this stays competitive with the ty find_references path.
-        let decl_by_name_range = &outputs.decl_by_name_range;
-        let class_by_selection = &outputs.class_by_selection;
-        let project_files: &[File] = &outputs.project_files;
-        let db_handle: Box<dyn ProjectDb> = ProjectDb::dyn_clone(&self.db);
-
-        // Materialize idx → fqname BEFORE allow_threads so the
-        // parallel scan can use it without the GIL.
-        let idx_fqname: Vec<String> = outputs
-            .builder
-            .nodes
-            .iter()
-            .map(|n| n.borrow(py).fqname.clone())
-            .collect();
-        let idx_fqname_ref = &idx_fqname;
-
-        // Per-file output: list of (child_class_idx, base_fqn).
-        // base_fqn is whatever the class header resolves to (project
-        // class fqname OR external fqname OR module.simple — anything
-        // a syntactic resolution can produce). The caller filters to
-        // the target set + BFS for transitive closure.
-        let pairs: Vec<(usize, String)> = py.allow_threads(move || {
-            par_scan_files(db_handle, project_files, &None, |db, file| {
-                let parsed = parsed_module(db, file).load(db);
-                // Cheap pre-walk filter: skip files with no
-                // top-level ClassDef at all.
-                if !parsed
-                    .syntax()
-                    .body
-                    .iter()
-                    .any(|s| matches!(s, Stmt::ClassDef(_)))
-                {
-                    return Vec::new();
-                }
-                let file_imports = collect_all_imports_local(&parsed);
-                // Same-file top-level classes — base references that
-                // are bare ``Name`` and not imported can resolve to a
-                // class defined earlier in this file.
-                let file_local_classes: FxHashMap<&str, usize> = parsed
-                    .syntax()
-                    .body
-                    .iter()
-                    .filter_map(|stmt| {
-                        let Stmt::ClassDef(cls) = stmt else {
-                            return None;
-                        };
-                        let key = (file, range_key(cls.name.range()));
-                        let idx = class_by_selection
-                            .get(&key)
-                            .copied()
-                            .or_else(|| decl_by_name_range.get(&key).copied())?;
-                        Some((cls.name.as_str(), idx))
-                    })
-                    .collect();
-                let mut local: Vec<(usize, String)> = Vec::new();
-                for stmt in &parsed.syntax().body {
-                    let Stmt::ClassDef(cls) = stmt else { continue };
-                    let Some(args) = &cls.arguments else { continue };
-                    let child_key = (file, range_key(cls.name.range()));
-                    let Some(&child_idx) = class_by_selection
-                        .get(&child_key)
-                        .or_else(|| decl_by_name_range.get(&child_key))
-                    else {
-                        continue;
-                    };
-                    for arg in &args.args {
-                        // Try import resolution first.
-                        if let Some(base_fqn) = resolve_base_fqn(arg, &file_imports) {
-                            local.push((child_idx, base_fqn));
-                            continue;
-                        }
-                        // Fallback: same-file class name reference.
-                        if let ruff_python_ast::Expr::Name(name) = arg {
-                            if let Some(&base_idx) = file_local_classes.get(name.id.as_str()) {
-                                let base_fqn = idx_fqname_ref[base_idx].clone();
-                                local.push((child_idx, base_fqn));
-                            }
-                        }
-                    }
-                }
-                local
-            })
-        });
-
-        // Build base_fqn → [child_class_idx] index. Drives both the
-        // direct-target filter AND the transitive BFS — pairs already
-        // covers every base→child edge we saw in the project, not
-        // just target hits.
-        let mut by_base: FxHashMap<String, Vec<usize>> = FxHashMap::default();
-        for (idx, base_fqn) in pairs {
-            by_base.entry(base_fqn).or_default().push(idx);
-        }
-
-        // BFS from each target fqname through `by_base`.
-        let mut visited: FxHashSet<usize> = FxHashSet::default();
-        let mut frontier: Vec<String> = base_fqns.into_iter().collect();
-        while let Some(seed_fqn) = frontier.pop() {
-            let Some(children) = by_base.get(&seed_fqn) else {
-                continue;
-            };
-            for &child in children {
-                if visited.insert(child) {
-                    // Next round: walk subclasses of this project
-                    // class via its own fqname.
-                    frontier.push(idx_fqname[child].clone());
+        };
+        let mut visited: FxHashSet<usize> = direct.iter().copied().collect();
+        if transitive {
+            for &d in direct {
+                for idx in transitive_subclasses_via_index(d, &outputs.children_by_node) {
+                    visited.insert(idx);
                 }
             }
         }
-
         Ok(visited
+            .into_iter()
+            .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
+            .collect())
+    }
+
+    /// Project classes that inherit (directly or transitively) from
+    /// ``class_node``. O(1) probe in ``children_by_node`` plus BFS for
+    /// the transitive walk. Returns an empty vec when ``class_node``
+    /// isn't a class kind. Symmetric to :meth:`subclasses_of_fqn` for
+    /// callers that already hold the seed as a `SymbolNode`.
+    #[pyo3(signature = (class_node, *, transitive = true))]
+    pub(crate) fn subclasses_of_node(
+        &self,
+        py: Python<'_>,
+        class_node: &SymbolNode,
+        transitive: bool,
+    ) -> PyResult<Vec<Py<SymbolNode>>> {
+        if class_node.kind != "class" {
+            return Ok(Vec::new());
+        }
+        let outputs = self.materialized("subclasses_of_node")?;
+        let Some((seed_file, seed_range)) = locate_class_def(
+            &self.db,
+            &outputs.path_to_file,
+            &class_node.path,
+            class_node,
+        ) else {
+            return Ok(Vec::new());
+        };
+        let rk = (seed_range.start().to_u32(), seed_range.end().to_u32());
+        let Some(&seed_idx) = outputs.class_by_selection.get(&(seed_file, rk)) else {
+            return Ok(Vec::new());
+        };
+        let out_idx = if transitive {
+            transitive_subclasses_via_index(seed_idx, &outputs.children_by_node)
+        } else {
+            outputs
+                .children_by_node
+                .get(&seed_idx)
+                .cloned()
+                .unwrap_or_default()
+        };
+        Ok(out_idx
             .into_iter()
             .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
             .collect())

--- a/src/project.rs
+++ b/src/project.rs
@@ -1710,6 +1710,36 @@ impl ProjectContext {
             .collect())
     }
 
+    /// One-hop reverse step: every node with an edge directly into
+    /// ``node`` (i.e. the immediate predecessors, *not* the transitive
+    /// closure :meth:`ancestors` returns). ``skip_flags`` filters edges
+    /// by intersecting flag mask — same semantics as :meth:`ancestors`.
+    ///
+    /// Dedups by source index, so a pair of parallel edges with
+    /// different ``EdgeFlags`` between the same two nodes only produces
+    /// one entry in the result. Result order is unspecified.
+    #[pyo3(signature = (node, *, skip_flags = 0))]
+    pub(crate) fn direct_predecessors(
+        &self,
+        py: Python<'_>,
+        node: &SymbolNode,
+        skip_flags: u32,
+    ) -> PyResult<Vec<Py<SymbolNode>>> {
+        let outputs = self.materialized("direct_predecessors")?;
+        let idx = lookup_idx(&outputs.builder, node, "node")?;
+        let mut seen: FxHashSet<usize> = FxHashSet::default();
+        let mut out: Vec<Py<SymbolNode>> = Vec::new();
+        for &(src, flags) in &outputs.builder.reverse_adj[idx] {
+            if flags & skip_flags != 0 {
+                continue;
+            }
+            if seen.insert(src) {
+                out.push(outputs.builder.nodes[src].clone_ref(py));
+            }
+        }
+        Ok(out)
+    }
+
     /// Forward closure from every node carrying any bit in
     /// ``seed_flags`` (defaults to ``NODE_FLAG_ENTRYPOINT`` for the
     /// classic "alive from entrypoints" question). The set of dead

--- a/src/project.rs
+++ b/src/project.rs
@@ -961,6 +961,14 @@ pub(crate) fn build_fqname_indices(
     let mut imports_by_module: FxHashMap<String, Vec<usize>> = FxHashMap::default();
     for (idx, node_py) in builder.nodes.iter().enumerate() {
         let node = node_py.borrow(py);
+        // `OVERLOAD`-flagged decls (the `@typing.overload`-decorated
+        // stubs of an in-file overload group) are excluded from the
+        // fqname trie so cross-module `from mod import f` resolves to
+        // the impl only. Reachability still anchors them via the
+        // explicit `impl → stub` edge emitted in `file_to_edges`.
+        if node.flags & crate::graph::NodeFlags::OVERLOAD != 0 {
+            continue;
+        }
         match node.kind {
             "module" => {
                 modules.insert(node.fqname.clone(), idx);

--- a/src/project.rs
+++ b/src/project.rs
@@ -1634,6 +1634,70 @@ impl ProjectContext {
         }
         Ok(out)
     }
+
+    /// Batched form of :meth:`module_surface`. Resolves every fqname
+    /// in ``module_fqns`` in a single scan of ``module_by_fqname`` +
+    /// ``decl_by_fqname`` instead of one scan per fqname. The N
+    /// per-call materialize-lookup + N scans collapse to one of each.
+    /// Returns a dict keyed by input fqname; missing modules map to
+    /// empty lists. Duplicate inputs share the same result list.
+    pub(crate) fn module_surfaces(
+        &self,
+        py: Python<'_>,
+        module_fqns: Vec<String>,
+    ) -> PyResult<FxHashMap<String, Vec<Py<SymbolNode>>>> {
+        let outputs = self.materialized("module_surfaces")?;
+        // Deduplicate the requested fqnames + pre-stage each one's
+        // (prefix, output vec) so a single map iteration can drop
+        // matches into the right bucket. Skip fqnames that don't name
+        // a project module — same per-call short-circuit as the
+        // singular ``module_surface``.
+        let mut buckets: FxHashMap<String, Vec<Py<SymbolNode>>> =
+            FxHashMap::with_capacity_and_hasher(module_fqns.len(), Default::default());
+        let mut prefixes: Vec<(String, String)> = Vec::with_capacity(module_fqns.len());
+        for fqn in &module_fqns {
+            if buckets.contains_key(fqn) {
+                continue;
+            }
+            let Some(&module_idx) = outputs.module_by_fqname.get(fqn) else {
+                buckets.insert(fqn.clone(), Vec::new());
+                continue;
+            };
+            buckets.insert(
+                fqn.clone(),
+                vec![outputs.builder.nodes[module_idx].clone_ref(py)],
+            );
+            prefixes.push((fqn.clone(), format!("{fqn}.")));
+        }
+        if prefixes.is_empty() {
+            return Ok(buckets);
+        }
+        // Single sweep over each map; per-fqname row goes into every
+        // bucket whose prefix matches. K small (≤ inputs), so the
+        // nested-loop ``starts_with`` is fine — a prefix trie would
+        // only help for K in the hundreds.
+        for (fqname, &idx) in &outputs.module_by_fqname {
+            for (key, prefix) in &prefixes {
+                if fqname.starts_with(prefix) {
+                    buckets
+                        .get_mut(key)
+                        .expect("seeded above")
+                        .push(outputs.builder.nodes[idx].clone_ref(py));
+                }
+            }
+        }
+        for (fqname, idxs) in &outputs.decl_by_fqname {
+            for (key, prefix) in &prefixes {
+                if fqname.starts_with(prefix) {
+                    let bucket = buckets.get_mut(key).expect("seeded above");
+                    for &idx in idxs {
+                        bucket.push(outputs.builder.nodes[idx].clone_ref(py));
+                    }
+                }
+            }
+        }
+        Ok(buckets)
+    }
 }
 
 #[pymethods]

--- a/src/project.rs
+++ b/src/project.rs
@@ -128,6 +128,19 @@ pub(crate) struct BuildOutputs {
     /// nodes — and a cheap ``imports_of_exists`` short-circuit for
     /// plugins that just need a per-module presence check.
     pub(crate) imports_by_module: FxHashMap<String, Vec<usize>>,
+    /// `parent_fqname -> [child node idx]`. Children are the indices of
+    /// nodes whose fqname's immediate parent (`fqname.rsplit_once('.').0`)
+    /// equals the key. Includes both module and decl nodes; the kind
+    /// can be read from ``builder.nodes[idx].kind`` when filtering.
+    /// Top-level decls (no `.` in fqname) are bucketed under the empty
+    /// string ``""``.
+    ///
+    /// Lets ``module_surface`` BFS the fqname tree (one O(matches)
+    /// hop per parent) instead of linear-scanning ``decl_by_fqname`` /
+    /// ``module_by_fqname`` with a ``starts_with`` filter, and lets
+    /// ``find_module_top_level_decls`` answer with a single
+    /// ``HashMap::get``.
+    pub(crate) children_by_parent: FxHashMap<String, Vec<usize>>,
     /// Project-wide class hierarchy keyed by parent class graph idx.
     /// `class_idx -> [direct subclass class_idx]`. Derived in
     /// `assemble_graph` from each file's per-file `class_bases`
@@ -366,7 +379,8 @@ pub(crate) fn build_project_graph(
     let ref_to_global = assembled.ref_to_global;
 
     let t4 = std::time::Instant::now();
-    let (decl_by_fqname, module_by_fqname, imports_by_module) = build_fqname_indices(py, &builder);
+    let (decl_by_fqname, module_by_fqname, imports_by_module, children_by_parent) =
+        build_fqname_indices(py, &builder);
     let t_fqname = t4.elapsed();
 
     // Class hierarchy fan-in: fold every file's per-file `class_bases`
@@ -423,6 +437,7 @@ pub(crate) fn build_project_graph(
         imports_by_module,
         children_by_node,
         children_by_fqn,
+        children_by_parent,
     })
 }
 
@@ -941,12 +956,19 @@ fn serial_lookup_or_mint<'db>(
 }
 
 /// Pre-build the fqname -> idx maps used by ``find_declarations``,
-/// ``find_module``, and ``find_imports_of``. One pass over interned
-/// nodes; module entries are 1:1 (one module node per fqname) while
-/// decl entries (and per-upstream-module import entries) can have
-/// multiple binders for the same key — try/except rebinds,
-/// conditional re-imports, and multiple ``from X import Y, Z`` aliases
-/// all bind into the same upstream module.
+/// ``find_module``, ``find_imports_of``, and ``module_surface``. One
+/// pass over interned nodes; module entries are 1:1 (one module node
+/// per fqname) while decl entries (and per-upstream-module import
+/// entries) can have multiple binders for the same key — try/except
+/// rebinds, conditional re-imports, and multiple ``from X import Y, Z``
+/// aliases all bind into the same upstream module.
+///
+/// ``children_by_parent`` is the fqname-tree index used by
+/// :meth:`ProjectContext::module_surface` and
+/// :meth:`ProjectContext::find_module_top_level_decls`: for every
+/// indexed node (module or decl), the entry is bucketed under the
+/// fqname's immediate parent (``rsplit_once('.').0``), with top-level
+/// names keyed under the empty string.
 #[allow(clippy::type_complexity)]
 pub(crate) fn build_fqname_indices(
     py: Python<'_>,
@@ -955,10 +977,12 @@ pub(crate) fn build_fqname_indices(
     FxHashMap<String, Vec<usize>>,
     FxHashMap<String, usize>,
     FxHashMap<String, Vec<usize>>,
+    FxHashMap<String, Vec<usize>>,
 ) {
     let mut decls: FxHashMap<String, Vec<usize>> = FxHashMap::default();
     let mut modules: FxHashMap<String, usize> = FxHashMap::default();
     let mut imports_by_module: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+    let mut children_by_parent: FxHashMap<String, Vec<usize>> = FxHashMap::default();
     for (idx, node_py) in builder.nodes.iter().enumerate() {
         let node = node_py.borrow(py);
         // `OVERLOAD`-flagged decls (the `@typing.overload`-decorated
@@ -969,12 +993,15 @@ pub(crate) fn build_fqname_indices(
         if node.flags & crate::graph::NodeFlags::OVERLOAD != 0 {
             continue;
         }
+        let mut index_child = false;
         match node.kind {
             "module" => {
                 modules.insert(node.fqname.clone(), idx);
+                index_child = true;
             }
             "function" | "class" | "variable" => {
                 decls.entry(node.fqname.clone()).or_default().push(idx);
+                index_child = true;
             }
             "import" => {
                 decls.entry(node.fqname.clone()).or_default().push(idx);
@@ -984,11 +1011,20 @@ pub(crate) fn build_fqname_indices(
                         .or_default()
                         .push(idx);
                 }
+                index_child = true;
             }
             _ => {}
         }
+        if index_child {
+            let parent = node
+                .fqname
+                .rsplit_once('.')
+                .map(|(p, _)| p.to_string())
+                .unwrap_or_default();
+            children_by_parent.entry(parent).or_default().push(idx);
+        }
     }
-    (decls, modules, imports_by_module)
+    (decls, modules, imports_by_module, children_by_parent)
 }
 
 /// Plugin-aware project graph builder.
@@ -1617,6 +1653,13 @@ impl ProjectContext {
     /// whole top-level surface plus everything its submodules expose.
     /// Empty list when ``module_fqn`` doesn't resolve to a project
     /// module.
+    ///
+    /// Walks the ``children_by_parent`` fqname-tree index breadth-first
+    /// starting from ``module_fqn``. Only module nodes are recursed
+    /// into — a decl ``pkg.foo.MyClass`` is included as a child of
+    /// ``pkg.foo`` but its synthetic sub-fqnames (``pkg.foo.MyClass.method``)
+    /// are not surfaced; nested defs aren't graph nodes anyway, and the
+    /// "module surface" contract is per-module.
     pub(crate) fn module_surface(
         &self,
         py: Python<'_>,
@@ -1627,16 +1670,31 @@ impl ProjectContext {
             return Ok(Vec::new());
         };
         let mut out = vec![outputs.builder.nodes[module_idx].clone_ref(py)];
-        let prefix = format!("{module_fqn}.");
-        for (fqname, &idx) in &outputs.module_by_fqname {
-            if fqname.starts_with(&prefix) {
-                out.push(outputs.builder.nodes[idx].clone_ref(py));
-            }
-        }
-        for (fqname, idxs) in &outputs.decl_by_fqname {
-            if fqname.starts_with(&prefix) {
-                for &idx in idxs {
-                    out.push(outputs.builder.nodes[idx].clone_ref(py));
+        // BFS over the fqname tree. Recurse only into module children:
+        // a decl ``pkg.foo.MyClass`` doesn't have submodule descendants,
+        // so chasing its sub-fqnames would just be wasted lookups.
+        // Queue holds owned ``String``s because ``children_by_parent``
+        // keys are owned strings and ``SymbolNode.fqname`` lives behind
+        // a ``PyRef`` guard that can't be held across iterations.
+        let mut queue: std::collections::VecDeque<String> =
+            std::collections::VecDeque::from([module_fqn.to_string()]);
+        while let Some(parent) = queue.pop_front() {
+            let Some(children) = outputs.children_by_parent.get(parent.as_str()) else {
+                continue;
+            };
+            for &child_idx in children {
+                let child_py = &outputs.builder.nodes[child_idx];
+                let child = child_py.borrow(py);
+                let is_module = child.kind == "module";
+                let child_fqname = if is_module {
+                    Some(child.fqname.clone())
+                } else {
+                    None
+                };
+                drop(child);
+                out.push(child_py.clone_ref(py));
+                if let Some(fqn) = child_fqname {
+                    queue.push_back(fqn);
                 }
             }
         }
@@ -1724,7 +1782,7 @@ impl ProjectContext {
         py: Python<'_>,
         module_fqn: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let indices = self.find_module_top_level_decls_indices(module_fqn)?;
+        let indices = self.find_module_top_level_decls_indices(py, module_fqn)?;
         let outputs = self.materialized("find_module_top_level_decls")?;
         Ok(indices
             .into_iter()
@@ -1737,23 +1795,25 @@ impl ProjectContext {
     /// than allocating ``Py<SymbolNode>`` clones.
     pub(crate) fn find_module_top_level_decls_indices(
         &self,
+        py: Python<'_>,
         module_fqn: &str,
     ) -> PyResult<Vec<usize>> {
         let outputs = self.materialized("find_module_top_level_decls_indices")?;
         if !outputs.module_by_fqname.contains_key(module_fqn) {
             return Ok(Vec::new());
         }
-        let prefix = format!("{module_fqn}.");
+        // One-level lookup via the ``children_by_parent`` fqname tree.
+        // Filter out module children so `from p.functions import *`
+        // doesn't surface ``p.functions.sub`` (matching the docstring's
+        // "submodules and their decls are excluded" contract).
         let mut out: Vec<usize> = Vec::new();
-        for (fqname, idxs) in &outputs.decl_by_fqname {
-            let Some(rest) = fqname.strip_prefix(&prefix) else {
-                continue;
-            };
-            // Skip transitive decls (`pkg.mod.sub.x` under `pkg.mod`).
-            if rest.contains('.') {
-                continue;
+        if let Some(children) = outputs.children_by_parent.get(module_fqn) {
+            for &idx in children {
+                if outputs.builder.nodes[idx].borrow(py).kind == "module" {
+                    continue;
+                }
+                out.push(idx);
             }
-            out.extend(idxs.iter().copied());
         }
         Ok(out)
     }

--- a/src/project.rs
+++ b/src/project.rs
@@ -1315,6 +1315,19 @@ impl ProjectContext {
         Ok(out)
     }
 
+    /// Idx-only variant of :meth:`find_imports_of`. Same lookup, but
+    /// returns the positional indices into ``ctx.nodes()`` rather than
+    /// materializing ``Py<SymbolNode>`` clones — drives the
+    /// :meth:`ImportQuery.indices` terminal.
+    pub(crate) fn find_imports_of_indices(&self, module_name: &str) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("find_imports_of_indices")?;
+        Ok(outputs
+            .imports_by_module
+            .get(module_name)
+            .cloned()
+            .unwrap_or_default())
+    }
+
     /// O(1) count of how many project import nodes target
     /// ``module_name`` — pre-built index lookup, no Py allocation.
     pub(crate) fn imports_of_count(&self, module_name: &str) -> usize {
@@ -2439,7 +2452,25 @@ impl ProjectContext {
         py: Python<'_>,
         method_name: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
+        let indices = self.find_classes_defining_method_indices(py, method_name)?;
         let outputs = self.materialized("find_classes_defining_method")?;
+        Ok(indices
+            .into_iter()
+            .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
+            .collect())
+    }
+}
+
+impl ProjectContext {
+    /// Idx-only variant of :meth:`find_classes_defining_method`. Same
+    /// per-file parallel walk, but returns positional indices into
+    /// ``ctx.nodes()`` instead of allocating ``Py<SymbolNode>`` clones.
+    pub(crate) fn find_classes_defining_method_indices(
+        &self,
+        py: Python<'_>,
+        method_name: &str,
+    ) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("find_classes_defining_method_indices")?;
         let global_index = &outputs.global_index;
         let project_files: &[File] = &outputs.project_files;
         let db_handle: Box<dyn ProjectDb> = ProjectDb::dyn_clone(&self.db);
@@ -2482,12 +2513,13 @@ impl ProjectContext {
                 local
             })
         });
-        Ok(indices
-            .into_iter()
-            .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
-            .collect())
+        drop(outputs);
+        Ok(indices)
     }
+}
 
+#[pymethods]
+impl ProjectContext {
     /// Return every transitive subclass of the given class node.
     ///
     /// Direct subtypes come from ty's `type_hierarchy_subtypes`; we BFS
@@ -2498,14 +2530,27 @@ impl ProjectContext {
         py: Python<'_>,
         class_node: &SymbolNode,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
+        let indices = self.find_subclasses_of_indices(class_node)?;
+        let outputs = self.materialized("find_subclasses_of")?;
+        Ok(indices
+            .into_iter()
+            .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
+            .collect())
+    }
+}
+
+impl ProjectContext {
+    /// Idx-only variant of :meth:`find_subclasses_of`. Same lookup,
+    /// returns positional indices into ``ctx.nodes()`` rather than
+    /// allocating ``Py<SymbolNode>`` clones.
+    pub(crate) fn find_subclasses_of_indices(
+        &self,
+        class_node: &SymbolNode,
+    ) -> PyResult<Vec<usize>> {
         if class_node.kind != "class" {
             return Ok(Vec::new());
         }
-        let outputs = self.materialized("find_subclasses_of")?;
-
-        // PROTOTYPE: try the in-memory class-hierarchy index first.
-        // The seed is a project class node, so we can locate it
-        // directly in `class_by_selection` without an AST walk.
+        let outputs = self.materialized("find_subclasses_of_indices")?;
         if let Some((seed_file, seed_range)) = locate_class_def(
             &self.db,
             &outputs.path_to_file,
@@ -2514,11 +2559,10 @@ impl ProjectContext {
         ) {
             let rk = (seed_range.start().to_u32(), seed_range.end().to_u32());
             if let Some(&seed_idx) = outputs.class_by_selection.get(&(seed_file, rk)) {
-                let out_idx = transitive_subclasses_via_index(seed_idx, &outputs.children_by_node);
-                return Ok(out_idx
-                    .into_iter()
-                    .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
-                    .collect());
+                return Ok(transitive_subclasses_via_index(
+                    seed_idx,
+                    &outputs.children_by_node,
+                ));
             }
         }
         Ok(Vec::new())
@@ -2644,7 +2688,26 @@ impl ProjectContext {
         base_fqn: &str,
         transitive: bool,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
+        let indices = self.find_subclasses_indices(py, base_fqn, transitive)?;
         let outputs = self.materialized("find_subclasses")?;
+        Ok(indices
+            .into_iter()
+            .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
+            .collect())
+    }
+}
+
+impl ProjectContext {
+    /// Idx-only variant of :meth:`find_subclasses`. Same lookup,
+    /// returns positional indices into ``ctx.nodes()`` rather than
+    /// allocating ``Py<SymbolNode>`` clones.
+    pub(crate) fn find_subclasses_indices(
+        &self,
+        py: Python<'_>,
+        base_fqn: &str,
+        transitive: bool,
+    ) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("find_subclasses_indices")?;
         let Some((seed_file, seed_range)) = locate_class_seed(&self.db, &outputs, py, base_fqn)
         else {
             return Ok(Vec::new());
@@ -2664,10 +2727,7 @@ impl ProjectContext {
                     .cloned()
                     .unwrap_or_default()
             };
-            return Ok(out_idx
-                .into_iter()
-                .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
-                .collect());
+            return Ok(out_idx);
         }
 
         // External seeds (seed file lives outside the project, e.g.
@@ -2753,12 +2813,12 @@ impl ProjectContext {
                 }
             }
         }
-        Ok(out_idx
-            .into_iter()
-            .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
-            .collect())
+        Ok(out_idx.into_iter().collect())
     }
+}
 
+#[pymethods]
+impl ProjectContext {
     /// Project classes that inherit (directly or transitively) from
     /// the class identified by ``fqn``. ``fqn`` may name a project
     /// class (e.g. ``pkg.module.MyBase``) or an external one
@@ -2932,6 +2992,209 @@ impl ProjectContext {
     /// Live edges as `(src_idx, dst_idx, flags)` triples.
     pub(crate) fn edges(&self) -> PyResult<Vec<(usize, usize, u32)>> {
         Ok(self.materialized("edges")?.builder.edges.clone())
+    }
+
+    /// Idx-only sibling of :meth:`reachable`. Same semantics: forward
+    /// closure from every node carrying any bit in ``seed_flags``,
+    /// filtering edges by ``skip_flags``. Returns positional indices
+    /// into ``ctx.nodes()`` rather than materialising
+    /// ``Py<SymbolNode>`` clones.
+    ///
+    /// Use when you only need set membership / counting on the
+    /// reached set — pair with :meth:`nodes_at` to revive specific
+    /// nodes on demand.
+    #[pyo3(signature = (*, skip_flags = 0, seed_flags = NODE_FLAG_ENTRYPOINT))]
+    pub(crate) fn reachable_indices(
+        &self,
+        py: Python<'_>,
+        skip_flags: u32,
+        seed_flags: u32,
+    ) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("reachable_indices")?;
+        let seeds = outputs
+            .builder
+            .nodes
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, n)| (n.borrow(py).flags & seed_flags != 0).then_some(idx));
+        Ok(bfs(&outputs.builder, seeds, Direction::Forward, skip_flags)
+            .into_iter()
+            .collect())
+    }
+
+    /// Flat-form predicate filter returning positional indices into
+    /// ``ctx.nodes()``. Mirrors the :class:`DeclQuery` predicate
+    /// vocabulary (``kind`` / ``kinds`` / ``filename`` /
+    /// ``filenames`` / ``simple_name`` / ``simple_names`` / ``paths``
+    /// / ``path_regex`` / ``flags`` / ``flags_any`` /
+    /// ``fqname_prefix``) but skips the builder construction —
+    /// useful when you only have one filter step and just need a
+    /// ``list[int]`` of indices.
+    ///
+    /// Every parameter is keyword-only and optional; unset arguments
+    /// don't filter. ``kind`` and ``kinds`` (and similarly ``filename``
+    /// / ``filenames``, ``simple_name`` / ``simple_names``) are merged
+    /// — pass either form. All set predicates AND together.
+    #[pyo3(signature = (
+        *,
+        kind = None,
+        kinds = None,
+        filename = None,
+        filenames = None,
+        simple_name = None,
+        simple_names = None,
+        paths = None,
+        path_regex = None,
+        flags = None,
+        flags_any = None,
+        fqname_prefix = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn indices_where(
+        &self,
+        py: Python<'_>,
+        kind: Option<String>,
+        kinds: Option<Vec<String>>,
+        filename: Option<String>,
+        filenames: Option<Vec<String>>,
+        simple_name: Option<String>,
+        simple_names: Option<Vec<String>>,
+        paths: Option<Vec<String>>,
+        path_regex: Option<String>,
+        flags: Option<u32>,
+        flags_any: Option<u32>,
+        fqname_prefix: Option<String>,
+    ) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("indices_where")?;
+        // Merge singular + plural forms once up front.
+        let kinds_vec: Option<Vec<String>> = match (kind, kinds) {
+            (None, None) => None,
+            (Some(s), None) => Some(vec![s]),
+            (None, Some(v)) => Some(v),
+            (Some(s), Some(mut v)) => {
+                v.push(s);
+                Some(v)
+            }
+        };
+        let filenames_vec: Option<Vec<String>> = match (filename, filenames) {
+            (None, None) => None,
+            (Some(s), None) => Some(vec![s]),
+            (None, Some(v)) => Some(v),
+            (Some(s), Some(mut v)) => {
+                v.push(s);
+                Some(v)
+            }
+        };
+        let simple_vec: Option<Vec<String>> = match (simple_name, simple_names) {
+            (None, None) => None,
+            (Some(s), None) => Some(vec![s]),
+            (None, Some(v)) => Some(v),
+            (Some(s), Some(mut v)) => {
+                v.push(s);
+                Some(v)
+            }
+        };
+
+        let kinds_set: Option<rustc_hash::FxHashSet<&str>> = kinds_vec
+            .as_ref()
+            .map(|v| v.iter().map(String::as_str).collect());
+        let filenames_set: Option<rustc_hash::FxHashSet<&str>> = filenames_vec
+            .as_ref()
+            .map(|v| v.iter().map(String::as_str).collect());
+        let simple_set: Option<rustc_hash::FxHashSet<&str>> = simple_vec
+            .as_ref()
+            .map(|v| v.iter().map(String::as_str).collect());
+        let paths_set: Option<rustc_hash::FxHashSet<&str>> = paths
+            .as_ref()
+            .map(|v| v.iter().map(String::as_str).collect());
+
+        let re_compiled: Option<regex::Regex> = match path_regex.as_deref() {
+            None => None,
+            Some(s) => Some(
+                regex::Regex::new(s)
+                    .map_err(|e| PyValueError::new_err(format!("invalid path regex {s:?}: {e}")))?,
+            ),
+        };
+
+        // ``flags`` (all-set) and ``flags_any`` (any-bit) — at most one
+        // should be passed; if both are given, AND them (require all
+        // bits in ``flags`` AND any bit in ``flags_any``).
+        let mut out: Vec<usize> = Vec::new();
+        for (idx, node_py) in outputs.builder.nodes.iter().enumerate() {
+            let node = node_py.borrow(py);
+            if let Some(k) = &kinds_set {
+                if !k.contains(node.kind) {
+                    continue;
+                }
+            }
+            if let Some(p) = &paths_set {
+                if !p.contains(node.path.as_str()) {
+                    continue;
+                }
+            }
+            if let Some(f) = &filenames_set {
+                let path = node.path.as_str();
+                let basename = path
+                    .rsplit_once(std::path::MAIN_SEPARATOR)
+                    .map(|(_, name)| name)
+                    .unwrap_or(path);
+                if !f.contains(basename) {
+                    continue;
+                }
+            }
+            if let Some(s) = &simple_set {
+                let fq = node.fqname.as_str();
+                let simple = fq.rsplit_once('.').map(|(_, n)| n).unwrap_or(fq);
+                if !s.contains(simple) {
+                    continue;
+                }
+            }
+            if let Some(mask) = flags {
+                if node.flags & mask != mask {
+                    continue;
+                }
+            }
+            if let Some(mask) = flags_any {
+                if node.flags & mask == 0 {
+                    continue;
+                }
+            }
+            if let Some(prefix) = &fqname_prefix {
+                if !node.fqname.starts_with(prefix.as_str()) {
+                    continue;
+                }
+            }
+            if let Some(re) = &re_compiled {
+                if !re.is_match(node.path.as_str()) {
+                    continue;
+                }
+            }
+            out.push(idx);
+        }
+        Ok(out)
+    }
+
+    /// Inverse of the ``.indices()`` terminals: materialize specific
+    /// nodes by their positional indices into ``ctx.nodes()``.
+    /// Validates bounds and raises :class:`IndexError` when any index
+    /// is out of range.
+    pub(crate) fn nodes_at(
+        &self,
+        py: Python<'_>,
+        indices: Vec<usize>,
+    ) -> PyResult<Vec<Py<SymbolNode>>> {
+        let outputs = self.materialized("nodes_at")?;
+        let len = outputs.builder.nodes.len();
+        let mut out: Vec<Py<SymbolNode>> = Vec::with_capacity(indices.len());
+        for idx in indices {
+            if idx >= len {
+                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                    "node index {idx} out of range (len={len})"
+                )));
+            }
+            out.push(outputs.builder.nodes[idx].clone_ref(py));
+        }
+        Ok(out)
     }
 }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -2,8 +2,11 @@
 //! `build_project_graph` pipeline entrypoint. This module owns the
 //! Salsa-backed analysis context that the rest of the crate operates on.
 
-use std::cell::{Ref, RefCell};
 use std::str::FromStr;
+use std::sync::Arc;
+
+use parking_lot::lock_api::RawRwLockRecursive;
+use parking_lot::{MappedRwLockReadGuard, Mutex, RwLock, RwLockReadGuard};
 
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use pyo3::exceptions::{PyOSError, PyRuntimeError, PyValueError};
@@ -995,7 +998,7 @@ pub(crate) fn build_fqname_indices(
 /// through `type_hierarchy_subtypes`, method-defines walks each class's
 /// `DefinitionKind::Class`, module dunders scan global-scope variable
 /// nodes, and comment patterns walk the parser's `Tokens` stream.
-#[pyclass(unsendable)]
+#[pyclass]
 pub(crate) struct ProjectContext {
     pub(crate) db: ProjectDatabase,
     /// Absolute path of the project root, echoed back to Python via the
@@ -1007,12 +1010,29 @@ pub(crate) struct ProjectContext {
     /// materialize call — `apply_graph_op` / queries assume it's
     /// `Some` and error if a plugin (incorrectly) caches the ctx and
     /// uses it after materialize returns.
-    pub(crate) outputs: RefCell<Option<BuildOutputs>>,
+    ///
+    /// Wrapped in [`parking_lot::RwLock`] so plugins can run
+    /// concurrently from a Python `ThreadPoolExecutor` — queries take a
+    /// read guard, the apply pass takes a write guard. ``parking_lot``
+    /// over ``std::sync`` because the former exposes
+    /// ``RwLockReadGuard::map`` for the ``Option`` projection that
+    /// :meth:`materialized` performs.
+    ///
+    /// Held inside an [`Arc`] so the apply path
+    /// (:func:`builder::apply_graph_op`) can clone the handle
+    /// **before** dropping the GIL and then acquire the write lock
+    /// without holding the GIL. Acquiring the write lock while
+    /// still holding the GIL would deadlock against a reader stuck
+    /// on ``take_gil`` (the reader can't drop its read guard until
+    /// it re-attaches).
+    pub(crate) outputs: Arc<RwLock<Option<BuildOutputs>>>,
     /// Compiled regexes keyed by the source pattern. Plugins call
     /// :meth:`decls_matching_name` / :meth:`find_comment_patterns`
     /// repeatedly across files with the same pattern, so caching keeps
-    /// us off the regex compiler in the hot path.
-    pub(crate) regex_cache: RefCell<FxHashMap<String, regex::Regex>>,
+    /// us off the regex compiler in the hot path. Mutex (rather than
+    /// RwLock) because the cache write path is cheap and the hot path
+    /// is a single hashmap lookup either way.
+    pub(crate) regex_cache: Mutex<FxHashMap<String, regex::Regex>>,
     /// When true, ``materialize`` and ``build_project_graph`` draw
     /// indicatif progress bars to stderr.
     pub(crate) show_progress: bool,
@@ -1055,8 +1075,8 @@ impl ProjectContext {
             db,
             root: root.to_string(),
             plugins: Vec::new(),
-            outputs: RefCell::new(None),
-            regex_cache: RefCell::new(FxHashMap::default()),
+            outputs: Arc::new(RwLock::new(None)),
+            regex_cache: Mutex::new(FxHashMap::default()),
             show_progress,
             stack_size: None,
         })
@@ -1114,17 +1134,31 @@ impl ProjectContext {
     /// Build the project-wide graph, run each plugin's `run(ctx)`,
     /// then snapshot the final state.
     ///
-    /// Borrows are released between phases so plugin `run` methods can
-    /// re-enter queries through the same ctx without aliasing violations.
+    /// Plugin execution may run serially in this method (legacy path,
+    /// also forced by `DEAD_CST_PLUGINS_SERIAL=1` in Python) or be
+    /// driven concurrently from Python via a
+    /// :class:`concurrent.futures.ThreadPoolExecutor` calling
+    /// :meth:`build_only` + :meth:`run_plugin` per worker.
+    ///
+    /// Ops are applied as they're yielded from each plugin so that
+    /// later steps inside the *same* plugin can call
+    /// ``ctx.descendants`` etc. and see the effect of earlier
+    /// yields. Across concurrent plugin invocations the
+    /// :class:`parking_lot::RwLock` on ``outputs`` serializes the
+    /// per-op write while letting the GIL-releasing queries run in
+    /// parallel.
     pub(crate) fn materialize(slf: Py<Self>, py: Python<'_>) -> PyResult<NativeGraph> {
         let show_progress = slf.borrow(py).show_progress;
         let stack_size = slf.borrow(py).stack_size;
         {
             let mut this = slf.borrow_mut(py);
             let outputs = build_project_graph(py, &mut this.db, show_progress, stack_size)?;
-            *this.outputs.borrow_mut() = Some(outputs);
+            *this.outputs.write() = Some(outputs);
         }
 
+        // Serial plugin pass (legacy / fallback path). Concurrent
+        // execution is driven from Python — see
+        // ``Analysis.materialize_all``.
         let plugins: Vec<PyObject> = slf
             .borrow(py)
             .plugins
@@ -1133,16 +1167,6 @@ impl ProjectContext {
             .collect();
         let plugin_bar = ProgressBars::plugin_bar(show_progress, plugins.len() as u64);
         for plugin in &plugins {
-            // ``plugin.run(ctx)`` yields ``GraphOp`` values; we apply
-            // each as it comes off the iterator. The plugin can run
-            // queries against ``ctx`` mid-iteration since each
-            // ``apply_graph_op`` call releases its borrows before
-            // returning control to the generator. ``None`` (a regular
-            // function that ran to completion without yielding) is
-            // allowed for plugins with nothing to do.
-            // Progress-bar label: use the plugin's class qualname.
-            // Falls back to ``<unnamed>`` if anything goes wrong (e.g.
-            // a plain function passed in by mistake).
             let plugin_name: String = plugin
                 .bind(py)
                 .get_type()
@@ -1151,23 +1175,15 @@ impl ProjectContext {
                 .and_then(|n| n.extract().ok())
                 .unwrap_or_else(|| "<unnamed>".to_string());
             plugin_bar.set_message(plugin_name);
-            let result = plugin.bind(py).call_method1("run", (slf.clone_ref(py),))?;
-            if !result.is_none() {
-                for item in result.iter()? {
-                    let op = item?;
-                    apply_graph_op(&slf, py, &op)?;
-                }
-            }
+            run_and_apply_plugin(py, &slf, plugin)?;
             plugin_bar.inc(1);
         }
         plugin_bar.finish_and_clear();
 
-        // Keep ``outputs`` alive past materialize so post-materialize
-        // queries (``descendants`` / ``ancestors`` / ``reachable``) still
-        // see the graph. Snapshot a fresh ``NativeGraph`` from the
-        // builder's interned node + edge vecs; the originals stay put.
+        // Snapshot a fresh ``NativeGraph`` from the builder's
+        // interned node + edge vecs; the originals stay put.
         let this = slf.borrow(py);
-        let outputs_ref = this.outputs.borrow();
+        let outputs_ref = this.outputs.read();
         let outputs = outputs_ref
             .as_ref()
             .ok_or_else(|| PyRuntimeError::new_err("ProjectContext lost its outputs"))?;
@@ -1181,6 +1197,112 @@ impl ProjectContext {
             edges: outputs.builder.edges.clone(),
         })
     }
+
+    /// Run a single plugin's ``run(ctx)`` callback, applying each
+    /// yielded op to the graph as it comes off the iterator. Called
+    /// from Python — by the serial fallback in :meth:`materialize`,
+    /// and (one call per plugin) by the
+    /// :class:`concurrent.futures.ThreadPoolExecutor` worker path.
+    ///
+    /// Concurrency note: every yielded op takes the ``outputs``
+    /// write guard briefly; intra-plugin ``ctx.descendants`` /
+    /// ``ctx.find_module`` etc. take read guards. With multiple
+    /// workers each holding read guards via the GIL-released query
+    /// paths, the writes serialize with bounded contention — the
+    /// per-op write window is sub-millisecond and the readers do
+    /// not starve writers under [`parking_lot`]'s fair policy.
+    pub(crate) fn run_plugin(slf: Py<Self>, py: Python<'_>, plugin: PyObject) -> PyResult<()> {
+        run_and_apply_plugin(py, &slf, &plugin)
+    }
+
+    /// Snapshot the current graph as a [`NativeGraph`]. Used after
+    /// concurrent plugin execution to return the final graph without
+    /// going through [`Self::materialize`] (which would re-run the
+    /// build).
+    pub(crate) fn snapshot_graph(&self, py: Python<'_>) -> PyResult<NativeGraph> {
+        let outputs_ref = self.outputs.read();
+        let outputs = outputs_ref
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("ProjectContext lost its outputs"))?;
+        Ok(NativeGraph {
+            nodes: outputs
+                .builder
+                .nodes
+                .iter()
+                .map(|n| n.clone_ref(py))
+                .collect(),
+            edges: outputs.builder.edges.clone(),
+        })
+    }
+
+    /// Run the materialize **build pass only** — populate
+    /// ``outputs`` from a project-wide scan, without running any
+    /// plugins. Python then drives plugins via a ``ThreadPoolExecutor``
+    /// (one :meth:`run_plugin` call per worker) and finishes with
+    /// :meth:`snapshot_graph` to return the final graph to Python.
+    pub(crate) fn build_only(slf: Py<Self>, py: Python<'_>) -> PyResult<()> {
+        let show_progress = slf.borrow(py).show_progress;
+        let stack_size = slf.borrow(py).stack_size;
+        let mut this = slf.borrow_mut(py);
+        let outputs = build_project_graph(py, &mut this.db, show_progress, stack_size)?;
+        *this.outputs.write() = Some(outputs);
+        Ok(())
+    }
+}
+
+/// Invoke ``plugin.run(ctx)`` and apply each yielded op to the graph
+/// in turn. Mirrors the per-yield apply behavior the codebase has
+/// relied on since plugins existed — ops from earlier steps in a
+/// plugin's body are visible to later ``ctx.descendants`` /
+/// ``ctx.find_*`` queries within the same plugin call.
+fn run_and_apply_plugin(
+    py: Python<'_>,
+    ctx: &Py<ProjectContext>,
+    plugin: &PyObject,
+) -> PyResult<()> {
+    let result = plugin.bind(py).call_method1("run", (ctx.clone_ref(py),))?;
+    if result.is_none() {
+        return Ok(());
+    }
+    for item in result.iter()? {
+        let op = item?;
+        apply_graph_op(ctx, py, &op)?;
+    }
+    Ok(())
+}
+
+/// Acquire a read guard on ``lock`` while releasing the GIL during
+/// the (potentially-parking) wait. Used by hot-path readers that
+/// would otherwise dead-lock with a concurrent
+/// :func:`builder::apply_graph_op` writer: the writer drops the GIL
+/// before contending for the write lock, but to call ``Py::new`` /
+/// ``intern_node`` it has to re-attach the GIL once it owns the
+/// guard. A reader that parks on ``read()`` *while holding the GIL*
+/// keeps the writer locked out of the GIL re-attach and the system
+/// hangs.
+///
+/// We use the recursive read path
+/// (:meth:`parking_lot::RwLock::read_recursive_unchecked`) so a
+/// queued writer doesn't starve us indefinitely (parking_lot's
+/// default ``read`` is writer-priority, which leads to a different
+/// deadlock pattern when the writer is itself parked on the GIL
+/// before it can release the queued-writer flag). The "recursive"
+/// name is slightly misleading — we're not actually re-entering;
+/// we just want the writer-priority bypass.
+fn acquire_read_releasing_gil(
+    lock: &RwLock<Option<BuildOutputs>>,
+) -> RwLockReadGuard<'_, Option<BuildOutputs>> {
+    Python::with_gil(|py| {
+        py.allow_threads(|| {
+            // SAFETY: ``lock_shared_recursive`` is the raw lock
+            // primitive that bypasses writer-priority. The matching
+            // ``make_read_guard_unchecked`` reconstructs the public
+            // guard.
+            unsafe { lock.raw() }.lock_shared_recursive();
+        });
+    });
+    // SAFETY: we just took the read lock above.
+    unsafe { lock.make_read_guard_unchecked() }
 }
 
 impl ProjectContext {
@@ -1188,11 +1310,40 @@ impl ProjectContext {
     /// "not materialized" error. Threads the `op` label into the
     /// error message so the caller name appears in the traceback.
     ///
-    /// The returned `Ref` keeps the `RefCell` borrow alive for the
-    /// lifetime of the receiver, so callers can hold it across an
-    /// entire query body without re-borrowing.
-    pub(crate) fn materialized(&self, op: &str) -> PyResult<Ref<'_, BuildOutputs>> {
-        Ref::filter_map(self.outputs.borrow(), Option::as_ref).map_err(|_| not_materialized(op))
+    /// The returned guard keeps the [`RwLock`] read borrow alive for
+    /// the lifetime of the receiver, so callers can hold it across
+    /// an entire query body without re-borrowing.
+    ///
+    /// Concurrent plugin invocations (from
+    /// :class:`concurrent.futures.ThreadPoolExecutor`) all take read
+    /// guards, so they don't serialize on this lock; only the apply
+    /// pass that mutates the graph takes the write side.
+    ///
+    /// **GIL discipline**: when the read lock is contended (a write
+    /// is pending), :func:`parking_lot::RwLock::read` parks. Any
+    /// thread parking while still holding the GIL deadlocks against
+    /// concurrent writers running in the apply path — the writer
+    /// holds the write lock and wants to re-acquire the GIL to call
+    /// ``Py::new`` / ``intern_node``, but can't because we have the
+    /// GIL parked on the read-acquire. This helper accepts ``py``
+    /// and drops the GIL during the acquire so writers can make
+    /// progress, then re-attaches after we own the read guard.
+    pub(crate) fn materialized(
+        &self,
+        op: &str,
+    ) -> PyResult<MappedRwLockReadGuard<'_, BuildOutputs>> {
+        // ``parking_lot::RwLock`` is uncontended by default — the
+        // fast path takes a single CAS and never parks. We only
+        // need the GIL-release dance when there's an actual writer
+        // waiting; ``try_read`` checks without parking.
+        let guard = match self.outputs.try_read() {
+            Some(g) => g,
+            None => acquire_read_releasing_gil(&self.outputs),
+        };
+        if guard.is_none() {
+            return Err(not_materialized(op));
+        }
+        Ok(RwLockReadGuard::map(guard, |o| o.as_ref().unwrap()))
     }
 }
 
@@ -1331,8 +1482,15 @@ impl ProjectContext {
     /// O(1) count of how many project import nodes target
     /// ``module_name`` — pre-built index lookup, no Py allocation.
     pub(crate) fn imports_of_count(&self, module_name: &str) -> usize {
-        self.outputs
-            .borrow()
+        // Fast path: uncontended read avoids GIL juggling. Slow
+        // path matches the GIL-drop discipline in
+        // :meth:`materialized` — see that method's docstring for
+        // the deadlock rationale.
+        let read_guard = match self.outputs.try_read() {
+            Some(g) => g,
+            None => acquire_read_releasing_gil(&self.outputs),
+        };
+        read_guard
             .as_ref()
             .and_then(|o| o.imports_by_module.get(module_name).map(Vec::len))
             .unwrap_or(0)
@@ -3233,13 +3391,13 @@ impl ProjectContext {
     /// is bounded by the (small) number of distinct patterns a plugin
     /// run uses, so unbounded growth isn't a concern in practice.
     pub(crate) fn compile_regex(&self, pattern: &str) -> PyResult<regex::Regex> {
-        if let Some(cached) = self.regex_cache.borrow().get(pattern) {
+        if let Some(cached) = self.regex_cache.lock().get(pattern) {
             return Ok(cached.clone());
         }
         let regex = regex::Regex::new(pattern)
             .map_err(|e| PyValueError::new_err(format!("invalid regex {pattern:?}: {e}")))?;
         self.regex_cache
-            .borrow_mut()
+            .lock()
             .insert(pattern.to_string(), regex.clone());
         Ok(regex)
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1300,6 +1300,14 @@ pub(crate) struct DeclQuery {
     pub(crate) flags_mask: Option<u32>,
     pub(crate) flags_match_any: bool,
     pub(crate) fqname_prefix: Option<String>,
+    /// Segment-bounded descendant filter, populated by
+    /// :meth:`with_fqname_under`. When ``Some(parent)``, restrict to
+    /// the node whose fqname equals ``parent`` plus every transitive
+    /// descendant of ``parent`` in the fqname tree (modules and decls,
+    /// segment-bounded). Backed by ``children_by_parent`` — see
+    /// :meth:`with_fqname_under` for the contract and comparison
+    /// against the raw-``starts_with`` :meth:`with_fqname_prefix`.
+    pub(crate) fqname_under: Option<String>,
     /// `where_fqname` literal-string candidates. ``None`` if the
     /// predicate isn't configured; ``Some(vec)`` if at least one
     /// literal was passed. Combined with ``fqname_regexes`` via OR.
@@ -1323,6 +1331,7 @@ impl DeclQuery {
             flags_mask: None,
             flags_match_any: false,
             fqname_prefix: None,
+            fqname_under: None,
             fqname_literals: None,
             fqname_regexes: None,
         }
@@ -1404,12 +1413,32 @@ impl DeclQuery {
         slf.flags_match_any = true;
         slf
     }
-    /// Restrict to nodes whose ``fqname`` starts with ``prefix``.
+    /// Restrict to nodes whose ``fqname`` starts with ``prefix`` (raw
+    /// string prefix — not segment-bounded). ``prefix="foo"`` matches
+    /// both ``foo.bar`` and ``foobar``. Use :meth:`with_fqname_under`
+    /// for the segment-bounded "descendants of this fqname" predicate
+    /// that walks the fqname tree.
     fn with_fqname_prefix<'py>(
         mut slf: PyRefMut<'py, Self>,
         prefix: String,
     ) -> PyRefMut<'py, Self> {
         slf.fqname_prefix = Some(prefix);
+        slf
+    }
+
+    /// Restrict to nodes whose ``fqname`` equals ``parent_fqn`` or is
+    /// a transitive descendant of it in the fqname tree.
+    ///
+    /// Segment-bounded: ``parent_fqn="pkg.foo"`` matches ``pkg.foo``,
+    /// ``pkg.foo.bar``, ``pkg.foo.bar.baz`` — but **not** ``pkg.foobar``.
+    /// Backed by the project's ``children_by_parent`` index, so this
+    /// is O(matches) instead of the O(all_nodes) scan
+    /// :meth:`with_fqname_prefix` performs.
+    fn with_fqname_under<'py>(
+        mut slf: PyRefMut<'py, Self>,
+        parent_fqn: String,
+    ) -> PyRefMut<'py, Self> {
+        slf.fqname_under = Some(parent_fqn);
         slf
     }
 
@@ -1494,8 +1523,51 @@ impl DeclQuery {
             .as_ref()
             .map(|v| v.iter().map(String::as_str).collect());
 
+        // For ``with_fqname_under``: BFS the children-by-parent tree
+        // once to materialise the candidate index set, then restrict
+        // the main loop to those indices. Empty set means "parent
+        // unknown" -> the query returns nothing.
+        let fqname_under_indices: Option<FxHashSet<usize>> =
+            self.fqname_under.as_ref().map(|root| {
+                let mut set: FxHashSet<usize> = FxHashSet::default();
+                // The root may be a module or a top-level decl. Include
+                // every direct hit before BFS-ing into modules below.
+                if let Some(&module_idx) = outputs.module_by_fqname.get(root.as_str()) {
+                    set.insert(module_idx);
+                }
+                if let Some(idxs) = outputs.decl_by_fqname.get(root.as_str()) {
+                    for &i in idxs {
+                        set.insert(i);
+                    }
+                }
+                let mut queue: std::collections::VecDeque<String> =
+                    std::collections::VecDeque::from([root.clone()]);
+                while let Some(parent) = queue.pop_front() {
+                    let Some(children) = outputs.children_by_parent.get(parent.as_str()) else {
+                        continue;
+                    };
+                    for &child_idx in children {
+                        if !set.insert(child_idx) {
+                            continue;
+                        }
+                        let child = outputs.builder.nodes[child_idx].borrow(py);
+                        if child.kind == "module" {
+                            queue.push_back(child.fqname.clone());
+                        }
+                    }
+                }
+                set
+            });
+
         let mut out = Vec::new();
-        for (idx, node_py) in outputs.builder.nodes.iter().enumerate() {
+        for (node_idx, node_py) in outputs.builder.nodes.iter().enumerate() {
+            // fqname-under (cheapest gate first when set — restricts
+            // to a tiny candidate set out of all nodes).
+            if let Some(set) = &fqname_under_indices {
+                if !set.contains(&node_idx) {
+                    continue;
+                }
+            }
             let node = node_py.borrow(py);
             // kind
             if let Some(k) = &kinds_set {
@@ -1565,7 +1637,7 @@ impl DeclQuery {
                     continue;
                 }
             }
-            out.push(idx);
+            out.push(node_idx);
         }
         Ok(out)
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -922,6 +922,22 @@ impl SubclassQuery {
             ))
         }
     }
+
+    /// Index-returning terminal. Same lookup as :meth:`collect`, but
+    /// emits each subclass's positional index into ``ctx.nodes()``
+    /// instead of allocating one ``Py<SymbolNode>`` per row.
+    fn indices(&self, py: Python<'_>) -> PyResult<Vec<usize>> {
+        let ctx = self.ctx.borrow(py);
+        if let Some(fqn) = &self.base_fqn {
+            ctx.find_subclasses_indices(py, fqn, self.transitive)
+        } else if let Some(node) = &self.base_node {
+            ctx.find_subclasses_of_indices(&node.borrow(py))
+        } else {
+            Err(PyValueError::new_err(
+                "SubclassQuery requires .of_fqn(...) or .of_node(...)",
+            ))
+        }
+    }
 }
 
 impl_query_methods!(no_first SubclassQuery);
@@ -956,6 +972,14 @@ impl ImportQuery {
         self.ctx
             .borrow(py)
             .find_imports_of(py, self.module_or_err()?)
+    }
+    /// Index-returning terminal. Reads positional indices straight
+    /// out of the pre-built ``imports_by_module`` index — no Python
+    /// allocation per row.
+    fn indices(&self, py: Python<'_>) -> PyResult<Vec<usize>> {
+        self.ctx
+            .borrow(py)
+            .find_imports_of_indices(self.module_or_err()?)
     }
     /// O(1) presence probe — does any project file import the
     /// configured module? Short-circuits on the first match without
@@ -1004,6 +1028,19 @@ impl ClassQuery {
             .as_deref()
             .ok_or_else(|| PyValueError::new_err("ClassQuery requires .defining_method(name)"))?;
         ctx.find_classes_defining_method(py, name)
+    }
+
+    /// Index-returning terminal. Same per-file parallel walk as
+    /// :meth:`collect`, but emits each class node's positional index
+    /// into ``ctx.nodes()`` instead of allocating ``Py<SymbolNode>``
+    /// clones.
+    fn indices(&self, py: Python<'_>) -> PyResult<Vec<usize>> {
+        let ctx = self.ctx.borrow(py);
+        let name = self
+            .defining_method
+            .as_deref()
+            .ok_or_else(|| PyValueError::new_err("ClassQuery requires .defining_method(name)"))?;
+        ctx.find_classes_defining_method_indices(py, name)
     }
 }
 
@@ -1193,6 +1230,45 @@ impl EdgeQuery {
         }
         Ok(refs)
     }
+
+    /// Index-returning terminal for edges. Same per-edge predicate
+    /// pipeline as :meth:`collect`, but emits ``(src_idx, dst_idx,
+    /// flags)`` triples instead of materialising one :class:`EdgeRef`
+    /// (and two ``Py<SymbolNode>`` clones) per row.
+    ///
+    /// Faster than :meth:`collect` when you only need set-membership
+    /// or counting over edge endpoints; pair with
+    /// :meth:`ProjectContext.nodes_at` to revive the surviving
+    /// endpoints on demand.
+    fn index_triples(&self, py: Python<'_>) -> PyResult<Vec<(usize, usize, u32)>> {
+        let ctx = self.ctx.borrow(py);
+        let outputs = ctx.materialized("EdgeQuery.index_triples")?;
+        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let edges: &[(usize, usize, u32)] = &outputs.builder.edges;
+        let flag_mask = self.flag_mask;
+        let src_kind = self.src_kind.as_deref();
+        let dst_kind = self.dst_kind.as_deref();
+        let mut out: Vec<(usize, usize, u32)> = Vec::new();
+        for &(src_idx, dst_idx, flags) in edges {
+            if let Some(mask) = flag_mask {
+                if flags & mask == 0 {
+                    continue;
+                }
+            }
+            if let Some(needle) = src_kind {
+                if nodes[src_idx].borrow(py).kind != needle {
+                    continue;
+                }
+            }
+            if let Some(needle) = dst_kind {
+                if nodes[dst_idx].borrow(py).kind != needle {
+                    continue;
+                }
+            }
+            out.push((src_idx, dst_idx, flags));
+        }
+        Ok(out)
+    }
 }
 
 impl_query_methods!(with_first EdgeQuery, EdgeRef);
@@ -1371,8 +1447,27 @@ impl DeclQuery {
     }
 
     fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<SymbolNode>>> {
+        let indices = self.indices(py)?;
         let ctx = self.ctx.borrow(py);
         let outputs = ctx.materialized("DeclQuery.collect")?;
+        Ok(indices
+            .into_iter()
+            .map(|i| outputs.builder.nodes[i].clone_ref(py))
+            .collect())
+    }
+
+    /// Index-returning terminal. Same predicate semantics as
+    /// :meth:`collect`, but emits each surviving node's positional
+    /// index into ``ctx.nodes()`` (a plain ``list[int]``) instead of
+    /// allocating one ``Py<SymbolNode>`` per row.
+    ///
+    /// Use when you only need set membership / counting on the
+    /// surviving nodes (or want to feed an index-keyed
+    /// :class:`AddEdgeByIdx`); call :meth:`ProjectContext.nodes_at`
+    /// to materialize back to ``SymbolNode`` later.
+    fn indices(&self, py: Python<'_>) -> PyResult<Vec<usize>> {
+        let ctx = self.ctx.borrow(py);
+        let outputs = ctx.materialized("DeclQuery.indices")?;
         let path_regex = _compile_path_regex(self.path_regex.as_deref())?;
 
         // Pre-compute hashsets for predicates that take lists. Singular
@@ -1400,7 +1495,7 @@ impl DeclQuery {
             .map(|v| v.iter().map(String::as_str).collect());
 
         let mut out = Vec::new();
-        for node_py in &outputs.builder.nodes {
+        for (idx, node_py) in outputs.builder.nodes.iter().enumerate() {
             let node = node_py.borrow(py);
             // kind
             if let Some(k) = &kinds_set {
@@ -1470,7 +1565,7 @@ impl DeclQuery {
                     continue;
                 }
             }
-            out.push(node_py.clone_ref(py));
+            out.push(idx);
         }
         Ok(out)
     }

--- a/tests/test_module_surface.py
+++ b/tests/test_module_surface.py
@@ -1,0 +1,256 @@
+"""Tests for the fqname-tree-backed ``ProjectContext.module_surface``
+and ``find_module_top_level_decls`` queries, and the matching
+``DeclQuery.with_fqname_under`` DSL predicate.
+
+All three are backed by ``BuildOutputs.children_by_parent``, a parent
+fqname -> [child node idx] index built in ``build_fqname_indices``.
+The behavior contracts these tests pin:
+
+* ``module_surface(M)``: module ``M`` plus every transitive descendant
+  in the fqname tree. Decls under ``M`` are included but their
+  sub-fqnames (synthetic method-of-class names, etc.) are NOT recursed
+  into — the BFS only steps through module children.
+* ``find_module_top_level_decls(M)``: just the immediate top-level
+  decls (non-module children of ``M``). Submodules are excluded.
+* ``DeclQuery.with_fqname_under(P)``: ``P`` itself plus every
+  segment-bounded descendant. Distinct from
+  ``with_fqname_prefix(P)`` which is raw ``starts_with``.
+"""
+
+from __future__ import annotations
+
+from dead_cst import _native as native
+
+
+# ---------------------------------------------------------------------------
+# module_surface
+# ---------------------------------------------------------------------------
+
+
+def test_module_surface_returns_module_and_all_decls(build_decl_graph):
+    """The module node itself + every top-level decl is included."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/mod.py": """
+            def foo(): ...
+            def bar(): ...
+            X = 1
+            """,
+        }
+    )
+    surface = ctx.module_surface("pkg.mod")
+    fqnames = {n.fqname for n in surface}
+    assert fqnames == {"pkg.mod", "pkg.mod.foo", "pkg.mod.bar", "pkg.mod.X"}
+
+
+def test_module_surface_includes_transitive_submodules(build_decl_graph):
+    """``importlib.import_module(pkg)`` would pull every submodule and
+    submodule decl — same here."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "def f(): ...\n",
+            "pkg/sub/__init__.py": "",
+            "pkg/sub/b.py": "def g(): ...\n",
+        }
+    )
+    surface = ctx.module_surface("pkg")
+    fqnames = {n.fqname for n in surface}
+    assert {"pkg", "pkg.a", "pkg.a.f", "pkg.sub", "pkg.sub.b", "pkg.sub.b.g"} <= fqnames
+
+
+def test_module_surface_segment_bounded(build_decl_graph):
+    """``module_surface(pkg.foo)`` must NOT pick up ``pkg.foobar`` —
+    the old linear-prefix-scan would have. The fqname-tree BFS is
+    segment-bounded by construction."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/foo/__init__.py": "X = 1\n",
+            "pkg/foobar.py": "Y = 2\n",
+        }
+    )
+    surface = ctx.module_surface("pkg.foo")
+    fqnames = {n.fqname for n in surface}
+    assert "pkg.foo" in fqnames
+    assert "pkg.foo.X" in fqnames
+    assert "pkg.foobar" not in fqnames
+    assert "pkg.foobar.Y" not in fqnames
+
+
+def test_module_surface_unknown_module_returns_empty(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): ...\n"})
+    assert ctx.module_surface("does.not.exist") == []
+
+
+def test_module_surface_does_not_recurse_into_decls(build_decl_graph):
+    """A class decl ``pkg.mod.Klass`` has fqname-tree children only if
+    it shadows a submodule path — which it can't here. The BFS shouldn't
+    chase decl children expecting deeper names: nested methods aren't
+    graph nodes."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/mod.py": """
+            class Klass:
+                def method(self): ...
+                def other(self): ...
+            """,
+        }
+    )
+    surface = ctx.module_surface("pkg.mod")
+    fqnames = {n.fqname for n in surface}
+    # The Klass node is in; its method nodes don't exist (nested defs
+    # are deliberately not graph nodes per the architecture invariant).
+    assert fqnames == {"pkg.mod", "pkg.mod.Klass"}
+
+
+# ---------------------------------------------------------------------------
+# find_module_top_level_decls
+# ---------------------------------------------------------------------------
+
+
+def test_find_top_level_decls_excludes_submodules(build_decl_graph):
+    """``from pkg import *`` doesn't pull in submodules — top-level
+    decls only."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "X = 1\n",
+            "pkg/sub.py": "def f(): ...\n",
+        }
+    )
+    decls = ctx.find_module_top_level_decls("pkg")
+    fqnames = {n.fqname for n in decls}
+    # X is top-level; sub (a submodule) is NOT included.
+    assert "pkg.X" in fqnames
+    assert "pkg.sub" not in fqnames
+
+
+def test_find_top_level_decls_does_not_descend(build_decl_graph):
+    """Transitive decls (``pkg.sub.x`` when querying ``pkg``) are
+    excluded — only immediate children."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "X = 1\n",
+            "pkg/sub/__init__.py": "",
+            "pkg/sub/inner.py": "def deep(): ...\n",
+        }
+    )
+    decls = ctx.find_module_top_level_decls("pkg")
+    fqnames = {n.fqname for n in decls}
+    assert "pkg.sub.inner" not in fqnames
+    assert "pkg.sub.inner.deep" not in fqnames
+
+
+def test_find_top_level_decls_segment_bounded(build_decl_graph):
+    """Same segment-bounded guarantee as ``module_surface``: the
+    sibling ``pkg.foobar`` is not pulled in by querying ``pkg.foo``."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/foo/__init__.py": "A = 1\n",
+            "pkg/foobar.py": "B = 2\n",
+        }
+    )
+    decls = ctx.find_module_top_level_decls("pkg.foo")
+    fqnames = {n.fqname for n in decls}
+    assert "pkg.foo.A" in fqnames
+    assert "pkg.foobar" not in fqnames
+    assert "pkg.foobar.B" not in fqnames
+
+
+def test_find_top_level_decls_unknown_module_returns_empty(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): ...\n"})
+    assert ctx.find_module_top_level_decls("does.not.exist") == []
+
+
+# ---------------------------------------------------------------------------
+# DeclQuery.with_fqname_under (new) vs with_fqname_prefix (raw)
+# ---------------------------------------------------------------------------
+
+
+def test_with_fqname_under_segment_bounded(build_decl_graph):
+    """``with_fqname_under("pkg.foo")`` matches ``pkg.foo`` and its
+    descendants — but NOT the sibling ``pkg.foobar``."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/foo/__init__.py": "A = 1\n",
+            "pkg/foo/inner.py": "B = 2\n",
+            "pkg/foobar.py": "C = 3\n",
+        }
+    )
+    fqnames = {r.fqname for r in native.query(ctx).decls().with_fqname_under("pkg.foo")}
+    assert "pkg.foo.A" in fqnames
+    assert "pkg.foo.inner.B" in fqnames
+    assert "pkg.foobar" not in fqnames
+    assert "pkg.foobar.C" not in fqnames
+
+
+def test_with_fqname_under_includes_root_module(build_decl_graph):
+    """The module ``pkg.foo`` itself is included (when its kind isn't
+    filtered out), not just its descendants."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/foo/__init__.py": "A = 1\n",
+        }
+    )
+    nodes = list(
+        native.query(ctx).decls().with_fqname_under("pkg.foo").with_kinds(["module", "variable"])
+    )
+    fqnames = {n.fqname for n in nodes}
+    assert "pkg.foo" in fqnames
+    assert "pkg.foo.A" in fqnames
+
+
+def test_with_fqname_under_unknown_parent_yields_empty(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "def f(): ...\n",
+        }
+    )
+    nodes = list(native.query(ctx).decls().with_fqname_under("does.not.exist"))
+    assert nodes == []
+
+
+def test_with_fqname_prefix_remains_raw_starts_with(build_decl_graph):
+    """``with_fqname_prefix`` is documented as raw ``starts_with``;
+    this test pins that behavior so the segment-bounded
+    ``with_fqname_under`` doesn't accidentally take its place."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/foo/__init__.py": "A = 1\n",
+            "pkg/foobar.py": "C = 3\n",
+        }
+    )
+    fqnames = {
+        r.fqname
+        for r in native.query(ctx).decls().with_kind("module").with_fqname_prefix("pkg.foo")
+    }
+    # Raw starts_with picks up both ``pkg.foo`` AND ``pkg.foobar``.
+    assert "pkg.foo" in fqnames
+    assert "pkg.foobar" in fqnames
+
+
+def test_with_fqname_under_composes_with_other_predicates(build_decl_graph):
+    """Predicates AND together. ``with_fqname_under("pkg") &
+    with_kind("function")`` yields only function decls under pkg."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": """
+            def foo(): ...
+            X = 1
+            class Klass: ...
+            """,
+        }
+    )
+    fqnames = {
+        r.fqname
+        for r in native.query(ctx).decls().with_fqname_under("pkg").with_kind("function")
+    }
+    assert fqnames == {"pkg.a.foo"}

--- a/tests/test_module_surface.py
+++ b/tests/test_module_surface.py
@@ -250,7 +250,6 @@ def test_with_fqname_under_composes_with_other_predicates(build_decl_graph):
         }
     )
     fqnames = {
-        r.fqname
-        for r in native.query(ctx).decls().with_fqname_under("pkg").with_kind("function")
+        r.fqname for r in native.query(ctx).decls().with_fqname_under("pkg").with_kind("function")
     }
     assert fqnames == {"pkg.a.foo"}

--- a/tests/test_overloads_and_pyi.py
+++ b/tests/test_overloads_and_pyi.py
@@ -109,6 +109,112 @@ def test_live_overloads_survive_codemod(tmp_path, make_analysis):
     assert rewritten.count("@overload") == 2
 
 
+def test_overload_stub_flag_set_on_stubs_only(build_decl_graph):
+    """`NodeFlags.OVERLOAD` is set on `@typing.overload`-decorated stubs and
+    not on the impl. Recognise both `@overload` (from-import / aliased) and
+    the `@typing.overload` attribute form (plain `import typing`)."""
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            from typing import overload as ovl
+            import typing
+
+            @ovl
+            def f(x: int) -> int: ...
+            @typing.overload
+            def f(x: str) -> str: ...
+            def f(x):
+                return x
+            """
+        }
+    )
+    # After build_decl_graph's dedent+strip the lines are:
+    #   1: from typing import overload as ovl
+    #   2: import typing
+    #   3: (blank)
+    #   4: @ovl
+    #   5: def f(x: int) -> int: ...      <- stub
+    #   6: @typing.overload
+    #   7: def f(x: str) -> str: ...      <- stub
+    #   8: def f(x):                      <- impl
+    f_nodes = [n for n in graph.nodes() if n.fqname == "mod.f" and n.kind == "function"]
+    by_line = {n.start_line: n for n in f_nodes}
+    assert set(by_line) == {5, 7, 8}, f"unexpected lines: {sorted(by_line)}"
+    assert by_line[5].flags & NodeFlags.OVERLOAD
+    assert by_line[7].flags & NodeFlags.OVERLOAD
+    assert not (by_line[8].flags & NodeFlags.OVERLOAD)
+
+
+def test_impl_to_overload_anchor_edges(build_decl_graph):
+    """Each in-file `@overload` stub gets an explicit `impl -> stub` edge,
+    visible in `descendants(impl)`."""
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            from typing import overload
+
+            @overload
+            def f(x: int) -> int: ...
+            @overload
+            def f(x: str) -> str: ...
+            def f(x):
+                return x
+            """
+        }
+    )
+    # After dedent+strip lines are:
+    #   1: from typing import overload
+    #   2: (blank)
+    #   3: @overload
+    #   4: def f(x: int) -> int: ...
+    #   5: @overload
+    #   6: def f(x: str) -> str: ...
+    #   7: def f(x):
+    impl = next(n for n in graph.nodes() if n.fqname == "mod.f" and n.start_line == 7)
+    stubs = [
+        n
+        for n in graph.nodes()
+        if n.fqname == "mod.f" and n.kind == "function" and n.start_line in (4, 6)
+    ]
+    assert len(stubs) == 2
+    descendants = set(graph.descendants(impl))
+    assert all(s in descendants for s in stubs), (
+        "Each overload stub should be a descendant of the impl via the anchor edge"
+    )
+
+
+def test_cross_module_import_reaches_impl_not_stubs(build_decl_graph):
+    """`from mod import f` should produce exactly one decl edge per consumer
+    use — to the impl, not the stubs (which are deliberately excluded from
+    the cross-module trie via `NodeFlags.OVERLOAD`)."""
+    graph = build_decl_graph(
+        {
+            "mod.py": """
+            from typing import overload
+
+            @overload
+            def f(x: int) -> int: ...
+            @overload
+            def f(x: str) -> str: ...
+            def f(x):
+                return x
+            """,
+            "main.py": "from mod import f\nf(1)\n",
+        }
+    )
+    main_alias = next(n for n in graph.nodes() if n.fqname == "main.f" and n.kind == "import")
+    nodes = graph.nodes()
+    # Direct successors of the import alias: filter to `mod.f` function
+    # decls and assert none of them carry the OVERLOAD flag.
+    targets = [
+        nodes[v]
+        for u, v, _ in graph.edges()
+        if nodes[u] == main_alias and nodes[v].fqname == "mod.f" and nodes[v].kind == "function"
+    ]
+    assert targets, "import alias should reach at least one mod.f decl"
+    assert all(not (t.flags & NodeFlags.OVERLOAD) for t in targets)
+
+
 # ---------------------------------------------------------------------------
 # ``.pyi`` ingestion -- compiled-extension orphan stubs
 # ---------------------------------------------------------------------------

--- a/tests/test_plugin_concurrency.py
+++ b/tests/test_plugin_concurrency.py
@@ -60,8 +60,7 @@ def test_plugins_run_concurrently(tmp_path: Path) -> None:
 
     assert len(observed) == 2
     assert observed[0] != observed[1], (
-        f"plugins ran on the same thread {observed[0]} — executor did "
-        "not actually parallelize"
+        f"plugins ran on the same thread {observed[0]} — executor did not actually parallelize"
     )
 
 
@@ -74,9 +73,7 @@ def test_serial_env_falls_back(tmp_path: Path) -> None:
     observed: list[int] = []
 
     class _RecorderPlugin(Plugin):
-        def run(
-            self, ctx: native.ProjectContext
-        ) -> Iterable[native.GraphOp]:  # pragma: no cover
+        def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:  # pragma: no cover
             observed.append(threading.get_ident())
             return ()
 
@@ -86,8 +83,7 @@ def test_serial_env_falls_back(tmp_path: Path) -> None:
 
     assert len(observed) == 3
     assert len(set(observed)) == 1, (
-        f"serial mode should run all plugins on one thread, got "
-        f"{set(observed)}"
+        f"serial mode should run all plugins on one thread, got {set(observed)}"
     )
 
 
@@ -101,9 +97,7 @@ def test_single_plugin_uses_serial_path(tmp_path: Path) -> None:
     observed: list[int] = []
 
     class _RecorderPlugin(Plugin):
-        def run(
-            self, ctx: native.ProjectContext
-        ) -> Iterable[native.GraphOp]:  # pragma: no cover
+        def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:  # pragma: no cover
             observed.append(threading.get_ident())
             return ()
 
@@ -120,9 +114,7 @@ def test_worker_count_env(tmp_path: Path, workers: str) -> None:
     (tmp_path / "a.py").write_text("x = 1\n")
 
     class _NoopPlugin(Plugin):
-        def run(
-            self, ctx: native.ProjectContext
-        ) -> Iterable[native.GraphOp]:  # pragma: no cover
+        def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:  # pragma: no cover
             return ()
 
     plugins = [_NoopPlugin(), _NoopPlugin(), _NoopPlugin()]

--- a/tests/test_plugin_concurrency.py
+++ b/tests/test_plugin_concurrency.py
@@ -1,0 +1,130 @@
+"""Concurrent plugin execution sanity checks.
+
+These tests don't measure speed — they prove that the Python-side
+:class:`concurrent.futures.ThreadPoolExecutor` driving plugins
+actually runs them in parallel, and that the kill-switch env var
+falls back to serial. Threading primitives (a :class:`threading.Barrier`)
+gate the parallel-claim test so it never flakes on slow CI.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from typing import Iterable
+from unittest.mock import patch
+
+import pytest
+
+from dead_cst import Analysis
+from dead_cst import _native as native
+from dead_cst.plugins import Plugin
+
+
+class _BarrierPlugin(Plugin):
+    """Plugin that ``barrier.wait()``s inside ``run`` and records its
+    thread id. Combined with a barrier of two participants, two such
+    plugins running on different threads both reach ``wait`` and
+    proceed; one stuck on a single-threaded executor would block
+    indefinitely (the barrier's timeout surfaces the failure).
+    """
+
+    def __init__(self, barrier: threading.Barrier, observed: list[int]) -> None:
+        self.barrier = barrier
+        self.observed = observed
+
+    def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:  # pragma: no cover
+        self.observed.append(threading.get_ident())
+        # If we're not actually parallel, the second plugin never
+        # reaches ``wait`` (the first never returns) and the barrier
+        # times out. The 5 s budget is comfortable on every CI we
+        # ship to and small enough that a real serial bug doesn't
+        # hang for minutes.
+        self.barrier.wait(timeout=5.0)
+        return ()
+
+
+def test_plugins_run_concurrently(tmp_path: Path) -> None:
+    """Two plugins on a two-thread barrier finish only if executed in
+    parallel — single-threaded execution times out on the barrier."""
+    (tmp_path / "a.py").write_text("x = 1\n")
+
+    barrier = threading.Barrier(2)
+    observed: list[int] = []
+    plugins = [
+        _BarrierPlugin(barrier, observed),
+        _BarrierPlugin(barrier, observed),
+    ]
+    Analysis(tmp_path, plugins=plugins).materialize_all()
+
+    assert len(observed) == 2
+    assert observed[0] != observed[1], (
+        f"plugins ran on the same thread {observed[0]} — executor did "
+        "not actually parallelize"
+    )
+
+
+def test_serial_env_falls_back(tmp_path: Path) -> None:
+    """``DEAD_CST_PLUGINS_SERIAL=1`` skips the executor — the
+    barrier-based parallel test would deadlock under serial, so we
+    use a thread-id collector instead: same thread means serial."""
+    (tmp_path / "a.py").write_text("x = 1\n")
+
+    observed: list[int] = []
+
+    class _RecorderPlugin(Plugin):
+        def run(
+            self, ctx: native.ProjectContext
+        ) -> Iterable[native.GraphOp]:  # pragma: no cover
+            observed.append(threading.get_ident())
+            return ()
+
+    plugins = [_RecorderPlugin(), _RecorderPlugin(), _RecorderPlugin()]
+    with patch.dict(os.environ, {"DEAD_CST_PLUGINS_SERIAL": "1"}):
+        Analysis(tmp_path, plugins=plugins).materialize_all()
+
+    assert len(observed) == 3
+    assert len(set(observed)) == 1, (
+        f"serial mode should run all plugins on one thread, got "
+        f"{set(observed)}"
+    )
+
+
+def test_single_plugin_uses_serial_path(tmp_path: Path) -> None:
+    """One-plugin Analysis hits the rust-side serial loop directly
+    (no executor overhead). Confirmed by the plugin landing on the
+    caller's thread."""
+    (tmp_path / "a.py").write_text("x = 1\n")
+
+    caller_thread = threading.get_ident()
+    observed: list[int] = []
+
+    class _RecorderPlugin(Plugin):
+        def run(
+            self, ctx: native.ProjectContext
+        ) -> Iterable[native.GraphOp]:  # pragma: no cover
+            observed.append(threading.get_ident())
+            return ()
+
+    Analysis(tmp_path, plugins=[_RecorderPlugin()]).materialize_all()
+
+    assert observed == [caller_thread]
+
+
+@pytest.mark.parametrize("workers", ["1", "2", "8"])
+def test_worker_count_env(tmp_path: Path, workers: str) -> None:
+    """``DEAD_CST_PLUGIN_WORKERS`` caps the pool size. We just verify
+    the call doesn't blow up — actual pool-size enforcement is a
+    cpython-internal concern."""
+    (tmp_path / "a.py").write_text("x = 1\n")
+
+    class _NoopPlugin(Plugin):
+        def run(
+            self, ctx: native.ProjectContext
+        ) -> Iterable[native.GraphOp]:  # pragma: no cover
+            return ()
+
+    plugins = [_NoopPlugin(), _NoopPlugin(), _NoopPlugin()]
+    with patch.dict(os.environ, {"DEAD_CST_PLUGIN_WORKERS": workers}):
+        Analysis(tmp_path, plugins=plugins).materialize_all()

--- a/tests/test_plugins/test_fastmcp.py
+++ b/tests/test_plugins/test_fastmcp.py
@@ -388,5 +388,53 @@ def test_fastmcp_plugin_factory_returns_configured_dispatch_app():
     plugin = fastmcp_plugin()
     assert isinstance(plugin, DispatchAppPlugin)
     assert plugin.marker_prefix == "fastmcp"
-    assert plugin.app_classes == ("fastmcp.FastMCP",)
+    assert plugin.app_classes == ("fastmcp.FastMCP", "mcp.server.fastmcp.FastMCP")
     assert plugin.seed_as_entrypoint is True
+
+
+def test_fastmcp_plugin_handles_anthropic_mcp_sdk_import(build_plugin_graph, reachable_fqnames):
+    """The Anthropic MCP SDK ships a compatibility layer at
+    ``mcp.server.fastmcp.FastMCP``. Projects on that path should get
+    the same handler wiring as the standalone ``fastmcp`` package."""
+    graph = build_plugin_graph(
+        {
+            "server/__init__.py": "",
+            "server/main.py": """
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("demo")
+
+            @mcp.tool()
+            def hello(): pass
+
+            @mcp.resource("res://config")
+            def config() -> dict:
+                return {}
+            """,
+        },
+        [fastmcp_plugin()],
+    )
+    reached = reachable_fqnames(graph)
+    assert "server.main.mcp" in reached
+    assert "server.main.hello" in reached
+    assert "server.main.config" in reached
+
+
+def test_fastmcp_plugin_handles_anthropic_sdk_module_import(build_plugin_graph, reachable_fqnames):
+    """``import mcp.server.fastmcp; mcp.server.fastmcp.FastMCP(...)`` —
+    the module-attribute form of the Anthropic SDK import."""
+    graph = build_plugin_graph(
+        {
+            "server/__init__.py": "",
+            "server/main.py": """
+            import mcp.server.fastmcp
+
+            srv = mcp.server.fastmcp.FastMCP("demo")
+
+            @srv.tool()
+            def hello(): pass
+            """,
+        },
+        [fastmcp_plugin()],
+    )
+    assert "server.main.hello" in reachable_fqnames(graph)

--- a/tests/test_plugins/test_flask.py
+++ b/tests/test_plugins/test_flask.py
@@ -496,6 +496,52 @@ def test_flask_plugin_handles_factory_function(build_plugin_graph, reachable_fqn
     assert "app.main.create_item" in reached
 
 
+def test_flask_plugin_factory_walk_requires_direct_successor(build_plugin_graph, reachable_fqnames):
+    """Step 6's factory-walk must be 1-hop: only the var whose *direct*
+    successor is the factory function gets promoted.
+
+    Regression for the over-promotion bug: ``wrapper = app`` puts
+    ``create_app`` in ``wrapper``'s transitive descendants, but
+    ``wrapper`` is two hops from the factory. Promoting it would also
+    revive its handlers, masking dead code.
+
+    Only ``app`` (whose direct successor is ``create_app``) promotes;
+    handlers attached to ``wrapper`` stay dead.
+    """
+    graph = build_plugin_graph(
+        {
+            "app/__init__.py": "",
+            "app/factory.py": """
+            from flask import Flask
+
+            def create_app() -> Flask:
+                return Flask(__name__)
+            """,
+            "app/main.py": """
+            from app.factory import create_app
+
+            app = create_app()
+            wrapper = app
+
+            @app.route("/things")
+            def list_things(): pass
+
+            @wrapper.route("/items")
+            def list_items(): pass
+            """,
+        },
+        [flask_plugin()],
+    )
+    reached = reachable_fqnames(graph)
+    # The direct factory chain promotes ``app`` and its handler.
+    assert "app.main.app" in reached
+    assert "app.main.list_things" in reached
+    # ``wrapper`` is two hops from ``create_app`` — must NOT promote,
+    # so handlers attached to it stay dead.
+    assert "app.main.wrapper" not in reached
+    assert "app.main.list_items" not in reached
+
+
 def test_flask_plugin_factory_returning_blueprint_stays_dead(build_plugin_graph, reachable_fqnames):
     """Factory-produced Blueprint is treated like a literal Blueprint --
     never auto-seeded as an entrypoint, so an unregistered one stays dead."""

--- a/tests/test_plugins/test_slack_bolt.py
+++ b/tests/test_plugins/test_slack_bolt.py
@@ -1,0 +1,343 @@
+"""Tests for :func:`slack_bolt_plugin`."""
+
+from __future__ import annotations
+
+import pytest
+
+from dead_cst.contrib import slack_bolt_plugin
+from dead_cst.plugins import DispatchAppPlugin
+
+
+def test_slack_bolt_plugin_marks_handlers(build_plugin_graph, reachable_fqnames):
+    graph = build_plugin_graph(
+        {
+            "bot/__init__.py": "",
+            "bot/main.py": """
+            import slack_bolt
+
+            app = slack_bolt.App(token="x", signing_secret="y")
+
+            @app.event("app_mention")
+            def handle_mention(event, say):
+                pass
+
+            @app.message("hello")
+            def message_hello(message, say):
+                pass
+
+            @app.command("/echo")
+            def echo_command(ack, command):
+                ack()
+
+            @app.action("button_click")
+            def handle_button(ack, body, client):
+                ack()
+
+            @app.shortcut("open_modal")
+            def open_modal(ack, shortcut, client):
+                pass
+
+            @app.view("view_submission")
+            def handle_submission(ack, body):
+                ack()
+
+            @app.options("external_select")
+            def options_handler(ack, body):
+                ack({})
+
+            @app.error
+            def custom_error_handler(error, body, logger):
+                pass
+
+            @app.step(callback_id="cb", edit=None)
+            def step_handler(step, edit):
+                pass
+
+            @app.function("my_function")
+            def function_handler(args):
+                pass
+
+            def helper():
+                pass
+            """,
+        },
+        [slack_bolt_plugin()],
+    )
+    reached = reachable_fqnames(graph)
+    assert "bot.main.app" in reached
+    assert "bot.main.handle_mention" in reached
+    assert "bot.main.message_hello" in reached
+    assert "bot.main.echo_command" in reached
+    assert "bot.main.handle_button" in reached
+    assert "bot.main.open_modal" in reached
+    assert "bot.main.handle_submission" in reached
+    assert "bot.main.options_handler" in reached
+    assert "bot.main.custom_error_handler" in reached
+    assert "bot.main.step_handler" in reached
+    assert "bot.main.function_handler" in reached
+    # Undecorated helper not referenced by any handler stays dead.
+    assert "bot.main.helper" not in reached
+
+
+def test_slack_bolt_plugin_handles_async_app(build_plugin_graph, reachable_fqnames):
+    graph = build_plugin_graph(
+        {
+            "bot/__init__.py": "",
+            "bot/main.py": """
+            from slack_bolt.async_app import AsyncApp
+
+            app = AsyncApp(token="x", signing_secret="y")
+
+            @app.event("app_mention")
+            async def handle_mention(event, say):
+                pass
+
+            @app.message("hello")
+            async def message_hello(message, say):
+                pass
+
+            @app.command("/echo")
+            async def echo_command(ack, command):
+                await ack()
+
+            @app.action("button_click")
+            async def handle_button(ack, body, client):
+                await ack()
+            """,
+        },
+        [slack_bolt_plugin()],
+    )
+    reached = reachable_fqnames(graph)
+    assert "bot.main.app" in reached
+    assert "bot.main.handle_mention" in reached
+    assert "bot.main.message_hello" in reached
+    assert "bot.main.echo_command" in reached
+    assert "bot.main.handle_button" in reached
+
+
+def test_slack_bolt_plugin_keeps_handler_dependencies_alive(build_plugin_graph, reachable_fqnames):
+    graph = build_plugin_graph(
+        {
+            "bot/__init__.py": "",
+            "bot/models.py": """
+            class Greeting:
+                pass
+
+            class Unused:
+                pass
+            """,
+            "bot/main.py": """
+            from slack_bolt import App
+            from bot.models import Greeting
+
+            app = App(token="x", signing_secret="y")
+
+            def build_greeting() -> Greeting:
+                return Greeting()
+
+            @app.event("app_mention")
+            def run(event, say):
+                return build_greeting()
+            """,
+        },
+        [slack_bolt_plugin()],
+    )
+    reached = reachable_fqnames(graph)
+    assert "bot.main.run" in reached
+    # Symbols transitively referenced from the handler stay alive.
+    assert "bot.main.build_greeting" in reached
+    assert "bot.models.Greeting" in reached
+    # Unrelated module symbol is still dead.
+    assert "bot.models.Unused" not in reached
+
+
+def test_slack_bolt_plugin_auto_seeds_app_as_entrypoint(build_plugin_graph, reachable_fqnames):
+    """Direct ``X = App(...)`` is an entrypoint even without a
+    ``__main__`` block or ``[project.scripts]`` entry. Slack Bolt apps
+    are typically launched via ``app.start(...)`` from a module-level
+    invocation, mirroring how Flask / FastAPI / FastMCP apps are
+    framework-visible the moment they're constructed."""
+    graph = build_plugin_graph(
+        {
+            "bot/__init__.py": "",
+            "bot/main.py": """
+            from slack_bolt import App
+
+            app = App(token="x", signing_secret="y")
+
+            @app.event("app_mention")
+            def hello(event, say):
+                pass
+            """,
+        },
+        [slack_bolt_plugin()],
+    )
+    reached = reachable_fqnames(graph)
+    assert "bot.main.app" in reached
+    assert "bot.main.hello" in reached
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        pytest.param(
+            """
+            from slack_bolt import App as Bolt
+
+            app = Bolt(token="x", signing_secret="y")
+
+            @app.event("app_mention")
+            def hello(event, say): pass
+            """,
+            id="aliased-class-import",
+        ),
+        pytest.param(
+            """
+            import slack_bolt
+
+            app = slack_bolt.App(token="x", signing_secret="y")
+
+            @app.event("app_mention")
+            def hello(event, say): pass
+            """,
+            id="module-import",
+        ),
+        pytest.param(
+            """
+            from slack_bolt import App
+
+            app: App = App(token="x", signing_secret="y")
+
+            @app.event("app_mention")
+            def hello(event, say): pass
+            """,
+            id="annotated-assignment",
+        ),
+        pytest.param(
+            """
+            from slack_bolt.async_app import AsyncApp as AsyncBolt
+
+            app = AsyncBolt(token="x", signing_secret="y")
+
+            @app.event("app_mention")
+            async def hello(event, say): pass
+            """,
+            id="async-aliased-class-import",
+        ),
+    ],
+)
+def test_slack_bolt_plugin_handles_import_variants(build_plugin_graph, reachable_fqnames, src):
+    graph = build_plugin_graph(
+        {"bot/__init__.py": "", "bot/main.py": src},
+        [slack_bolt_plugin()],
+    )
+    assert "bot.main.hello" in reachable_fqnames(graph)
+
+
+def test_slack_bolt_plugin_ignores_bare_decorators(build_plugin_graph, reachable_fqnames):
+    graph = build_plugin_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/mod.py": """
+            from slack_bolt import App
+
+            app = App(token="x", signing_secret="y")
+
+            def event(fn):
+                return fn
+
+            @event
+            def looks_like_event(): pass
+            """,
+        },
+        [slack_bolt_plugin()],
+    )
+    # Bare ``@event`` (no attribute access) is not a Bolt registration --
+    # matching it would clobber unrelated decorators with the same name.
+    assert "pkg.mod.looks_like_event" not in reachable_fqnames(graph)
+
+
+def test_slack_bolt_plugin_ignores_unrelated_decorators(build_plugin_graph, reachable_fqnames):
+    graph = build_plugin_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/mod.py": """
+            class Thing:
+                def event(self, fn):
+                    return fn
+
+            t = Thing()
+
+            @t.event
+            def not_a_handler(): pass
+            """,
+        },
+        [slack_bolt_plugin()],
+    )
+    # ``t`` isn't a ``slack_bolt.App`` instance, so its ``.event`` decorator
+    # is ignored.
+    assert "pkg.mod.not_a_handler" not in reachable_fqnames(graph)
+
+
+def test_slack_bolt_plugin_does_nothing_without_slack_bolt_imports(
+    build_plugin_graph, reachable_fqnames
+):
+    graph = build_plugin_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/mod.py": """
+            class App:
+                def event(self, name):
+                    def wrap(fn): return fn
+                    return wrap
+
+            app = App()
+
+            @app.event("ping")
+            def looks_like_handler(): pass
+            """,
+        },
+        [slack_bolt_plugin()],
+    )
+    # ``app`` here is not a slack_bolt App -- no ``slack_bolt`` import in scope.
+    assert "pkg.mod.looks_like_handler" not in reachable_fqnames(graph)
+
+
+def test_slack_bolt_plugin_handles_factory_function(build_plugin_graph, reachable_fqnames):
+    graph = build_plugin_graph(
+        {
+            "bot/__init__.py": "",
+            "bot/factory.py": """
+            from slack_bolt import App
+
+            def make_app() -> App:
+                return App(token="x", signing_secret="y")
+            """,
+            "bot/main.py": """
+            from bot.factory import make_app
+
+            app = make_app()
+
+            @app.event("app_mention")
+            def handle_mention(event, say):
+                pass
+
+            @app.command("/echo")
+            def echo_command(ack, command):
+                ack()
+            """,
+        },
+        [slack_bolt_plugin()],
+    )
+    reached = reachable_fqnames(graph)
+    assert "bot.main.app" in reached
+    assert "bot.main.handle_mention" in reached
+    assert "bot.main.echo_command" in reached
+
+
+def test_slack_bolt_plugin_factory_returns_configured_dispatch_app():
+    plugin = slack_bolt_plugin()
+    assert isinstance(plugin, DispatchAppPlugin)
+    assert plugin.marker_prefix == "slack-bolt"
+    assert plugin.app_classes == ("slack_bolt.App", "slack_bolt.async_app.AsyncApp")
+    assert plugin.seed_as_entrypoint is True

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -62,6 +62,7 @@ EXPECTED_PUBLIC_API: dict[str, list[str]] = {
         "fastapi_plugin",
         "fastmcp_plugin",
         "flask_plugin",
+        "slack_bolt_plugin",
         "typer_plugin",
     ],
 }

--- a/tests/test_query_indices.py
+++ b/tests/test_query_indices.py
@@ -1,0 +1,299 @@
+"""Tests for the index-returning terminals on the chainable query DSL,
+the ``ctx.reachable_indices`` / ``ctx.indices_where`` / ``ctx.nodes_at``
+sibling helpers on :class:`ProjectContext`, and the
+:class:`AddEdgeByIdx` graph op.
+
+These cover the additive surface added to let plugins do index-level set
+operations without paying the per-row ``Py<SymbolNode>`` allocation that
+``.collect()`` does.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dead_cst import _native as native
+
+
+# ---------------------------------------------------------------------------
+# DeclQuery.indices — parity with collect() + lookup
+# ---------------------------------------------------------------------------
+
+
+def test_decl_query_indices_matches_collect(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "def alpha(): pass\n",
+            "pkg/b.py": "def beta(): pass\n",
+        }
+    )
+    q = native.query(ctx).decls().with_kind("function")
+    nodes = q.collect()
+    indices = q.indices()
+    assert len(nodes) == len(indices)
+    all_nodes = ctx.nodes()
+    for node, idx in zip(nodes, indices, strict=True):
+        assert all_nodes[idx].fqname == node.fqname
+        assert all_nodes[idx].path == node.path
+        assert all_nodes[idx].start_line == node.start_line
+
+
+def test_decl_query_indices_predicate_combos(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def handler(): pass\nclass Service: pass\n",
+            "pkg/util.py": "def helper(): pass\n",
+        }
+    )
+    # kind + path filename narrows to just pkg.svc.handler.
+    indices = (
+        native.query(ctx)
+        .decls()
+        .with_kind("function")
+        .with_filename("svc.py")
+        .indices()
+    )
+    nodes = ctx.nodes_at(indices)
+    fqnames = {n.fqname for n in nodes}
+    assert fqnames == {"pkg.svc.handler"}
+
+
+# ---------------------------------------------------------------------------
+# SubclassQuery.indices
+# ---------------------------------------------------------------------------
+
+
+def test_subclass_query_indices_matches_collect(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/bases.py": "class Base: pass\n",
+            "pkg/sub.py": """
+            from pkg.bases import Base
+            class Mid(Base): pass
+            class Leaf(Mid): pass
+            """,
+        }
+    )
+    q = native.query(ctx).subclasses().of_fqn("pkg.bases.Base")
+    indices = q.indices()
+    nodes = q.collect()
+    assert len(indices) == len(nodes)
+    # Round-trip back through nodes_at — same fqnames.
+    revived = ctx.nodes_at(indices)
+    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
+
+
+# ---------------------------------------------------------------------------
+# ImportQuery.indices
+# ---------------------------------------------------------------------------
+
+
+def test_import_query_indices_matches_collect(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "from os.path import join\n",
+            "pkg/b.py": "from os.path import join as j2\n",
+        }
+    )
+    q = native.query(ctx).imports().of("os.path")
+    indices = q.indices()
+    nodes = q.collect()
+    assert len(indices) == len(nodes)
+    assert len(indices) >= 2  # at least the two import nodes
+    revived = ctx.nodes_at(indices)
+    assert {n.kind for n in revived} == {"import"}
+
+
+# ---------------------------------------------------------------------------
+# ClassQuery.indices
+# ---------------------------------------------------------------------------
+
+
+def test_class_query_indices_matches_collect(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": """
+            class Greeter:
+                def greet(self): pass
+            class Counter:
+                def increment(self): pass
+            """,
+        }
+    )
+    q = native.query(ctx).classes().defining_method("greet")
+    indices = q.indices()
+    nodes = q.collect()
+    assert len(indices) == len(nodes) == 1
+    revived = ctx.nodes_at(indices)
+    assert revived[0].fqname == "pkg.a.Greeter"
+
+
+# ---------------------------------------------------------------------------
+# EdgeQuery.index_triples
+# ---------------------------------------------------------------------------
+
+
+def test_edge_query_index_triples_matches_collect(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "def f(): pass\ndef g(): f()\n",
+        }
+    )
+    q = native.query(ctx).edges().with_src_kind("function")
+    triples = q.index_triples()
+    refs = q.collect()
+    assert len(triples) == len(refs)
+    all_nodes = ctx.nodes()
+    for (src_idx, dst_idx, flags), ref in zip(triples, refs, strict=True):
+        assert all_nodes[src_idx].fqname == ref.src.fqname
+        assert all_nodes[dst_idx].fqname == ref.dst.fqname
+        assert flags == ref.flags
+
+
+# ---------------------------------------------------------------------------
+# ctx.reachable_indices parity with ctx.reachable
+# ---------------------------------------------------------------------------
+
+
+def test_reachable_indices_matches_reachable(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/main.py": """
+            def used(): pass
+            def unused(): pass
+            used()
+            """,
+        }
+    )
+    # Same seed_flags / skip_flags: idx and node forms must agree.
+    nodes = ctx.reachable()
+    indices = ctx.reachable_indices()
+    assert {ctx.nodes()[i].fqname for i in indices} == {n.fqname for n in nodes}
+
+
+# ---------------------------------------------------------------------------
+# ctx.indices_where predicate combos
+# ---------------------------------------------------------------------------
+
+
+def test_indices_where_kind_and_filename(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def handler(): pass\n",
+            "pkg/util.py": "def helper(): pass\n",
+        }
+    )
+    indices = ctx.indices_where(kind="function", filename="svc.py")
+    revived = ctx.nodes_at(indices)
+    assert {n.fqname for n in revived} == {"pkg.svc.handler"}
+
+
+def test_indices_where_fqname_prefix(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/sub/__init__.py": "",
+            "pkg/sub/inner.py": "def deep(): pass\n",
+            "pkg/top.py": "def shallow(): pass\n",
+        }
+    )
+    indices = ctx.indices_where(kind="function", fqname_prefix="pkg.sub")
+    revived = ctx.nodes_at(indices)
+    assert {n.fqname for n in revived} == {"pkg.sub.inner.deep"}
+
+
+def test_indices_where_unconstrained_yields_all(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    indices = ctx.indices_where()
+    assert len(indices) == len(ctx.nodes())
+
+
+# ---------------------------------------------------------------------------
+# ctx.nodes_at — bounds + happy path
+# ---------------------------------------------------------------------------
+
+
+def test_nodes_at_happy_path(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): pass\n"})
+    all_nodes = ctx.nodes()
+    revived = ctx.nodes_at([0, len(all_nodes) - 1])
+    assert revived[0].fqname == all_nodes[0].fqname
+    assert revived[-1].fqname == all_nodes[-1].fqname
+
+
+def test_nodes_at_out_of_range_raises(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): pass\n"})
+    n = len(ctx.nodes())
+    with pytest.raises(IndexError, match="out of range"):
+        ctx.nodes_at([n])
+    with pytest.raises(IndexError, match="out of range"):
+        ctx.nodes_at([0, n + 100])
+
+
+# ---------------------------------------------------------------------------
+# AddEdgeByIdx — graph op
+# ---------------------------------------------------------------------------
+
+
+def test_add_edge_by_idx_round_trip(tmp_path):
+    """``AddEdgeByIdx`` accepts positional indices into ``ctx.nodes()``
+    and materializes an edge in the snapshot just like ``AddEdge``."""
+    from dead_cst.analyze import Analysis
+    from dead_cst.plugins._base import Plugin
+
+    (tmp_path / "mod.py").write_text("def f(): pass\ndef g(): pass\n")
+
+    class WireByIdx(Plugin):
+        name = "wire_by_idx"
+        version = 1
+
+        def run(self, ctx: native.ProjectContext):
+            # Find f and g by fqname using indices_where + nodes_at.
+            f_idx = ctx.indices_where(fqname_prefix="mod.f")
+            g_idx = ctx.indices_where(fqname_prefix="mod.g")
+            assert len(f_idx) == 1
+            assert len(g_idx) == 1
+            yield native.AddEdgeByIdx(f_idx[0], g_idx[0])
+
+    analysis = Analysis(tmp_path, plugins=[WireByIdx()])
+    ctx = analysis.materialize_all()
+    fqnames = [n.fqname for n in ctx.nodes()]
+    f_idx = fqnames.index("mod.f")
+    g_idx = fqnames.index("mod.g")
+    # Edge present in the snapshot.
+    assert any(s == f_idx and d == g_idx for (s, d, _f) in ctx.edges())
+
+
+def test_add_edge_by_idx_carries_flags(tmp_path):
+    from dead_cst.analyze import Analysis
+    from dead_cst.plugins._base import Plugin
+
+    (tmp_path / "mod.py").write_text("def f(): pass\ndef g(): pass\n")
+
+    class WireWithFlags(Plugin):
+        name = "wire_with_flags"
+        version = 1
+
+        def run(self, ctx: native.ProjectContext):
+            f_idx = ctx.indices_where(fqname_prefix="mod.f")[0]
+            g_idx = ctx.indices_where(fqname_prefix="mod.g")[0]
+            yield native.AddEdgeByIdx(f_idx, g_idx, flags=native.EdgeFlags.DEAD_BRANCH)
+
+    analysis = Analysis(tmp_path, plugins=[WireWithFlags()])
+    ctx = analysis.materialize_all()
+    fqnames = [n.fqname for n in ctx.nodes()]
+    f_idx = fqnames.index("mod.f")
+    g_idx = fqnames.index("mod.g")
+    matching = [
+        (s, d, f) for (s, d, f) in ctx.edges()
+        if s == f_idx and d == g_idx and f == native.EdgeFlags.DEAD_BRANCH
+    ]
+    assert matching

--- a/tests/test_query_indices.py
+++ b/tests/test_query_indices.py
@@ -48,13 +48,7 @@ def test_decl_query_indices_predicate_combos(build_decl_graph):
         }
     )
     # kind + path filename narrows to just pkg.svc.handler.
-    indices = (
-        native.query(ctx)
-        .decls()
-        .with_kind("function")
-        .with_filename("svc.py")
-        .indices()
-    )
+    indices = native.query(ctx).decls().with_kind("function").with_filename("svc.py").indices()
     nodes = ctx.nodes_at(indices)
     fqnames = {n.fqname for n in nodes}
     assert fqnames == {"pkg.svc.handler"}
@@ -293,7 +287,8 @@ def test_add_edge_by_idx_carries_flags(tmp_path):
     f_idx = fqnames.index("mod.f")
     g_idx = fqnames.index("mod.g")
     matching = [
-        (s, d, f) for (s, d, f) in ctx.edges()
+        (s, d, f)
+        for (s, d, f) in ctx.edges()
         if s == f_idx and d == g_idx and f == native.EdgeFlags.DEAD_BRANCH
     ]
     assert matching


### PR DESCRIPTION
## Summary

Release **0.12.2**. Sweeping pass that landed several new query / graph-op APIs, restored the ``@typing.overload`` mechanism dropped in the libcst→rust transition, parallelised ``plugin.run``, tightened ``DispatchAppPlugin`` step-6 to a direct-predecessor check, and added the Slack Bolt contrib plugin. Suite goes 606 → 659 tests across the new coverage; CI green, clippy + fmt + prek clean.

## Performance

### ``assemble_graph`` / fan-in
- **``class_bases`` per-file payload** (`#744de28`). Unifies the previously-overlapping ``build_class_children`` + ``find_subclasses_via_bases`` mechanisms behind a single salsa-tracked per-file payload. Fan-in derives both ``children_by_node`` (intra-project subclass walks) and ``children_by_fqn`` (external-seed dispatch). 118 → 70 ms cold materialize on dead_cst self-corpus. Removes ~275 LOC of duplicated AST walks.
- **``children_by_parent`` fqname-tree index** (`#a09eb6b`). Built in ``build_fqname_indices``, keyed by each node's immediate fqname parent. ``module_surface`` / ``find_module_top_level_decls`` switch from a linear ``starts_with`` scan to a one-level lookup / BFS. 0.185 ms median ``module_surface`` on a 1200-sibling-module synthetic.

### Plugin tail
- **Parallel ``plugin.run``** (`#d1b8eca`). ``ProjectContext`` lost ``#[pyclass(unsendable)]``; ``outputs`` becomes ``Arc<RwLock<…>>``. ``apply_graph_op`` rewritten as prepare-then-allow_threads-then-with_gil to break the GIL/RwLock deadlock. Python driver runs plugins on ``ThreadPoolExecutor`` when there are ≥ 2. Built-in plugins are within noise (the tail is already small); synthetic heavy plugins doing many ``find_subclasses`` calls per ``run()`` see **1.23×-1.51× speedup**. Worker count via ``DEAD_CST_PLUGIN_WORKERS``; kill switch ``DEAD_CST_PLUGINS_SERIAL=1``.
- **DispatchApp step-6 1-hop tightening** (`#3188e2c`). Replaces ``ctx.descendants(var)`` per unclassified handler with a one-shot ``factory_reachers: set[SymbolNode]`` built from ``ctx.direct_predecessors(fref.decl)``. Fixes the over-promotion case ``wrapper = app; app = create_app()`` where ``wrapper``'s transitive descendants reach the factory but its direct successor doesn't.

## New query / graph-op surface

- **``ctx.query().edges()``** — ``EdgeQuery`` chainable with ``with_flags(mask)``, ``with_src_kind(kind)``, ``with_dst_kind(kind)``. Yields ``EdgeRef`` rows with endpoint ``SymbolNode``s pre-resolved.
- **``ctx.query().decls()``** — ``DeclQuery`` chainable with ``with_kind`` / ``with_kinds``, ``with_filename`` / ``with_filenames``, ``with_simple_name`` / ``with_simple_names``, ``with_paths``, ``with_path_regex``, ``with_flags`` / ``with_any_flag``, ``with_fqname_prefix``, ``with_fqname_under`` (segment-bounded BFS over ``children_by_parent``), and ``where_fqname`` (accepts ``str`` / ``list[str]`` / ``re.Pattern`` / ``list[re.Pattern]`` / mixed sequence). Returns ``SymbolNode`` rows directly.
- **``.indices()`` terminals** — ``DeclQuery.indices()``, ``SubclassQuery.indices()``, ``ClassQuery.indices()``, ``ImportQuery.indices()``, ``EdgeQuery.index_triples()``. Skip ``Py<SymbolNode>`` materialisation entirely.
- **``ProjectContext`` helpers** — ``reachable_indices``, ``indices_where``, ``nodes_at``, ``module_surfaces`` (batched form of ``module_surface``), ``subclasses_of_fqn``, ``subclasses_of_node``, ``direct_predecessors``, ``find_module_top_level_decls_indices``, ``find_module_dunder_all_exports_indices``.
- **``AddEdgeByIdx``** graph op — sibling of ``AddEdge`` for callers that already hold indices.
- **``Plugin.prepare(self, repo_root: Path) -> None``** — new pre-graph hook on the ``Plugin`` base. Called once per plugin per ``Analysis.materialize_all`` invocation, before any graph construction. Default no-op; plugins that scan the repo for config files / framework manifests override.

## Regressions fixed

- **``@typing.overload``** (`#1ae14f8`). The libcst→rust transition (``ca92e12``) silently dropped the ``OVERLOAD`` flag setter + the ``impl → stub`` anchor edge emitter. ``NodeFlags::OVERLOAD = 4`` and its docstring stayed in ``src/graph.rs`` but nothing set the flag. Three behavioural tests in ``tests/test_overloads_and_pyi.py`` passed by accident via the same-fqname grouping. Restored:
  - ``OVERLOAD`` flag detection for ``@overload`` / ``@typing.overload`` / ``@typing_extensions.overload`` / aliased / called forms.
  - ``impl → stub`` anchor edges (new ``overload_anchors: Box<[(u32, u32)]>`` field on ``FileNodes``; ``file_to_edges`` translates each pair to one edge).
  - Cross-module lookup exclusion in ``exports_by_name`` + ``build_fqname_indices``.
  - 3 new edge-shape tests covering each piece.

## Query DSL correctness

- ``where_module`` / ``of_module`` accept ``str | list[str]`` on every chainable (OR semantics).
- Syntactic matchers (``decorators`` / ``constructions`` / ``calls`` / ``factories``) resolve relative imports: ``from .foo import N`` no longer slips through ``where_module(M).where_name(N)``.
- ``where_name`` matches subscripted constructors (``Generic[T]()``, ``Logger[Self]("name")``).

## Plugin migrations to the new surfaces

| plugin | migration | perf win |
|---|---|---|
| `ServerConfigPlugin` | `ctx.query().decls()` | **153×** (`pathlib.Path(...).name` Python hop was the killer) |
| `InitSubclassPlugin` | class-hierarchy index | **~280×** on 800f/3200-class synthetic |
| `UnittestPlugin` | class-hierarchy index | ~14× on 800f/3200-class synthetic |
| `DiscordPyPlugin` | `ctx.query().decls()` + `ctx.module_surfaces` | ~18.8× |
| `PytestPlugin` | `ctx.query().decls()` | ~2.2× |
| `DispatchAppPlugin` framework-class lookup | `find_subclasses_via_bases` (no venv load) → `subclasses_of_fqn` | typer plugin **+173 ms → ~0** on dead_cst |
| `DispatchAppPlugin` step 6 | inversion + 1-hop tightening | O(handlers × graph) → O(factory_decls) + O(1) lookup |
| `DynamicImportFallbackPlugin` | `index_triples()` + `AddEdgeByIdx` + `find_module_*_indices` | per-edge `lookup_idx` × 2 elimination |
| `LiteralListPlugin` | `ctx.module_surfaces([...])` batched | N scans → 1 |
| `FastMCPPlugin` | extended to handle ``mcp.server.fastmcp.FastMCP`` | n/a |

## New: Slack Bolt contrib plugin (`#5e10e84`)

``dead_cst.contrib.slack_bolt_plugin`` keeps ``slack_bolt.App`` / ``slack_bolt.async_app.AsyncApp`` instances alive, with handler wiring through the ten registration decorators (``event`` / ``message`` / ``command`` / ``action`` / ``shortcut`` / ``view`` / ``options`` / ``error`` / ``step`` / ``function``). Registered under CLI key ``"slack_bolt"``. 13 tests mirror the FastMCP coverage.

## Release procedure

After merge, tag ``v0.12.2`` via ``gh release create v0.12.2`` to trigger the PyPI publish workflow (same flow as 0.12.0 / 0.12.1).

## Test plan

- [x] ``uv run pytest -q`` — 659 passed (+53 vs 0.12.1)
- [x] ``cargo test --no-default-features --lib`` — 131 passed
- [x] ``cargo clippy --all-targets --locked -- -D warnings`` clean
- [x] ``cargo fmt --check`` clean
- [x] ``uv run prek run --all-files`` clean
- [ ] CI green on the latest SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)