### PR TITLE
rust: index-form APIs for ctx + ref-query terminals + AddNodeByIdx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,55 @@ two versions.
 
 ## [Unreleased]
 
+### Added
+- Index-form siblings on `ProjectContext`: `find_declarations_indices`,
+  `module_for_indices`, `modules_for_paths`, `module_surface_indices`,
+  `module_surfaces_indices`, `find_main_blocks_indices`. Each returns
+  positional indices into `ctx.nodes()` rather than allocating
+  `Py<SymbolNode>` clones — pair with `AddEdgeByIdx` / `AddNodeByIdx` to
+  stay in idx-space end-to-end.
+- `ProjectContext.node_attrs(indices)` — batched snapshot of
+  `(kind, path, fqname, flags)` per index. One FFI hop instead of N
+  per-attribute `borrow` round-trips. Plugins that filter / partition
+  by these four fields stay GIL-free in the inner loop, which matters
+  once the plugin pass runs concurrently.
+- `.row_indices()` terminal on `DecoratorQuery`, `ConstructionQuery`,
+  `CallQuery`, `FactoryQuery`. Same dispatch as `.collect()`, but each
+  row carries a positional index (`decorated_idx` / `var_idx` /
+  `owner_idx` / `decl_idx`) instead of a `SymbolNode`, and the
+  `args` / `kwargs` row payloads are skipped. Returned rows are new
+  pyclasses `DecoratorIdxRef`, `ConstructionIdxRef`, `CallIdxRef`,
+  `FactoryIdxRef`.
+- `AddNodeByIdx` graph op — index-keyed sibling of `AddNode`.
+  Wires the freshly-minted synthetic node with positional indices
+  into `ctx.nodes()` (`edges_from_idx`, `edges_to_idx`) instead of
+  `SymbolNode` references, so plugins working in index space
+  (paired with the `.indices()` query terminals or
+  `ctx.indices_where`) don't round-trip through `Py<SymbolNode>`
+  just to wire their markers. Bounds-checked at apply time; an
+  out-of-range index raises `IndexError` before the new node is
+  interned, so a bad endpoint never leaves an unconnected
+  synthetic behind.
+
+### Changed
+- `AddNode`'s apply pass now pre-resolves every `edges_from` /
+  `edges_to` key to its builder index *before* minting the
+  synthetic node, matching the discipline `AddNodeByIdx`
+  introduces. A missing key now surfaces as a clean `ValueError`
+  without leaving an orphan node in the graph (previously the
+  synthetic was interned first, then the failing key lookup
+  aborted, stranding the new node).
+- Internal: the `ctx.find_*` helpers backing the chainable query DSL
+  (`find_decorated_decls`, `find_instance_constructions`,
+  `find_handler_decorators`, `find_handler_decorators_via`,
+  `find_calls_to_imported`, `find_calls_on_var`, `find_calls_on_attr`,
+  `find_factory_decls`, plus the `find_decorated`,
+  `find_constructions`, `find_decorations_on` thin wrappers) now
+  return `(idx, …)` tuples instead of `(Py<SymbolNode>, …)`. The
+  `Py<SymbolNode>` materialization moved into the queries' `.collect()`
+  terminals — `.row_indices()` skips it entirely. No public Python API
+  change.
+
 ## [0.12.2] - 2026-05-25
 
 ### Added

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -257,7 +257,41 @@ class AddNode:
         edges_to: Iterable[SymbolNode] = ...,
     ) -> None: ...
 
-GraphOp = AddEdge | AddEdgeByIdx | AddEntrypoint | AddNode
+class AddNodeByIdx:
+    """Index-keyed variant of :class:`AddNode`. Wires the freshly-minted
+    synthetic node with positional indices into ``ctx.nodes()`` instead
+    of :class:`SymbolNode` references for ``edges_from`` / ``edges_to``.
+
+    Pairs with the ``.indices()`` query terminals and
+    :meth:`ProjectContext.indices_where` so plugins that already work
+    in index space don't round-trip through ``Py<SymbolNode>`` just to
+    wire their synthetic markers. The apply pass treats it identically
+    to :class:`AddNode` once the indices land in the builder.
+
+    Raises :class:`IndexError` at apply time when any endpoint is out
+    of range. The bounds check runs *before* the new node is interned,
+    so a bad index never leaves an unconnected synthetic behind.
+    """
+
+    fqname: str
+    kind: NodeKind
+    path: str
+    flags: int
+    edges_from_idx: list[int]
+    edges_to_idx: list[int]
+
+    def __init__(
+        self,
+        fqname: str,
+        *,
+        path: str,
+        kind: NodeKind = "synthetic",
+        flags: int = 0,
+        edges_from_idx: Iterable[int] = ...,
+        edges_to_idx: Iterable[int] = ...,
+    ) -> None: ...
+
+GraphOp = AddEdge | AddEdgeByIdx | AddEntrypoint | AddNode | AddNodeByIdx
 
 class CollectedOps:
     """Opaque handle to one plugin's collected graph ops.
@@ -593,6 +627,17 @@ class ProjectContext:
         """
         ...
 
+    def find_declarations_indices(self, fqname: str) -> list[int]:
+        """Idx-only variant of :meth:`find_declarations`.
+
+        Same walk-back rules; returns positional indices into
+        :meth:`nodes` rather than allocating ``SymbolNode`` clones — pair
+        with :class:`AddEdgeByIdx` / :class:`AddNodeByIdx` to skip the
+        ``SymbolNode -> idx`` round-trip when wiring against the matched
+        decls.
+        """
+        ...
+
     def find_module(self, fqname: str) -> SymbolNode | None:
         """Return the module node for the given dotted fqname, if one
         exists in the project graph."""
