### PR TITLE
QoL: frozen-graph plugin execution + progress-callback API

### DIFF
--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -11,7 +11,10 @@ should land in both places at once.
 """
 
 import re
-from typing import Any, Iterable, Iterator, Literal, Protocol, Sequence
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, Literal, Protocol, Sequence
+
+if TYPE_CHECKING:
+    from dead_cst.analyze import ProgressSnapshot
 
 # The set of stable kind strings ``SymbolNode.kind`` can carry. Use a
 # ``Literal`` rather than ``str`` so the type checker catches typos at
@@ -417,18 +420,12 @@ class ProjectContext:
         without re-running :meth:`materialize`."""
         ...
 
-    def read_progress_snapshot(self) -> dict[str, object]:
-        """Atomic snapshot of the build-progress counters as a plain
-        :class:`dict`. Drives :class:`dead_cst.Analysis`'s polling
-        thread; user code should prefer the structured
-        ``progress_callback`` API on :class:`dead_cst.Analysis`.
-
-        Most values are integers; the ``phase`` discriminant maps to
-        one of :data:`dead_cst.analyze.PROGRESS_PHASES`. The
-        ``plugin_states`` value is a ``list[tuple[str, int, int]]``
-        of ``(name, started_us, finished_us)`` triples in
-        registration order — ``started_us == 0`` means "not yet
-        running", ``finished_us == 0`` means "still running".
+    def read_progress_snapshot(self) -> "ProgressSnapshot":
+        """Atomic snapshot of the build-progress counters as a
+        :class:`dead_cst.analyze.ProgressSnapshot` ``TypedDict``.
+        Drives :class:`dead_cst.Analysis`'s polling thread; user code
+        should prefer the structured ``progress_callback`` API on
+        :class:`dead_cst.Analysis`.
 
         ``materialize`` holds the context's ``borrow_mut`` for the
         whole build, so a concurrent polling thread calling this
@@ -1449,7 +1446,7 @@ class ProgressHandle:
     handle to read counters concurrently with a long-running build.
     """
 
-    def snapshot(self) -> dict[str, object]:
+    def snapshot(self) -> "ProgressSnapshot":
         """Atomic snapshot of every counter as a plain Python dict
         (``int`` values; ``finished`` is ``bool``). Same key set as
         :meth:`ProjectContext.read_progress_snapshot`."""

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -417,14 +417,18 @@ class ProjectContext:
         without re-running :meth:`materialize`."""
         ...
 
-    def read_progress_snapshot(self) -> dict[str, int]:
+    def read_progress_snapshot(self) -> dict[str, object]:
         """Atomic snapshot of the build-progress counters as a plain
         :class:`dict`. Drives :class:`dead_cst.Analysis`'s polling
         thread; user code should prefer the structured
         ``progress_callback`` API on :class:`dead_cst.Analysis`.
 
-        The dict has integer values; the ``phase`` discriminant maps
-        to one of :data:`dead_cst.analyze.PROGRESS_PHASES`.
+        Most values are integers; the ``phase`` discriminant maps to
+        one of :data:`dead_cst.analyze.PROGRESS_PHASES`. The
+        ``plugin_states`` value is a ``list[tuple[str, int, int]]``
+        of ``(name, started_us, finished_us)`` triples in
+        registration order — ``started_us == 0`` means "not yet
+        running", ``finished_us == 0`` means "still running".
 
         ``materialize`` holds the context's ``borrow_mut`` for the
         whole build, so a concurrent polling thread calling this
@@ -455,10 +459,27 @@ class ProjectContext:
         signal per-plugin completion to the polling thread."""
         ...
 
-    def progress_plugins_start(self, total: int) -> None:
-        """Stamp the plugins phase as started + record its total.
-        Called by :class:`dead_cst.Analysis` before launching the
+    def progress_plugins_start(self, names: list[str]) -> None:
+        """Stamp the plugins phase as started + allocate per-plugin
+        counter slabs keyed by registration order. ``names`` is
+        the plugin list (``type(plugin).__qualname__`` per entry);
+        indices passed to :meth:`progress_plugin_started` /
+        :meth:`progress_plugin_finished` match. Called by
+        :class:`dead_cst.Analysis` before launching the
         :class:`concurrent.futures.ThreadPoolExecutor`."""
+        ...
+
+    def progress_plugin_started(self, idx: int) -> None:
+        """Stamp the indexed plugin's start time. Called by the
+        :class:`concurrent.futures.ThreadPoolExecutor` worker on
+        entry so the per-plugin slot snapshot reflects the actual
+        start order (not the registration order)."""
+        ...
+
+    def progress_plugin_finished(self, idx: int) -> None:
+        """Stamp the indexed plugin's finish time. Called by the
+        :class:`concurrent.futures.ThreadPoolExecutor` worker on
+        exit (both success and exception paths)."""
         ...
 
     def progress_plugins_finish(self) -> None:

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -1449,7 +1449,7 @@ class ProgressHandle:
     handle to read counters concurrently with a long-running build.
     """
 
-    def snapshot(self) -> dict[str, int]:
+    def snapshot(self) -> dict[str, object]:
         """Atomic snapshot of every counter as a plain Python dict
         (``int`` values; ``finished`` is ``bool``). Same key set as
         :meth:`ProjectContext.read_progress_snapshot`."""

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -256,6 +256,19 @@ class AddNode:
 
 GraphOp = AddEdge | AddEdgeByIdx | AddEntrypoint | AddNode
 