@@ -607,6 +652,21 @@ class ProjectContext:
         """
         ...
 
+    def module_for_indices(self, path: str) -> int | None:
+        """Idx-only variant of :meth:`module_for`. Same O(1) lookup,
+        returns the positional index into :meth:`nodes` (``None`` if
+        ``path`` doesn't name a project module).
+        """
+        ...
+
+    def modules_for_paths(self, paths: list[str]) -> list[int | None]:
+        """Bulk form of :meth:`module_for_indices`. One ``materialize``
+        check + one O(1) lookup per path; missing paths map to ``None``.
+        Lets plugins that ``module_for(path)`` once per ref row collapse
+        N FFI hops into one.
+        """
+        ...
+
     def module_surface(self, module_fqn: str) -> list[SymbolNode]:
         """Module node + every transitive decl whose fqname lives
         under ``module_fqn``.
@@ -615,6 +675,20 @@ class ProjectContext:
         whole top-level surface plus everything its submodules expose.
         Empty list when ``module_fqn`` doesn't resolve to a project
         module.
+        """
+        ...
+
+    def module_surface_indices(self, module_fqn: str) -> list[int]:
+        """Idx-only variant of :meth:`module_surface`. Same BFS over
+        the fqname tree; returns positional indices into :meth:`nodes`
+        rather than allocating ``SymbolNode`` clones.
+        """
+        ...
+
+    def module_surfaces_indices(self, module_fqns: list[str]) -> dict[str, list[int]]:
+        """Idx-only variant of :meth:`module_surfaces`. Same single-
+        sweep scan; the per-fqname buckets carry positional indices
+        into :meth:`nodes` rather than ``SymbolNode`` clones.
         """
         ...
 
@@ -822,6 +896,18 @@ class ProjectContext:
         """
         ...
 
+    def node_attrs(self, indices: Sequence[int]) -> list[tuple[NodeKind, str, str, int]]:
+        """Batched snapshot of ``(kind, path, fqname, flags)`` per
+        index. One FFI hop instead of N per-attribute ``borrow``
+        round-trips — lets plugins that filter or partition by these
+        four fields stay GIL-free in the inner loop, which matters
+        once the plugin pass runs concurrently.
+
+        Validates bounds the same way :meth:`nodes_at` does and raises
+        :class:`IndexError` when any index is out of range.
+        """
+        ...
+
     # ----- Pure scans over the in-progress graph ------------------------
 
     def find_module_dunders(self) -> list[SymbolNode]:
@@ -852,6 +938,15 @@ class ProjectContext:
         / import nodes whose source position falls inside the block's
         range — same shape ``MainBlockPlugin``'s libcst path computes
         from the visitor's payload.
+        """
+        ...
+
+    def find_main_blocks_indices(self) -> list[tuple[int, list[int]]]:
+        """Idx-only variant of :meth:`find_main_blocks`. Returns
+        ``(module_idx, [decl_idx])`` pairs into :meth:`nodes` rather
+        than ``SymbolNode`` clones — pair with :class:`AddNodeByIdx` to
+        emit a marker per main block without round-tripping its decls
+        through ``Py<SymbolNode>``.
         """
         ...
 
@@ -1046,6 +1141,56 @@ class CallRef:
     @property
     def path(self) -> str: ...
 
+class DecoratorIdxRef:
+    """Index-form sibling of :class:`DecoratorRef`. Same metadata
+    fields, minus ``args`` / ``kwargs``; ``decorated_idx`` indexes into
+    :meth:`ProjectContext.nodes`.
+
+    Returned by :meth:`DecoratorQuery.row_indices`. Pair with
+    :meth:`ProjectContext.node_attrs` to batch-fetch any node fields
+    the plugin still needs without per-row ``borrow`` ping-pong.
+    """
+
+    decorated_idx: int
+    decorator_name: str | None
+    decorator_owner: str | None
+    decorator_via: str | None
+
+class ConstructionIdxRef:
+    """Index-form sibling of :class:`ConstructionRef`. Same metadata
+    fields, minus ``args`` / ``kwargs``; ``var_idx`` indexes into
+    :meth:`ProjectContext.nodes`.
+
+    Returned by :meth:`ConstructionQuery.row_indices`.
+    """
+
+    var_idx: int
+    class_name: str
+
+class CallIdxRef:
+    """Index-form sibling of :class:`CallRef`. Same metadata fields,
+    minus ``args`` / ``kwargs``; ``owner_idx`` indexes into
+    :meth:`ProjectContext.nodes`. ``string_arg`` (the literal at the
+    configured positional index) is preserved because most call-shape
+    plugins key on it.
+
+    Returned by :meth:`CallQuery.row_indices`.
+    """
+
+    owner_idx: int
+    string_arg: str
+
+class FactoryIdxRef:
+    """Index-form sibling of :class:`FactoryRef`. ``decl_idx`` indexes
+    into :meth:`ProjectContext.nodes`; ``kinds`` is the same sorted set
+    of matched constructor bare-names the node-returning terminal emits.
+
+    Returned by :meth:`FactoryQuery.row_indices`.
+    """
+
+    decl_idx: int
+    kinds: list[str]
+
 def query(ctx: ProjectContext) -> QueryBuilder:
     """Open a chainable query builder against ``ctx``.
 
@@ -1119,6 +1264,15 @@ class DecoratorQuery:
     def first(self) -> DecoratorRef | None: ...
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[DecoratorRef]: ...
+    def row_indices(self) -> list[DecoratorIdxRef]:
+        """Index-form row terminal. Same dispatch as :meth:`collect`,
+        but each row carries ``decorated_idx`` (a positional index into
+        :meth:`ProjectContext.nodes`) instead of a ``SymbolNode``, and
+        the ``args`` / ``kwargs`` row payloads are skipped. Pair with
+        :meth:`ProjectContext.node_attrs` for plugins that need a few
+        node fields without per-row borrow ping-pong.
+        """
+        ...
 
 class ConstructionQuery:
     """Find module-scope ``<var> = <Ctor>(...)`` sites."""
@@ -1137,6 +1291,13 @@ class ConstructionQuery:
     def first(self) -> ConstructionRef | None: ...
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[ConstructionRef]: ...
+    def row_indices(self) -> list[ConstructionIdxRef]:
+        """Index-form row terminal. Same dispatch as :meth:`collect`,
+        but each row carries ``var_idx`` (a positional index into
+        :meth:`ProjectContext.nodes`) instead of a ``SymbolNode``, and
+        the ``args`` / ``kwargs`` row payloads are skipped.
+        """
+        ...
 
 class CallQuery:
     """Find call sites with a captured positional string-literal arg.
@@ -1173,6 +1334,15 @@ class CallQuery:
     def first(self) -> CallRef | None: ...
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[CallRef]: ...
+    def row_indices(self) -> list[CallIdxRef]:
+        """Index-form row terminal. Same dispatch as :meth:`collect`,
+        but each row carries ``owner_idx`` (a positional index into
+        :meth:`ProjectContext.nodes`) instead of a ``SymbolNode``, and
+        the ``args`` / ``kwargs`` row payloads are skipped.
+        ``string_arg`` is preserved because most call-shape plugins
+        key on it.
+        """
+        ...
 
 class SubclassQuery:
     """Walk the subclass closure of a class.
@@ -1279,6 +1449,12 @@ class FactoryQuery:
     def collect(self) -> list[FactoryRef]: ...
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[FactoryRef]: ...
+    def row_indices(self) -> list[FactoryIdxRef]:
+        """Index-form row terminal. Same dispatch as :meth:`collect`;
+        each row carries ``decl_idx`` (a positional index into
+        :meth:`ProjectContext.nodes`) instead of a ``SymbolNode``.
+        """
+        ...
 
 class EdgeRef:
     """One graph edge with both endpoint nodes resolved.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6,7 +6,7 @@
 
 use std::sync::OnceLock;
 
-use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::exceptions::{PyIndexError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use ruff_db::files::File;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -276,6 +276,60 @@ impl AddNode {
     }
 }
 
+/// Index-keyed variant of :class:`AddNode`. Wires the freshly-minted
+/// synthetic node with positional indices into ``ctx.nodes()`` instead
+/// of ``SymbolNode`` references for ``edges_from`` / ``edges_to``.
+///
+/// Pairs with the ``.indices()`` query terminals and
+/// :meth:`ProjectContext.indices_where` so plugins that work in index
+/// space don't have to round-trip through ``Py<SymbolNode>`` just to
+/// wire their synthetic markers. The apply pass treats it identically
+/// to :class:`AddNode` once the indices land in the builder.
+///
+/// Raises :class:`IndexError` at apply time when any endpoint is out
+/// of range for the current graph snapshot (pre-intern, so the new
+/// node is not created if any endpoint check fails).
+#[pyclass(frozen, get_all)]
+pub(crate) struct AddNodeByIdx {
+    pub(crate) fqname: String,
+    pub(crate) kind: &'static str,
+    pub(crate) path: String,
+    pub(crate) flags: u32,
+    pub(crate) edges_from_idx: Vec<usize>,
+    pub(crate) edges_to_idx: Vec<usize>,
+}
+
+#[pymethods]
+impl AddNodeByIdx {
+    #[new]
+    #[pyo3(signature = (
+        fqname,
+        *,
+        path,
+        kind = "synthetic",
+        flags = 0,
+        edges_from_idx = Vec::new(),
+        edges_to_idx = Vec::new(),
+    ))]
+    fn new(
+        fqname: String,
+        path: String,
+        kind: &str,
+        flags: u32,
+        edges_from_idx: Vec<usize>,
+        edges_to_idx: Vec<usize>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            fqname,
+            kind: intern_kind(kind)?,
+            path,
+            flags,
+            edges_from_idx,
+            edges_to_idx,
+        })
+    }
+}
+
 pub(crate) fn not_materialized(op: &str) -> PyErr {
     PyRuntimeError::new_err(format!(
         "ProjectContext.{op}() called outside an active materialize() — \
@@ -393,6 +447,14 @@ pub(crate) enum PreparedOp {
         edges_from: Vec<NodeKey>,
         edges_to: Vec<NodeKey>,
     },
+    NodeByIdx {
+        fqname: String,
+        kind: &'static str,
+        path: String,
+        flags: u32,
+        edges_from_idx: Vec<usize>,
+        edges_to_idx: Vec<usize>,
+    },
 }
 
 /// Opaque Python handle wrapping a plugin's pre-prepared op queue.
@@ -481,9 +543,19 @@ pub(crate) fn prepare_graph_op(py: Python<'_>, op: &Bound<'_, PyAny>) -> PyResul
             edges_from,
             edges_to,
         }
+    } else if let Ok(add_node_idx) = op.extract::<PyRef<AddNodeByIdx>>() {
+        PreparedOp::NodeByIdx {
+            fqname: add_node_idx.fqname.clone(),
+            kind: add_node_idx.kind,
+            path: add_node_idx.path.clone(),
+            flags: add_node_idx.flags,
+            edges_from_idx: add_node_idx.edges_from_idx.clone(),
+            edges_to_idx: add_node_idx.edges_to_idx.clone(),
+        }
     } else {
         return Err(PyValueError::new_err(format!(
-            "expected a GraphOp (AddEdge / AddEdgeByIdx / AddEntrypoint / AddNode), got {:?}",
+            "expected a GraphOp (AddEdge / AddEdgeByIdx / AddEntrypoint / AddNode / AddNodeByIdx), \
+             got {:?}",
             op.get_type().name()?,
         )));
     };
@@ -551,16 +623,8 @@ fn apply_prepared(
             flags,
         } => {
             let len = outputs.builder.nodes.len();
-            if src_idx >= len {
-                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                    "AddEdgeByIdx: src_idx {src_idx} out of range (len={len})"
-                )));
-            }
-            if dst_idx >= len {
-                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                    "AddEdgeByIdx: dst_idx {dst_idx} out of range (len={len})"
-                )));
-            }
+            check_idx_in_range(len, src_idx, "AddEdgeByIdx", "src_idx")?;
+            check_idx_in_range(len, dst_idx, "AddEdgeByIdx", "dst_idx")?;
             outputs.builder.add_edge(src_idx, dst_idx, flags);
             Ok(())
         }
@@ -587,20 +651,96 @@ fn apply_prepared(
             edges_from,
             edges_to,
         } => {
+            // Resolve endpoint keys to indices *before* minting the
+            // node — a missing key then surfaces as a clean
+            // ``ValueError`` without leaving an unconnected synthetic
+            // behind in the graph. Same pre-validation discipline as
+            // the ``NodeByIdx`` arm below.
+            let from_idxs = resolve_edge_keys(&outputs.builder, &edges_from, "edges_from")?;
+            let to_idxs = resolve_edge_keys(&outputs.builder, &edges_to, "edges_to")?;
             let node_idx = outputs
                 .builder
                 .intern_node(py, synthetic_node(fqname, kind, path, flags))?;
-            for src in &edges_from {
-                let src_idx = lookup_idx_by_key(&outputs.builder, src, "edges_from")?;
-                outputs.builder.add_edge(src_idx, node_idx, 0);
-            }
-            for dst in &edges_to {
-                let dst_idx = lookup_idx_by_key(&outputs.builder, dst, "edges_to")?;
-                outputs.builder.add_edge(node_idx, dst_idx, 0);
-            }
+            wire_synthetic_edges(&mut outputs.builder, node_idx, &from_idxs, &to_idxs);
+            Ok(())
+        }
+        PreparedOp::NodeByIdx {
+            fqname,
+            kind,
+            path,
+            flags,
+            edges_from_idx,
+            edges_to_idx,
+        } => {
+            // Bounds-check every endpoint *before* minting the new
+            // node so that a bad index doesn't leave an unconnected
+            // synthetic in the graph. The check uses the pre-intern
+            // node count: callers cannot reference an idx that
+            // doesn't yet exist (including the about-to-be-minted
+            // node).
+            let len = outputs.builder.nodes.len();
+            check_idx_slice_in_range(len, &edges_from_idx, "AddNodeByIdx", "edges_from_idx")?;
+            check_idx_slice_in_range(len, &edges_to_idx, "AddNodeByIdx", "edges_to_idx")?;
+            let node_idx = outputs
+                .builder
+                .intern_node(py, synthetic_node(fqname, kind, path, flags))?;
+            wire_synthetic_edges(
+                &mut outputs.builder,
+                node_idx,
+                &edges_from_idx,
+                &edges_to_idx,
+            );
             Ok(())
         }
     }
+}
+
+/// Wire a freshly-minted synthetic node into the graph: every entry
+/// of ``edges_from_idx`` becomes ``source -> node``, every entry of
+/// ``edges_to_idx`` becomes ``node -> target``. Endpoints are already
+/// validated indices.
+fn wire_synthetic_edges(
+    builder: &mut GraphBuilder,
+    node_idx: usize,
+    edges_from_idx: &[usize],
+    edges_to_idx: &[usize],
+) {
+    for &src_idx in edges_from_idx {
+        builder.add_edge(src_idx, node_idx, 0);
+    }
+    for &dst_idx in edges_to_idx {
+        builder.add_edge(node_idx, dst_idx, 0);
+    }
+}
+
+/// Resolve every endpoint key to its builder-side index, propagating
+/// the first lookup failure as a ``ValueError`` with the matching
+/// ``side`` label.
+fn resolve_edge_keys(builder: &GraphBuilder, keys: &[NodeKey], side: &str) -> PyResult<Vec<usize>> {
+    keys.iter()
+        .map(|k| lookup_idx_by_key(builder, k, side))
+        .collect()
+}
+
+/// Bounds-check a single index against the builder's current node
+/// count, surfacing an ``IndexError`` matching the existing
+/// ``AddEdgeByIdx`` style.
+fn check_idx_in_range(len: usize, idx: usize, op: &str, side: &str) -> PyResult<()> {
+    if idx >= len {
+        return Err(PyIndexError::new_err(format!(
+            "{op}: {side} {idx} out of range (len={len})"
+        )));
+    }
+    Ok(())
+}
+
+/// Bounds-check every index in a slice. Returns on the first
+/// out-of-range index with the matching ``IndexError``.
+fn check_idx_slice_in_range(len: usize, idxs: &[usize], op: &str, side: &str) -> PyResult<()> {
+    for &idx in idxs {
+        check_idx_in_range(len, idx, op, side)?;
+    }
+    Ok(())
 }
 
 /// Resolve a `SymbolNode` reference to its builder-side index for an

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,15 +42,15 @@ mod query;
 
 use pyo3::prelude::*;
 
-use crate::builder::{AddEdge, AddEdgeByIdx, AddEntrypoint, AddNode, CollectedOps};
+use crate::builder::{AddEdge, AddEdgeByIdx, AddEntrypoint, AddNode, AddNodeByIdx, CollectedOps};
 use crate::graph::{EdgeFlags, Import, NativeGraph, NodeFlags, SymbolNode};
 use crate::io::{read_graph, write_graph, GraphMetadata};
 use crate::progress::ProgressHandle;
 use crate::project::{Project, ProjectContext};
 use crate::query::{
-    CallQuery, CallRef, ClassQuery, ConstructionQuery, ConstructionRef, DeclQuery, DecoratorQuery,
-    DecoratorRef, EdgeQuery, EdgeRef, FactoryQuery, FactoryRef, ImportQuery, QueryBuilder,
-    SubclassQuery,
+    CallIdxRef, CallQuery, CallRef, ClassQuery, ConstructionIdxRef, ConstructionQuery,
+    ConstructionRef, DeclQuery, DecoratorIdxRef, DecoratorQuery, DecoratorRef, EdgeQuery, EdgeRef,
+    FactoryIdxRef, FactoryQuery, FactoryRef, ImportQuery, QueryBuilder, SubclassQuery,
 };
 
 // ---------------------------------------------------------------------------
@@ -77,12 +77,16 @@ fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<AddEdgeByIdx>()?;
     m.add_class::<AddEntrypoint>()?;
     m.add_class::<AddNode>()?;
+    m.add_class::<AddNodeByIdx>()?;
     m.add_class::<CollectedOps>()?;
     m.add_class::<NodeFlags>()?;
     m.add_class::<EdgeFlags>()?;
     m.add_class::<DecoratorRef>()?;
+    m.add_class::<DecoratorIdxRef>()?;
     m.add_class::<ConstructionRef>()?;
+    m.add_class::<ConstructionIdxRef>()?;
     m.add_class::<CallRef>()?;
+    m.add_class::<CallIdxRef>()?;
     m.add_class::<QueryBuilder>()?;
     m.add_class::<DecoratorQuery>()?;
     m.add_class::<ConstructionQuery>()?;
@@ -92,6 +96,7 @@ fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ClassQuery>()?;
     m.add_class::<FactoryQuery>()?;
     m.add_class::<FactoryRef>()?;
+    m.add_class::<FactoryIdxRef>()?;
     m.add_class::<EdgeQuery>()?;
     m.add_class::<EdgeRef>()?;
     m.add_class::<DeclQuery>()?;

--- a/src/project.rs
+++ b/src/project.rs
@@ -1766,20 +1766,19 @@ impl ProjectContext {
         fqname: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
         let outputs = self.materialized("find_declarations")?;
-        // Try exact match first, then strip trailing segments.
-        let mut prefix = fqname;
-        loop {
-            if let Some(idxs) = outputs.decl_by_fqname.get(prefix) {
-                return Ok(idxs
-                    .iter()
-                    .map(|&i| outputs.builder.nodes[i].clone_ref(py))
-                    .collect());
-            }
-            match prefix.rsplit_once('.') {
-                Some((parent, _)) => prefix = parent,
-                None => return Ok(Vec::new()),
-            }
-        }
+        let indices = find_declarations_indices_in(&outputs, fqname);
+        Ok(indices
+            .into_iter()
+            .map(|i| outputs.builder.nodes[i].clone_ref(py))
+            .collect())
+    }
+
+    /// Idx-only variant of :meth:`find_declarations`. Same walk-back
+    /// rules, returns positional indices into ``ctx.nodes()`` rather
+    /// than allocating ``Py<SymbolNode>`` clones.
+    pub(crate) fn find_declarations_indices(&self, fqname: &str) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("find_declarations_indices")?;
+        Ok(find_declarations_indices_in(&outputs, fqname))
     }
 
     /// Return the module node for the given dotted fqname, if it
@@ -1808,13 +1807,28 @@ impl ProjectContext {
         path: &str,
     ) -> PyResult<Option<Py<SymbolNode>>> {
         let outputs = self.materialized("module_for")?;
-        let Some(&file) = outputs.path_to_file.get(path) else {
-            return Ok(None);
-        };
-        let Some(&idx) = outputs.module_nodes_by_file.get(&file) else {
-            return Ok(None);
-        };
-        Ok(Some(outputs.builder.nodes[idx].clone_ref(py)))
+        Ok(module_for_idx_in(&outputs, path).map(|idx| outputs.builder.nodes[idx].clone_ref(py)))
+    }
+
+    /// Idx-only variant of :meth:`module_for`. Same O(1) lookup,
+    /// returns the positional index into ``ctx.nodes()`` (``None`` if
+    /// ``path`` doesn't name a project module).
+    pub(crate) fn module_for_indices(&self, path: &str) -> PyResult<Option<usize>> {
+        let outputs = self.materialized("module_for_indices")?;
+        Ok(module_for_idx_in(&outputs, path))
+    }
+
+    /// Bulk form of :meth:`module_for_indices`. One materialize check
+    /// + one ``path_to_file`` / ``module_nodes_by_file`` lookup per
+    /// path; missing paths map to ``None``. Lets plugins that
+    /// ``module_for(path)`` once per ref row collapse N FFI hops into
+    /// one.
+    pub(crate) fn modules_for_paths(&self, paths: Vec<String>) -> PyResult<Vec<Option<usize>>> {
+        let outputs = self.materialized("modules_for_paths")?;
+        Ok(paths
+            .iter()
+            .map(|p| module_for_idx_in(&outputs, p))
+            .collect())
     }
 
     /// Resolve a dotted FQN to either a declaration or a module node.
@@ -1863,39 +1877,23 @@ impl ProjectContext {
         module_fqn: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
         let outputs = self.materialized("module_surface")?;
-        let Some(&module_idx) = outputs.module_by_fqname.get(module_fqn) else {
-            return Ok(Vec::new());
-        };
-        let mut out = vec![outputs.builder.nodes[module_idx].clone_ref(py)];
-        // BFS over the fqname tree. Recurse only into module children:
-        // a decl ``pkg.foo.MyClass`` doesn't have submodule descendants,
-        // so chasing its sub-fqnames would just be wasted lookups.
-        // Queue holds owned ``String``s because ``children_by_parent``
-        // keys are owned strings and ``SymbolNode.fqname`` lives behind
-        // a ``PyRef`` guard that can't be held across iterations.
-        let mut queue: std::collections::VecDeque<String> =
-            std::collections::VecDeque::from([module_fqn.to_string()]);
-        while let Some(parent) = queue.pop_front() {
-            let Some(children) = outputs.children_by_parent.get(parent.as_str()) else {
-                continue;
-            };
-            for &child_idx in children {
-                let child_py = &outputs.builder.nodes[child_idx];
-                let child = child_py.borrow(py);
-                let is_module = child.kind == "module";
-                let child_fqname = if is_module {
-                    Some(child.fqname.clone())
-                } else {
-                    None
-                };
-                drop(child);
-                out.push(child_py.clone_ref(py));
-                if let Some(fqn) = child_fqname {
-                    queue.push_back(fqn);
-                }
-            }
-        }
-        Ok(out)
+        let indices = module_surface_indices_in(&outputs, py, module_fqn);
+        Ok(indices
+            .into_iter()
+            .map(|i| outputs.builder.nodes[i].clone_ref(py))
+            .collect())
+    }
+
+    /// Idx-only variant of :meth:`module_surface`. Same BFS over the
+    /// fqname tree; returns positional indices into ``ctx.nodes()``
+    /// instead of allocating ``Py<SymbolNode>`` clones.
+    pub(crate) fn module_surface_indices(
+        &self,
+        py: Python<'_>,
+        module_fqn: &str,
+    ) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("module_surface_indices")?;
+        Ok(module_surface_indices_in(&outputs, py, module_fqn))
     }
 
     /// Batched form of :meth:`module_surface`. Resolves every fqname
@@ -1904,60 +1902,32 @@ impl ProjectContext {
     /// per-call materialize-lookup + N scans collapse to one of each.
     /// Returns a dict keyed by input fqname; missing modules map to
     /// empty lists. Duplicate inputs share the same result list.
+    /// Idx-only variant of :meth:`module_surfaces`. Same single-sweep
+    /// scan; the per-fqname buckets carry positional indices into
+    /// ``ctx.nodes()`` instead of allocated ``Py<SymbolNode>`` clones.
+    pub(crate) fn module_surfaces_indices(
+        &self,
+        module_fqns: Vec<String>,
+    ) -> PyResult<FxHashMap<String, Vec<usize>>> {
+        let outputs = self.materialized("module_surfaces_indices")?;
+        Ok(module_surfaces_indices_in(&outputs, &module_fqns))
+    }
+
     pub(crate) fn module_surfaces(
         &self,
         py: Python<'_>,
         module_fqns: Vec<String>,
     ) -> PyResult<FxHashMap<String, Vec<Py<SymbolNode>>>> {
         let outputs = self.materialized("module_surfaces")?;
-        // Deduplicate the requested fqnames + pre-stage each one's
-        // (prefix, output vec) so a single map iteration can drop
-        // matches into the right bucket. Skip fqnames that don't name
-        // a project module — same per-call short-circuit as the
-        // singular ``module_surface``.
+        let idx_buckets = module_surfaces_indices_in(&outputs, &module_fqns);
         let mut buckets: FxHashMap<String, Vec<Py<SymbolNode>>> =
-            FxHashMap::with_capacity_and_hasher(module_fqns.len(), Default::default());
-        let mut prefixes: Vec<(String, String)> = Vec::with_capacity(module_fqns.len());
-        for fqn in &module_fqns {
-            if buckets.contains_key(fqn) {
-                continue;
-            }
-            let Some(&module_idx) = outputs.module_by_fqname.get(fqn) else {
-                buckets.insert(fqn.clone(), Vec::new());
-                continue;
-            };
-            buckets.insert(
-                fqn.clone(),
-                vec![outputs.builder.nodes[module_idx].clone_ref(py)],
-            );
-            prefixes.push((fqn.clone(), format!("{fqn}.")));
-        }
-        if prefixes.is_empty() {
-            return Ok(buckets);
-        }
-        // Single sweep over each map; per-fqname row goes into every
-        // bucket whose prefix matches. K small (≤ inputs), so the
-        // nested-loop ``starts_with`` is fine — a prefix trie would
-        // only help for K in the hundreds.
-        for (fqname, &idx) in &outputs.module_by_fqname {
-            for (key, prefix) in &prefixes {
-                if fqname.starts_with(prefix) {
-                    buckets
-                        .get_mut(key)
-                        .expect("seeded above")
-                        .push(outputs.builder.nodes[idx].clone_ref(py));
-                }
-            }
-        }
-        for (fqname, idxs) in &outputs.decl_by_fqname {
-            for (key, prefix) in &prefixes {
-                if fqname.starts_with(prefix) {
-                    let bucket = buckets.get_mut(key).expect("seeded above");
-                    for &idx in idxs {
-                        bucket.push(outputs.builder.nodes[idx].clone_ref(py));
-                    }
-                }
-            }
+            FxHashMap::with_capacity_and_hasher(idx_buckets.len(), Default::default());
+        for (key, idxs) in idx_buckets {
+            let nodes = idxs
+                .into_iter()
+                .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
+                .collect();
+            buckets.insert(key, nodes);
         }
         Ok(buckets)
     }
@@ -2296,7 +2266,28 @@ impl ProjectContext {
     /// range — same shape ``MainBlockPlugin``'s libcst path computes
     /// from the visitor's payload.
     pub(crate) fn find_main_blocks(&self, py: Python<'_>) -> PyResult<Vec<MainBlock>> {
+        let indexed = self.find_main_blocks_indices()?;
         let outputs = self.materialized("find_main_blocks")?;
+        Ok(indexed
+            .into_iter()
+            .map(|(module_idx, decl_idxs)| {
+                let module = outputs.builder.nodes[module_idx].clone_ref(py);
+                let decls = decl_idxs
+                    .into_iter()
+                    .map(|i| outputs.builder.nodes[i].clone_ref(py))
+                    .collect();
+                (module, decls)
+            })
+            .collect())
+    }
+
+    /// Idx-only variant of :meth:`find_main_blocks`. Returns
+    /// ``(module_idx, [decl_idx])`` pairs into ``ctx.nodes()`` rather
+    /// than allocating ``Py<SymbolNode>`` clones. Same single-pass
+    /// ``__main__`` substring filter + ``find_main_block_range`` +
+    /// global-index bucketing as the node form.
+    pub(crate) fn find_main_blocks_indices(&self) -> PyResult<Vec<(usize, Vec<usize>)>> {
+        let outputs = self.materialized("find_main_blocks_indices")?;
 
         // First pass: identify files that actually contain a top-level
         // ``if __name__ == "__main__":`` block. The cheap ``__main__``
@@ -2341,17 +2332,17 @@ impl ProjectContext {
             }
         }
 
-        let mut out: Vec<MainBlock> = Vec::with_capacity(hits.len());
+        let mut out: Vec<(usize, Vec<usize>)> = Vec::with_capacity(hits.len());
         for (file, module_idx, (block_start, block_end)) in hits {
-            let mut decls: Vec<Py<SymbolNode>> = Vec::new();
+            let mut decl_idxs: Vec<usize> = Vec::new();
             if let Some(file_decls) = decls_by_file.get(&file) {
                 for &(start, end, idx) in file_decls {
                     if start >= block_start && end <= block_end {
-                        decls.push(outputs.builder.nodes[idx].clone_ref(py));
+                        decl_idxs.push(idx);
                     }
                 }
             }
-            out.push((outputs.builder.nodes[module_idx].clone_ref(py), decls));
+            out.push((module_idx, decl_idxs));
         }
         Ok(out)
     }
@@ -2378,7 +2369,7 @@ impl ProjectContext {
         decorator_modules: &[String],
         decorator_names: Vec<String>,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, CallArgs)>> {
+    ) -> PyResult<Vec<(usize, CallArgs)>> {
         let outputs = self.materialized("find_decorated_decls")?;
         let path_re = _compile_path_regex(path_regex)?;
         let names: FxHashSet<&str> = decorator_names.iter().map(String::as_str).collect();
@@ -2436,10 +2427,8 @@ impl ProjectContext {
                 local
             })
         });
-        Ok(pairs
-            .into_iter()
-            .map(|(idx, call_args)| (outputs.builder.nodes[idx].clone_ref(py), call_args))
-            .collect())
+        drop(outputs);
+        Ok(pairs)
     }
 
     /// Find top-level ``<var> = <Ctor>(...)`` constructions where
@@ -2463,7 +2452,7 @@ impl ProjectContext {
         modules: &[String],
         ctor_names: Vec<String>,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, String, CallArgs)>> {
+    ) -> PyResult<Vec<(usize, String, CallArgs)>> {
         let outputs = self.materialized("find_instance_constructions")?;
         let path_re = _compile_path_regex(path_regex)?;
         let allowed: FxHashSet<&str> = ctor_names.iter().map(String::as_str).collect();
@@ -2515,13 +2504,8 @@ impl ProjectContext {
                 local
             })
         });
-        let out: Vec<(Py<SymbolNode>, String, CallArgs)> = pairs
-            .into_iter()
-            .map(|(idx, name, call_args)| {
-                (outputs.builder.nodes[idx].clone_ref(py), name, call_args)
-            })
-            .collect();
-        Ok(out)
+        drop(outputs);
+        Ok(pairs)
     }
 
     /// Find top-level functions decorated with ``@<owner>.<attr>(...)``
@@ -2538,7 +2522,7 @@ impl ProjectContext {
         py: Python<'_>,
         decorator_attrs: Vec<String>,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(String, Py<SymbolNode>, CallArgs)>> {
+    ) -> PyResult<Vec<(String, usize, CallArgs)>> {
         let outputs = self.materialized("find_handler_decorators")?;
         let path_re = _compile_path_regex(path_regex)?;
         let attrs: FxHashSet<&str> = decorator_attrs.iter().map(String::as_str).collect();
@@ -2599,12 +2583,8 @@ impl ProjectContext {
                 local
             })
         });
-        Ok(triples
-            .into_iter()
-            .map(|(name, idx, call_args)| {
-                (name, outputs.builder.nodes[idx].clone_ref(py), call_args)
-            })
-            .collect())
+        drop(outputs);
+        Ok(triples)
     }
 
     /// Like ``find_handler_decorators`` but matches the two-level form
@@ -2619,7 +2599,7 @@ impl ProjectContext {
         via_attr: &str,
         decorator_attrs: Vec<String>,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(String, Py<SymbolNode>, CallArgs)>> {
+    ) -> PyResult<Vec<(String, usize, CallArgs)>> {
         let outputs = self.materialized("find_handler_decorators_via")?;
         let path_re = _compile_path_regex(path_regex)?;
         let attrs: FxHashSet<&str> = decorator_attrs.iter().map(String::as_str).collect();
@@ -2683,12 +2663,8 @@ impl ProjectContext {
                 local
             })
         });
-        Ok(triples
-            .into_iter()
-            .map(|(name, idx, call_args)| {
-                (name, outputs.builder.nodes[idx].clone_ref(py), call_args)
-            })
-            .collect())
+        drop(outputs);
+        Ok(triples)
     }
 
     /// Find calls of the form ``<expr>.<attr>(...)`` regardless of
@@ -2709,7 +2685,7 @@ impl ProjectContext {
         attr: &str,
         arg_index: usize,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, String, CallArgs)>> {
+    ) -> PyResult<Vec<(usize, String, CallArgs)>> {
         let outputs = self.materialized("find_calls_on_attr")?;
         let path_re = _compile_path_regex(path_regex)?;
         let decl_by_name_range = &outputs.decl_by_name_range;
@@ -2751,10 +2727,8 @@ impl ProjectContext {
                 local
             })
         });
-        Ok(triples
-            .into_iter()
-            .map(|(idx, arg, call_args)| (outputs.builder.nodes[idx].clone_ref(py), arg, call_args))
-            .collect())
+        drop(outputs);
+        Ok(triples)
     }
 }
 
@@ -2774,7 +2748,7 @@ impl ProjectContext {
         py: Python<'_>,
         modules: &[String],
         ctor_names: Vec<String>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, Vec<String>)>> {
+    ) -> PyResult<Vec<(usize, Vec<String>)>> {
         let outputs = self.materialized("find_factory_decls")?;
         let allowed: FxHashSet<&str> = ctor_names.iter().map(String::as_str).collect();
         let needle_strs: Vec<&str> = ctor_names.iter().map(String::as_str).collect();
@@ -2830,10 +2804,8 @@ impl ProjectContext {
                 local
             })
         });
-        Ok(pairs
-            .into_iter()
-            .map(|(idx, kinds)| (outputs.builder.nodes[idx].clone_ref(py), kinds))
-            .collect())
+        drop(outputs);
+        Ok(pairs)
     }
 }
 
@@ -2853,7 +2825,7 @@ impl ProjectContext {
         name: &str,
         arg_index: usize,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, String, CallArgs)>> {
+    ) -> PyResult<Vec<(usize, String, CallArgs)>> {
         let outputs = self.materialized("find_calls_to_imported")?;
         let path_re = _compile_path_regex(path_regex)?;
         let allowed: FxHashSet<&str> = [name].into_iter().collect();
@@ -2911,10 +2883,8 @@ impl ProjectContext {
                 local
             })
         });
-        Ok(triples
-            .into_iter()
-            .map(|(idx, arg, call_args)| (outputs.builder.nodes[idx].clone_ref(py), arg, call_args))
-            .collect())
+        drop(outputs);
+        Ok(triples)
     }
 
     /// Find ``<owner>.<attr>(...)`` calls where ``owner`` is the textual
@@ -2937,7 +2907,7 @@ impl ProjectContext {
         arg_index: usize,
         required_positional: Option<usize>,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, String, CallArgs)>> {
+    ) -> PyResult<Vec<(usize, String, CallArgs)>> {
         let outputs = self.materialized("find_calls_on_var")?;
         let path_re = _compile_path_regex(path_regex)?;
         let decl_by_name_range = &outputs.decl_by_name_range;
@@ -2984,10 +2954,8 @@ impl ProjectContext {
                 local
             })
         });
-        Ok(triples
-            .into_iter()
-            .map(|(idx, arg, call_args)| (outputs.builder.nodes[idx].clone_ref(py), arg, call_args))
-            .collect())
+        drop(outputs);
+        Ok(triples)
     }
 }
 
@@ -3120,6 +3088,117 @@ impl ProjectContext {
     }
 }
 
+/// Shared BFS used by :meth:`ProjectContext::module_surface` and
+/// :meth:`module_surface_indices` — the module index, then every
+/// transitive child node (modules recursed into; non-module decls
+/// surfaced but not chased for sub-fqnames).
+fn module_surface_indices_in(
+    outputs: &BuildOutputs,
+    py: Python<'_>,
+    module_fqn: &str,
+) -> Vec<usize> {
+    let Some(&module_idx) = outputs.module_by_fqname.get(module_fqn) else {
+        return Vec::new();
+    };
+    let mut out: Vec<usize> = vec![module_idx];
+    let mut queue: std::collections::VecDeque<String> =
+        std::collections::VecDeque::from([module_fqn.to_string()]);
+    while let Some(parent) = queue.pop_front() {
+        let Some(children) = outputs.children_by_parent.get(parent.as_str()) else {
+            continue;
+        };
+        for &child_idx in children {
+            let child_py = &outputs.builder.nodes[child_idx];
+            let child = child_py.borrow(py);
+            let is_module = child.kind == "module";
+            let child_fqname = if is_module {
+                Some(child.fqname.clone())
+            } else {
+                None
+            };
+            drop(child);
+            out.push(child_idx);
+            if let Some(fqn) = child_fqname {
+                queue.push_back(fqn);
+            }
+        }
+    }
+    out
+}
+
+/// Shared bulk-resolution loop used by
+/// :meth:`ProjectContext::module_surfaces` and
+/// :meth:`module_surfaces_indices`: dedupe the input fqnames, seed
+/// each requested bucket with its module idx (if any), then sweep
+/// ``module_by_fqname`` + ``decl_by_fqname`` once and drop matches
+/// into every bucket whose prefix lights up.
+fn module_surfaces_indices_in(
+    outputs: &BuildOutputs,
+    module_fqns: &[String],
+) -> FxHashMap<String, Vec<usize>> {
+    let mut buckets: FxHashMap<String, Vec<usize>> =
+        FxHashMap::with_capacity_and_hasher(module_fqns.len(), Default::default());
+    let mut prefixes: Vec<(String, String)> = Vec::with_capacity(module_fqns.len());
+    for fqn in module_fqns {
+        if buckets.contains_key(fqn) {
+            continue;
+        }
+        let Some(&module_idx) = outputs.module_by_fqname.get(fqn) else {
+            buckets.insert(fqn.clone(), Vec::new());
+            continue;
+        };
+        buckets.insert(fqn.clone(), vec![module_idx]);
+        prefixes.push((fqn.clone(), format!("{fqn}.")));
+    }
+    if prefixes.is_empty() {
+        return buckets;
+    }
+    // Single sweep — K small (≤ inputs), so the nested ``starts_with``
+    // is fine. Mirrors the original ``module_surfaces`` body, just
+    // staying in idx-space.
+    for (fqname, &idx) in &outputs.module_by_fqname {
+        for (key, prefix) in &prefixes {
+            if fqname.starts_with(prefix) {
+                buckets.get_mut(key).expect("seeded above").push(idx);
+            }
+        }
+    }
+    for (fqname, idxs) in &outputs.decl_by_fqname {
+        for (key, prefix) in &prefixes {
+            if fqname.starts_with(prefix) {
+                let bucket = buckets.get_mut(key).expect("seeded above");
+                bucket.extend(idxs.iter().copied());
+            }
+        }
+    }
+    buckets
+}
+
+/// `path -> module-node idx`, shared by :meth:`ProjectContext::module_for`,
+/// :meth:`module_for_indices`, and :meth:`modules_for_paths`. Returns
+/// ``None`` when the path doesn't name a project module.
+fn module_for_idx_in(outputs: &BuildOutputs, path: &str) -> Option<usize> {
+    let &file = outputs.path_to_file.get(path)?;
+    outputs.module_nodes_by_file.get(&file).copied()
+}
+
+/// Walk-back lookup shared by :meth:`ProjectContext::find_declarations`
+/// and :meth:`ProjectContext::find_declarations_indices` — try an exact
+/// match first, then strip trailing dotted segments until either a
+/// decl bucket lands or no parent remains.
+fn find_declarations_indices_in(outputs: &BuildOutputs, fqname: &str) -> Vec<usize> {
+    let mut prefix = fqname;
+    loop {
+        if let Some(idxs) = outputs.decl_by_fqname.get(prefix) {
+            return idxs.clone();
+        }
+        match prefix.rsplit_once('.') {
+            Some((parent, _)) => prefix = parent,
+            None => return Vec::new(),
+        }
+    }
+}
+
 /// BFS from `seed_idx` through `children_by_node`. Returns the
 /// transitive closure (excluding the seed itself).
 fn transitive_subclasses_via_index(
@@ -3152,7 +3231,7 @@ impl ProjectContext {
         py: Python<'_>,
         decorator_fqn: &str,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, CallArgs)>> {
+    ) -> PyResult<Vec<(usize, CallArgs)>> {
         let Some((module, name)) = decorator_fqn.rsplit_once('.') else {
             return Err(PyValueError::new_err(format!(
                 "expected a dotted decorator fqn (e.g. 'pytest.fixture'), got {decorator_fqn:?}"
@@ -3169,7 +3248,7 @@ impl ProjectContext {
         class_fqn: &str,
         include_subclasses: bool,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, CallArgs)>> {
+    ) -> PyResult<Vec<(usize, CallArgs)>> {
         let Some((module, name)) = class_fqn.rsplit_once('.') else {
             return Err(PyValueError::new_err(format!(
                 "expected a dotted class fqn, got {class_fqn:?}"
@@ -3194,7 +3273,7 @@ impl ProjectContext {
         let triples = self.find_instance_constructions(py, &modules, ctors, path_regex)?;
         Ok(triples
             .into_iter()
-            .map(|(node, _name, call_args)| (node, call_args))
+            .map(|(idx, _name, call_args)| (idx, call_args))
             .collect())
     }
 
@@ -3205,18 +3284,19 @@ impl ProjectContext {
         instance: &SymbolNode,
         method_names: Vec<String>,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, CallArgs)>> {
+    ) -> PyResult<Vec<(usize, CallArgs)>> {
         let instance_simple = instance.fqname.rsplit('.').next().unwrap_or("").to_string();
         let handlers = self.find_handler_decorators(py, method_names, path_regex)?;
-        let mut out = Vec::new();
-        for (owner_name, handler, call_args) in handlers {
+        let outputs = self.materialized("find_decorations_on")?;
+        let mut out: Vec<(usize, CallArgs)> = Vec::new();
+        for (owner_name, handler_idx, call_args) in handlers {
             if owner_name != instance_simple {
                 continue;
             }
-            if handler.borrow(py).path != instance.path {
+            if outputs.builder.nodes[handler_idx].borrow(py).path != instance.path {
                 continue;
             }
-            out.push((handler, call_args));
+            out.push((handler_idx, call_args));
         }
         Ok(out)
     }
@@ -3744,6 +3824,38 @@ impl ProjectContext {
                 )));
             }
             out.push(outputs.builder.nodes[idx].clone_ref(py));
+        }
+        Ok(out)
+    }
+
+    /// Batched snapshot of ``(kind, path, fqname, flags)`` for each
+    /// index in ``indices``. One FFI hop instead of N per-attribute
+    /// ``borrow`` round-trips — lets plugins that filter / partition by
+    /// these four fields stay GIL-free in the inner loop.
+    ///
+    /// Validates bounds the same way :meth:`nodes_at` does and raises
+    /// :class:`IndexError` when any index is out of range.
+    pub(crate) fn node_attrs(
+        &self,
+        py: Python<'_>,
+        indices: Vec<usize>,
+    ) -> PyResult<Vec<(String, String, String, u32)>> {
+        let outputs = self.materialized("node_attrs")?;
+        let len = outputs.builder.nodes.len();
+        let mut out: Vec<(String, String, String, u32)> = Vec::with_capacity(indices.len());
+        for idx in indices {
+            if idx >= len {
+                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                    "node index {idx} out of range (len={len})"
+                )));
+            }
+            let node = outputs.builder.nodes[idx].borrow(py);
+            out.push((
+                node.kind.to_string(),
+                node.path.clone(),
+                node.fqname.clone(),
+                node.flags,
+            ));
         }
         Ok(out)
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -105,6 +105,58 @@ impl CallRef {
 }
 
 // ---------------------------------------------------------------------------
+// Index-form result rows
+//
+// Lean siblings of the ref types: same dispatch, but every
+// ``SymbolNode`` field is replaced with a positional index into
+// ``ctx.nodes()`` and the costly ``args`` / ``kwargs`` row payloads
+// are dropped. Returned by the ``.row_indices()`` terminals on
+// :class:`DecoratorQuery` / :class:`ConstructionQuery` /
+// :class:`CallQuery` / :class:`FactoryQuery`. Pair with
+// :meth:`ProjectContext.node_attrs` to batch-fetch any
+// ``(kind, path, fqname, flags)`` the plugin still needs without
+// per-row ``borrow`` ping-pong.
+// ---------------------------------------------------------------------------
+
+/// Index-form sibling of :class:`DecoratorRef`. Same metadata fields,
+/// minus ``args`` / ``kwargs``; ``decorated_idx`` indexes into
+/// ``ctx.nodes()``.
+#[pyclass(frozen, get_all)]
+pub(crate) struct DecoratorIdxRef {
+    pub(crate) decorated_idx: usize,
+    pub(crate) decorator_name: Option<String>,
+    pub(crate) decorator_owner: Option<String>,
+    pub(crate) decorator_via: Option<String>,
+}
+
+/// Index-form sibling of :class:`ConstructionRef`. Same metadata
+/// fields, minus ``args`` / ``kwargs``; ``var_idx`` indexes into
+/// ``ctx.nodes()``.
+#[pyclass(frozen, get_all)]
+pub(crate) struct ConstructionIdxRef {
+    pub(crate) var_idx: usize,
+    pub(crate) class_name: String,
+}
+
+/// Index-form sibling of :class:`CallRef`. Same metadata fields,
+/// minus ``args`` / ``kwargs``; ``owner_idx`` indexes into
+/// ``ctx.nodes()``.
+#[pyclass(frozen, get_all)]
+pub(crate) struct CallIdxRef {
+    pub(crate) owner_idx: usize,
+    pub(crate) string_arg: String,
+}
+
+/// Index-form sibling of :class:`FactoryRef`. ``decl_idx`` indexes
+/// into ``ctx.nodes()``; ``kinds`` is the same sorted set of matched
+/// constructor bare-names the node-returning terminal emits.
+#[pyclass(frozen, get_all)]
+pub(crate) struct FactoryIdxRef {
+    pub(crate) decl_idx: usize,
+    pub(crate) kinds: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
 // Builder query API: builders
 // ---------------------------------------------------------------------------
 
@@ -491,38 +543,71 @@ impl DecoratorQuery {
     }
 
     fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<DecoratorRef>>> {
+        let rows = self.decorator_rows(py)?;
         let ctx = self.ctx.borrow(py);
-        let path_regex = self.path_regex.as_deref();
-        let mut refs: Vec<Py<DecoratorRef>> = Vec::new();
-        // Cache a snapshot of the build's node pool for arg materialization.
-        // Keep the borrow alive for the duration of the loop so we don't
-        // reborrow on every iteration.
         let outputs = ctx.materialized("DecoratorQuery.collect")?;
         let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let mut refs: Vec<Py<DecoratorRef>> = Vec::with_capacity(rows.len());
+        for row in rows {
+            let args = args_to_py_vec(py, &row.call_args.args, nodes);
+            let kwargs = kwargs_to_py_map(py, &row.call_args.kwargs, nodes);
+            refs.push(Py::new(
+                py,
+                DecoratorRef {
+                    decorated: nodes[row.decorated_idx].clone_ref(py),
+                    decorator_name: row.decorator_name,
+                    decorator_owner: row.decorator_owner,
+                    decorator_via: row.decorator_via,
+                    args,
+                    kwargs,
+                },
+            )?);
+        }
+        Ok(refs)
+    }
+}
+
+/// Idx-form intermediate produced by :meth:`DecoratorQuery::decorator_rows`.
+/// Carries the same metadata as :class:`DecoratorRef` minus the
+/// ``Py<SymbolNode>`` allocation — the node identity is just an index
+/// into ``ctx.nodes()``. ``call_args`` is kept so kwarg filtering and
+/// ``collect()``'s ``args`` / ``kwargs`` materialization can both share
+/// the same upstream.
+struct DecoratorRowIdx {
+    decorated_idx: usize,
+    decorator_name: Option<String>,
+    decorator_owner: Option<String>,
+    decorator_via: Option<String>,
+    call_args: crate::helpers::CallArgs,
+}
+
+impl DecoratorQuery {
+    /// Shared dispatch used by both terminals (:meth:`collect` and
+    /// :meth:`row_indices`). Stays in idx-space throughout so
+    /// ``row_indices`` can skip the ``Py<SymbolNode>`` and
+    /// ``args_to_py_vec`` allocations entirely.
+    fn decorator_rows(&self, py: Python<'_>) -> PyResult<Vec<DecoratorRowIdx>> {
+        let ctx = self.ctx.borrow(py);
+        let path_regex = self.path_regex.as_deref();
         let kwarg_matchers = &self.kwarg_matchers;
+        let mut out: Vec<DecoratorRowIdx> = Vec::new();
         if let Some(owner_attrs) = &self.owner_attrs {
             let triples = if let Some(via) = &self.via_attr {
                 ctx.find_handler_decorators_via(py, via, owner_attrs.clone(), path_regex)?
             } else {
                 ctx.find_handler_decorators(py, owner_attrs.clone(), path_regex)?
             };
-            for (owner_name, decorated, call_args) in triples {
+            for (owner_name, decorated_idx, call_args) in triples {
                 if !call_args_match_kwargs(&call_args, kwarg_matchers) {
                     continue;
                 }
-                let args = args_to_py_vec(py, &call_args.args, nodes);
-                let kwargs = kwargs_to_py_map(py, &call_args.kwargs, nodes);
-                refs.push(Py::new(
-                    py,
-                    DecoratorRef {
-                        decorated,
-                        decorator_name: None,
-                        decorator_owner: Some(owner_name),
-                        decorator_via: self.via_attr.clone(),
-                        args,
-                        kwargs,
-                    },
-                )?);
+                out.push(DecoratorRowIdx {
+                    decorated_idx,
+                    decorator_name: None,
+                    decorator_owner: Some(owner_name),
+                    decorator_via: self.via_attr.clone(),
+                    call_args,
+                });
             }
         } else if let Some(in_decl_node) = &self.in_decl {
             let names = self.names.as_ref().ok_or_else(|| {
@@ -537,63 +622,45 @@ impl DecoratorQuery {
                 .unwrap_or("")
                 .to_string();
             drop(in_decl_ref);
-            for (d, call_args) in decls {
+            for (decorated_idx, call_args) in decls {
                 if !call_args_match_kwargs(&call_args, kwarg_matchers) {
                     continue;
                 }
-                let args = args_to_py_vec(py, &call_args.args, nodes);
-                let kwargs = kwargs_to_py_map(py, &call_args.kwargs, nodes);
-                refs.push(Py::new(
-                    py,
-                    DecoratorRef {
-                        decorated: d,
-                        decorator_name: None,
-                        decorator_owner: Some(owner_simple.clone()),
-                        decorator_via: None,
-                        args,
-                        kwargs,
-                    },
-                )?);
+                out.push(DecoratorRowIdx {
+                    decorated_idx,
+                    decorator_name: None,
+                    decorator_owner: Some(owner_simple.clone()),
+                    decorator_via: None,
+                    call_args,
+                });
             }
         } else if let Some(fqn) = &self.callee_fqn {
             let decls = ctx.find_decorated(py, fqn, path_regex)?;
-            for (d, call_args) in decls {
+            for (decorated_idx, call_args) in decls {
                 if !call_args_match_kwargs(&call_args, kwarg_matchers) {
                     continue;
                 }
-                let args = args_to_py_vec(py, &call_args.args, nodes);
-                let kwargs = kwargs_to_py_map(py, &call_args.kwargs, nodes);
-                refs.push(Py::new(
-                    py,
-                    DecoratorRef {
-                        decorated: d,
-                        decorator_name: None,
-                        decorator_owner: None,
-                        decorator_via: None,
-                        args,
-                        kwargs,
-                    },
-                )?);
+                out.push(DecoratorRowIdx {
+                    decorated_idx,
+                    decorator_name: None,
+                    decorator_owner: None,
+                    decorator_via: None,
+                    call_args,
+                });
             }
         } else if let (Some(modules), Some(names)) = (&self.modules, &self.names) {
             let decls = ctx.find_decorated_decls(py, modules, names.clone(), path_regex)?;
-            for (d, call_args) in decls {
+            for (decorated_idx, call_args) in decls {
                 if !call_args_match_kwargs(&call_args, kwarg_matchers) {
                     continue;
                 }
-                let args = args_to_py_vec(py, &call_args.args, nodes);
-                let kwargs = kwargs_to_py_map(py, &call_args.kwargs, nodes);
-                refs.push(Py::new(
-                    py,
-                    DecoratorRef {
-                        decorated: d,
-                        decorator_name: None,
-                        decorator_owner: None,
-                        decorator_via: None,
-                        args,
-                        kwargs,
-                    },
-                )?);
+                out.push(DecoratorRowIdx {
+                    decorated_idx,
+                    decorator_name: None,
+                    decorator_owner: None,
+                    decorator_via: None,
+                    call_args,
+                });
             }
         } else {
             return Err(PyValueError::new_err(
@@ -602,11 +669,37 @@ impl DecoratorQuery {
                  where_owner_attr_via(via, attrs); or in_decl(node) + where_name(...)",
             ));
         }
-        Ok(refs)
+        Ok(out)
     }
 }
 
 impl_query_methods!(with_first DecoratorQuery, DecoratorRef);
+
+#[pymethods]
+impl DecoratorQuery {
+    /// Index-form row terminal. Same dispatch as :meth:`collect`, but
+    /// each row carries ``decorated_idx`` (a positional index into
+    /// ``ctx.nodes()``) instead of a ``Py<SymbolNode>``, and the
+    /// ``args`` / ``kwargs`` row payloads are skipped. Pairs with
+    /// :meth:`ProjectContext.node_attrs` and :class:`AddEdgeByIdx` /
+    /// :class:`AddNodeByIdx` to stay GIL-light end-to-end.
+    fn row_indices(&self, py: Python<'_>) -> PyResult<Vec<Py<DecoratorIdxRef>>> {
+        let rows = self.decorator_rows(py)?;
+        rows.into_iter()
+            .map(|row| {
+                Py::new(
+                    py,
+                    DecoratorIdxRef {
+                        decorated_idx: row.decorated_idx,
+                        decorator_name: row.decorator_name,
+                        decorator_owner: row.decorator_owner,
+                        decorator_via: row.decorator_via,
+                    },
+                )
+            })
+            .collect()
+    }
+}
 
 /// Find module-scope ``<var> = <Ctor>(...)`` sites. Pick exactly one
 /// of ``where_module + where_name`` or
@@ -672,42 +765,61 @@ impl ConstructionQuery {
     }
 
     fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<ConstructionRef>>> {
+        let rows = self.construction_rows(py)?;
         let ctx = self.ctx.borrow(py);
-        let path_regex = self.path_regex.as_deref();
-        let mut refs: Vec<Py<ConstructionRef>> = Vec::new();
         let outputs = ctx.materialized("ConstructionQuery.collect")?;
         let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let mut refs: Vec<Py<ConstructionRef>> = Vec::with_capacity(rows.len());
+        for row in rows {
+            let args = args_to_py_vec(py, &row.call_args.args, nodes);
+            let kwargs = kwargs_to_py_map(py, &row.call_args.kwargs, nodes);
+            refs.push(Py::new(
+                py,
+                ConstructionRef {
+                    var: nodes[row.var_idx].clone_ref(py),
+                    class_name: row.class_name,
+                    args,
+                    kwargs,
+                },
+            )?);
+        }
+        Ok(refs)
+    }
+}
+
+/// Idx-form intermediate produced by :meth:`ConstructionQuery::construction_rows`.
+struct ConstructionRowIdx {
+    var_idx: usize,
+    class_name: String,
+    call_args: crate::helpers::CallArgs,
+}
+
+impl ConstructionQuery {
+    /// Shared dispatch used by both terminals (:meth:`collect` and
+    /// :meth:`row_indices`). Stays in idx-space throughout.
+    fn construction_rows(&self, py: Python<'_>) -> PyResult<Vec<ConstructionRowIdx>> {
+        let ctx = self.ctx.borrow(py);
+        let path_regex = self.path_regex.as_deref();
+        let mut out: Vec<ConstructionRowIdx> = Vec::new();
         if let Some(fqn) = &self.class_fqn {
             let pairs = ctx.find_constructions(py, fqn, self.include_subclasses, path_regex)?;
             let cls_name = fqn.rsplit('.').next().unwrap_or("").to_string();
-            for (d, call_args) in pairs {
-                let args = args_to_py_vec(py, &call_args.args, nodes);
-                let kwargs = kwargs_to_py_map(py, &call_args.kwargs, nodes);
-                refs.push(Py::new(
-                    py,
-                    ConstructionRef {
-                        var: d,
-                        class_name: cls_name.clone(),
-                        args,
-                        kwargs,
-                    },
-                )?);
+            for (var_idx, call_args) in pairs {
+                out.push(ConstructionRowIdx {
+                    var_idx,
+                    class_name: cls_name.clone(),
+                    call_args,
+                });
             }
         } else if let (Some(modules), Some(names)) = (&self.modules, &self.names) {
             let triples =
                 ctx.find_instance_constructions(py, modules, names.clone(), path_regex)?;
-            for (var, name, call_args) in triples {
-                let args = args_to_py_vec(py, &call_args.args, nodes);
-                let kwargs = kwargs_to_py_map(py, &call_args.kwargs, nodes);
-                refs.push(Py::new(
-                    py,
-                    ConstructionRef {
-                        var,
-                        class_name: name,
-                        args,
-                        kwargs,
-                    },
-                )?);
+            for (var_idx, name, call_args) in triples {
+                out.push(ConstructionRowIdx {
+                    var_idx,
+                    class_name: name,
+                    call_args,
+                });
             }
         } else {
             return Err(PyValueError::new_err(
@@ -715,11 +827,33 @@ impl ConstructionQuery {
                  or where_module(...) + where_name(...)",
             ));
         }
-        Ok(refs)
+        Ok(out)
     }
 }
 
 impl_query_methods!(with_first ConstructionQuery, ConstructionRef);
+
+#[pymethods]
+impl ConstructionQuery {
+    /// Index-form row terminal. Same dispatch as :meth:`collect`, but
+    /// each row carries ``var_idx`` (a positional index into
+    /// ``ctx.nodes()``) instead of a ``Py<SymbolNode>``, and the
+    /// ``args`` / ``kwargs`` row payloads are skipped.
+    fn row_indices(&self, py: Python<'_>) -> PyResult<Vec<Py<ConstructionIdxRef>>> {
+        let rows = self.construction_rows(py)?;
+        rows.into_iter()
+            .map(|row| {
+                Py::new(
+                    py,
+                    ConstructionIdxRef {
+                        var_idx: row.var_idx,
+                        class_name: row.class_name,
+                    },
+                )
+            })
+            .collect()
+    }
+}
 
 /// Find call sites whose positional string-literal at the configured
 /// index is captured. :meth:`string_arg_at` is required. Pick one of:
@@ -815,6 +949,39 @@ impl CallQuery {
     }
 
     fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<CallRef>>> {
+        let rows = self.call_rows(py)?;
+        let ctx = self.ctx.borrow(py);
+        let outputs = ctx.materialized("CallQuery.collect")?;
+        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let mut refs: Vec<Py<CallRef>> = Vec::with_capacity(rows.len());
+        for row in rows {
+            let args = args_to_py_vec(py, &row.call_args.args, nodes);
+            let kwargs = kwargs_to_py_map(py, &row.call_args.kwargs, nodes);
+            refs.push(Py::new(
+                py,
+                CallRef {
+                    owner: nodes[row.owner_idx].clone_ref(py),
+                    string_arg: row.string_arg,
+                    args,
+                    kwargs,
+                },
+            )?);
+        }
+        Ok(refs)
+    }
+}
+
+/// Idx-form intermediate produced by :meth:`CallQuery::call_rows`.
+struct CallRowIdx {
+    owner_idx: usize,
+    string_arg: String,
+    call_args: crate::helpers::CallArgs,
+}
+
+impl CallQuery {
+    /// Shared dispatch used by both terminals (:meth:`collect` and
+    /// :meth:`row_indices`). Stays in idx-space throughout.
+    fn call_rows(&self, py: Python<'_>) -> PyResult<Vec<CallRowIdx>> {
         let ctx = self.ctx.borrow(py);
         let arg_index = self
             .arg_index
@@ -839,31 +1006,47 @@ impl CallQuery {
                  where_owner(...) + where_attr(...); or where_attr(...)",
             ));
         };
-        let outputs = ctx.materialized("CallQuery.collect")?;
-        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
         let kwarg_matchers = &self.kwarg_matchers;
-        let mut refs: Vec<Py<CallRef>> = Vec::new();
-        for (owner_node, s, call_args) in triples {
+        let mut out: Vec<CallRowIdx> = Vec::new();
+        for (owner_idx, string_arg, call_args) in triples {
             if !call_args_match_kwargs(&call_args, kwarg_matchers) {
                 continue;
             }
-            let args = args_to_py_vec(py, &call_args.args, nodes);
-            let kwargs = kwargs_to_py_map(py, &call_args.kwargs, nodes);
-            refs.push(Py::new(
-                py,
-                CallRef {
-                    owner: owner_node,
-                    string_arg: s,
-                    args,
-                    kwargs,
-                },
-            )?);
+            out.push(CallRowIdx {
+                owner_idx,
+                string_arg,
+                call_args,
+            });
         }
-        Ok(refs)
+        Ok(out)
     }
 }
 
 impl_query_methods!(with_first CallQuery, CallRef);
+
+#[pymethods]
+impl CallQuery {
+    /// Index-form row terminal. Same dispatch as :meth:`collect`, but
+    /// each row carries ``owner_idx`` (a positional index into
+    /// ``ctx.nodes()``) instead of a ``Py<SymbolNode>``, and the
+    /// ``args`` / ``kwargs`` row payloads are skipped. ``string_arg``
+    /// — the literal at the configured positional index — is preserved
+    /// because most call-shape plugins key on it.
+    fn row_indices(&self, py: Python<'_>) -> PyResult<Vec<Py<CallIdxRef>>> {
+        let rows = self.call_rows(py)?;
+        rows.into_iter()
+            .map(|row| {
+                Py::new(
+                    py,
+                    CallIdxRef {
+                        owner_idx: row.owner_idx,
+                        string_arg: row.string_arg,
+                    },
+                )
+            })
+            .collect()
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Subclass / Import / Class / Factory queries
@@ -1105,6 +1288,29 @@ impl FactoryQuery {
         Ok(slf)
     }
     fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<FactoryRef>>> {
+        let pairs = self.factory_rows(py)?;
+        let ctx = self.ctx.borrow(py);
+        let outputs = ctx.materialized("FactoryQuery.collect")?;
+        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        pairs
+            .into_iter()
+            .map(|(decl_idx, kinds)| {
+                Py::new(
+                    py,
+                    FactoryRef {
+                        decl: nodes[decl_idx].clone_ref(py),
+                        kinds,
+                    },
+                )
+            })
+            .collect()
+    }
+}
+
+impl FactoryQuery {
+    /// Shared dispatch used by both terminals (:meth:`collect` and
+    /// :meth:`row_indices`). Stays in idx-space throughout.
+    fn factory_rows(&self, py: Python<'_>) -> PyResult<Vec<(usize, Vec<String>)>> {
         let ctx = self.ctx.borrow(py);
         let modules = self
             .modules
@@ -1114,15 +1320,27 @@ impl FactoryQuery {
             .names
             .clone()
             .ok_or_else(|| PyValueError::new_err("FactoryQuery requires .where_name(...)"))?;
-        let pairs = ctx.find_factory_decls(py, modules, names)?;
-        pairs
-            .into_iter()
-            .map(|(decl, kinds)| Py::new(py, FactoryRef { decl, kinds }))
-            .collect()
+        ctx.find_factory_decls(py, modules, names)
     }
 }
 
 impl_query_methods!(no_first FactoryQuery);
+
+#[pymethods]
+impl FactoryQuery {
+    /// Index-form row terminal. Same dispatch as :meth:`collect`;
+    /// each row carries ``decl_idx`` (a positional index into
+    /// ``ctx.nodes()``) instead of a ``Py<SymbolNode>``. ``kinds`` is
+    /// the same sorted set of matched constructor bare-names the
+    /// node-returning terminal emits.
+    fn row_indices(&self, py: Python<'_>) -> PyResult<Vec<Py<FactoryIdxRef>>> {
+        let pairs = self.factory_rows(py)?;
+        pairs
+            .into_iter()
+            .map(|(decl_idx, kinds)| Py::new(py, FactoryIdxRef { decl_idx, kinds }))
+            .collect()
+    }
+}
 
 // ---------------------------------------------------------------------------
 // EdgeQuery — filtered enumeration over the in-progress graph's edges

--- a/tests/test_query_indices.py
+++ b/tests/test_query_indices.py
@@ -292,3 +292,403 @@ def test_add_edge_by_idx_carries_flags(tmp_path):
         if s == f_idx and d == g_idx and f == native.EdgeFlags.DEAD_BRANCH
     ]
     assert matching
+
+
+# ---------------------------------------------------------------------------
+# AddNodeByIdx — graph op
+# ---------------------------------------------------------------------------
+
+
+def test_add_node_by_idx_round_trip(tmp_path):
+    """``AddNodeByIdx`` mints a synthetic node and wires its edges from
+    positional indices, the same way ``AddNode`` does with
+    ``SymbolNode`` endpoints."""
+    from dead_cst.analyze import Analysis
+    from dead_cst.plugins._base import Plugin
+
+    (tmp_path / "mod.py").write_text("def f(): pass\ndef g(): pass\n")
+
+    class MintByIdx(Plugin):
+        name = "mint_by_idx"
+        version = 1
+
+        def run(self, ctx: native.ProjectContext):
+            f_idx = ctx.indices_where(fqname_prefix="mod.f")[0]
+            g_idx = ctx.indices_where(fqname_prefix="mod.g")[0]
+            yield native.AddNodeByIdx(
+                "<marker>:mint",
+                path="mod.py",
+                edges_from_idx=[f_idx],
+                edges_to_idx=[g_idx],
+            )
+
+    analysis = Analysis(tmp_path, plugins=[MintByIdx()])
+    ctx = analysis.materialize_all()
+    fqnames = [n.fqname for n in ctx.nodes()]
+    assert "<marker>:mint" in fqnames
+
+    marker_idx = fqnames.index("<marker>:mint")
+    f_idx = fqnames.index("mod.f")
+    g_idx = fqnames.index("mod.g")
+    edges = [(s, d) for (s, d, _f) in ctx.edges()]
+    assert (f_idx, marker_idx) in edges
+    assert (marker_idx, g_idx) in edges
+
+
+def test_add_node_by_idx_entrypoint_flag(tmp_path):
+    """``AddNodeByIdx`` honors ``NodeFlags.ENTRYPOINT`` so a multi-target
+    marker (the idiomatic non-sugar reason to prefer it over
+    ``AddEntrypoint``) makes its targets reachable."""
+    from dead_cst.analyze import Analysis
+    from dead_cst.plugins._base import Plugin
+
+    (tmp_path / "mod.py").write_text(
+        "def alive(): pass\ndef also_alive(): pass\ndef dead(): pass\n"
+    )
+
+    class SeedBoth(Plugin):
+        name = "seed_both"
+        version = 1
+
+        def run(self, ctx: native.ProjectContext):
+            a = ctx.indices_where(fqname_prefix="mod.alive")[0]
+            b = ctx.indices_where(fqname_prefix="mod.also_alive")[0]
+            yield native.AddNodeByIdx(
+                "<seed>:multi",
+                path="mod.py",
+                flags=native.NodeFlags.ENTRYPOINT,
+                edges_to_idx=[a, b],
+            )
+
+    analysis = Analysis(tmp_path, plugins=[SeedBoth()])
+    analysis.materialize_all()
+    dead_fqnames = {n.fqname for n in analysis.dead()}
+    assert "mod.alive" not in dead_fqnames
+    assert "mod.also_alive" not in dead_fqnames
+    assert "mod.dead" in dead_fqnames
+
+
+def test_add_node_by_idx_out_of_range_raises(tmp_path):
+    """An out-of-range ``edges_*_idx`` raises ``IndexError`` at apply
+    time and does *not* leave an orphan synthetic node behind."""
+    from dead_cst.analyze import Analysis
+    from dead_cst.plugins._base import Plugin
+
+    (tmp_path / "mod.py").write_text("def f(): pass\n")
+
+    class BadIdx(Plugin):
+        name = "bad_idx"
+        version = 1
+
+        def run(self, ctx: native.ProjectContext):
+            yield native.AddNodeByIdx(
+                "<should-not-land>",
+                path="mod.py",
+                edges_to_idx=[10**9],
+            )
+
+    analysis = Analysis(tmp_path, plugins=[BadIdx()])
+    with pytest.raises(IndexError, match="edges_to_idx"):
+        analysis.materialize_all()
+
+
+def test_add_node_by_idx_default_no_edges(tmp_path):
+    """A bare ``AddNodeByIdx(fqname, path=...)`` with no edges mints a
+    standalone synthetic node — same defaults as ``AddNode``."""
+    from dead_cst.analyze import Analysis
+    from dead_cst.plugins._base import Plugin
+
+    (tmp_path / "mod.py").write_text("x = 1\n")
+
+    class JustMint(Plugin):
+        name = "just_mint"
+        version = 1
+
+        def run(self, ctx: native.ProjectContext):
+            yield native.AddNodeByIdx("<bare>:marker", path="mod.py")
+
+    analysis = Analysis(tmp_path, plugins=[JustMint()])
+    ctx = analysis.materialize_all()
+    fqnames = [n.fqname for n in ctx.nodes()]
+    assert "<bare>:marker" in fqnames
+
+
+# ---------------------------------------------------------------------------
+# ctx.find_declarations_indices
+# ---------------------------------------------------------------------------
+
+
+def test_find_declarations_indices_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def handler(): pass\nclass Service: pass\n",
+        }
+    )
+    nodes = ctx.find_declarations("pkg.svc.handler")
+    indices = ctx.find_declarations_indices("pkg.svc.handler")
+    assert len(nodes) == len(indices) == 1
+    all_nodes = ctx.nodes()
+    assert all_nodes[indices[0]].fqname == nodes[0].fqname
+
+
+def test_find_declarations_indices_walks_back(build_decl_graph):
+    """``pkg.svc.Cls.method`` resolves to ``pkg.svc.Cls`` — methods don't
+    get their own graph node."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "class Cls:\n    def method(self): pass\n",
+        }
+    )
+    indices = ctx.find_declarations_indices("pkg.svc.Cls.method")
+    revived = ctx.nodes_at(indices)
+    assert {n.fqname for n in revived} == {"pkg.svc.Cls"}
+
+
+def test_find_declarations_indices_unknown_returns_empty(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    assert ctx.find_declarations_indices("nothing.here") == []
+
+
+# ---------------------------------------------------------------------------
+# ctx.module_for_indices + modules_for_paths
+# ---------------------------------------------------------------------------
+
+
+def test_module_for_indices_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def f(): pass\n",
+        }
+    )
+    # ``module_for`` keys on the absolute path stored on the SymbolNode.
+    svc_path = next(n.path for n in ctx.nodes() if n.fqname == "pkg.svc")
+    node = ctx.module_for(svc_path)
+    assert node is not None
+    idx = ctx.module_for_indices(svc_path)
+    assert idx is not None
+    assert ctx.nodes()[idx].fqname == node.fqname
+
+
+def test_module_for_indices_missing_path(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    assert ctx.module_for_indices("/not/a/real/path.py") is None
+
+
+def test_modules_for_paths_bulk(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def f(): pass\n",
+            "pkg/util.py": "def g(): pass\n",
+        }
+    )
+    svc_path = next(n.path for n in ctx.nodes() if n.fqname == "pkg.svc")
+    util_path = next(n.path for n in ctx.nodes() if n.fqname == "pkg.util")
+    results = ctx.modules_for_paths([svc_path, util_path, "/missing.py"])
+    assert len(results) == 3
+    assert results[0] is not None
+    assert results[1] is not None
+    assert results[2] is None
+    all_nodes = ctx.nodes()
+    assert all_nodes[results[0]].fqname == "pkg.svc"
+    assert all_nodes[results[1]].fqname == "pkg.util"
+
+
+# ---------------------------------------------------------------------------
+# ctx.module_surface_indices + module_surfaces_indices
+# ---------------------------------------------------------------------------
+
+
+def test_module_surface_indices_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def handler(): pass\nclass Service: pass\n",
+            "pkg/sub/__init__.py": "",
+            "pkg/sub/inner.py": "def deep(): pass\n",
+        }
+    )
+    nodes = ctx.module_surface("pkg")
+    indices = ctx.module_surface_indices("pkg")
+    assert len(nodes) == len(indices)
+    assert {ctx.nodes()[i].fqname for i in indices} == {n.fqname for n in nodes}
+
+
+def test_module_surface_indices_unknown_returns_empty(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    assert ctx.module_surface_indices("nothing.here") == []
+
+
+def test_module_surfaces_indices_bulk(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def handler(): pass\n",
+            "pkg/util.py": "def helper(): pass\n",
+            "other/__init__.py": "",
+            "other/m.py": "def m(): pass\n",
+        }
+    )
+    node_buckets = ctx.module_surfaces(["pkg", "other", "missing"])
+    idx_buckets = ctx.module_surfaces_indices(["pkg", "other", "missing"])
+    assert set(node_buckets.keys()) == set(idx_buckets.keys())
+    for key in node_buckets:
+        node_fqs = {n.fqname for n in node_buckets[key]}
+        idx_fqs = {ctx.nodes()[i].fqname for i in idx_buckets[key]}
+        assert node_fqs == idx_fqs
+
+
+# ---------------------------------------------------------------------------
+# ctx.find_main_blocks_indices
+# ---------------------------------------------------------------------------
+
+
+def test_find_main_blocks_indices_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/m.py": (
+                'def helper(): pass\nif __name__ == "__main__":\n    helper()\n    x = 1\n'
+            ),
+        }
+    )
+    node_pairs = ctx.find_main_blocks()
+    idx_pairs = ctx.find_main_blocks_indices()
+    assert len(node_pairs) == len(idx_pairs) == 1
+    (mod_node, decls) = node_pairs[0]
+    (mod_idx, decl_idxs) = idx_pairs[0]
+    assert ctx.nodes()[mod_idx].fqname == mod_node.fqname
+    assert {ctx.nodes()[i].fqname for i in decl_idxs} == {d.fqname for d in decls}
+
+
+def test_find_main_blocks_indices_no_main_block(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    assert ctx.find_main_blocks_indices() == []
+
+
+# ---------------------------------------------------------------------------
+# ctx.node_attrs — batched node-field snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_node_attrs_round_trip(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "def alpha(): pass\nclass Beta: pass\n",
+        }
+    )
+    all_nodes = ctx.nodes()
+    indices = list(range(len(all_nodes)))
+    rows = ctx.node_attrs(indices)
+    assert len(rows) == len(indices)
+    for idx, (kind, path, fqname, flags) in zip(indices, rows, strict=True):
+        n = all_nodes[idx]
+        assert kind == n.kind
+        assert path == n.path
+        assert fqname == n.fqname
+        assert flags == n.flags
+
+
+def test_node_attrs_subset(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def alpha(): pass\n"})
+    indices = ctx.indices_where(kind="function", fqname_prefix="pkg.a")
+    assert len(indices) == 1
+    [(kind, path, fqname, _flags)] = ctx.node_attrs(indices)
+    assert kind == "function"
+    assert fqname == "pkg.a.alpha"
+    assert path.endswith("a.py")
+
+
+def test_node_attrs_bounds_check(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    n = len(ctx.nodes())
+    with pytest.raises(IndexError, match="out of range"):
+        ctx.node_attrs([n])
+
+
+# ---------------------------------------------------------------------------
+# *Query.row_indices — index-form row terminals
+# ---------------------------------------------------------------------------
+
+
+def test_decorator_query_row_indices_matches_collect(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": ("import functools\n@functools.lru_cache\ndef cached(): pass\n"),
+        }
+    )
+    q = native.query(ctx).decorators().where_module("functools").where_name("lru_cache")
+    refs = q.collect()
+    rows = q.row_indices()
+    assert len(refs) == len(rows) == 1
+    all_nodes = ctx.nodes()
+    for ref, row in zip(refs, rows, strict=True):
+        assert all_nodes[row.decorated_idx].fqname == ref.decorated.fqname
+        assert row.decorator_name == ref.decorator_name
+        assert row.decorator_owner == ref.decorator_owner
+        assert row.decorator_via == ref.decorator_via
+
+
+def test_construction_query_row_indices_matches_collect(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/app.py": "import flask\napp = flask.Flask(__name__)\n",
+        }
+    )
+    q = native.query(ctx).constructions().where_module("flask").where_name("Flask")
+    refs = q.collect()
+    rows = q.row_indices()
+    assert len(refs) == len(rows) == 1
+    all_nodes = ctx.nodes()
+    for ref, row in zip(refs, rows, strict=True):
+        assert all_nodes[row.var_idx].fqname == ref.var.fqname
+        assert row.class_name == ref.class_name
+
+
+def test_call_query_row_indices_matches_collect(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/app.py": (
+                'import flask\napp = flask.Flask(__name__)\napp.config.from_object("settings")\n'
+            ),
+        }
+    )
+    q = (
+        native.query(ctx)
+        .calls()
+        .where_owner("app.config")
+        .where_attr("from_object")
+        .string_arg_at(0)
+    )
+    refs = q.collect()
+    rows = q.row_indices()
+    assert len(refs) == len(rows)
+    if refs:
+        all_nodes = ctx.nodes()
+        for ref, row in zip(refs, rows, strict=True):
+            assert all_nodes[row.owner_idx].fqname == ref.owner.fqname
+            assert row.string_arg == ref.string_arg
+
+
+def test_factory_query_row_indices_matches_collect(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/factory.py": ("import flask\ndef make_app():\n    return flask.Flask(__name__)\n"),
+        }
+    )
+    q = native.query(ctx).factories().of_module("flask").where_name("Flask")
+    refs = q.collect()
+    rows = q.row_indices()
+    assert len(refs) == len(rows)
+    all_nodes = ctx.nodes()
+    for ref, row in zip(refs, rows, strict=True):
+        assert all_nodes[row.decl_idx].fqname == ref.decl.fqname
+        assert row.kinds == ref.kinds


### PR DESCRIPTION
## Summary

Builds out the idx-only surface plugins need to stay out of `Py<SymbolNode>` space — the precondition for the parallel-plugin pass to actually parallelise without GIL contention.

### New `ProjectContext` APIs

- `find_declarations_indices(fqname)` / `module_for_indices(path)` /
  `modules_for_paths(paths)`
- `module_surface_indices(fqn)` / `module_surfaces_indices(fqns)`
- `find_main_blocks_indices()` → `list[(module_idx, [decl_idx])]`
- `node_attrs(indices)` — batched `(kind, path, fqname, flags)` snapshot. One FFI hop instead of N per-attribute `borrow` round-trips.

### New ref-query terminals

`DecoratorQuery.row_indices()` / `ConstructionQuery.row_indices()` / `CallQuery.row_indices()` / `FactoryQuery.row_indices()` — each returns a new `*IdxRef` pyclass carrying a positional index into `ctx.nodes()` (`decorated_idx` / `var_idx` / `owner_idx` / `decl_idx`) instead of a `SymbolNode`, and skipping the `args` / `kwargs` payload work. Stays in idx-space end-to-end.

### New graph op

`AddNodeByIdx` — index-keyed sibling of `AddNode`. Bounds-checked at apply time *before* interning the synthetic, so a bad endpoint never strands an unconnected node.