+class CollectedOps:
+    """Opaque handle to one plugin's collected graph ops.
+
+    Returned by :meth:`ProjectContext.run_plugin_collect`; consumed by
+    :meth:`ProjectContext.apply_ops_batched`. The handle is single-use:
+    a second ``apply_ops_batched`` on the same instance raises
+    :class:`ValueError`.
+
+    There is no Python-side constructor or accessor — the type exists
+    solely as a transport for the (pure-rust) prepared ops between
+    the collect and apply phases of plugin execution.
+    """
+
 class NativeGraph:
     """The project-wide graph snapshot returned by ``Project.build()``
     and ``ProjectContext.materialize()``.
@@ -368,11 +381,33 @@ class ProjectContext:
         ...
 
     def run_plugin(self, plugin: _ProjectPluginLike | Any) -> None:
-        """Invoke ``plugin.run(ctx)`` once, applying every yielded
-        op to the graph as it comes off the iterator. Safe to call
-        concurrently from multiple Python threads — graph mutations
-        serialize on the rust-side lock while read-only queries on
-        the in-progress graph run in parallel."""
+        """Invoke ``plugin.run(ctx)`` once, collecting every yielded
+        op and applying the batch under one write-lock window at
+        the end. The plugin's own emissions are invisible to its
+        own queries — the graph is frozen for the duration of
+        ``run``. Prefer :meth:`run_plugin_collect` +
+        :meth:`apply_ops_batched` when driving multiple plugins
+        concurrently so the apply pass runs once for the full
+        cohort."""
+        ...
+
+    def run_plugin_collect(self, plugin: _ProjectPluginLike | Any) -> CollectedOps:
+        """Invoke ``plugin.run(ctx)`` once and return its yielded ops
+        as an opaque :class:`CollectedOps` handle without mutating
+        the graph. Safe to call concurrently from multiple Python
+        threads — the graph is read-only for the duration. The
+        handle is passed (alongside other plugins' handles) to
+        :meth:`apply_ops_batched`, which folds them all into the
+        graph under one write-lock window."""
+        ...
+
+    def apply_ops_batched(self, ops: list[CollectedOps]) -> None:
+        """Apply a list of :class:`CollectedOps` handles to the graph
+        in list order under a single write-lock window. Each handle
+        is consumed; re-applying the same handle raises
+        :class:`ValueError`. Ops within a handle apply in the order
+        the plugin yielded them; ops across handles apply in
+        ``ops`` order."""
         ...
 
     def snapshot_graph(self) -> NativeGraph:

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -417,6 +417,56 @@ class ProjectContext:
         without re-running :meth:`materialize`."""
         ...
 
+    def read_progress_snapshot(self) -> dict[str, int]:
+        """Atomic snapshot of the build-progress counters as a plain
+        :class:`dict`. Drives :class:`dead_cst.Analysis`'s polling
+        thread; user code should prefer the structured
+        ``progress_callback`` API on :class:`dead_cst.Analysis`.
+
+        The dict has integer values; the ``phase`` discriminant maps
+        to one of :data:`dead_cst.analyze.PROGRESS_PHASES`.
+
+        ``materialize`` holds the context's ``borrow_mut`` for the
+        whole build, so a concurrent polling thread calling this
+        method will see ``RuntimeError("Already mutably borrowed")``
+        until the build releases. For race-free polling, use
+        :meth:`progress_handle` instead — the returned handle reads
+        the same atomic counters without touching pyo3's borrow flag."""
+        ...
+
+    def progress_handle(self) -> "ProgressHandle":
+        """Mint a borrow-free handle over the progress counters.
+        The handle holds an :class:`Arc` over the rust-side atomics
+        so the polling thread can call :meth:`ProgressHandle.snapshot`
+        concurrently with a long-running ``materialize`` call (which
+        keeps the context's ``borrow_mut`` token held for the entire
+        build)."""
+        ...
+
+    def mark_progress_finished(self) -> None:
+        """Force the build-progress ``finished`` atomic to ``True``.
+        Used by :class:`dead_cst.Analysis` after a build error so the
+        polling thread exits cleanly. Idempotent."""
+        ...
+
+    def progress_plugin_done(self) -> None:
+        """Bump the plugins-done counter by one. Used by the Python
+        :class:`concurrent.futures.ThreadPoolExecutor` plugin pass to
+        signal per-plugin completion to the polling thread."""
+        ...
+
+    def progress_plugins_start(self, total: int) -> None:
+        """Stamp the plugins phase as started + record its total.
+        Called by :class:`dead_cst.Analysis` before launching the
+        :class:`concurrent.futures.ThreadPoolExecutor`."""
+        ...
+
+    def progress_plugins_finish(self) -> None:
+        """Stamp the plugins phase as finished + mark the whole
+        build pipeline finished. Called by :class:`dead_cst.Analysis`
+        once every plugin future has resolved."""
+        ...
+
     def query(self) -> QueryBuilder:
         """Open a chainable query builder against this context.
 
@@ -1365,6 +1415,24 @@ class GraphMetadata:
     file_count: int
     line_count: int
     user_meta: list[tuple[str, str]]
+
+class ProgressHandle:
+    """Borrow-free view over the build-progress atomic counters.
+
+    Created by :meth:`ProjectContext.progress_handle` — the handle
+    holds a shared ``Arc`` over the rust counters, so calling
+    :meth:`snapshot` is GIL-bound but doesn't go through the pyo3
+    borrow flag that ``materialize`` holds for the entire build. The
+    Python polling thread driving
+    :class:`dead_cst.Analysis`'s ``progress_callback`` API uses this
+    handle to read counters concurrently with a long-running build.
+    """
+
+    def snapshot(self) -> dict[str, int]:
+        """Atomic snapshot of every counter as a plain Python dict
+        (``int`` values; ``finished`` is ``bool``). Same key set as
+        :meth:`ProjectContext.read_progress_snapshot`."""
+        ...
 
 def write_graph(
     path: str,

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -314,11 +314,14 @@ class _ProgressPoller:
                         total=(total if total > 0 else None),
                     )
 
-                # Plugin start/end synthesis. Treat each
-                # ``plugins_done`` increment as the end of the
-                # plugin whose index equals the old count.
-                if name == "plugins" and self._plugin_names:
-                    self._emit_plugin_events(done, total)
+                # Plugin start/end synthesis. The rust side
+                # publishes a per-plugin slot snapshot — one
+                # ``(name, started_us, finished_us)`` triple per
+                # registered plugin, in registration order. The
+                # poller diffs them against ``_plugin_states_seen``
+                # so each transition fires exactly one event.
+                if name == "plugins":
+                    self._emit_plugin_events_from_slots(snap, total)
 
             # ``phase_end`` fires when the rust side has moved past
             # this phase (current_phase_id > phase_id), or when the
@@ -351,28 +354,30 @@ class _ProgressPoller:
                     elapsed_ms=elapsed_us // 1000,
                 )
 
-    def _emit_plugin_events(self, done: int, total: int) -> None:
-        """Translate ``plugins_done`` increments into per-plugin
-        ``plugin_start`` / ``plugin_end`` events.
+    def _emit_plugin_events_from_slots(self, snap: dict[str, object], total: int) -> None:
+        """Diff the rust per-plugin slot snapshot against
+        ``_plugins_signalled_{start,end}`` and fire one event per
+        observed transition.
 
-        The rust side reports plugin completion *count* but not which
-        plugin finished — we infer order from the registration order
-        Python stashed in ``plugin_names``. With the concurrent
-        ``ThreadPoolExecutor`` plugin pass this is best-effort:
-        completions may arrive out of registration order, so the
-        reported ``name`` is the next-unseen plugin in registration
-        order rather than the actual one. This is documented as a
-        known limitation in the callback contract.
+        Each slot is a ``(name, started_us, finished_us)`` triple:
+
+        * ``started_us > 0`` and ``idx`` not in signalled-start →
+          fire ``plugin_start(name=..., index=idx, total=...)``.
+        * ``finished_us > 0`` and ``idx`` not in signalled-end →
+          fire ``plugin_end(name=..., elapsed_ms=...)`` with the
+          per-plugin elapsed time computed from the slot pair.
+
+        Slot order is registration order, so ``idx`` is meaningful;
+        completion order across slots can interleave freely under the
+        parallel ``ThreadPoolExecutor`` pass — each slot writes only
+        to its own atomic so attribution is exact.
         """
-        plugin_total = total if total > 0 else len(self._plugin_names)
-        # Fire ``plugin_start`` for any plugin whose index <= done
-        # but hasn't been signalled yet.
-        for idx in range(min(done, plugin_total)):
-            if idx not in self._plugins_signalled_start:
+        states = snap.get("plugin_states") or []
+        plugin_total = total if total > 0 else len(states)
+        for idx, triple in enumerate(states):
+            name, started_us, finished_us = triple
+            if started_us > 0 and idx not in self._plugins_signalled_start:
                 self._plugins_signalled_start.add(idx)
-                name = (
-                    self._plugin_names[idx] if idx < len(self._plugin_names) else f"<plugin {idx}>"
-                )
                 _safe_invoke_callback(
                     self._cb,
                     "plugin_start",
@@ -380,20 +385,15 @@ class _ProgressPoller:
                     index=idx,
                     total=plugin_total,
                 )
-            if idx not in self._plugins_signalled_end:
+            if finished_us > 0 and idx not in self._plugins_signalled_end:
                 self._plugins_signalled_end.add(idx)
-                name = (
-                    self._plugin_names[idx] if idx < len(self._plugin_names) else f"<plugin {idx}>"
-                )
-                # ops_emitted is not tracked per-plugin yet; report 0
-                # as a placeholder so the callback contract stays
-                # stable.
+                elapsed_us = finished_us - started_us if finished_us >= started_us else 0
                 _safe_invoke_callback(
                     self._cb,
                     "plugin_end",
                     name=name,
                     ops_emitted=0,
-                    elapsed_ms=0,
+                    elapsed_ms=elapsed_us // 1000,
                 )
 
 
@@ -595,7 +595,8 @@ class Analysis:
             else:
                 ctx.build_only()
                 workers = _plugin_worker_count(len(self._plugins))
-                ctx.progress_plugins_start(len(self._plugins))
+                plugin_names = [type(p).__qualname__ for p in self._plugins]
+                ctx.progress_plugins_start(plugin_names)
                 try:
                     # Plugins are scheduled in registration order;
                     # ``.result()`` waits in the same order. Errors
@@ -604,17 +605,29 @@ class Analysis:
                     # handle (no graph mutation); the main thread
                     # folds every handle into the graph in registration
                     # order via one ``apply_ops_batched`` call.
-                    def _run_collect(plugin: Plugin):
+                    #
+                    # The per-plugin ``progress_plugin_started`` /
+                    # ``progress_plugin_finished`` stamps live in this
+                    # worker so the rust per-plugin counter slabs see
+                    # the actual completion order (the polling thread
+                    # uses those to attribute ``plugin_end`` events to
+                    # the right plugin even when futures resolve out of
+                    # registration order).
+                    def _run_collect(idx: int, plugin: Plugin):
+                        ctx.progress_plugin_started(idx)
                         try:
                             return ctx.run_plugin_collect(plugin)
                         finally:
+                            ctx.progress_plugin_finished(idx)
                             ctx.progress_plugin_done()
 
                     with ThreadPoolExecutor(
                         max_workers=workers,
                         thread_name_prefix="dead-cst-plugin",
                     ) as pool:
-                        futures = [pool.submit(_run_collect, p) for p in self._plugins]
+                        futures = [
+                            pool.submit(_run_collect, idx, p) for idx, p in enumerate(self._plugins)
+                        ]
                         collected = [fut.result() for fut in futures]
                     ctx.apply_ops_batched(collected)
                 finally:

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -231,36 +231,42 @@ class _ProgressPoller:
                 # without one here to avoid racing against it.
                 return
 
-    def _dispatch(self, snap: dict[str, int]) -> None:
+    def _dispatch(self, snap: dict[str, object]) -> None:
         # Map snapshot fields to per-phase (done, total, elapsed_us).
+        # The snapshot dict is ``dict[str, object]`` since
+        # ``plugin_states`` is a list-of-tuples; every other value is
+        # an int. Read with a per-key ``int(...)`` cast so the type
+        # checker sees the narrow type without giving up the heterogeneous
+        # dict shape.
+        def _i(key: str) -> int:
+            v = snap[key]
+            assert isinstance(v, int), f"expected int for {key!r}, got {type(v).__name__}"
+            return v
+
         phase_stats: dict[str, tuple[int, int, int]] = {
-            "enum": (
-                snap["enum_done"],
-                snap["enum_total"],
-                snap["enum_elapsed_us"],
-            ),
+            "enum": (_i("enum_done"), _i("enum_total"), _i("enum_elapsed_us")),
             "populate": (
-                snap["populate_done"],
-                snap["populate_total"],
-                snap["populate_elapsed_us"],
+                _i("populate_done"),
+                _i("populate_total"),
+                _i("populate_elapsed_us"),
             ),
             "assemble": (
-                snap["assemble_done"],
-                snap["assemble_total"],
-                snap["assemble_elapsed_us"],
+                _i("assemble_done"),
+                _i("assemble_total"),
+                _i("assemble_elapsed_us"),
             ),
             "fqname": (
-                snap["fqname_done"],
-                snap["fqname_total"],
-                snap["fqname_elapsed_us"],
+                _i("fqname_done"),
+                _i("fqname_total"),
+                _i("fqname_elapsed_us"),
             ),
             "plugins": (
-                snap["plugins_done"],
-                snap["plugins_total"],
-                snap["plugins_elapsed_us"],
+                _i("plugins_done"),
+                _i("plugins_total"),
+                _i("plugins_elapsed_us"),
             ),
         }
-        current_phase_id = snap["phase"]
+        current_phase_id = _i("phase")
 
         for name in PROGRESS_PHASES:
             done, total, elapsed_us = phase_stats[name]
@@ -372,10 +378,26 @@ class _ProgressPoller:
         parallel ``ThreadPoolExecutor`` pass — each slot writes only
         to its own atomic so attribution is exact.
         """
-        states = snap.get("plugin_states") or []
-        plugin_total = total if total > 0 else len(states)
-        for idx, triple in enumerate(states):
-            name, started_us, finished_us = triple
+        raw = snap.get("plugin_states")
+        # ``raw`` is a rust-built ``list[tuple[str, u64, u64]]``.
+        # Narrow + flatten into typed locals so ty sees the field
+        # types on the unpacked names rather than ``object``.
+        if not isinstance(raw, list):
+            return
+        plugin_total = total if total > 0 else len(raw)
+        for idx, triple in enumerate(raw):
+            if not isinstance(triple, tuple) or len(triple) != 3:
+                continue
+            name_obj, started_obj, finished_obj = triple
+            if not (
+                isinstance(name_obj, str)
+                and isinstance(started_obj, int)
+                and isinstance(finished_obj, int)
+            ):
+                continue
+            name: str = name_obj
+            started_us: int = started_obj
+            finished_us: int = finished_obj
             if started_us > 0 and idx not in self._plugins_signalled_start:
                 self._plugins_signalled_start.add(idx)
                 _safe_invoke_callback(

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -5,7 +5,7 @@ import threading
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Sequence, TypedDict
 
 from .graph import KEEPALIVE_DEFAULT, EdgeFlags, SymbolNode
 
@@ -40,6 +40,40 @@ PROGRESS_POLL_INTERVAL_S: float = 0.1
 
 ProgressEvent = str
 ProgressCallback = Callable[..., None]
+
+
+class ProgressSnapshot(TypedDict):
+    """Shape returned by :meth:`native.ProjectContext.read_progress_snapshot`
+    and :meth:`native.ProgressHandle.snapshot`.
+
+    Every counter field is an integer in either microseconds (the
+    ``*_elapsed_us`` keys) or item count (``*_done`` / ``*_total``).
+    The ``phase`` discriminant maps to one of
+    :data:`PROGRESS_PHASES` via :data:`_PHASE_ID_TO_NAME`.
+    ``plugin_states`` carries one ``(name, started_us, finished_us)``
+    triple per registered plugin in registration order; both
+    timestamps are ``0`` until stamped (``started_us == 0`` ⇔ not
+    yet running, ``finished_us == 0`` ⇔ still running).
+    """
+
+    phase: int
+    finished: bool
+    enum_done: int
+    enum_total: int
+    enum_elapsed_us: int
+    populate_done: int
+    populate_total: int
+    populate_elapsed_us: int
+    assemble_done: int
+    assemble_total: int
+    assemble_elapsed_us: int
+    fqname_done: int
+    fqname_total: int
+    fqname_elapsed_us: int
+    plugins_done: int
+    plugins_total: int
+    plugins_elapsed_us: int
+    plugin_states: list[tuple[str, int, int]]
 
 
 _NON_DECL_TYPES: frozenset[str] = frozenset({"module", "synthetic"})
@@ -231,42 +265,36 @@ class _ProgressPoller:
                 # without one here to avoid racing against it.
                 return
 
-    def _dispatch(self, snap: dict[str, object]) -> None:
+    def _dispatch(self, snap: ProgressSnapshot) -> None:
         # Map snapshot fields to per-phase (done, total, elapsed_us).
-        # The snapshot dict is ``dict[str, object]`` since
-        # ``plugin_states`` is a list-of-tuples; every other value is
-        # an int. Read with a per-key ``int(...)`` cast so the type
-        # checker sees the narrow type without giving up the heterogeneous
-        # dict shape.
-        def _i(key: str) -> int:
-            v = snap[key]
-            assert isinstance(v, int), f"expected int for {key!r}, got {type(v).__name__}"
-            return v
-
         phase_stats: dict[str, tuple[int, int, int]] = {
-            "enum": (_i("enum_done"), _i("enum_total"), _i("enum_elapsed_us")),
+            "enum": (
+                snap["enum_done"],
+                snap["enum_total"],
+                snap["enum_elapsed_us"],
+            ),
             "populate": (
-                _i("populate_done"),
-                _i("populate_total"),
-                _i("populate_elapsed_us"),
+                snap["populate_done"],
+                snap["populate_total"],
+                snap["populate_elapsed_us"],
             ),
             "assemble": (
-                _i("assemble_done"),
-                _i("assemble_total"),
-                _i("assemble_elapsed_us"),
+                snap["assemble_done"],
+                snap["assemble_total"],
+                snap["assemble_elapsed_us"],
             ),
             "fqname": (
-                _i("fqname_done"),
-                _i("fqname_total"),
-                _i("fqname_elapsed_us"),
+                snap["fqname_done"],
+                snap["fqname_total"],
+                snap["fqname_elapsed_us"],
             ),
             "plugins": (
-                _i("plugins_done"),
-                _i("plugins_total"),
-                _i("plugins_elapsed_us"),
+                snap["plugins_done"],
+                snap["plugins_total"],
+                snap["plugins_elapsed_us"],
             ),
         }
-        current_phase_id = _i("phase")
+        current_phase_id = snap["phase"]
 
         for name in PROGRESS_PHASES:
             done, total, elapsed_us = phase_stats[name]
@@ -360,7 +388,7 @@ class _ProgressPoller:
                     elapsed_ms=elapsed_us // 1000,
                 )
 
-    def _emit_plugin_events_from_slots(self, snap: dict[str, object], total: int) -> None:
+    def _emit_plugin_events_from_slots(self, snap: ProgressSnapshot, total: int) -> None:
         """Diff the rust per-plugin slot snapshot against
         ``_plugins_signalled_{start,end}`` and fire one event per
         observed transition.
@@ -378,26 +406,9 @@ class _ProgressPoller:
         parallel ``ThreadPoolExecutor`` pass — each slot writes only
         to its own atomic so attribution is exact.
         """
-        raw = snap.get("plugin_states")
-        # ``raw`` is a rust-built ``list[tuple[str, u64, u64]]``.
-        # Narrow + flatten into typed locals so ty sees the field
-        # types on the unpacked names rather than ``object``.
-        if not isinstance(raw, list):
-            return
-        plugin_total = total if total > 0 else len(raw)
-        for idx, triple in enumerate(raw):
-            if not isinstance(triple, tuple) or len(triple) != 3:
-                continue
-            name_obj, started_obj, finished_obj = triple
-            if not (
-                isinstance(name_obj, str)
-                and isinstance(started_obj, int)
-                and isinstance(finished_obj, int)
-            ):
-                continue
-            name: str = name_obj
-            started_us: int = started_obj
-            finished_us: int = finished_obj
+        states = snap["plugin_states"]
+        plugin_total = total if total > 0 else len(states)
+        for idx, (name, started_us, finished_us) in enumerate(states):
             if started_us > 0 and idx not in self._plugins_signalled_start:
                 self._plugins_signalled_start.add(idx)
                 _safe_invoke_callback(

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -174,14 +174,19 @@ class Analysis:
             ctx.set_stack_size(self._stack_size)
 
         # ``DEAD_CST_PLUGINS_SERIAL=1`` (or no plugins / a single
-        # plugin) keeps the legacy rust-side loop. Otherwise we drive
+        # plugin) keeps the rust-side serial loop. Otherwise we drive
         # plugins from a ``ThreadPoolExecutor`` so any plugin time
         # spent in GIL-releasing rust queries (``find_decorated_decls``,
         # ``find_subclasses_of_class``, ``find_handler_decorators``, ...)
-        # overlaps across workers. Mutations to the graph still
-        # serialize behind the rust-side ``RwLock`` on ``outputs`` —
-        # only one ``apply_graph_op`` write runs at a time — but the
-        # read path is fully concurrent.
+        # overlaps across workers.
+        #
+        # Both paths satisfy the *frozen-graph* contract: every
+        # plugin's ``run(ctx)`` observes the same base-graph state.
+        # Ops collected from each plugin land in registration order
+        # via a single end-of-pass :meth:`apply_ops_batched` call —
+        # a plugin's own emissions are invisible to its own queries,
+        # and to every other plugin's queries, until the apply pass
+        # runs.
         if _serial_mode() or len(self._plugins) <= 1:
             for plugin in self._plugins:
                 ctx.add_plugin(plugin)
@@ -191,14 +196,18 @@ class Analysis:
             workers = _plugin_worker_count(len(self._plugins))
             # Plugins are scheduled in registration order; results
             # ``.result()`` waits in the same order. Errors propagate
-            # via the future's ``.result()`` call.
+            # via the future's ``.result()`` call. We collect each
+            # plugin's ops into a :class:`CollectedOps` handle off
+            # the worker thread, then fold them all into the graph
+            # in registration order via one ``apply_ops_batched``
+            # call on the main thread.
             with ThreadPoolExecutor(
                 max_workers=workers,
                 thread_name_prefix="dead-cst-plugin",
             ) as pool:
-                futures = [pool.submit(ctx.run_plugin, p) for p in self._plugins]
-                for fut in futures:
-                    fut.result()
+                futures = [pool.submit(ctx.run_plugin_collect, p) for p in self._plugins]
+                collected = [fut.result() for fut in futures]
+            ctx.apply_ops_batched(collected)
         self._ctx = ctx
         return ctx
 

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import os
+import threading
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterator, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Sequence
 
 from .graph import KEEPALIVE_DEFAULT, EdgeFlags, SymbolNode
 
@@ -11,6 +13,33 @@ if TYPE_CHECKING:
     from dead_cst import _native as native
 
     from .plugins import Plugin
+
+
+#: Public, ordered list of progress phases. The polling thread fires
+#: ``phase_start`` / ``phase_progress`` / ``phase_end`` events keyed on
+#: these names; callbacks can use the order to drive a multi-bar UI or
+#: a single rolling progress line. Order matches the rust pipeline.
+PROGRESS_PHASES: tuple[str, ...] = ("enum", "populate", "assemble", "fqname", "plugins")
+
+# Discriminants the rust side stores in ``ProgressCounters.phase``.
+# Mirror ``src/progress.rs``'s ``PHASE_*`` constants; the polling
+# thread maps these back to ``PROGRESS_PHASES`` names.
+_PHASE_NONE = 0
+_PHASE_ID_TO_NAME: dict[int, str] = {
+    1: "enum",
+    2: "populate",
+    3: "assemble",
+    4: "fqname",
+    5: "plugins",
+}
+
+#: Polling interval (seconds) for the progress thread. ~100 ms is
+#: small enough that a UI bar feels smooth and large enough that we
+#: don't drown the user's callback in events for sub-second builds.
+PROGRESS_POLL_INTERVAL_S: float = 0.1
+
+ProgressEvent = str
+ProgressCallback = Callable[..., None]
 
 
 _NON_DECL_TYPES: frozenset[str] = frozenset({"module", "synthetic"})
@@ -57,6 +86,350 @@ def _plugin_worker_count(n_plugins: int) -> int:
     return min(n_plugins, os.cpu_count() or 4)
 
 
+def _safe_invoke_callback(cb: ProgressCallback, event: str, **kwargs: Any) -> None:
+    """Invoke the user callback, swallowing-and-warning on any exception.
+
+    A buggy callback must never deadlock the build — the rust pipeline
+    is oblivious to the polling thread, but a raise that propagates
+    out of the polling thread's loop would silently kill it, leaving
+    later events on the floor. Warn once per exception with
+    :func:`warnings.warn` (stacklevel pointing past the helper) and
+    keep polling.
+    """
+    try:
+        cb(event, **kwargs)
+    except Exception as exc:  # noqa: BLE001 — see docstring
+        warnings.warn(
+            f"dead-cst progress_callback raised {type(exc).__name__}: {exc!r} "
+            f"on event {event!r}; suppressing and continuing",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
+class _ProgressPoller:
+    """Polling thread driver that translates rust-side atomic counters
+    into structured Python callback events.
+
+    Lifecycle: created in :meth:`Analysis.materialize_all` right before
+    the rust build; ``start()`` spawns a daemon thread that reads a
+    counter snapshot every :data:`PROGRESS_POLL_INTERVAL_S` seconds.
+    On each tick the poller fires ``phase_start`` / ``phase_progress``
+    / ``phase_end`` events for any phase that advanced. When the rust
+    side stamps ``finished=True`` (or :meth:`stop` is called) the
+    thread flushes any pending ``*_end`` events and exits.
+
+    The poller calls into rust via
+    :meth:`native.ProjectContext.read_progress_snapshot`, which is a
+    plain atomic-load → dict conversion. The user callback runs on
+    the poller's thread, *not* on the main thread — callbacks that
+    touch shared state need their own synchronisation.
+    """
+
+    def __init__(
+        self,
+        ctx: native.ProjectContext,
+        callback: ProgressCallback,
+        interval_s: float = PROGRESS_POLL_INTERVAL_S,
+        *,
+        plugin_names: Sequence[str] = (),
+    ) -> None:
+        self._ctx = ctx
+        # Pre-mint the borrow-free progress handle so polls during a
+        # long ``materialize`` call don't race with the context's
+        # ``borrow_mut`` token. Created up-front (outside the build)
+        # so the poller doesn't have to re-enter the context lock.
+        self._handle: Any = ctx.progress_handle()
+        self._cb = callback
+        self._interval = interval_s
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        # Per-phase running state: which phases have we started /
+        # ended so far?  Built as we go so a phase that skips
+        # forward (e.g. enum -> assemble) still fires the missing
+        # start/end pair.
+        self._started: set[str] = set()
+        self._ended: set[str] = set()
+        # Last-seen ``*_done`` count per phase. Lets us emit a final
+        # ``phase_progress`` flush when the phase ends, so callbacks
+        # that gate UI on ``current == total`` see the terminal state.
+        self._last_progress: dict[str, int] = {}
+        # Plugin start/finish bookkeeping. ``plugins_done`` is an
+        # atomic counter on the rust side; the poller infers which
+        # plugin index just finished by diffing snapshots.
+        self._plugin_names: tuple[str, ...] = tuple(plugin_names)
+        self._plugins_signalled_start: set[int] = set()
+        self._plugins_signalled_end: set[int] = set()
+        self._plugins_phase_total: int | None = None
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._run,
+            name="dead-cst-progress",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 1.0) -> None:
+        """Signal the polling thread to exit, join it, then run one
+        final dispatch on the caller's thread. Idempotent.
+
+        The final dispatch is what makes sub-100 ms builds work: the
+        rust pipeline can finish before the polling thread completes
+        its first 100 ms wait, so without an explicit drain at stop
+        time the callback would never see any events. Joining the
+        poller first keeps the dispatch single-threaded; ``_dispatch``
+        is otherwise lock-free.
+        """
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            self._thread = None
+        # Final drain on the caller's thread. The rust side has
+        # already stamped ``finished=True`` (since materialize_all
+        # exits before stop() is called), so this dispatch picks up
+        # every phase the poller missed because of timing.
+        try:
+            snap = self._handle.snapshot()
+        except Exception:  # noqa: BLE001
+            return
+        self._dispatch(snap)
+
+    def _run(self) -> None:
+        # Loop until the rust side flips ``finished`` or ``stop()``
+        # is called. We read one final snapshot after the rust side
+        # signals done so any trailing increments (e.g. the last
+        # populate file or the final fqname node) show up before we
+        # emit ``phase_end``.
+        finished_seen = False
+        while True:
+            try:
+                snap = self._handle.snapshot()
+            except Exception as exc:  # noqa: BLE001
+                # If the rust side disappears (ctx GC'd, native crash),
+                # warn and exit. Don't try to fire more events.
+                warnings.warn(
+                    f"dead-cst progress poller lost ctx: {type(exc).__name__}: {exc!r}",
+                    RuntimeWarning,
+                    stacklevel=1,
+                )
+                return
+            self._dispatch(snap)
+            if finished_seen:
+                return
+            if snap["finished"]:
+                # One more iteration so we catch any final increments
+                # that landed between the last poll and the rust-side
+                # ``mark_finished``.
+                finished_seen = True
+                continue
+            if self._stop.wait(self._interval):
+                # External stop — the ``stop()`` caller will do a
+                # final drain dispatch on its own thread; we exit
+                # without one here to avoid racing against it.
+                return
+
+    def _dispatch(self, snap: dict[str, int]) -> None:
+        # Map snapshot fields to per-phase (done, total, elapsed_us).
+        phase_stats: dict[str, tuple[int, int, int]] = {
+            "enum": (
+                snap["enum_done"],
+                snap["enum_total"],
+                snap["enum_elapsed_us"],
+            ),
+            "populate": (
+                snap["populate_done"],
+                snap["populate_total"],
+                snap["populate_elapsed_us"],
+            ),
+            "assemble": (
+                snap["assemble_done"],
+                snap["assemble_total"],
+                snap["assemble_elapsed_us"],
+            ),
+            "fqname": (
+                snap["fqname_done"],
+                snap["fqname_total"],
+                snap["fqname_elapsed_us"],
+            ),
+            "plugins": (
+                snap["plugins_done"],
+                snap["plugins_total"],
+                snap["plugins_elapsed_us"],
+            ),
+        }
+        current_phase_id = snap["phase"]
+
+        for name in PROGRESS_PHASES:
+            done, total, elapsed_us = phase_stats[name]
+            phase_id = next(
+                (pid for pid, n in _PHASE_ID_TO_NAME.items() if n == name),
+                _PHASE_NONE,
+            )
+            already_started = name in self._started
+            already_ended = name in self._ended
+
+            # ``phase_start`` fires when the rust side advances past
+            # this phase's ID, or when this phase is the current one,
+            # or (defensively) when there's any progress data for a
+            # not-yet-started phase. ``finished=True`` with non-zero
+            # totals forces us to flush any phases we never observed
+            # mid-flight.
+            should_start = (
+                not already_started
+                and (
+                    current_phase_id > phase_id
+                    or current_phase_id == phase_id
+                    or done > 0
+                    or total > 0
+                    or (snap["finished"] and (total > 0 or elapsed_us > 0))
+                )
+                # Only fire ``phase_start`` once the rust side has
+                # actually begun the phase. Zero everything = no
+                # signal yet.
+                and (current_phase_id >= phase_id or done > 0 or total > 0)
+            )
+            if should_start:
+                self._started.add(name)
+                _safe_invoke_callback(
+                    self._cb,
+                    "phase_start",
+                    phase=name,
+                    total=(total if total > 0 else None),
+                )
+                if name == "plugins":
+                    self._plugins_phase_total = total if total > 0 else None
+
+            if name in self._started and not already_ended:
+                last = self._last_progress.get(name, -1)
+                if done != last:
+                    self._last_progress[name] = done
+                    _safe_invoke_callback(
+                        self._cb,
+                        "phase_progress",
+                        phase=name,
+                        current=done,
+                        total=(total if total > 0 else None),
+                    )
+
+                # Plugin start/end synthesis. Treat each
+                # ``plugins_done`` increment as the end of the
+                # plugin whose index equals the old count.
+                if name == "plugins" and self._plugin_names:
+                    self._emit_plugin_events(done, total)
+
+            # ``phase_end`` fires when the rust side has moved past
+            # this phase (current_phase_id > phase_id), or when the
+            # whole pipeline is marked finished. ``elapsed_us`` of
+            # zero is fine — the rust side guarantees a finish_phase
+            # write before stamping the next phase.
+            should_end = (
+                name in self._started
+                and not already_ended
+                and (current_phase_id > phase_id or snap["finished"])
+            )
+            if should_end:
+                self._ended.add(name)
+                # If we never reported total=done, do one last flush
+                # before emitting ``phase_end``. Idempotency-safe;
+                # callbacks should already handle ``current == total``.
+                if total > 0 and self._last_progress.get(name) != total:
+                    self._last_progress[name] = total
+                    _safe_invoke_callback(
+                        self._cb,
+                        "phase_progress",
+                        phase=name,
+                        current=total,
+                        total=total,
+                    )
+                _safe_invoke_callback(
+                    self._cb,
+                    "phase_end",
+                    phase=name,
+                    elapsed_ms=elapsed_us // 1000,
+                )
+
+    def _emit_plugin_events(self, done: int, total: int) -> None:
+        """Translate ``plugins_done`` increments into per-plugin
+        ``plugin_start`` / ``plugin_end`` events.
+
+        The rust side reports plugin completion *count* but not which
+        plugin finished — we infer order from the registration order
+        Python stashed in ``plugin_names``. With the concurrent
+        ``ThreadPoolExecutor`` plugin pass this is best-effort:
+        completions may arrive out of registration order, so the
+        reported ``name`` is the next-unseen plugin in registration
+        order rather than the actual one. This is documented as a
+        known limitation in the callback contract.
+        """
+        plugin_total = total if total > 0 else len(self._plugin_names)
+        # Fire ``plugin_start`` for any plugin whose index <= done
+        # but hasn't been signalled yet.
+        for idx in range(min(done, plugin_total)):
+            if idx not in self._plugins_signalled_start:
+                self._plugins_signalled_start.add(idx)
+                name = (
+                    self._plugin_names[idx] if idx < len(self._plugin_names) else f"<plugin {idx}>"
+                )
+                _safe_invoke_callback(
+                    self._cb,
+                    "plugin_start",
+                    name=name,
+                    index=idx,
+                    total=plugin_total,
+                )
+            if idx not in self._plugins_signalled_end:
+                self._plugins_signalled_end.add(idx)
+                name = (
+                    self._plugin_names[idx] if idx < len(self._plugin_names) else f"<plugin {idx}>"
+                )
+                # ops_emitted is not tracked per-plugin yet; report 0
+                # as a placeholder so the callback contract stays
+                # stable.
+                _safe_invoke_callback(
+                    self._cb,
+                    "plugin_end",
+                    name=name,
+                    ops_emitted=0,
+                    elapsed_ms=0,
+                )
+
+
+def _make_indicatif_callback() -> ProgressCallback:
+    """Default progress callback for ``show_progress=True``.
+
+    Logs each phase transition to stderr in a fixed-width format —
+    not as fancy as the indicatif multi-bar setup, but it's pure
+    Python and visible everywhere indicatif is (TTYs, redirected
+    stderr, CI logs). Indicatif itself is still running on the rust
+    side; this callback complements rather than replaces it.
+    """
+    import sys
+
+    def _cb(event: str, **kwargs: Any) -> None:
+        if event == "phase_start":
+            phase = kwargs.get("phase", "?")
+            total = kwargs.get("total")
+            tag = f"  {phase:<10}"
+            if total is None:
+                print(f"[dead-cst] {tag} start", file=sys.stderr)
+            else:
+                print(f"[dead-cst] {tag} start (total={total})", file=sys.stderr)
+        elif event == "phase_end":
+            phase = kwargs.get("phase", "?")
+            elapsed_ms = kwargs.get("elapsed_ms", 0)
+            tag = f"  {phase:<10}"
+            print(f"[dead-cst] {tag} done in {elapsed_ms} ms", file=sys.stderr)
+        # phase_progress / plugin_* are deliberately swallowed: too
+        # noisy for the default stderr-text fallback. Users wanting a
+        # bar should plug indicatif's *Python* binding (or rich's
+        # Progress) into their own callback.
+
+    return _cb
+
+
 class Analysis:
     """Lazy entrypoint to the dead-cst pipeline.
 
@@ -88,11 +461,24 @@ class Analysis:
         venv: Path | None = None,
         plugins: Sequence[Plugin] = (),
         show_progress: bool = False,
+        progress_callback: ProgressCallback | None = None,
     ) -> None:
+        if progress_callback is not None and show_progress:
+            raise ValueError(
+                "Pass either show_progress=True or progress_callback=..., "
+                "not both. show_progress=True installs a default callback."
+            )
         self._project_root: Path = project_root
         self._venv: Path | None = venv
         self._plugins: tuple[Plugin, ...] = tuple(plugins)
         self._show_progress: bool = show_progress
+        # ``show_progress=True`` installs a default stderr-text
+        # callback so the rust-side indicatif bars get a Python-side
+        # echo. The two paths don't conflict — rust prints to its
+        # MultiProgress draw target, Python prints per-phase headers.
+        self._progress_callback: ProgressCallback | None = progress_callback or (
+            _make_indicatif_callback() if show_progress else None
+        )
         # Buffered until ``materialize_all`` constructs the ctx.
         # ``None`` means "no override" — the rust side uses rayon's
         # global pool with rayon's own default stack.
@@ -173,6 +559,20 @@ class Analysis:
         if self._stack_size is not None:
             ctx.set_stack_size(self._stack_size)
 
+        # Spin up the progress polling thread if the user asked for
+        # callbacks. The thread reads rust-side atomic counters at
+        # ~100 ms and fires structured events. Joined in a ``finally``
+        # so a build failure still drains the queue.
+        poller: _ProgressPoller | None = None
+        if self._progress_callback is not None:
+            plugin_names = tuple(type(p).__qualname__ for p in self._plugins)
+            poller = _ProgressPoller(
+                ctx,
+                self._progress_callback,
+                plugin_names=plugin_names,
+            )
+            poller.start()
+
         # ``DEAD_CST_PLUGINS_SERIAL=1`` (or no plugins / a single
         # plugin) keeps the rust-side serial loop. Otherwise we drive
         # plugins from a ``ThreadPoolExecutor`` so any plugin time
@@ -187,27 +587,47 @@ class Analysis:
         # a plugin's own emissions are invisible to its own queries,
         # and to every other plugin's queries, until the apply pass
         # runs.
-        if _serial_mode() or len(self._plugins) <= 1:
-            for plugin in self._plugins:
-                ctx.add_plugin(plugin)
-            ctx.materialize()
-        else:
-            ctx.build_only()
-            workers = _plugin_worker_count(len(self._plugins))
-            # Plugins are scheduled in registration order; results
-            # ``.result()`` waits in the same order. Errors propagate
-            # via the future's ``.result()`` call. We collect each
-            # plugin's ops into a :class:`CollectedOps` handle off
-            # the worker thread, then fold them all into the graph
-            # in registration order via one ``apply_ops_batched``
-            # call on the main thread.
-            with ThreadPoolExecutor(
-                max_workers=workers,
-                thread_name_prefix="dead-cst-plugin",
-            ) as pool:
-                futures = [pool.submit(ctx.run_plugin_collect, p) for p in self._plugins]
-                collected = [fut.result() for fut in futures]
-            ctx.apply_ops_batched(collected)
+        try:
+            if _serial_mode() or len(self._plugins) <= 1:
+                for plugin in self._plugins:
+                    ctx.add_plugin(plugin)
+                ctx.materialize()
+            else:
+                ctx.build_only()
+                workers = _plugin_worker_count(len(self._plugins))
+                ctx.progress_plugins_start(len(self._plugins))
+                try:
+                    # Plugins are scheduled in registration order;
+                    # ``.result()`` waits in the same order. Errors
+                    # propagate via the future. Each worker collects
+                    # its plugin's ops into a :class:`CollectedOps`
+                    # handle (no graph mutation); the main thread
+                    # folds every handle into the graph in registration
+                    # order via one ``apply_ops_batched`` call.
+                    def _run_collect(plugin: Plugin):
+                        try:
+                            return ctx.run_plugin_collect(plugin)
+                        finally:
+                            ctx.progress_plugin_done()
+
+                    with ThreadPoolExecutor(
+                        max_workers=workers,
+                        thread_name_prefix="dead-cst-plugin",
+                    ) as pool:
+                        futures = [pool.submit(_run_collect, p) for p in self._plugins]
+                        collected = [fut.result() for fut in futures]
+                    ctx.apply_ops_batched(collected)
+                finally:
+                    ctx.progress_plugins_finish()
+        except BaseException:
+            # Make sure the polling thread doesn't outlive a failed
+            # build. ``mark_progress_finished`` flips the rust-side
+            # atomic so the poller exits on its next tick.
+            ctx.mark_progress_finished()
+            raise
+        finally:
+            if poller is not None:
+                poller.stop()
         self._ctx = ctx
         return ctx
 
@@ -254,4 +674,7 @@ class Analysis:
 
 __all__ = [
     "Analysis",
+    "PROGRESS_PHASES",
+    "PROGRESS_POLL_INTERVAL_S",
+    "ProgressCallback",
 ]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,8 @@
 //! Graph-construction primitives: `NodeKey` (positional identity for an
 //! interned node), `GraphBuilder` (the in-progress graph), the
 //! plugin-facing graph ops (`AddNode`/`AddEdge`/`AddEntrypoint`), the
-//! generic BFS walker, and the `apply_graph_op` apply pass.
+//! generic BFS walker, and the batched `apply_prepared_batch`
+//! apply pass.
 
 use std::sync::OnceLock;
 
@@ -362,11 +363,11 @@ pub(crate) fn synthetic_node(
 
 /// A [`GraphOp`] prepared for application: every Python-owned field
 /// has been hoisted into pure-rust storage so that
-/// [`apply_graph_op`] can drop the GIL before contending for the
-/// write lock on ``outputs``. Edge endpoints are represented as
+/// [`apply_prepared_batch`] can drop the GIL before contending for
+/// the write lock on ``outputs``. Edge endpoints are represented as
 /// [`NodeKey`]s (the positional identity used by the builder's
 /// index) plus the source ``decl.fqname`` for entrypoint markers.
-/// See [`apply_graph_op`] for the concurrency rationale.
+/// See [`apply_prepared_batch`] for the concurrency rationale.
 pub(crate) enum PreparedOp {
     Edge {
         src: NodeKey,
@@ -394,21 +395,53 @@ pub(crate) enum PreparedOp {
     },
 }
 
-pub(crate) fn apply_graph_op(
-    ctx: &Py<ProjectContext>,
-    py: Python<'_>,
-    op: &Bound<'_, PyAny>,
-) -> PyResult<()> {
-    // GIL-required prep: extract everything we need from the
-    // (potentially Python-owned) op into pure-rust state before we
-    // touch the lock. Concurrent plugins running on a Python
-    // :class:`ThreadPoolExecutor` can hold the ``outputs`` read
-    // guard across :meth:`pyo3::Python::allow_threads`; if we
-    // acquired the write lock while still holding the GIL, a reader
-    // returning from ``allow_threads`` would block on
-    // :func:`take_gil`, and the write side would block on
-    // ``wait_for_readers`` — classic deadlock. Dropping the GIL
-    // before contending for the write lock breaks that cycle.
+/// Opaque Python handle wrapping a plugin's pre-prepared op queue.
+///
+/// :meth:`ProjectContext.run_plugin_collect` mints one of these per
+/// plugin (containing the plugin's full yield order in pure-rust
+/// form); :meth:`ProjectContext.apply_ops_batched` takes a list of
+/// these and folds them all into the graph under a single write-lock
+/// window. Holding the prepared ops in an opaque pyclass lets the
+/// Python driver shuttle them through a
+/// :class:`concurrent.futures.ThreadPoolExecutor` without paying
+/// per-op FFI roundtrips and without ``PreparedOp`` having to be a
+/// pyclass itself.
+///
+/// Concurrency: the inner [`Mutex`] is never observed contended by
+/// design — each `CollectedOps` is created on one thread, consumed
+/// on another (the apply pass), and never aliased. The lock is here
+/// so the pyclass can be ``Send``.
+#[pyclass]
+pub(crate) struct CollectedOps {
+    pub(crate) ops: parking_lot::Mutex<Option<Vec<PreparedOp>>>,
+}
+
+impl CollectedOps {
+    pub(crate) fn new(ops: Vec<PreparedOp>) -> Self {
+        Self {
+            ops: parking_lot::Mutex::new(Some(ops)),
+        }
+    }
+
+    /// Drain the inner ops. Returns an error if already drained
+    /// (calling :meth:`apply_ops_batched` twice on the same handle).
+    pub(crate) fn take(&self) -> PyResult<Vec<PreparedOp>> {
+        self.ops.lock().take().ok_or_else(|| {
+            PyValueError::new_err(
+                "CollectedOps already drained: \
+                 apply_ops_batched consumes the handle and it cannot be re-used.",
+            )
+        })
+    }
+}
+
+/// Convert a single Python-owned :class:`GraphOp` into a [`PreparedOp`].
+///
+/// The "prepare" half of the old single-op apply pipeline. Splitting
+/// this out lets the batched-apply pass extract every op's fields
+/// under one GIL window, then drop the GIL once for the full apply
+/// rather than ping-ponging the GIL / write lock per op.
+pub(crate) fn prepare_graph_op(py: Python<'_>, op: &Bound<'_, PyAny>) -> PyResult<PreparedOp> {
     let prepared = if let Ok(add_edge) = op.extract::<PyRef<AddEdge>>() {
         PreparedOp::Edge {
             src: node_key_of(&add_edge.src.borrow(py)),
@@ -454,7 +487,26 @@ pub(crate) fn apply_graph_op(
             op.get_type().name()?,
         )));
     };
+    Ok(prepared)
+}
 
+/// Apply a batch of pre-prepared ops to the graph in a single
+/// write-lock window. The GIL is released before contending for the
+/// write lock and re-acquired only inside [`apply_prepared`] for the
+/// ops that actually need it — amortised across the whole batch
+/// rather than per-op as the legacy single-op apply did.
+///
+/// Ops apply in input order; an error in any op fails the whole
+/// batch with that op's error. Earlier ops in the batch still land
+/// — graph state is not transactional.
+pub(crate) fn apply_prepared_batch(
+    ctx: &Py<ProjectContext>,
+    py: Python<'_>,
+    prepared: Vec<PreparedOp>,
+) -> PyResult<()> {
+    if prepared.is_empty() {
+        return Ok(());
+    }
     // The ``write()`` MUST happen with the GIL released, then the
     // GIL re-acquired *after* we own the write guard. Otherwise a
     // concurrent reader returning from ``allow_threads`` and waiting
@@ -471,11 +523,13 @@ pub(crate) fn apply_graph_op(
         let mut outputs = outputs_lock.write();
         let outputs = outputs
             .as_mut()
-            .ok_or_else(|| not_materialized("apply_graph_op"))?;
-        // With the write guard owned, re-acquire the GIL only for
-        // the calls that genuinely need it (``Py::new`` for the new
-        // node, ``clone_ref(py)`` for refcounted edges).
-        Python::with_gil(|py| apply_prepared(outputs, py, prepared))
+            .ok_or_else(|| not_materialized("apply_ops_batched"))?;
+        Python::with_gil(|py| {
+            for op in prepared {
+                apply_prepared(outputs, py, op)?;
+            }
+            Ok(())
+        })
     })
 }
 
@@ -566,7 +620,7 @@ pub(crate) fn lookup_idx(builder: &GraphBuilder, node: &SymbolNode, side: &str) 
 }
 
 /// Variant of [`lookup_idx`] that takes a [`NodeKey`] directly so it
-/// can be called from [`apply_graph_op`]'s GIL-free post-prepare
+/// can be called from [`apply_prepared_batch`]'s GIL-free post-prepare
 /// section — see [`PreparedOp`] for why the key is pre-extracted.
 pub(crate) fn lookup_idx_by_key(
     builder: &GraphBuilder,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ mod query;
 
 use pyo3::prelude::*;
 
-use crate::builder::{AddEdge, AddEdgeByIdx, AddEntrypoint, AddNode};
+use crate::builder::{AddEdge, AddEdgeByIdx, AddEntrypoint, AddNode, CollectedOps};
 use crate::graph::{EdgeFlags, Import, NativeGraph, NodeFlags, SymbolNode};
 use crate::io::{read_graph, write_graph, GraphMetadata};
 use crate::project::{Project, ProjectContext};
@@ -75,6 +75,7 @@ fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<AddEdgeByIdx>()?;
     m.add_class::<AddEntrypoint>()?;
     m.add_class::<AddNode>()?;
+    m.add_class::<CollectedOps>()?;
     m.add_class::<NodeFlags>()?;
     m.add_class::<EdgeFlags>()?;
     m.add_class::<DecoratorRef>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ mod graph;
 mod helpers;
 mod ingest;
 mod io;
+mod progress;
 mod project;
 mod query;
 
@@ -44,6 +45,7 @@ use pyo3::prelude::*;
 use crate::builder::{AddEdge, AddEdgeByIdx, AddEntrypoint, AddNode, CollectedOps};
 use crate::graph::{EdgeFlags, Import, NativeGraph, NodeFlags, SymbolNode};
 use crate::io::{read_graph, write_graph, GraphMetadata};
+use crate::progress::ProgressHandle;
 use crate::project::{Project, ProjectContext};
 use crate::query::{
     CallQuery, CallRef, ClassQuery, ConstructionQuery, ConstructionRef, DeclQuery, DecoratorQuery,
@@ -94,6 +96,7 @@ fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<EdgeRef>()?;
     m.add_class::<DeclQuery>()?;
     m.add_class::<GraphMetadata>()?;
+    m.add_class::<ProgressHandle>()?;
     m.add_function(wrap_pyfunction!(query_fn, m)?)?;
     m.add_function(wrap_pyfunction!(write_graph, m)?)?;
     m.add_function(wrap_pyfunction!(read_graph, m)?)?;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,332 @@
+//! GIL-free progress counters shared between the rust build pipeline
+//! and a Python-side polling thread.
+//!
+//! The rust side increments [`AtomicUsize`] / [`AtomicU64`] / [`AtomicBool`]
+//! fields with [`Ordering::Relaxed`] — no GIL, no contention. A Python
+//! polling thread reads a snapshot at ~100 ms cadence via
+//! [`crate::project::ProjectContext::read_progress_snapshot`] and fires
+//! structured callback events.
+//!
+//! Phase discriminants live in [`PHASE_*`] constants and are compared
+//! to ``AtomicUsize::load`` on the Python side. Adding a new phase:
+//! append a new ``PHASE_*`` constant, increment the matching counter
+//! fields, and extend the Python-side dispatch in
+//! ``Analysis.materialize_all``.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+/// "No phase active yet" — what the counters report before the build
+/// pass calls [`ProgressCounters::start_phase`].
+pub(crate) const PHASE_NONE: usize = 0;
+/// File enumeration (`db.project().files(db)`).
+pub(crate) const PHASE_ENUM: usize = 1;
+/// Parallel rayon ingest (`file_to_nodes` / `file_to_edges` /
+/// `file_to_ref_edges`).
+pub(crate) const PHASE_POPULATE: usize = 2;
+/// Serial fan-in (`assemble_graph`).
+pub(crate) const PHASE_ASSEMBLE: usize = 3;
+/// Post-assemble fqname-index build (`build_fqname_indices`).
+pub(crate) const PHASE_FQNAME: usize = 4;
+/// Per-plugin `run(ctx)` invocations driven from Python.
+pub(crate) const PHASE_PLUGINS: usize = 5;
+
+/// Shared atomic counters describing build progress.
+///
+/// Every field is GIL-free; rust workers (rayon, serial passes, plugin
+/// driver) bump them with [`Ordering::Relaxed`]. The Python polling
+/// thread reads them via [`Self::snapshot`].
+///
+/// `*_total` of `0` always means "unknown / not yet computed". Phase
+/// totals are written exactly once at the start of each phase, before
+/// the matching `*_done` counter starts moving.
+pub(crate) struct ProgressCounters {
+    /// Current phase discriminant (one of the `PHASE_*` constants).
+    pub(crate) phase: AtomicUsize,
+    /// `true` once the rust build finishes (success or error). Signals
+    /// the Python polling thread to flush any pending `phase_end`
+    /// events and exit.
+    pub(crate) finished: AtomicBool,
+
+    /// Files enumerated so far (cheap; one increment after the project
+    /// scan completes).
+    pub(crate) enum_files: AtomicUsize,
+    /// Total files enumerated (0 = unknown until enum completes).
+    pub(crate) enum_total: AtomicUsize,
+    /// `Instant`-relative microseconds at which the enum phase started.
+    pub(crate) enum_started_us: AtomicU64,
+    /// Microseconds elapsed in the enum phase (set at phase end; 0
+    /// while running).
+    pub(crate) enum_elapsed_us: AtomicU64,
+
+    /// Files whose populate-side salsa queries have completed.
+    pub(crate) populate_done: AtomicUsize,
+    /// Total files the populate phase will process (set at phase start).
+    pub(crate) populate_total: AtomicUsize,
+    pub(crate) populate_started_us: AtomicU64,
+    pub(crate) populate_elapsed_us: AtomicU64,
+
+    /// Files whose serial-assemble fold has completed.
+    pub(crate) assemble_done: AtomicUsize,
+    /// Total files the assemble phase will process.
+    pub(crate) assemble_total: AtomicUsize,
+    pub(crate) assemble_started_us: AtomicU64,
+    pub(crate) assemble_elapsed_us: AtomicU64,
+
+    /// Nodes the fqname-indices builder has folded so far.
+    pub(crate) fqname_done: AtomicUsize,
+    /// Total nodes the fqname-indices builder will fold.
+    pub(crate) fqname_total: AtomicUsize,
+    pub(crate) fqname_started_us: AtomicU64,
+    pub(crate) fqname_elapsed_us: AtomicU64,
+
+    /// Plugins whose `run(ctx)` returned.
+    pub(crate) plugins_done: AtomicUsize,
+    /// Total plugins registered.
+    pub(crate) plugins_total: AtomicUsize,
+    pub(crate) plugins_started_us: AtomicU64,
+    pub(crate) plugins_elapsed_us: AtomicU64,
+
+    /// Process-wide monotonic clock anchor used to compute the
+    /// `*_started_us` markers. Set at construction.
+    start: Instant,
+}
+
+impl ProgressCounters {
+    pub(crate) fn new() -> Self {
+        Self {
+            phase: AtomicUsize::new(PHASE_NONE),
+            finished: AtomicBool::new(false),
+            enum_files: AtomicUsize::new(0),
+            enum_total: AtomicUsize::new(0),
+            enum_started_us: AtomicU64::new(0),
+            enum_elapsed_us: AtomicU64::new(0),
+            populate_done: AtomicUsize::new(0),
+            populate_total: AtomicUsize::new(0),
+            populate_started_us: AtomicU64::new(0),
+            populate_elapsed_us: AtomicU64::new(0),
+            assemble_done: AtomicUsize::new(0),
+            assemble_total: AtomicUsize::new(0),
+            assemble_started_us: AtomicU64::new(0),
+            assemble_elapsed_us: AtomicU64::new(0),
+            fqname_done: AtomicUsize::new(0),
+            fqname_total: AtomicUsize::new(0),
+            fqname_started_us: AtomicU64::new(0),
+            fqname_elapsed_us: AtomicU64::new(0),
+            plugins_done: AtomicUsize::new(0),
+            plugins_total: AtomicUsize::new(0),
+            plugins_started_us: AtomicU64::new(0),
+            plugins_elapsed_us: AtomicU64::new(0),
+            start: Instant::now(),
+        }
+    }
+
+    /// Microseconds since [`Self::new`].
+    fn now_us(&self) -> u64 {
+        u64::try_from(self.start.elapsed().as_micros()).unwrap_or(u64::MAX)
+    }
+
+    /// Stamp the current phase discriminant and (optionally) its total.
+    /// `total` is `None` when the phase doesn't pre-compute a total.
+    pub(crate) fn start_phase(&self, phase: usize, total: Option<usize>) {
+        let now = self.now_us();
+        match phase {
+            PHASE_ENUM => self.enum_started_us.store(now, Ordering::Relaxed),
+            PHASE_POPULATE => {
+                if let Some(t) = total {
+                    self.populate_total.store(t, Ordering::Relaxed);
+                }
+                self.populate_started_us.store(now, Ordering::Relaxed);
+            }
+            PHASE_ASSEMBLE => {
+                if let Some(t) = total {
+                    self.assemble_total.store(t, Ordering::Relaxed);
+                }
+                self.assemble_started_us.store(now, Ordering::Relaxed);
+            }
+            PHASE_FQNAME => {
+                if let Some(t) = total {
+                    self.fqname_total.store(t, Ordering::Relaxed);
+                }
+                self.fqname_started_us.store(now, Ordering::Relaxed);
+            }
+            PHASE_PLUGINS => {
+                if let Some(t) = total {
+                    self.plugins_total.store(t, Ordering::Relaxed);
+                }
+                self.plugins_started_us.store(now, Ordering::Relaxed);
+            }
+            _ => {}
+        }
+        self.phase.store(phase, Ordering::Relaxed);
+    }
+
+    /// Record the phase's elapsed time (microseconds). Called once at
+    /// phase end. The Python polling thread reads this when it sees
+    /// the phase discriminant advance.
+    pub(crate) fn finish_phase(&self, phase: usize) {
+        let now = self.now_us();
+        let elapsed = |started: &AtomicU64| now.saturating_sub(started.load(Ordering::Relaxed));
+        match phase {
+            PHASE_ENUM => self
+                .enum_elapsed_us
+                .store(elapsed(&self.enum_started_us), Ordering::Relaxed),
+            PHASE_POPULATE => self
+                .populate_elapsed_us
+                .store(elapsed(&self.populate_started_us), Ordering::Relaxed),
+            PHASE_ASSEMBLE => self
+                .assemble_elapsed_us
+                .store(elapsed(&self.assemble_started_us), Ordering::Relaxed),
+            PHASE_FQNAME => self
+                .fqname_elapsed_us
+                .store(elapsed(&self.fqname_started_us), Ordering::Relaxed),
+            PHASE_PLUGINS => self
+                .plugins_elapsed_us
+                .store(elapsed(&self.plugins_started_us), Ordering::Relaxed),
+            _ => {}
+        }
+    }
+
+    /// Mark the whole pipeline finished — the polling thread will
+    /// flush pending end events and exit on its next tick.
+    pub(crate) fn mark_finished(&self) {
+        self.finished.store(true, Ordering::Relaxed);
+    }
+
+    /// Atomic-load every counter into a plain-int tuple. Called from
+    /// the Python polling thread under the GIL.
+    ///
+    /// The tuple order is the public contract between this rust
+    /// helper and `Analysis._poll_progress` — do not reorder without
+    /// updating both sides.
+    pub(crate) fn snapshot(&self) -> ProgressSnapshot {
+        ProgressSnapshot {
+            phase: self.phase.load(Ordering::Relaxed),
+            finished: self.finished.load(Ordering::Relaxed),
+            enum_done: self.enum_files.load(Ordering::Relaxed),
+            enum_total: self.enum_total.load(Ordering::Relaxed),
+            enum_elapsed_us: self.enum_elapsed_us.load(Ordering::Relaxed),
+            populate_done: self.populate_done.load(Ordering::Relaxed),
+            populate_total: self.populate_total.load(Ordering::Relaxed),
+            populate_elapsed_us: self.populate_elapsed_us.load(Ordering::Relaxed),
+            assemble_done: self.assemble_done.load(Ordering::Relaxed),
+            assemble_total: self.assemble_total.load(Ordering::Relaxed),
+            assemble_elapsed_us: self.assemble_elapsed_us.load(Ordering::Relaxed),
+            fqname_done: self.fqname_done.load(Ordering::Relaxed),
+            fqname_total: self.fqname_total.load(Ordering::Relaxed),
+            fqname_elapsed_us: self.fqname_elapsed_us.load(Ordering::Relaxed),
+            plugins_done: self.plugins_done.load(Ordering::Relaxed),
+            plugins_total: self.plugins_total.load(Ordering::Relaxed),
+            plugins_elapsed_us: self.plugins_elapsed_us.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Stash the file-enumeration total (and bump `enum_files` to
+    /// match, since enumeration is atomic from the polling-thread's
+    /// perspective).
+    pub(crate) fn set_enum_total(&self, total: usize) {
+        self.enum_total.store(total, Ordering::Relaxed);
+        self.enum_files.store(total, Ordering::Relaxed);
+    }
+
+    /// Bump the populate-files-done counter. Called from rayon workers
+    /// after each file's salsa queries return. Relaxed ordering is
+    /// fine — the Python side only reads the running count.
+    pub(crate) fn populate_inc(&self) {
+        self.populate_done.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Bump the assemble-files-done counter.
+    pub(crate) fn assemble_inc(&self) {
+        self.assemble_done.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Bump the fqname-nodes-done counter.
+    pub(crate) fn fqname_inc(&self) {
+        self.fqname_done.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Bump the plugins-done counter.
+    pub(crate) fn plugins_inc(&self) {
+        self.plugins_done.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Plain-data snapshot of [`ProgressCounters`] — what
+/// [`crate::project::ProjectContext::read_progress_snapshot`] returns
+/// to Python. All fields are `usize` / `u64` / `bool` so the pyo3
+/// conversion is a cheap memcpy.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ProgressSnapshot {
+    pub(crate) phase: usize,
+    pub(crate) finished: bool,
+    pub(crate) enum_done: usize,
+    pub(crate) enum_total: usize,
+    pub(crate) enum_elapsed_us: u64,
+    pub(crate) populate_done: usize,
+    pub(crate) populate_total: usize,
+    pub(crate) populate_elapsed_us: u64,
+    pub(crate) assemble_done: usize,
+    pub(crate) assemble_total: usize,
+    pub(crate) assemble_elapsed_us: u64,
+    pub(crate) fqname_done: usize,
+    pub(crate) fqname_total: usize,
+    pub(crate) fqname_elapsed_us: u64,
+    pub(crate) plugins_done: usize,
+    pub(crate) plugins_total: usize,
+    pub(crate) plugins_elapsed_us: u64,
+}
+
+impl ProgressSnapshot {
+    /// Convert the snapshot to a Python dict. The key set is the
+    /// public contract that ``Analysis._ProgressPoller`` reads.
+    pub(crate) fn to_pydict<'py>(self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let dict = PyDict::new_bound(py);
+        dict.set_item("phase", self.phase)?;
+        dict.set_item("finished", self.finished)?;
+        dict.set_item("enum_done", self.enum_done)?;
+        dict.set_item("enum_total", self.enum_total)?;
+        dict.set_item("enum_elapsed_us", self.enum_elapsed_us)?;
+        dict.set_item("populate_done", self.populate_done)?;
+        dict.set_item("populate_total", self.populate_total)?;
+        dict.set_item("populate_elapsed_us", self.populate_elapsed_us)?;
+        dict.set_item("assemble_done", self.assemble_done)?;
+        dict.set_item("assemble_total", self.assemble_total)?;
+        dict.set_item("assemble_elapsed_us", self.assemble_elapsed_us)?;
+        dict.set_item("fqname_done", self.fqname_done)?;
+        dict.set_item("fqname_total", self.fqname_total)?;
+        dict.set_item("fqname_elapsed_us", self.fqname_elapsed_us)?;
+        dict.set_item("plugins_done", self.plugins_done)?;
+        dict.set_item("plugins_total", self.plugins_total)?;
+        dict.set_item("plugins_elapsed_us", self.plugins_elapsed_us)?;
+        Ok(dict)
+    }
+}
+
+/// Python-visible handle over the [`Arc<ProgressCounters>`] live in
+/// the rust pipeline. The polling thread reads this handle's
+/// :meth:`snapshot` without touching the parent
+/// :class:`crate::project::ProjectContext`'s pyo3 borrow flag, so it
+/// can poll concurrently with a long-running ``materialize`` call
+/// that holds the context's ``borrow_mut`` token.
+///
+/// Cloning the handle is cheap — it's just an ``Arc::clone``. The
+/// counters live as long as either the originating ``ProjectContext``
+/// or any outstanding handle.
+#[pyclass(name = "ProgressHandle", module = "dead_cst._native")]
+pub(crate) struct ProgressHandle {
+    pub(crate) counters: Arc<ProgressCounters>,
+}
+
+#[pymethods]
+impl ProgressHandle {
+    /// Atomic snapshot of every counter as a plain Python dict.
+    /// Each value is a non-negative integer (`bool` for ``finished``).
+    pub(crate) fn snapshot<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        self.counters.snapshot().to_pydict(py)
+    }
+}

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -14,7 +14,7 @@
 //! ``Analysis.materialize_all``.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 
 use pyo3::prelude::*;
@@ -91,9 +91,35 @@ pub(crate) struct ProgressCounters {
     pub(crate) plugins_started_us: AtomicU64,
     pub(crate) plugins_elapsed_us: AtomicU64,
 
+    /// Per-plugin slabs initialised once at the start of the plugin
+    /// pass via [`Self::init_plugin_slots`]. Each plugin worker writes
+    /// only to its own slot, so the parallel ``ThreadPoolExecutor``
+    /// path can attribute completions to the actual plugin (not the
+    /// "next-unseen plugin in registration order" approximation the
+    /// global counter forces).
+    pub(crate) plugin_slots: OnceLock<PluginSlots>,
+
     /// Process-wide monotonic clock anchor used to compute the
     /// `*_started_us` markers. Set at construction.
     start: Instant,
+}
+
+/// Pre-sized per-plugin counter slabs. The Python driver stamps each
+/// plugin's index when it calls
+/// [`crate::project::ProjectContext::run_plugin_collect`]; the rust
+/// side writes the started / finished timestamps into the matching
+/// slot. All three vectors are the same length and indexed by the
+/// plugin's registration order.
+pub(crate) struct PluginSlots {
+    /// Display names — ``type(plugin).__qualname__`` (or a fallback).
+    /// Read-only after [`ProgressCounters::init_plugin_slots`] returns.
+    pub(crate) names: Vec<String>,
+    /// Microseconds (relative to [`ProgressCounters::start`]) at which
+    /// the indexed plugin's ``run`` entered. `0` until stamped.
+    pub(crate) started_us: Box<[AtomicU64]>,
+    /// Microseconds at which the indexed plugin's ``run`` returned.
+    /// `0` while still running.
+    pub(crate) finished_us: Box<[AtomicU64]>,
 }
 
 impl ProgressCounters {
@@ -121,7 +147,48 @@ impl ProgressCounters {
             plugins_total: AtomicUsize::new(0),
             plugins_started_us: AtomicU64::new(0),
             plugins_elapsed_us: AtomicU64::new(0),
+            plugin_slots: OnceLock::new(),
             start: Instant::now(),
+        }
+    }
+
+    /// Allocate the per-plugin counter slabs once. ``names`` is the
+    /// plugin list in registration order; indices passed to
+    /// [`Self::plugin_started`] / [`Self::plugin_finished`] match.
+    /// Calls after the first are silently ignored (the
+    /// [`OnceLock`] preserves the first set) — a [`ProjectContext`]
+    /// drives at most one materialize pass, so this matches the
+    /// expected lifecycle.
+    pub(crate) fn init_plugin_slots(&self, names: Vec<String>) {
+        let n = names.len();
+        let _ = self.plugin_slots.set(PluginSlots {
+            names,
+            started_us: (0..n).map(|_| AtomicU64::new(0)).collect(),
+            finished_us: (0..n).map(|_| AtomicU64::new(0)).collect(),
+        });
+    }
+
+    /// Stamp the per-plugin start time. Called by
+    /// [`crate::project::ProjectContext::run_plugin_collect`] on
+    /// worker-thread entry. No-op if the slot wasn't pre-allocated
+    /// (e.g. a caller that skipped [`Self::init_plugin_slots`]).
+    pub(crate) fn plugin_started(&self, idx: usize) {
+        if let Some(slots) = self.plugin_slots.get() {
+            if let Some(cell) = slots.started_us.get(idx) {
+                cell.store(self.now_us(), Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Stamp the per-plugin finish time. Called by
+    /// [`crate::project::ProjectContext::run_plugin_collect`] on
+    /// worker-thread exit (success path or exception path — the
+    /// Python driver wraps the call in a ``try/finally``).
+    pub(crate) fn plugin_finished(&self, idx: usize) {
+        if let Some(slots) = self.plugin_slots.get() {
+            if let Some(cell) = slots.finished_us.get(idx) {
+                cell.store(self.now_us(), Ordering::Relaxed);
+            }
         }
     }
 
@@ -204,6 +271,22 @@ impl ProgressCounters {
     /// helper and `Analysis._poll_progress` — do not reorder without
     /// updating both sides.
     pub(crate) fn snapshot(&self) -> ProgressSnapshot {
+        let plugin_states = self
+            .plugin_slots
+            .get()
+            .map(|slots| {
+                slots
+                    .names
+                    .iter()
+                    .enumerate()
+                    .map(|(i, name)| PluginState {
+                        name: name.clone(),
+                        started_us: slots.started_us[i].load(Ordering::Relaxed),
+                        finished_us: slots.finished_us[i].load(Ordering::Relaxed),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
         ProgressSnapshot {
             phase: self.phase.load(Ordering::Relaxed),
             finished: self.finished.load(Ordering::Relaxed),
@@ -222,6 +305,7 @@ impl ProgressCounters {
             plugins_done: self.plugins_done.load(Ordering::Relaxed),
             plugins_total: self.plugins_total.load(Ordering::Relaxed),
             plugins_elapsed_us: self.plugins_elapsed_us.load(Ordering::Relaxed),
+            plugin_states,
         }
     }
 
@@ -260,7 +344,7 @@ impl ProgressCounters {
 /// [`crate::project::ProjectContext::read_progress_snapshot`] returns
 /// to Python. All fields are `usize` / `u64` / `bool` so the pyo3
 /// conversion is a cheap memcpy.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct ProgressSnapshot {
     pub(crate) phase: usize,
     pub(crate) finished: bool,
@@ -279,12 +363,25 @@ pub(crate) struct ProgressSnapshot {
     pub(crate) plugins_done: usize,
     pub(crate) plugins_total: usize,
     pub(crate) plugins_elapsed_us: u64,
+    /// Per-plugin slot snapshot in registration order. Empty when
+    /// [`ProgressCounters::init_plugin_slots`] hasn't been called
+    /// (e.g. mid-build during a phase that precedes plugins).
+    pub(crate) plugin_states: Vec<PluginState>,
+}
+
+/// One plugin's slot at snapshot time. ``started_us == 0`` ⇔ not yet
+/// running; ``finished_us == 0`` ⇔ still running (or never ran).
+#[derive(Clone, Debug)]
+pub(crate) struct PluginState {
+    pub(crate) name: String,
+    pub(crate) started_us: u64,
+    pub(crate) finished_us: u64,
 }
 
 impl ProgressSnapshot {
     /// Convert the snapshot to a Python dict. The key set is the
     /// public contract that ``Analysis._ProgressPoller`` reads.
-    pub(crate) fn to_pydict<'py>(self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+    pub(crate) fn to_pydict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let dict = PyDict::new_bound(py);
         dict.set_item("phase", self.phase)?;
         dict.set_item("finished", self.finished)?;
@@ -303,6 +400,16 @@ impl ProgressSnapshot {
         dict.set_item("plugins_done", self.plugins_done)?;
         dict.set_item("plugins_total", self.plugins_total)?;
         dict.set_item("plugins_elapsed_us", self.plugins_elapsed_us)?;
+        // Per-plugin slot snapshot. ``[(name, started_us, finished_us), ...]``
+        // in registration order. The polling thread uses these to fire
+        // ``plugin_start`` / ``plugin_end`` with accurate attribution
+        // when plugins run concurrently.
+        let plugin_states: Vec<(String, u64, u64)> = self
+            .plugin_states
+            .iter()
+            .map(|s| (s.name.clone(), s.started_us, s.finished_us))
+            .collect();
+        dict.set_item("plugin_states", plugin_states)?;
         Ok(dict)
     }
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -1254,19 +1254,27 @@ impl ProjectContext {
             .map(|p| p.clone_ref(py))
             .collect();
         let plugin_bar = ProgressBars::plugin_bar(show_progress, plugins.len() as u64);
-        counters.start_phase(PHASE_PLUGINS, Some(plugins.len()));
-        let plugin_result = (|| -> PyResult<()> {
-            let mut prepared: Vec<PreparedOp> = Vec::new();
-            for plugin in &plugins {
-                let plugin_name: String = plugin
-                    .bind(py)
+        let plugin_names: Vec<String> = plugins
+            .iter()
+            .map(|p| {
+                p.bind(py)
                     .get_type()
                     .getattr("__qualname__")
                     .ok()
                     .and_then(|n| n.extract().ok())
-                    .unwrap_or_else(|| "<unnamed>".to_string());
-                plugin_bar.set_message(plugin_name);
-                collect_prepared_plugin_ops(py, &slf, plugin, &mut prepared)?;
+                    .unwrap_or_else(|| "<unnamed>".to_string())
+            })
+            .collect();
+        counters.init_plugin_slots(plugin_names.clone());
+        counters.start_phase(PHASE_PLUGINS, Some(plugins.len()));
+        let plugin_result = (|| -> PyResult<()> {
+            let mut prepared: Vec<PreparedOp> = Vec::new();
+            for (idx, plugin) in plugins.iter().enumerate() {
+                plugin_bar.set_message(plugin_names[idx].clone());
+                counters.plugin_started(idx);
+                let res = collect_prepared_plugin_ops(py, &slf, plugin, &mut prepared);
+                counters.plugin_finished(idx);
+                res?;
                 plugin_bar.inc(1);
                 counters.plugins_inc();
             }
@@ -1445,11 +1453,29 @@ impl ProjectContext {
         self.progress.plugins_inc();
     }
 
-    /// Stamp the plugins phase as started + record its total. Called
-    /// from Python before launching the
-    /// :class:`concurrent.futures.ThreadPoolExecutor`.
-    pub(crate) fn progress_plugins_start(&self, total: usize) {
+    /// Stamp the plugins phase as started + record its total + name
+    /// the registered plugins. ``names`` is the plugin list in
+    /// registration order (``type(plugin).__qualname__`` per entry);
+    /// indices passed to :meth:`progress_plugin_started` /
+    /// :meth:`progress_plugin_finished` match.
+    pub(crate) fn progress_plugins_start(&self, names: Vec<String>) {
+        let total = names.len();
+        self.progress.init_plugin_slots(names);
         self.progress.start_phase(PHASE_PLUGINS, Some(total));
+    }
+
+    /// Stamp the indexed plugin's start time. Called on worker-thread
+    /// entry. Idempotent on out-of-range indices — the
+    /// [`crate::progress::ProgressCounters`] no-ops a missing slot.
+    pub(crate) fn progress_plugin_started(&self, idx: usize) {
+        self.progress.plugin_started(idx);
+    }
+
+    /// Stamp the indexed plugin's finish time. Called on worker-thread
+    /// exit (both the success and exception paths — the Python driver
+    /// wraps the call in ``try/finally``).
+    pub(crate) fn progress_plugin_finished(&self, idx: usize) {
+        self.progress.plugin_finished(idx);
     }
 
     /// Stamp the plugins phase as finished + mark the whole pipeline

--- a/src/project.rs
+++ b/src/project.rs
@@ -45,6 +45,10 @@ use crate::helpers::{
     FactoryCallFinder, StringArgCallFinder, NODE_FLAG_ENTRYPOINT,
 };
 use crate::ingest::{emit_visitor_warning, file_package_name, string_literal_list};
+use crate::progress::{
+    ProgressCounters, ProgressHandle, ProgressSnapshot, PHASE_ASSEMBLE, PHASE_ENUM, PHASE_FQNAME,
+    PHASE_PLUGINS, PHASE_POPULATE,
+};
 use crate::query::{
     _compile_path_regex, _contains_any_identifier, _contains_identifier, par_scan_files,
     QueryBuilder,
@@ -85,7 +89,8 @@ impl Project {
 
     /// Build the project-wide symbol graph (single-pass, no plugins).
     pub(crate) fn build(&mut self, py: Python<'_>) -> PyResult<NativeGraph> {
-        let outputs = build_project_graph(py, &mut self.db, false, None)?;
+        let counters = Arc::new(ProgressCounters::new());
+        let outputs = build_project_graph(py, &mut self.db, false, None, &counters)?;
         Ok(NativeGraph {
             nodes: outputs.builder.nodes,
             edges: outputs.builder.edges,
@@ -236,11 +241,14 @@ pub(crate) fn build_project_graph(
     db: &mut ProjectDatabase,
     show_progress: bool,
     stack_size: Option<usize>,
+    counters: &Arc<ProgressCounters>,
 ) -> PyResult<BuildOutputs> {
     let timing = std::env::var_os("DEAD_CST_TIMING").is_some();
 
+    counters.start_phase(PHASE_ENUM, None);
     let t0 = std::time::Instant::now();
     let project_files: Vec<File> = (&db.project().files(db)).into_iter().collect();
+    counters.set_enum_total(project_files.len());
     let mut path_to_file: FxHashMap<String, File> =
         FxHashMap::with_capacity_and_hasher(project_files.len(), Default::default());
     for &file in &project_files {
@@ -269,8 +277,10 @@ pub(crate) fn build_project_graph(
         }
     }
     let t_enum = t0.elapsed();
+    counters.finish_phase(PHASE_ENUM);
 
     let progress = ProgressBars::new(show_progress, project_files.len() as u64);
+    counters.start_phase(PHASE_POPULATE, Some(project_files.len()));
 
     // (prewarm phase deleted — confirmed redundant after the
     // fan-out refactor. The populate phase below already
@@ -326,6 +336,7 @@ pub(crate) fn build_project_graph(
         // commit message for the hazard.
         let dist_db: ProjectDatabase = db.clone();
         let files_ref: &[File] = &project_files;
+        let counters_ref = Arc::clone(counters);
         let run_populate = move || {
             use salsa::Database as _;
             dist_db.attach(|local_db| {
@@ -335,6 +346,7 @@ pub(crate) fn build_project_graph(
                 for &file in files_ref {
                     let db_tx = db_tx.clone();
                     let db_rx = db_rx.clone();
+                    let counters_inner = Arc::clone(&counters_ref);
                     s.spawn(move |_| {
                         let local_db = db_rx.recv().expect("snapshot available");
                         local_db.attach(|local_db| {
@@ -343,6 +355,7 @@ pub(crate) fn build_project_graph(
                             let _ = file_to_ref_edges(local_db, file);
                         });
                         db_tx.send(local_db).expect("channel open");
+                        counters_inner.populate_inc();
                     });
                 }
             });
@@ -360,9 +373,12 @@ pub(crate) fn build_project_graph(
         });
     }
     let t_populate_elapsed = t_populate.elapsed();
+    counters.finish_phase(PHASE_POPULATE);
     progress.ingest.finish_and_clear();
     progress.imports.finish_and_clear();
     progress.references.finish_and_clear();
+
+    counters.start_phase(PHASE_ASSEMBLE, Some(project_files.len()));
 
     // Serial assembly pass: walk files in deterministic order,
     // assign global graph node indices to each NodeRef, translate
@@ -371,8 +387,9 @@ pub(crate) fn build_project_graph(
     // memoized from the parallel pre-populate above so this pass
     // is pure hashmap/index work plus the GIL-bound Py creation.
     let t_assemble = std::time::Instant::now();
-    let assembled = assemble_graph(py, db, &project_files, &peer_pyi_to_py)?;
+    let assembled = assemble_graph(py, db, &project_files, &peer_pyi_to_py, counters)?;
     let t_assemble_elapsed = t_assemble.elapsed();
+    counters.finish_phase(PHASE_ASSEMBLE);
 
     let mut builder = assembled.builder;
     let global_index = assembled.global_index;
@@ -381,10 +398,12 @@ pub(crate) fn build_project_graph(
     let decl_by_name_range = assembled.decl_by_name_range;
     let ref_to_global = assembled.ref_to_global;
 
+    counters.start_phase(PHASE_FQNAME, Some(builder.nodes.len()));
     let t4 = std::time::Instant::now();
     let (decl_by_fqname, module_by_fqname, imports_by_module, children_by_parent) =
-        build_fqname_indices(py, &builder);
+        build_fqname_indices(py, &builder, counters);
     let t_fqname = t4.elapsed();
+    counters.finish_phase(PHASE_FQNAME);
 
     // Class hierarchy fan-in: fold every file's per-file `class_bases`
     // payload (see `file_payload::FileNodes::class_bases`) into two
@@ -509,6 +528,7 @@ fn assemble_graph<'db>(
     db: &'db ProjectDatabase,
     project_files: &[File],
     peer_pyi_to_py: &FxHashMap<File, File>,
+    counters: &Arc<ProgressCounters>,
 ) -> PyResult<AssembledGraph<'db>> {
     // Pre-count total nodes across project_files. file_to_nodes is
     // salsa-memoized from the parallel populate phase, so this is a
@@ -631,6 +651,7 @@ fn assemble_graph<'db>(
                 }
             }
         }
+        counters.assemble_inc();
     }
 
     // Pass 2: edge translation.
@@ -976,6 +997,7 @@ fn serial_lookup_or_mint<'db>(
 pub(crate) fn build_fqname_indices(
     py: Python<'_>,
     builder: &GraphBuilder,
+    counters: &Arc<ProgressCounters>,
 ) -> (
     FxHashMap<String, Vec<usize>>,
     FxHashMap<String, usize>,
@@ -987,6 +1009,7 @@ pub(crate) fn build_fqname_indices(
     let mut imports_by_module: FxHashMap<String, Vec<usize>> = FxHashMap::default();
     let mut children_by_parent: FxHashMap<String, Vec<usize>> = FxHashMap::default();
     for (idx, node_py) in builder.nodes.iter().enumerate() {
+        counters.fqname_inc();
         let node = node_py.borrow(py);
         // `OVERLOAD`-flagged decls (the `@typing.overload`-decorated
         // stubs of an in-file overload group) are excluded from the
@@ -1083,6 +1106,13 @@ pub(crate) struct ProjectContext {
     /// When true, ``materialize`` and ``build_project_graph`` draw
     /// indicatif progress bars to stderr.
     pub(crate) show_progress: bool,
+    /// GIL-free atomic counters shared between the build pipeline
+    /// and a Python-side polling thread (see
+    /// :func:`crate::progress::ProgressCounters`). Created once per
+    /// ``ProjectContext`` and reset between successive ``materialize``
+    /// calls so callers can re-use a context. The Python polling
+    /// thread reads snapshots via :meth:`read_progress_snapshot`.
+    pub(crate) progress: Arc<ProgressCounters>,
     /// Optional override for the rayon worker stack size (bytes)
     /// used by the populate phase. `None` (the default) uses the
     /// global rayon pool, which honours rayon's own size (2 MiB
@@ -1126,6 +1156,7 @@ impl ProjectContext {
             regex_cache: Mutex::new(FxHashMap::default()),
             show_progress,
             stack_size: None,
+            progress: Arc::new(ProgressCounters::new()),
         })
     }
 
@@ -1197,11 +1228,19 @@ impl ProjectContext {
     pub(crate) fn materialize(slf: Py<Self>, py: Python<'_>) -> PyResult<NativeGraph> {
         let show_progress = slf.borrow(py).show_progress;
         let stack_size = slf.borrow(py).stack_size;
-        {
+        let counters = Arc::clone(&slf.borrow(py).progress);
+        let build_result = {
             let mut this = slf.borrow_mut(py);
-            let outputs = build_project_graph(py, &mut this.db, show_progress, stack_size)?;
-            *this.outputs.write() = Some(outputs);
-        }
+            build_project_graph(py, &mut this.db, show_progress, stack_size, &counters)
+        };
+        let outputs = match build_result {
+            Ok(o) => o,
+            Err(e) => {
+                counters.mark_finished();
+                return Err(e);
+            }
+        };
+        *slf.borrow(py).outputs.write() = Some(outputs);
 
         // Serial plugin pass (legacy / fallback path). Concurrent
         // execution is driven from Python — see
@@ -1215,21 +1254,29 @@ impl ProjectContext {
             .map(|p| p.clone_ref(py))
             .collect();
         let plugin_bar = ProgressBars::plugin_bar(show_progress, plugins.len() as u64);
-        let mut prepared: Vec<PreparedOp> = Vec::new();
-        for plugin in &plugins {
-            let plugin_name: String = plugin
-                .bind(py)
-                .get_type()
-                .getattr("__qualname__")
-                .ok()
-                .and_then(|n| n.extract().ok())
-                .unwrap_or_else(|| "<unnamed>".to_string());
-            plugin_bar.set_message(plugin_name);
-            collect_prepared_plugin_ops(py, &slf, plugin, &mut prepared)?;
-            plugin_bar.inc(1);
-        }
+        counters.start_phase(PHASE_PLUGINS, Some(plugins.len()));
+        let plugin_result = (|| -> PyResult<()> {
+            let mut prepared: Vec<PreparedOp> = Vec::new();
+            for plugin in &plugins {
+                let plugin_name: String = plugin
+                    .bind(py)
+                    .get_type()
+                    .getattr("__qualname__")
+                    .ok()
+                    .and_then(|n| n.extract().ok())
+                    .unwrap_or_else(|| "<unnamed>".to_string());
+                plugin_bar.set_message(plugin_name);
+                collect_prepared_plugin_ops(py, &slf, plugin, &mut prepared)?;
+                plugin_bar.inc(1);
+                counters.plugins_inc();
+            }
+            apply_prepared_batch(&slf, py, prepared)?;
+            Ok(())
+        })();
         plugin_bar.finish_and_clear();
-        apply_prepared_batch(&slf, py, prepared)?;
+        counters.finish_phase(PHASE_PLUGINS);
+        counters.mark_finished();
+        plugin_result?;
 
         // Snapshot a fresh ``NativeGraph`` from the builder's
         // interned node + edge vecs; the originals stay put.
@@ -1332,10 +1379,85 @@ impl ProjectContext {
     pub(crate) fn build_only(slf: Py<Self>, py: Python<'_>) -> PyResult<()> {
         let show_progress = slf.borrow(py).show_progress;
         let stack_size = slf.borrow(py).stack_size;
+        let counters = Arc::clone(&slf.borrow(py).progress);
         let mut this = slf.borrow_mut(py);
-        let outputs = build_project_graph(py, &mut this.db, show_progress, stack_size)?;
-        *this.outputs.write() = Some(outputs);
-        Ok(())
+        match build_project_graph(py, &mut this.db, show_progress, stack_size, &counters) {
+            Ok(outputs) => {
+                *this.outputs.write() = Some(outputs);
+                Ok(())
+            }
+            Err(e) => {
+                counters.mark_finished();
+                Err(e)
+            }
+        }
+    }
+
+    /// Atomic snapshot of the build-progress counters as a Python
+    /// dict. Called from the Python polling thread at ~100 ms cadence
+    /// to drive structured progress events. Field semantics live on
+    /// :class:`crate::progress::ProgressCounters`.
+    ///
+    /// Reading is GIL-bound + non-blocking — every counter is a
+    /// relaxed atomic load. Calling this before
+    /// :meth:`materialize` / :meth:`build_only` returns the
+    /// zero-initialised state (`phase=0`, `finished=False`).
+    ///
+    /// **Note on long-running ``materialize`` calls**: this method
+    /// takes ``&self``, which acquires a pyo3 borrow on the
+    /// ``ProjectContext``. ``materialize`` holds ``borrow_mut`` for
+    /// the full build, so a concurrent reader thread will see
+    /// "Already mutably borrowed" until the build releases. For
+    /// race-free polling, prefer :meth:`progress_handle` (returns a
+    /// shared Arc-backed handle that's read without re-borrowing
+    /// the context).
+    pub(crate) fn read_progress_snapshot<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, pyo3::types::PyDict>> {
+        let snap: ProgressSnapshot = self.progress.snapshot();
+        snap.to_pydict(py)
+    }
+
+    /// Hand out a borrow-free handle over the progress counters.
+    /// The handle can be polled concurrently with a long-running
+    /// :meth:`materialize` call — it doesn't go through pyo3's
+    /// per-context borrow flag (which materialize holds mutably for
+    /// the full build).
+    pub(crate) fn progress_handle(&self) -> ProgressHandle {
+        ProgressHandle {
+            counters: Arc::clone(&self.progress),
+        }
+    }
+
+    /// Mark progress as finished. Called from Python after a build
+    /// error so the polling thread exits its loop and stops firing
+    /// events. Idempotent.
+    pub(crate) fn mark_progress_finished(&self) {
+        self.progress.mark_finished();
+    }
+
+    /// Bump the per-plugin counter. Called from Python when the
+    /// :class:`concurrent.futures.ThreadPoolExecutor` plugin pass
+    /// finishes a plugin (the rust side can't observe Python-side
+    /// completion ordering without re-entering the GIL).
+    pub(crate) fn progress_plugin_done(&self) {
+        self.progress.plugins_inc();
+    }
+
+    /// Stamp the plugins phase as started + record its total. Called
+    /// from Python before launching the
+    /// :class:`concurrent.futures.ThreadPoolExecutor`.
+    pub(crate) fn progress_plugins_start(&self, total: usize) {
+        self.progress.start_phase(PHASE_PLUGINS, Some(total));
+    }
+
+    /// Stamp the plugins phase as finished + mark the whole pipeline
+    /// finished. Called from Python once every plugin future has
+    /// resolved (or one raised).
+    pub(crate) fn progress_plugins_finish(&self) {
+        self.progress.finish_phase(PHASE_PLUGINS);
+        self.progress.mark_finished();
     }
 }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -28,7 +28,10 @@ use ty_python_core::program::UseDefaultStrategy;
 use ty_python_core::scope::FileScopeId;
 use ty_python_core::semantic_index;
 
-use crate::builder::{apply_graph_op, bfs, lookup_idx, not_materialized, Direction, GraphBuilder};
+use crate::builder::{
+    apply_prepared_batch, bfs, lookup_idx, not_materialized, prepare_graph_op, CollectedOps,
+    Direction, GraphBuilder, PreparedOp,
+};
 use crate::file_payload::{file_to_edges, file_to_nodes, FileEdges, NodeKind, NodeRef};
 use crate::file_ref_edges::{file_to_ref_edges, FileRefEdges};
 use crate::graph::{intern_kind, DeclIndex, Import, MainBlock, NativeGraph, SymbolNode};
@@ -1051,19 +1054,19 @@ pub(crate) struct ProjectContext {
     pub(crate) root: String,
     pub(crate) plugins: Vec<PyObject>,
     /// Populated by `materialize` before plugins run. `None` outside a
-    /// materialize call — `apply_graph_op` / queries assume it's
+    /// materialize call — the apply pass / queries assume it's
     /// `Some` and error if a plugin (incorrectly) caches the ctx and
     /// uses it after materialize returns.
     ///
     /// Wrapped in [`parking_lot::RwLock`] so plugins can run
     /// concurrently from a Python `ThreadPoolExecutor` — queries take a
-    /// read guard, the apply pass takes a write guard. ``parking_lot``
-    /// over ``std::sync`` because the former exposes
+    /// read guard, the end-of-pass apply takes a write guard.
+    /// ``parking_lot`` over ``std::sync`` because the former exposes
     /// ``RwLockReadGuard::map`` for the ``Option`` projection that
     /// :meth:`materialized` performs.
     ///
     /// Held inside an [`Arc`] so the apply path
-    /// (:func:`builder::apply_graph_op`) can clone the handle
+    /// (:func:`builder::apply_prepared_batch`) can clone the handle
     /// **before** dropping the GIL and then acquire the write lock
     /// without holding the GIL. Acquiring the write lock while
     /// still holding the GIL would deadlock against a reader stuck
@@ -1182,15 +1185,15 @@ impl ProjectContext {
     /// also forced by `DEAD_CST_PLUGINS_SERIAL=1` in Python) or be
     /// driven concurrently from Python via a
     /// :class:`concurrent.futures.ThreadPoolExecutor` calling
-    /// :meth:`build_only` + :meth:`run_plugin` per worker.
+    /// :meth:`build_only` + :meth:`run_plugin_collect` per worker
+    /// followed by :meth:`apply_ops_batched`.
     ///
-    /// Ops are applied as they're yielded from each plugin so that
-    /// later steps inside the *same* plugin can call
-    /// ``ctx.descendants`` etc. and see the effect of earlier
-    /// yields. Across concurrent plugin invocations the
-    /// :class:`parking_lot::RwLock` on ``outputs`` serializes the
-    /// per-op write while letting the GIL-releasing queries run in
-    /// parallel.
+    /// Plugins operate on a **frozen graph**: every plugin's
+    /// ``run(ctx)`` sees the same base-graph state, the yielded ops
+    /// accumulate in registration / yield order, and a single
+    /// end-of-pass write-lock window folds the lot into the graph.
+    /// A plugin's own emissions are invisible to its own subsequent
+    /// queries (and to other plugins' queries) during ``run``.
     pub(crate) fn materialize(slf: Py<Self>, py: Python<'_>) -> PyResult<NativeGraph> {
         let show_progress = slf.borrow(py).show_progress;
         let stack_size = slf.borrow(py).stack_size;
@@ -1202,7 +1205,9 @@ impl ProjectContext {
 
         // Serial plugin pass (legacy / fallback path). Concurrent
         // execution is driven from Python — see
-        // ``Analysis.materialize_all``.
+        // ``Analysis.materialize_all``. We collect ops per plugin
+        // then apply once at the end, matching the parallel path's
+        // frozen-graph contract.
         let plugins: Vec<PyObject> = slf
             .borrow(py)
             .plugins
@@ -1210,6 +1215,7 @@ impl ProjectContext {
             .map(|p| p.clone_ref(py))
             .collect();
         let plugin_bar = ProgressBars::plugin_bar(show_progress, plugins.len() as u64);
+        let mut prepared: Vec<PreparedOp> = Vec::new();
         for plugin in &plugins {
             let plugin_name: String = plugin
                 .bind(py)
@@ -1219,10 +1225,11 @@ impl ProjectContext {
                 .and_then(|n| n.extract().ok())
                 .unwrap_or_else(|| "<unnamed>".to_string());
             plugin_bar.set_message(plugin_name);
-            run_and_apply_plugin(py, &slf, plugin)?;
+            collect_prepared_plugin_ops(py, &slf, plugin, &mut prepared)?;
             plugin_bar.inc(1);
         }
         plugin_bar.finish_and_clear();
+        apply_prepared_batch(&slf, py, prepared)?;
 
         // Snapshot a fresh ``NativeGraph`` from the builder's
         // interned node + edge vecs; the originals stay put.
@@ -1242,21 +1249,59 @@ impl ProjectContext {
         })
     }
 
-    /// Run a single plugin's ``run(ctx)`` callback, applying each
-    /// yielded op to the graph as it comes off the iterator. Called
-    /// from Python — by the serial fallback in :meth:`materialize`,
-    /// and (one call per plugin) by the
-    /// :class:`concurrent.futures.ThreadPoolExecutor` worker path.
+    /// Run a single plugin's ``run(ctx)`` callback and apply every
+    /// yielded op to the graph in one end-of-plugin write-lock
+    /// window. The plugin's own emissions are **not** visible to
+    /// queries issued from its own body — the graph is frozen for
+    /// the duration of ``run``.
     ///
-    /// Concurrency note: every yielded op takes the ``outputs``
-    /// write guard briefly; intra-plugin ``ctx.descendants`` /
-    /// ``ctx.find_module`` etc. take read guards. With multiple
-    /// workers each holding read guards via the GIL-released query
-    /// paths, the writes serialize with bounded contention — the
-    /// per-op write window is sub-millisecond and the readers do
-    /// not starve writers under [`parking_lot`]'s fair policy.
+    /// Useful when callers want one plugin's emissions landed before
+    /// the next plugin runs; the Python concurrent driver prefers
+    /// :meth:`run_plugin_collect` + :meth:`apply_ops_batched` so
+    /// every plugin in a pool sees the same frozen base graph.
     pub(crate) fn run_plugin(slf: Py<Self>, py: Python<'_>, plugin: PyObject) -> PyResult<()> {
-        run_and_apply_plugin(py, &slf, &plugin)
+        let mut prepared: Vec<PreparedOp> = Vec::new();
+        collect_prepared_plugin_ops(py, &slf, &plugin, &mut prepared)?;
+        apply_prepared_batch(&slf, py, prepared)
+    }
+
+    /// Run a plugin's ``run(ctx)``, collect every yielded op into a
+    /// :class:`CollectedOps` handle, and return it without touching
+    /// the graph. The handle is fed back to
+    /// :meth:`apply_ops_batched` (one or more handles per call) so
+    /// the apply pass runs in a single write-lock window.
+    ///
+    /// Python's :class:`concurrent.futures.ThreadPoolExecutor` drives
+    /// this concurrently across plugins so query time spent in
+    /// GIL-releasing rust paths (``find_decorated_decls`` etc.)
+    /// overlaps. The graph is read-only during the collect window —
+    /// every plugin sees the same base graph.
+    pub(crate) fn run_plugin_collect(
+        slf: Py<Self>,
+        py: Python<'_>,
+        plugin: PyObject,
+    ) -> PyResult<CollectedOps> {
+        let mut prepared: Vec<PreparedOp> = Vec::new();
+        collect_prepared_plugin_ops(py, &slf, &plugin, &mut prepared)?;
+        Ok(CollectedOps::new(prepared))
+    }
+
+    /// Apply a flat list of :class:`CollectedOps` handles to the
+    /// graph in registration / yield order under one write-lock
+    /// window. Each handle is drained on consumption; calling
+    /// :meth:`apply_ops_batched` twice on the same handle raises
+    /// :class:`ValueError`.
+    pub(crate) fn apply_ops_batched(
+        slf: Py<Self>,
+        py: Python<'_>,
+        ops: Vec<Py<CollectedOps>>,
+    ) -> PyResult<()> {
+        let mut flat: Vec<PreparedOp> = Vec::new();
+        for handle in &ops {
+            let mut taken = handle.borrow(py).take()?;
+            flat.append(&mut taken);
+        }
+        apply_prepared_batch(&slf, py, flat)
     }
 
     /// Snapshot the current graph as a [`NativeGraph`]. Used after
@@ -1294,15 +1339,19 @@ impl ProjectContext {
     }
 }
 
-/// Invoke ``plugin.run(ctx)`` and apply each yielded op to the graph
-/// in turn. Mirrors the per-yield apply behavior the codebase has
-/// relied on since plugins existed — ops from earlier steps in a
-/// plugin's body are visible to later ``ctx.descendants`` /
-/// ``ctx.find_*`` queries within the same plugin call.
-fn run_and_apply_plugin(
+/// Invoke ``plugin.run(ctx)`` and collect every yielded op into
+/// ``sink`` as a [`PreparedOp`]. The graph is read-only for the
+/// duration — the plugin's own emissions never make it into
+/// ``outputs`` until the apply pass runs.
+///
+/// Used by both the serial fallback in :meth:`ProjectContext::materialize`
+/// and the per-plugin :meth:`ProjectContext::run_plugin_collect` worker
+/// driven from Python.
+fn collect_prepared_plugin_ops(
     py: Python<'_>,
     ctx: &Py<ProjectContext>,
     plugin: &PyObject,
+    sink: &mut Vec<PreparedOp>,
 ) -> PyResult<()> {
     let result = plugin.bind(py).call_method1("run", (ctx.clone_ref(py),))?;
     if result.is_none() {
@@ -1310,7 +1359,7 @@ fn run_and_apply_plugin(
     }
     for item in result.iter()? {
         let op = item?;
-        apply_graph_op(ctx, py, &op)?;
+        sink.push(prepare_graph_op(py, &op)?);
     }
     Ok(())
 }
@@ -1318,7 +1367,7 @@ fn run_and_apply_plugin(
 /// Acquire a read guard on ``lock`` while releasing the GIL during
 /// the (potentially-parking) wait. Used by hot-path readers that
 /// would otherwise dead-lock with a concurrent
-/// :func:`builder::apply_graph_op` writer: the writer drops the GIL
+/// :func:`builder::apply_prepared_batch` writer: the writer drops the GIL
 /// before contending for the write lock, but to call ``Py::new`` /
 /// ``intern_node`` it has to re-attach the GIL once it owns the
 /// guard. A reader that parks on ``read()`` *while holding the GIL*

--- a/tests/prototype/test_plugin_protocol.py
+++ b/tests/prototype/test_plugin_protocol.py
@@ -269,7 +269,13 @@ def test_query_outside_materialize_raises(make_ctx):
 
 
 def test_materialize_is_idempotent(make_ctx):
-    """Calling materialize twice rebuilds; the same plugin re-runs once per call."""
+    """Calling materialize twice rebuilds; the same plugin re-runs once per call.
+
+    The frozen-graph contract means a plugin's own emissions are not
+    visible to its own queries during ``run`` (the apply pass runs
+    at end-of-cohort). Both runs therefore see ``0`` during ``run``;
+    the post-materialize graph still has the emission.
+    """
     counts: list[int] = []
 
     class CountAdded:
@@ -283,6 +289,9 @@ def test_materialize_is_idempotent(make_ctx):
     ctx.add_plugin(CountAdded())
     g1 = ctx.materialize()
     g2 = ctx.materialize()
-    # The second run gets a fresh outputs (not the accumulated state).
-    assert counts == [1, 1]
+    # Plugin queries see the *base* graph — own emissions invisible
+    # until the end-of-pass apply lands them.
+    assert counts == [0, 0]
+    # ``<seed>`` does land in the materialized graph snapshot.
+    assert "<seed>" in {n.fqname for n in g1.nodes}
     assert {n.fqname for n in g1.nodes} == {n.fqname for n in g2.nodes}

--- a/tests/test_frozen_graph.py
+++ b/tests/test_frozen_graph.py
@@ -18,10 +18,8 @@ the env var so we exercise both.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Iterable
-from unittest.mock import patch
 
 import pytest
 
@@ -105,9 +103,7 @@ def test_plugin_does_not_see_its_own_emission(tmp_path: Path, plugin_mode: str) 
     assert "<frozen-test-own>" in fqnames
 
 
-def test_plugin_does_not_see_other_plugins_emissions(
-    tmp_path: Path, plugin_mode: str
-) -> None:
+def test_plugin_does_not_see_other_plugins_emissions(tmp_path: Path, plugin_mode: str) -> None:
     """Plugin B can't see plugin A's emission during ``run`` —
     every plugin in the cohort starts from the same base graph.
     """
@@ -213,17 +209,12 @@ def test_intra_plugin_yield_order_preserved(tmp_path: Path, plugin_mode: str) ->
         assert m in fqnames, f"missing marker {m!r}"
 
 
-def test_descendants_query_sees_base_graph_not_emissions(
-    tmp_path: Path, plugin_mode: str
-) -> None:
+def test_descendants_query_sees_base_graph_not_emissions(tmp_path: Path, plugin_mode: str) -> None:
     """``ctx.descendants`` issued from inside a plugin walks the
     *base* graph — synthetic markers the plugin emitted earlier in
     its own ``run`` don't influence the walk.
     """
-    (tmp_path / "a.py").write_text(
-        "def f(): pass\n"
-        "def g(): pass\n"
-    )
+    (tmp_path / "a.py").write_text("def f(): pass\ndef g(): pass\n")
 
     walks: list[int] = []
 
@@ -242,9 +233,7 @@ def test_descendants_query_sees_base_graph_not_emissions(
                 edges_from=[f],
                 edges_to=[g],
             )
-            walks.append(
-                sum(1 for d in ctx.descendants(f) if d.fqname == "<frozen-walk-target>")
-            )
+            walks.append(sum(1 for d in ctx.descendants(f) if d.fqname == "<frozen-walk-target>"))
 
     class _Noop(Plugin):
         def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:  # pragma: no cover

--- a/tests/test_frozen_graph.py
+++ b/tests/test_frozen_graph.py
@@ -1,0 +1,292 @@
+"""Frozen-graph contract for the plugin pass.
+
+The plugin pass collects every plugin's ops then applies the lot
+under one write-lock window at the end. Two invariants follow:
+
+1. **Frozen graph during run**. A plugin's own emissions are
+   invisible to its own queries during ``run``; a later plugin
+   running in the same cohort also can't see what an earlier
+   plugin emitted, because nothing applies until the end.
+2. **Apply order**. Ops collected from plugins land in registration
+   order at end-of-pass — order-independent fan-out (two plugins
+   that each emit edges referencing a base-graph decl) both land.
+
+These hold under both the parallel executor path and the
+``DEAD_CST_PLUGINS_SERIAL=1`` fallback. The tests parameterise on
+the env var so we exercise both.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable
+from unittest.mock import patch
+
+import pytest
+
+from dead_cst import Analysis
+from dead_cst import _native as native
+from dead_cst.plugins import Plugin
+
+
+@pytest.fixture(params=["parallel", "serial"], ids=["parallel", "serial"])
+def plugin_mode(request, monkeypatch):
+    """Run each test once under the parallel executor and once under
+    the rust-side serial fallback. The two paths must satisfy the
+    same frozen-graph contract.
+    """
+    if request.param == "serial":
+        monkeypatch.setenv("DEAD_CST_PLUGINS_SERIAL", "1")
+    else:
+        monkeypatch.delenv("DEAD_CST_PLUGINS_SERIAL", raising=False)
+    return request.param
+
+
+class _EmitSyntheticThenQuery(Plugin):
+    """Plugin that emits a synthetic node *and then* queries the
+    graph for that synthetic's fqname in the same ``run``. Under
+    the frozen-graph contract the query should return ``0``.
+    """
+
+    def __init__(self, fqname: str, observed: list[int]) -> None:
+        self.fqname = fqname
+        self.observed = observed
+
+    def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:  # pragma: no cover
+        op = native.AddNode(fqname=self.fqname, path="/")
+        # Emit, *then* check whether our own emission is visible
+        # via ``ctx.nodes()``. Per the frozen-graph contract it
+        # is not — the apply pass runs end-of-cohort.
+        # The yield happens first (so the emission is queued) but
+        # the apply only lands when the whole cohort finishes.
+        yield op
+        self.observed.append(sum(1 for n in ctx.nodes() if n.fqname == self.fqname))
+
+
+class _ObserveOthersEmission(Plugin):
+    """Plugin that just queries for a fqname some other plugin in
+    the cohort claims to emit. Used to prove that cross-plugin
+    emissions are also invisible until the apply pass runs.
+    """
+
+    def __init__(self, target_fqname: str, observed: list[int]) -> None:
+        self.target_fqname = target_fqname
+        self.observed = observed
+
+    def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:  # pragma: no cover
+        self.observed.append(sum(1 for n in ctx.nodes() if n.fqname == self.target_fqname))
+        return ()
+
+
+def test_plugin_does_not_see_its_own_emission(tmp_path: Path, plugin_mode: str) -> None:
+    """A plugin querying the graph after a yield sees the base graph,
+    not its own emission. This is the core frozen-graph guarantee.
+    """
+    (tmp_path / "a.py").write_text("def f(): pass\n")
+
+    observed: list[int] = []
+    # Pair with a no-op plugin so the parallel path actually kicks
+    # in (single-plugin Analysis takes the serial rust path).
+    plugin = _EmitSyntheticThenQuery("<frozen-test-own>", observed)
+
+    class _Noop(Plugin):
+        def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:  # pragma: no cover
+            return ()
+
+    analysis = Analysis(tmp_path, plugins=[plugin, _Noop()])
+    analysis.materialize_all()
+
+    # During ``run``, the plugin's own AddNode is queued but not yet
+    # applied — the query returns 0.
+    assert observed == [0]
+    # Post-materialize, the synthetic *is* in the final graph.
+    fqnames = {n.fqname for n in analysis.materialize_all().nodes()}
+    assert "<frozen-test-own>" in fqnames
+
+
+def test_plugin_does_not_see_other_plugins_emissions(
+    tmp_path: Path, plugin_mode: str
+) -> None:
+    """Plugin B can't see plugin A's emission during ``run`` —
+    every plugin in the cohort starts from the same base graph.
+    """
+    (tmp_path / "a.py").write_text("def f(): pass\n")
+
+    own_observed: list[int] = []
+    other_observed: list[int] = []
+    emitter = _EmitSyntheticThenQuery("<frozen-test-cross>", own_observed)
+    observer = _ObserveOthersEmission("<frozen-test-cross>", other_observed)
+
+    Analysis(tmp_path, plugins=[emitter, observer]).materialize_all()
+
+    assert own_observed == [0]
+    assert other_observed == [0]
+
+
+class _EmitEdgeToBaseDecl(Plugin):
+    """Two of these in a cohort prove the apply pass runs in
+    registration order without dropping ops. Each plugin emits an
+    ``AddNode`` referencing the same base-graph decl via
+    ``edges_to``. After materialize, both synthetics + both edges
+    must be present.
+    """
+
+    def __init__(self, fqname: str, decl_fqname: str) -> None:
+        self.fqname = fqname
+        self.decl_fqname = decl_fqname
+
+    def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:  # pragma: no cover
+        decls = [n for n in ctx.nodes() if n.fqname == self.decl_fqname]
+        if not decls:
+            return
+        yield native.AddNode(
+            fqname=self.fqname,
+            path=decls[0].path,
+            edges_to=[decls[0]],
+        )
+
+
+def test_apply_order_lands_every_plugins_ops(tmp_path: Path, plugin_mode: str) -> None:
+    """Two plugins in a cohort, each minting a synthetic anchored on
+    the same base decl. After materialize both synthetics and both
+    edges must be present — the end-of-pass apply doesn't drop ops
+    just because the same write lock window covers them all.
+    """
+    (tmp_path / "a.py").write_text("def f(): pass\n")
+
+    a = _EmitEdgeToBaseDecl("<frozen-order-A>", "a.f")
+    b = _EmitEdgeToBaseDecl("<frozen-order-B>", "a.f")
+
+    analysis = Analysis(tmp_path, plugins=[a, b])
+    ctx = analysis.materialize_all()
+    fqnames = {n.fqname for n in ctx.nodes()}
+    assert "<frozen-order-A>" in fqnames
+    assert "<frozen-order-B>" in fqnames
+
+    # Both synthetics point at ``a.f``.
+    nodes = list(ctx.nodes())
+    by_fqname = {n.fqname: i for i, n in enumerate(nodes)}
+    decl_idx = by_fqname["a.f"]
+    edges = list(ctx.edges())
+    assert (by_fqname["<frozen-order-A>"], decl_idx, 0) in edges
+    assert (by_fqname["<frozen-order-B>"], decl_idx, 0) in edges
+
+
+class _EmitMultipleOps(Plugin):
+    """Plugin that emits several ops in defined yield order.
+    Used to verify intra-plugin yield order is preserved through
+    the collect → apply pipeline.
+    """
+
+    def __init__(self, decl_fqname: str, markers: list[str]) -> None:
+        self.decl_fqname = decl_fqname
+        self.markers = markers
+
+    def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:  # pragma: no cover
+        decls = [n for n in ctx.nodes() if n.fqname == self.decl_fqname]
+        if not decls:
+            return
+        decl = decls[0]
+        for m in self.markers:
+            yield native.AddNode(fqname=m, path=decl.path, edges_to=[decl])
+
+
+def test_intra_plugin_yield_order_preserved(tmp_path: Path, plugin_mode: str) -> None:
+    """Yield order within one plugin survives the collect → apply
+    hop: every yielded marker lands as a node in the final graph
+    (with its corresponding edge).
+    """
+    (tmp_path / "a.py").write_text("def f(): pass\n")
+
+    markers = [f"<frozen-yield-{i}>" for i in range(5)]
+    plugin = _EmitMultipleOps("a.f", markers)
+
+    # Pair with a noop so the parallel path engages.
+    class _Noop(Plugin):
+        def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:  # pragma: no cover
+            return ()
+
+    ctx = Analysis(tmp_path, plugins=[plugin, _Noop()]).materialize_all()
+    fqnames = {n.fqname for n in ctx.nodes()}
+    for m in markers:
+        assert m in fqnames, f"missing marker {m!r}"
+
+
+def test_descendants_query_sees_base_graph_not_emissions(
+    tmp_path: Path, plugin_mode: str
+) -> None:
+    """``ctx.descendants`` issued from inside a plugin walks the
+    *base* graph — synthetic markers the plugin emitted earlier in
+    its own ``run`` don't influence the walk.
+    """
+    (tmp_path / "a.py").write_text(
+        "def f(): pass\n"
+        "def g(): pass\n"
+    )
+
+    walks: list[int] = []
+
+    class _EmitThenWalk(Plugin):
+        def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:  # pragma: no cover
+            decls = {n.fqname: n for n in ctx.nodes()}
+            f = decls["a.f"]
+            g = decls["a.g"]
+            # Emit a synthetic that ``edges_from`` ``f`` to ``g``.
+            # If applied mid-run, ``descendants(f)`` would now reach
+            # the synthetic. Under the frozen-graph contract it must
+            # not.
+            yield native.AddNode(
+                fqname="<frozen-walk-target>",
+                path=f.path,
+                edges_from=[f],
+                edges_to=[g],
+            )
+            walks.append(
+                sum(1 for d in ctx.descendants(f) if d.fqname == "<frozen-walk-target>")
+            )
+
+    class _Noop(Plugin):
+        def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:  # pragma: no cover
+            return ()
+
+    Analysis(tmp_path, plugins=[_EmitThenWalk(), _Noop()]).materialize_all()
+
+    assert walks == [0]
+
+
+def test_collected_ops_handle_is_single_use(tmp_path: Path) -> None:
+    """``apply_ops_batched`` consumes the :class:`CollectedOps`
+    handle; re-applying the same handle raises ``ValueError``.
+    """
+    (tmp_path / "a.py").write_text("def f(): pass\n")
+
+    class _Emitter(Plugin):
+        def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:  # pragma: no cover
+            decls = [n for n in ctx.nodes() if n.fqname == "a.f"]
+            yield native.AddNode(
+                fqname="<frozen-single-use>",
+                path=decls[0].path,
+                edges_to=decls,
+            )
+
+    ctx = native.ProjectContext(str(tmp_path), python_env=None, show_progress=False)
+    ctx.build_only()
+    handle = ctx.run_plugin_collect(_Emitter())
+    ctx.apply_ops_batched([handle])
+    # Second apply on the same handle fails.
+    with pytest.raises(ValueError, match="already drained"):
+        ctx.apply_ops_batched([handle])
+
+
+def test_apply_ops_batched_with_empty_list_is_noop(tmp_path: Path) -> None:
+    """An empty :func:`apply_ops_batched` call applies nothing and
+    doesn't error — the parallel path hits this when every plugin
+    yields nothing.
+    """
+    (tmp_path / "a.py").write_text("def f(): pass\n")
+    ctx = native.ProjectContext(str(tmp_path), python_env=None, show_progress=False)
+    ctx.build_only()
+    pre = sum(1 for _ in ctx.nodes())
+    ctx.apply_ops_batched([])
+    assert sum(1 for _ in ctx.nodes()) == pre

--- a/tests/test_progress_callback.py
+++ b/tests/test_progress_callback.py
@@ -1,0 +1,232 @@
+"""Coverage for :class:`Analysis`'s structured progress-callback API.
+
+Counters live on the rust side as relaxed atomics; a Python polling
+thread reads them every ~100 ms and fires events. These tests assert
+the event taxonomy, the show_progress mutex, and that callback
+exceptions don't deadlock the build.
+"""
+
+from __future__ import annotations
+
+import textwrap
+import warnings
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from dead_cst import Analysis
+from dead_cst.analyze import PROGRESS_PHASES
+
+
+def _write(tmp_path: Path, files: dict[str, str]) -> None:
+    for name, src in files.items():
+        p = tmp_path / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(textwrap.dedent(src).strip() + "\n")
+
+
+def _materialize_with_callback(
+    tmp_path: Path,
+    cb: Any,
+    *,
+    files: dict[str, str] | None = None,
+    **kwargs: Any,
+) -> Analysis:
+    files = files or {
+        "a.py": "def f(): pass",
+        "b.py": "from a import f\nf()",
+        "c.py": "x = 1\ny = x + 1",
+    }
+    _write(tmp_path, files)
+    analysis = Analysis(tmp_path, progress_callback=cb, **kwargs)
+    analysis.materialize_all()
+    return analysis
+
+
+def test_progress_callback_emits_full_event_sequence(tmp_path: Path) -> None:
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    def cb(event: str, **kwargs: Any) -> None:
+        events.append((event, kwargs))
+
+    _materialize_with_callback(tmp_path, cb)
+
+    # Every phase should bracket: start ... progress* ... end.
+    seen = {name: {"start": False, "end": False} for name in PROGRESS_PHASES}
+    for event, kwargs in events:
+        if event == "phase_start":
+            assert kwargs["phase"] in PROGRESS_PHASES
+            seen[kwargs["phase"]]["start"] = True
+        elif event == "phase_end":
+            assert kwargs["phase"] in PROGRESS_PHASES
+            assert "elapsed_ms" in kwargs
+            seen[kwargs["phase"]]["end"] = True
+        elif event == "phase_progress":
+            assert kwargs["phase"] in PROGRESS_PHASES
+            assert "current" in kwargs
+            assert "total" in kwargs
+
+    # The plugin phase fires even when zero plugins were registered —
+    # rust still stamps it to make the event taxonomy uniform.
+    for name in ("enum", "populate", "assemble", "fqname", "plugins"):
+        assert seen[name]["start"], f"missing phase_start for {name!r}"
+        assert seen[name]["end"], f"missing phase_end for {name!r}"
+
+
+def test_progress_callback_phase_ordering(tmp_path: Path) -> None:
+    """phase_start events fire in the documented pipeline order."""
+    starts: list[str] = []
+
+    def cb(event: str, **kwargs: Any) -> None:
+        if event == "phase_start":
+            starts.append(kwargs["phase"])
+
+    _materialize_with_callback(tmp_path, cb)
+
+    # Filter to the canonical phase list (in case a phase repeated,
+    # which it shouldn't).
+    seen_order = [p for p in starts if p in PROGRESS_PHASES]
+    # Each phase starts at most once.
+    assert len(set(seen_order)) == len(seen_order)
+    # Order matches PROGRESS_PHASES.
+    indices = [PROGRESS_PHASES.index(p) for p in seen_order]
+    assert indices == sorted(indices)
+
+
+def test_phase_progress_carries_count_and_total(tmp_path: Path) -> None:
+    """phase_progress fires with sensible counts and (where known) totals."""
+    progresses: list[dict[str, Any]] = []
+
+    def cb(event: str, **kwargs: Any) -> None:
+        if event == "phase_progress":
+            progresses.append(kwargs)
+
+    _materialize_with_callback(tmp_path, cb)
+
+    # Populate / assemble / fqname / plugins always carry a non-None total.
+    # enum reports total once the scan completes.
+    by_phase: dict[str, list[dict[str, Any]]] = {}
+    for p in progresses:
+        by_phase.setdefault(p["phase"], []).append(p)
+
+    for name in ("populate", "assemble", "fqname"):
+        events = by_phase.get(name, [])
+        assert events, f"no phase_progress events for {name!r}"
+        # current monotonically non-decreasing.
+        currents = [e["current"] for e in events]
+        assert currents == sorted(currents)
+        # final event reaches the total.
+        last = events[-1]
+        assert last["current"] == last["total"]
+
+
+def test_show_progress_and_callback_are_mutually_exclusive(tmp_path: Path) -> None:
+    def cb(event: str, **kwargs: Any) -> None:
+        pass
+
+    with pytest.raises(ValueError, match="show_progress=True or progress_callback"):
+        Analysis(tmp_path, progress_callback=cb, show_progress=True)
+
+
+def test_show_progress_installs_default_callback(tmp_path: Path) -> None:
+    """show_progress=True should silently install a stderr-text default
+    callback; passing it shouldn't raise and should still drive the
+    build to completion.
+    """
+    _write(tmp_path, {"a.py": "x = 1"})
+    analysis = Analysis(tmp_path, show_progress=True)
+    ctx = analysis.materialize_all()
+    # Sanity check the build actually ran.
+    nodes = list(ctx.nodes())
+    assert nodes
+
+
+def test_callback_exception_does_not_deadlock(tmp_path: Path) -> None:
+    """If the callback raises on every event, the polling thread must
+    swallow the exception (via warnings.warn) and keep going so the
+    build finishes.
+    """
+    saw_call: list[str] = []
+
+    def cb(event: str, **kwargs: Any) -> None:
+        saw_call.append(event)
+        raise RuntimeError("oh no")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        analysis = _materialize_with_callback(tmp_path, cb)
+        ctx = analysis.materialize_all()  # idempotent — no re-run.
+
+    # The build completed.
+    assert list(ctx.nodes())
+    # The callback was definitely called at least once.
+    assert saw_call
+    # At least one RuntimeWarning surfaced for the swallowed raise.
+    assert any(
+        issubclass(w.category, RuntimeWarning)
+        and "progress_callback raised RuntimeError" in str(w.message)
+        for w in caught
+    )
+
+
+def test_progress_callback_with_concurrent_plugins(tmp_path: Path) -> None:
+    """Concurrent plugin pass (>1 plugin) emits plugin_start / plugin_end
+    for each plugin via the Python-side ThreadPoolExecutor wrapper.
+    """
+    from dead_cst.plugins import ExplicitEntrypointPlugin, ModuleDundersPlugin
+
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    def cb(event: str, **kwargs: Any) -> None:
+        events.append((event, kwargs))
+
+    _write(tmp_path, {"a.py": "def f(): pass\nf()"})
+    analysis = Analysis(
+        tmp_path,
+        plugins=[
+            ExplicitEntrypointPlugin(specs=["a.py"]),
+            ModuleDundersPlugin(),
+        ],
+        progress_callback=cb,
+    )
+    analysis.materialize_all()
+
+    plugin_starts = [k for (e, k) in events if e == "plugin_start"]
+    plugin_ends = [k for (e, k) in events if e == "plugin_end"]
+    assert len(plugin_starts) == 2
+    assert len(plugin_ends) == 2
+    names = [k["name"] for k in plugin_starts]
+    # The two plugin class qualnames should both have surfaced.
+    assert "ExplicitEntrypointPlugin" in names
+    assert "ModuleDundersPlugin" in names
+
+
+def test_progress_snapshot_dict_shape(tmp_path: Path) -> None:
+    """``read_progress_snapshot`` exposes the documented integer keys."""
+    _write(tmp_path, {"a.py": "x = 1"})
+    analysis = Analysis(tmp_path)
+    ctx = analysis.materialize_all()
+    snap = ctx.read_progress_snapshot()
+    expected_keys = {
+        "phase",
+        "finished",
+        "enum_done",
+        "enum_total",
+        "enum_elapsed_us",
+        "populate_done",
+        "populate_total",
+        "populate_elapsed_us",
+        "assemble_done",
+        "assemble_total",
+        "assemble_elapsed_us",
+        "fqname_done",
+        "fqname_total",
+        "fqname_elapsed_us",
+        "plugins_done",
+        "plugins_total",
+        "plugins_elapsed_us",
+    }
+    assert expected_keys.issubset(snap.keys())
+    assert snap["finished"] is True
+    assert snap["enum_total"] >= 1

--- a/tests/test_progress_callback.py
+++ b/tests/test_progress_callback.py
@@ -200,6 +200,15 @@ def test_progress_callback_with_concurrent_plugins(tmp_path: Path) -> None:
     # The two plugin class qualnames should both have surfaced.
     assert "ExplicitEntrypointPlugin" in names
     assert "ModuleDundersPlugin" in names
+    # With per-plugin counter slabs, each ``plugin_end`` carries the
+    # plugin's actual name (not the registration-order approximation
+    # the old global-counter path used) and a real elapsed_ms.
+    end_names = [k["name"] for k in plugin_ends]
+    assert sorted(end_names) == sorted(names)
+    # Each plugin's slot index in ``plugin_start`` matches its
+    # registration order.
+    indices = sorted(k["index"] for k in plugin_starts)
+    assert indices == [0, 1]
 
 
 def test_progress_snapshot_dict_shape(tmp_path: Path) -> None:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -17,6 +17,9 @@ EXPECTED_PUBLIC_API: dict[str, list[str]] = {
     ],
     "dead_cst.analyze": [
         "Analysis",
+        "PROGRESS_PHASES",
+        "PROGRESS_POLL_INTERVAL_S",
+        "ProgressCallback",
     ],
     "dead_cst.codemod": ["generate_patch", "remove_code"],
     "dead_cst.graph": [


### PR DESCRIPTION
## Summary

Two QoL changes the user asked for, stacked.

### 1. Frozen-graph plugin execution (``ddd976f``)

Plugins now see the **base graph** during ``plugin.run(ctx)`` — no plugin sees another's emissions (or its own earlier yields) mid-run. Ops collected per plugin into a ``CollectedOps`` handle; main thread invokes one ``ctx.apply_ops_batched(...)`` after every plugin returns.

Required rust changes:

- Split ``apply_graph_op`` into ``prepare_graph_op`` (GIL-required field extraction → ``PreparedOp``) + ``apply_prepared_batch`` (single write-lock window).
- New ``run_plugin_collect`` / ``apply_ops_batched`` pymethods on ``ProjectContext``.
- Both the parallel ``ThreadPoolExecutor`` path and the serial fallback share the new contract.

Tests: 12 new in ``tests/test_frozen_graph.py`` (parametrised parallel/serial). Cover own-emission invisible mid-run, cross-plugin emissions invisible, apply-order lands every op, intra-plugin yield order preserved, single-use ``CollectedOps`` handle, empty-cohort no-op. One existing test (``test_materialize_is_idempotent``) had relied on the old see-own-emission behaviour — updated to the new contract.

**``AddNode`` audit** (the user was tempted to kill it): 15 callers, 6 shape variants. Migration to a smaller ``AddSynthetic`` op would be a 3-PR shuffle where 8+ callers each grow ~3 ops. **Recommendation: keep ``AddNode``** — net DX cost > API-surface saving. Full breakdown in the agent's ``FROZEN_GRAPH_REPORT.md``.

### 2. Progress-callback API (``dcc45c0``)

New ``Analysis(progress_callback=fn)`` kwarg. ``fn(event, **kwargs)`` receives structured events for each phase:

- ``phase_start(phase, total)`` — ``total`` is ``None`` when not known up front.
- ``phase_progress(phase, current, total)`` — fired every ~100 ms.
- ``phase_end(phase, elapsed_ms)``.
- ``plugin_start(name, index, total)`` / ``plugin_end(name, elapsed_ms)``.

Mutually exclusive with the legacy ``show_progress=True``; that flag now installs a default stderr-text callback that maps each event to the existing ``indicatif`` bar.

Rust side (``src/progress.rs``):

- ``ProgressCounters`` — ``AtomicUsize`` / ``AtomicU64`` / ``AtomicBool`` fields with ``Ordering::Relaxed`` writers. No GIL, no contention.
- ``ProgressHandle`` pyclass holding an ``Arc<ProgressCounters>`` — the snapshot read path bypasses pyo3's per-instance borrow flag, so polling doesn't conflict with the ``materialize`` borrow token.
- Counters wired through ``build_project_graph`` / ``assemble_graph`` / ``build_fqname_indices`` / ``materialize``.

Python side:

- ``_ProgressPoller`` daemon thread polls ``ProgressHandle.snapshot()`` every 100 ms; diffs against last snapshot; fires events.
- Final drain on the caller's thread at ``stop()`` so sub-100 ms builds still see every event.
- Callback exceptions swallowed with ``warnings.warn(..., RuntimeWarning)`` so a buggy callback can't deadlock the build.
- Build failures route through ``try/except BaseException`` that calls ``mark_progress_finished`` so the poller exits even on abort.

Tests: 8 new in ``tests/test_progress_callback.py`` covering event sequence + ordering + count/total invariants + mutex with ``show_progress`` + default-callback + exception-doesn't-deadlock + concurrent-plugin attribution + snapshot shape.

Suite: 659 → **679** (12 new frozen-graph + 8 new progress-callback).

## Public API additions

- ``Analysis(progress_callback=...)``
- ``ProgressCallback`` type alias, ``PROGRESS_PHASES`` constant, ``PROGRESS_POLL_INTERVAL_S`` constant — exported from ``dead_cst.analyze``, pinned in ``tests/test_public_api.py``.
- ``ProjectContext.run_plugin_collect``, ``apply_ops_batched``, ``progress_handle``, ``read_progress_snapshot``, ``mark_progress_finished``, ``progress_plugin_done``, ``progress_plugins_start``, ``progress_plugins_finish`` (rust + ``.pyi`` stubs).
- ``CollectedOps`` pyclass — opaque transport, single-use drain.

## Test plan

- [x] ``uv run pytest -q`` — 679 passed
- [x] ``cargo clippy --all-targets --locked -- -D warnings`` clean
- [x] ``cargo fmt --check`` clean
- [x] ``uv run prek run --all-files`` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)