### Internal refactor (no public Python API change)

The eight `ctx.find_*` helpers backing the ref queries (plus the three thin wrappers) now return `Vec<(usize, ..., CallArgs)>` instead of allocating `Py<SymbolNode>` themselves. The materialisation moved into each query's `.collect()` terminal; `.row_indices()` skips it entirely.

`AddNode`'s apply pass pre-resolves every endpoint key before minting the synthetic, matching the discipline `AddNodeByIdx` introduces. A missing key now surfaces as a clean `ValueError` instead of stranding an unconnected synthetic.

Shared helpers `wire_synthetic_edges` / `resolve_edge_keys` / `check_idx_in_range` / `check_idx_slice_in_range` factored out of the op-apply arms.

## Test plan

- [x] `uv run pytest` — 701 passed (existing 663 + 22 new + 16 from the merged QOL work).
- [x] `uv run prek run --all-files` — ruff, ruff-format, ty all green.
- [x] `cargo check` / `cargo clippy` clean.
- [ ] Reviewer spot-check the audit table in the conversation for missing idx APIs (`AddEntrypointByIdx`, `SubclassQuery.of_idx`, `find_subclasses_of_idx`) — leaving those for a follow-up; this PR is already large.

🤖 Generated with [Claude Code](https://claude.com/claude-code)