### PR TITLE
rust: idx-only plugin surface — APIs, AddNodeByIdx/AddEntrypointByIdx, plugin port, BatchDispatchAppPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,18 @@ two versions.
   instances and runs them with fused queries. Same observable output
   as registering every wrapped plugin individually, but the
   construction / factory / variable scans run once across the union
-  of all plugins' configs instead of once per plugin. Per-plugin
-  emission stays in `_emit_ops` (newly extracted), called once per
-  wrapped plugin against the shared row/var fetches.
+  of all plugins' configs instead of once per plugin.
+- `DispatchAppSpec` (frozen dataclass) + `DispatchAppGather`
+  (dataclass) split each plugin into a pure-data spec (what to
+  gather) and a `policy(ctx, gathered)` method (how to emit ops from
+  the gathered data). Subclasses customize behavior by overriding
+  `policy()`; the override is honored uniformly by both the
+  standalone `DispatchAppPlugin.run` path and the batched
+  `BatchDispatchAppPlugin.run` path (the previous batched design
+  invoked the standard emission and skipped subclass extensions).
+  `CeleryPlugin`'s `@shared_task` fan-out moved from a `run()`
+  override to a `policy()` override; it now fires correctly when
+  Celery is wrapped in a batch.
 - `AddEntrypointByIdx` graph op — index-keyed sibling of
   `AddEntrypoint`. Takes a positional index into `ctx.nodes()`; the
   apply pass reads the decl's `fqname` / `path` on the rust side to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,20 @@ two versions.
   than `Py<SymbolNode>` — keeps the idx surface honest end-to-end.
 
 ### Removed
+- `ctx.find_subclasses(fqn)` / `find_subclasses_indices` /
+  `find_subclasses_of(node)` / `find_subclasses_of_indices` /
+  `find_subclasses_of_idx(idx)` / `subclasses_of_fqn(fqn)` /
+  `subclasses_of_fqn_indices` / `subclasses_of_node` /
+  `find_classes_defining_method(name)` /
+  `find_classes_defining_method_indices` /
+  `find_imports_of(module)` / `find_imports_of_indices` /
+  `has_imports_of` / `imports_of_count`. All four cleanly duplicated
+  the DSL — plugin authors migrate to the chainable form:
+  `native.query(ctx).subclasses().of_fqn(fqn).indices()` /
+  `.of_idx(idx)` / `.of_node(node)`,
+  `native.query(ctx).classes().defining_method(name).indices()`,
+  `native.query(ctx).imports().of(module).indices()` /
+  `.count()` / `.exists()`.
 - The non-idx result types `DecoratorRef` / `ConstructionRef` /
   `CallRef` / `FactoryRef` and the `.row_indices()` terminal on the
   four ref queries. `.collect()` now returns the idx-form rows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ two versions.
 ## [Unreleased]
 
 ### Added
+- `AddEntrypointByIdx` graph op — index-keyed sibling of
+  `AddEntrypoint`. Takes a positional index into `ctx.nodes()`; the
+  apply pass reads the decl's `fqname` / `path` on the rust side to
+  mint the marker, so plugins working in idx-space don't pay a
+  `Py<SymbolNode>` allocation to flag a seed.
+- `SubclassQuery.of_idx(idx)` and `ctx.find_subclasses_of_idx(idx)`
+  — idx-keyed siblings of `of_node` / `find_subclasses_of`.
+- `DecoratorQuery.in_decl_idx(idx)` — idx-form sibling of `in_decl`.
+- `ctx.find_module_idx`, `ctx.find_module_dunders_indices`,
+  `ctx.find_nodes_matching_specs_indices`,
+  `ctx.subclasses_of_fqn_indices`, `ctx.direct_predecessors_idx` —
+  the missing idx-form siblings the bundled plugins needed.
 - Index-form siblings on `ProjectContext`: `find_declarations_indices`,
   `module_for_indices`, `modules_for_paths`, `module_surface_indices`,
   `module_surfaces_indices`, `find_main_blocks_indices`. Each returns
@@ -40,6 +52,13 @@ two versions.
   synthetic behind.
 
 ### Changed
+- Every bundled plugin (`plugins/*` and `contrib/*`) ported to the
+  index-form APIs — no plugin in the tree allocates or reads a
+  `Py<SymbolNode>` anymore. Plugins fan out through `row_indices()` /
+  `.indices()` terminals, batch attr fetches via `ctx.node_attrs`,
+  and yield `AddEdgeByIdx` / `AddNodeByIdx` / `AddEntrypointByIdx`
+  exclusively. The legacy node-returning APIs still work for
+  out-of-tree plugins.
 - `AddNode`'s apply pass now pre-resolves every `edges_from` /
   `edges_to` key to its builder index *before* minting the
   synthetic node, matching the discipline `AddNodeByIdx`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ two versions.
   `ctx.find_nodes_matching_specs_indices`,
   `ctx.subclasses_of_fqn_indices`, `ctx.direct_predecessors_idx` —
   the missing idx-form siblings the bundled plugins needed.
+- `ctx.resolve_idx`, `ctx.decls_under_indices`,
+  `ctx.decls_matching_indices`, `ctx.decls_matching_name_indices`,
+  `ctx.descendants_indices`, `ctx.ancestors_indices` — idx-form
+  siblings of the last six lookup / traversal helpers that still
+  allocated ``Py<SymbolNode>`` rows.
 - Index-form siblings on `ProjectContext`: `find_declarations_indices`,
   `module_for_indices`, `modules_for_paths`, `module_surface_indices`,
   `module_surfaces_indices`, `find_main_blocks_indices`. Each returns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,55 @@ two versions.
 
 ## [Unreleased]
 
+### Added
+- Index-form siblings on `ProjectContext`: `find_declarations_indices`,
+  `module_for_indices`, `modules_for_paths`, `module_surface_indices`,
+  `module_surfaces_indices`, `find_main_blocks_indices`. Each returns
+  positional indices into `ctx.nodes()` rather than allocating
+  `Py<SymbolNode>` clones — pair with `AddEdgeByIdx` / `AddNodeByIdx` to
+  stay in idx-space end-to-end.
+- `ProjectContext.node_attrs(indices)` — batched snapshot of
+  `(kind, path, fqname, flags)` per index. One FFI hop instead of N
+  per-attribute `borrow` round-trips. Plugins that filter / partition
+  by these four fields stay GIL-free in the inner loop, which matters
+  once the plugin pass runs concurrently.
+- `.row_indices()` terminal on `DecoratorQuery`, `ConstructionQuery`,
+  `CallQuery`, `FactoryQuery`. Same dispatch as `.collect()`, but each
+  row carries a positional index (`decorated_idx` / `var_idx` /
+  `owner_idx` / `decl_idx`) instead of a `SymbolNode`, and the
+  `args` / `kwargs` row payloads are skipped. Returned rows are new
+  pyclasses `DecoratorIdxRef`, `ConstructionIdxRef`, `CallIdxRef`,
+  `FactoryIdxRef`.
+- `AddNodeByIdx` graph op — index-keyed sibling of `AddNode`.
+  Wires the freshly-minted synthetic node with positional indices
+  into `ctx.nodes()` (`edges_from_idx`, `edges_to_idx`) instead of
+  `SymbolNode` references, so plugins working in index space
+  (paired with the `.indices()` query terminals or
+  `ctx.indices_where`) don't round-trip through `Py<SymbolNode>`
+  just to wire their markers. Bounds-checked at apply time; an
+  out-of-range index raises `IndexError` before the new node is
+  interned, so a bad endpoint never leaves an unconnected
+  synthetic behind.
+
+### Changed
+- `AddNode`'s apply pass now pre-resolves every `edges_from` /
+  `edges_to` key to its builder index *before* minting the
+  synthetic node, matching the discipline `AddNodeByIdx`
+  introduces. A missing key now surfaces as a clean `ValueError`
+  without leaving an orphan node in the graph (previously the
+  synthetic was interned first, then the failing key lookup
+  aborted, stranding the new node).
+- Internal: the `ctx.find_*` helpers backing the chainable query DSL
+  (`find_decorated_decls`, `find_instance_constructions`,
+  `find_handler_decorators`, `find_handler_decorators_via`,
+  `find_calls_to_imported`, `find_calls_on_var`, `find_calls_on_attr`,
+  `find_factory_decls`, plus the `find_decorated`,
+  `find_constructions`, `find_decorations_on` thin wrappers) now
+  return `(idx, …)` tuples instead of `(Py<SymbolNode>, …)`. The
+  `Py<SymbolNode>` materialization moved into the queries' `.collect()`
+  terminals — `.row_indices()` skips it entirely. No public Python API
+  change.
+
 ## [0.12.2] - 2026-05-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ two versions.
 ## [Unreleased]
 
 ### Added
+- Uniform terminal set on every Tier-1 query stream (`DeclQuery`,
+  `ModuleQuery`, `SubclassQuery`, `ImportQuery`, `ClassQuery`,
+  `DeclarationsQuery`):
+  - `.attrs() -> list[NodeAttrs]` — :class:`NodeAttrs` for every
+    matched index. Folds the `ctx.node_attrs(q.indices())`
+    boilerplate into a single chainable call.
+  - `.first_idx() -> int | None` — first matched index or `None`.
+    `ModuleQuery` already had this; the rest gain it.
+  - `.indices_by_path() -> dict[str, list[int]]` — group matched
+    indices by their owning file path. One `ctx.node_paths` lookup
+    internally; lets plugins fan out per-file work without
+    re-querying.
+- `indices_by_path()` on every Tier-2 row query (`DecoratorQuery`,
+  `ConstructionQuery`, `CallQuery`, `FactoryQuery`). Bucketing reads
+  `path` straight off each row — no extra FFI hop.
+- `NodeAttrs` — tuple-like pyclass returned by
+  `ProjectContext.node_attrs()` and every `.attrs()` terminal.
+  Supports attribute access (`attr.fqname`) AND tuple semantics
+  (`kind, path, fqname, flags = attr`; `attr[2]`; `len(attr) == 4`).
+  Not a `typing.NamedTuple` instance but drop-in compatible for
+  unpacking and subscript.
 - `Analysis` auto-batches `DispatchAppPlugin` instances. Registering
   multiple dispatch plugins with `Analysis` now triggers a single
   fused `_gather_batched` on the main thread between the build pass
@@ -66,6 +87,22 @@ two versions.
   old `list[Any]` shape that mixed primitives and `SymbolNode` refs.
   Embedded decl references surface as `ArgNodeRef(idx=...)` rather
   than `Py<SymbolNode>` — keeps the idx surface honest end-to-end.
+
+### Changed
+- `DecoratorQuery.with_args` / `ConstructionQuery.with_args` /
+  `CallQuery.with_args` flipped from opt-out to opt-in. Default is
+  now `False` — the per-row `extract_call_args_kwargs` walk is
+  skipped and row `args` / `kwargs` getters surface empty
+  containers. Plugins that actually read `args` / `kwargs` off rows
+  must call `.with_args(True)`. The kwarg filter (`.where_kwarg`)
+  still forces extraction back on, so kwarg-filtered queries don't
+  need the explicit opt-in.
+- `ProjectContext.node_attrs(indices)` now returns `list[NodeAttrs]`
+  (the new tuple-like pyclass) instead of `list[tuple[str, str, str,
+  int]]`. Existing destructure callers (`(kind, path, fqname, flags)
+  = attr`) keep working via `__iter__`; subscript (`attr[2]`) keeps
+  working via `__getitem__`. Plugins that prefer attribute access
+  (`attr.fqname`) get that too.
 
 ### Removed
 - `BatchDispatchAppPlugin` — `Analysis` auto-batches every registered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ two versions.
   `ctx.descendants_indices`, `ctx.ancestors_indices` — idx-form
   siblings of the last six lookup / traversal helpers that still
   allocated ``Py<SymbolNode>`` rows.
+- `DecoratorQuery.with_args(bool)` / `ConstructionQuery.with_args(bool)`
+  / `CallQuery.with_args(bool)` — opt out of rust-side
+  `extract_call_args_kwargs` extraction per query. Defaults to `True`.
+  When `False`, the row's lazy `args` / `kwargs` getters surface
+  empty containers; saves the per-row rust-side enum allocation when
+  the plugin doesn't need to inspect args/kwargs. On `CallQuery` /
+  `DecoratorQuery`, auto-forced back to `True` at row-collection time
+  when any `where_kwarg(...)` is set — kwarg filtering needs the data.
 - `ArgLiteral` / `ArgNodeRef` / `ArgOpaque` pyclasses + `CallArg`
   discriminated-union alias. The four ref-query terminals now expose
   `args` / `kwargs` lazily as `list[CallArg]` / `dict[str, CallArg]`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,27 @@ two versions.
   `ctx.descendants_indices`, `ctx.ancestors_indices` — idx-form
   siblings of the last six lookup / traversal helpers that still
   allocated ``Py<SymbolNode>`` rows.
+- `ArgLiteral` / `ArgNodeRef` / `ArgOpaque` pyclasses + `CallArg`
+  discriminated-union alias. The four ref-query terminals now expose
+  `args` / `kwargs` lazily as `list[CallArg]` / `dict[str, CallArg]`,
+  walking each row's rust-side `CallArgs` on access. Plugins that
+  never read args/kwargs pay zero Python allocation cost for the
+  payload; plugins that do read them get a tagged dispatch
+  (``isinstance(a, ArgLiteral)`` / ``match`` patterns) instead of the
+  old `list[Any]` shape that mixed primitives and `SymbolNode` refs.
+  Embedded decl references surface as `ArgNodeRef(idx=...)` rather
+  than `Py<SymbolNode>` — keeps the idx surface honest end-to-end.
+
+### Removed
+- The non-idx result types `DecoratorRef` / `ConstructionRef` /
+  `CallRef` / `FactoryRef` and the `.row_indices()` terminal on the
+  four ref queries. `.collect()` now returns the idx-form rows
+  (`DecoratorIdxRef` etc.) directly. Plugins migrate via
+  `s/row_indices/collect/` + replacing `ref.decorated.fqname` with
+  `ctx.nodes()[ref.decorated_idx].fqname` (and similar). No bundled
+  plugin pulled args/kwargs off the node-form refs, so the
+  discriminated-union args/kwargs change is purely additive for
+  in-tree usage.
 - Index-form siblings on `ProjectContext`: `find_declarations_indices`,
   `module_for_indices`, `modules_for_paths`, `module_surface_indices`,
   `module_surfaces_indices`, `find_main_blocks_indices`. Each returns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,22 +10,27 @@ two versions.
 ## [Unreleased]
 
 ### Added
-- `BatchDispatchAppPlugin` — composes a list of `DispatchAppPlugin`
-  instances and runs them with fused queries. Same observable output
-  as registering every wrapped plugin individually, but the
-  construction / factory / variable scans run once across the union
-  of all plugins' configs instead of once per plugin.
+- `Analysis` auto-batches `DispatchAppPlugin` instances. Registering
+  multiple dispatch plugins with `Analysis` now triggers a single
+  fused `_gather_batched` on the main thread between the build pass
+  and the plugin fan-out; per-plugin `policy(ctx, gathered)` calls
+  fan out through the same `ThreadPoolExecutor` the harness uses for
+  every other plugin. Replaces the explicit `BatchDispatchAppPlugin`
+  wrapper — same observable output, but the construction / factory /
+  variable scans run once across the union of all dispatch plugins'
+  configs instead of once per plugin, and subclass `policy()`
+  overrides are honored uniformly without any user-side glue.
 - `DispatchAppSpec` (frozen dataclass) + `DispatchAppGather`
   (dataclass) split each plugin into a pure-data spec (what to
   gather) and a `policy(ctx, gathered)` method (how to emit ops from
   the gathered data). Subclasses customize behavior by overriding
   `policy()`; the override is honored uniformly by both the
-  standalone `DispatchAppPlugin.run` path and the batched
-  `BatchDispatchAppPlugin.run` path (the previous batched design
-  invoked the standard emission and skipped subclass extensions).
-  `CeleryPlugin`'s `@shared_task` fan-out moved from a `run()`
-  override to a `policy()` override; it now fires correctly when
-  Celery is wrapped in a batch.
+  standalone `DispatchAppPlugin.run` path and the harness's auto-
+  batched gather (the previous batched design invoked the standard
+  emission and skipped subclass extensions). `CeleryPlugin`'s
+  `@shared_task` fan-out moved from a `run()` override to a `policy()`
+  override; it now fires correctly when Celery is registered
+  alongside other dispatch plugins.
 - `AddEntrypointByIdx` graph op — index-keyed sibling of
   `AddEntrypoint`. Takes a positional index into `ctx.nodes()`; the
   apply pass reads the decl's `fqname` / `path` on the rust side to
@@ -63,6 +68,11 @@ two versions.
   than `Py<SymbolNode>` — keeps the idx surface honest end-to-end.
 
 ### Removed
+- `BatchDispatchAppPlugin` — `Analysis` auto-batches every registered
+  `DispatchAppPlugin` (see Added). Migrate by replacing
+  `[BatchDispatchAppPlugin(plugins=[flask_plugin(), fastapi_plugin()])]`
+  with `[flask_plugin(), fastapi_plugin()]` in the
+  `Analysis(plugins=...)` argument.
 - `ctx.find_subclasses(fqn)` / `find_subclasses_indices` /
   `find_subclasses_of(node)` / `find_subclasses_of_indices` /
   `find_subclasses_of_idx(idx)` / `subclasses_of_fqn(fqn)` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ two versions.
 ## [Unreleased]
 
 ### Added
+- `BatchDispatchAppPlugin` — composes a list of `DispatchAppPlugin`
+  instances and runs them with fused queries. Same observable output
+  as registering every wrapped plugin individually, but the
+  construction / factory / variable scans run once across the union
+  of all plugins' configs instead of once per plugin. Per-plugin
+  emission stays in `_emit_ops` (newly extracted), called once per
+  wrapped plugin against the shared row/var fetches.
 - `AddEntrypointByIdx` graph op — index-keyed sibling of
   `AddEntrypoint`. Takes a positional index into `ctx.nodes()`; the
   apply pass reads the decl's `fqname` / `path` on the rust side to

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -253,7 +253,8 @@ class AddNode:
     freshly-minted node from subsequent ops. Set
     ``flags = NodeFlags.ENTRYPOINT`` to make the node a reachability
     seed; for the common single-target entrypoint pattern, prefer
-    ``AddEntrypoint(decl, marker=...)``.
+    :class:`AddEntrypoint` (or :class:`AddEntrypointByIdx` from
+    idx-space).
     """
 
     fqname: str
@@ -1006,8 +1007,24 @@ class ProjectContext:
         four fields stay GIL-free in the inner loop, which matters
         once the plugin pass runs concurrently.
 
+        When the plugin only needs ``path`` (the common "bucket by
+        file" case), prefer :meth:`node_paths` — it skips the per-row
+        ``kind`` / ``fqname`` / ``flags`` clones that ``node_attrs``
+        would allocate but the plugin would throw away.
+
         Validates bounds the same way :meth:`nodes_at` does and raises
         :class:`IndexError` when any index is out of range.
+        """
+        ...
+
+    def node_paths(self, indices: Sequence[int]) -> list[str]:
+        """Batched ``path``-only snapshot for each index. Same FFI shape
+        as :meth:`node_attrs` but allocates only one ``str`` per row
+        instead of a 4-tuple — roughly 3× fewer Python allocations on
+        the common "bucket by file" path.
+
+        Validates bounds and raises :class:`IndexError` when any index
+        is out of range.
         """
         ...
 
@@ -1257,9 +1274,18 @@ class DecoratorIdxRef:
     :meth:`ProjectContext.nodes`. ``path`` is preserved because plugins
     routinely bucket by path before any further query.
 
+    ``args`` / ``kwargs`` are dropped on the idx form because entries
+    inside them can be :class:`SymbolNode` references that would
+    re-introduce the GIL hops the idx surface is designed to avoid.
+    Plugins that need them fall back to :meth:`DecoratorQuery.collect`;
+    plugins that only need to filter by kwarg keep using
+    :meth:`DecoratorQuery.where_kwarg`, which runs rust-side before
+    row construction either way.
+
     Returned by :meth:`DecoratorQuery.row_indices`. Pair with
-    :meth:`ProjectContext.node_attrs` to batch-fetch any other node
-    fields the plugin needs without per-row ``borrow`` ping-pong.
+    :meth:`ProjectContext.node_attrs` (or :meth:`node_paths` when only
+    ``path`` is needed) to batch-fetch any other node fields the
+    plugin needs without per-row ``borrow`` ping-pong.
     """
 
     decorated_idx: int
@@ -1272,7 +1298,9 @@ class ConstructionIdxRef:
     """Index-form sibling of :class:`ConstructionRef`. Same metadata
     fields, minus ``args`` / ``kwargs``; ``var_idx`` indexes into
     :meth:`ProjectContext.nodes`. ``path`` is preserved as a cheap
-    bucket key for plugins that fan out per file.
+    bucket key for plugins that fan out per file. ``args`` /
+    ``kwargs`` are dropped for the same reason
+    :class:`DecoratorIdxRef` drops them — see its docstring.
 
     Returned by :meth:`ConstructionQuery.row_indices`.
     """
@@ -1285,8 +1313,13 @@ class CallIdxRef:
     """Index-form sibling of :class:`CallRef`. Same metadata fields,
     minus ``args`` / ``kwargs``; ``owner_idx`` indexes into
     :meth:`ProjectContext.nodes`. ``path`` is the owning decl's path;
-    ``string_arg`` (the literal at the configured positional index) is
-    preserved because most call-shape plugins key on it.
+    ``string_arg`` (the literal at the configured positional index)
+    is preserved because (a) most call-shape plugins key on it and
+    (b) it's a plain ``str`` with no ``SymbolNode`` content, so it
+    doesn't cost a borrow per row.
+
+    ``args`` / ``kwargs`` are dropped for the same reason
+    :class:`DecoratorIdxRef` drops them — see its docstring.
 
     Returned by :meth:`CallQuery.row_indices`.
     """

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -648,6 +648,13 @@ class ProjectContext:
         """
         ...
 
+    def resolve_idx(self, fqname: str) -> int | None:
+        """Idx-only variant of :meth:`resolve`. Same walk-back rules,
+        returns the positional index into :meth:`nodes` (``None`` when
+        the fqname can't be found anywhere).
+        """
+        ...
+
     def find_declarations(self, fqname: str) -> list[SymbolNode]:
         """Every declaration matching ``fqname``, walking back through
         dotted segments to find the enclosing top-level decl when the
@@ -814,11 +821,24 @@ class ProjectContext:
         """Every node whose ``path`` starts with the given prefix."""
         ...
 
+    def decls_under_indices(self, path_prefix: str) -> list[int]:
+        """Idx-only variant of :meth:`decls_under`. Same scan, returns
+        positional indices into :meth:`nodes` rather than allocating
+        ``SymbolNode`` clones.
+        """
+        ...
+
     def decls_matching(self, substring: str) -> list[SymbolNode]:
         """Every node whose ``path`` contains ``substring`` anywhere.
 
         Useful for path-pattern plugins (``alembic/versions/``,
         ``.ignore.py``).
+        """
+        ...
+
+    def decls_matching_indices(self, substring: str) -> list[int]:
+        """Idx-only variant of :meth:`decls_matching`. Same scan,
+        returns positional indices into :meth:`nodes`.
         """
         ...
 
@@ -829,6 +849,12 @@ class ProjectContext:
         Used by plugins that key on naming conventions —
         :class:`ModuleDundersPlugin` (``__xxx__`` names),
         :class:`PytestPlugin` (``test_*`` / ``Test*``), etc.
+        """
+        ...
+
+    def decls_matching_name_indices(self, pattern: str) -> list[int]:
+        """Idx-only variant of :meth:`decls_matching_name`. Same scan
+        and kind filter, returns positional indices into :meth:`nodes`.
         """
         ...
 
@@ -875,12 +901,28 @@ class ProjectContext:
         """
         ...
 
+    def descendants_indices(self, root_idx: int, *, skip_flags: int = 0) -> list[int]:
+        """Idx-keyed variant of :meth:`descendants`. Takes a positional
+        index into :meth:`nodes` and returns descendant indices rather
+        than allocating ``SymbolNode`` clones. Raises
+        :class:`IndexError` when ``root_idx`` is out of range.
+        """
+        ...
+
     def ancestors(self, decl: SymbolNode, *, skip_flags: int = 0) -> list[SymbolNode]:
         """Reverse closure: every node that can reach ``decl`` by
         following graph edges.
 
         Used for predecessor-chain walks and blast-radius scoping.
         ``skip_flags`` works the same as in :meth:`descendants`.
+        """
+        ...
+
+    def ancestors_indices(self, decl_idx: int, *, skip_flags: int = 0) -> list[int]:
+        """Idx-keyed variant of :meth:`ancestors`. Takes a positional
+        index into :meth:`nodes` and returns ancestor indices rather
+        than allocating ``SymbolNode`` clones. Raises
+        :class:`IndexError` when ``decl_idx`` is out of range.
         """
         ...
 

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -564,169 +564,85 @@ class ProjectContext:
     # with ``.collect()`` or ``.indices()`` terminals.
 
     # ----- FQN resolution ------------------------------------------------
-
-    def resolve(self, fqname: str) -> SymbolNode | None:
-        """Resolve a dotted FQN to either a declaration or a module
-        node.
-
-        Tries an exact decl match first, then an exact module match,
-        then walks back through dotted segments looking for an
-        enclosing decl (``pkg.lib.Cls.method`` resolves to
-        ``pkg.lib.Cls`` because methods don't get their own graph
-        nodes). Returns ``None`` when the fqname can't be found
-        anywhere — never raises.
-        """
-        ...
+    #
+    # Plugins use the DSL: ``query(ctx).declarations()`` for fqname
+    # → decl lookup, ``query(ctx).modules()`` for module fqname /
+    # path lookup, surface / top-level / dunder-all transforms, and
+    # ``query(ctx).literal_lists().for_fqn(fqn).entries()`` for
+    # module-scope string-literal lists. The flat idx-form helpers
+    # below back those DSL terminals and stay on :class:`ProjectContext`
+    # as a low-level escape hatch.
 
     def resolve_idx(self, fqname: str) -> int | None:
-        """Idx-only variant of :meth:`resolve`. Same walk-back rules,
-        returns the positional index into :meth:`nodes` (``None`` when
-        the fqname can't be found anywhere).
-        """
-        ...
-
-    def find_declarations(self, fqname: str) -> list[SymbolNode]:
-        """Every declaration matching ``fqname``, walking back through
-        dotted segments to find the enclosing top-level decl when the
-        exact name doesn't match.
-
-        ``pkg.lib.Cls.method`` returns ``pkg.lib.Cls`` because methods
-        aren't represented as their own graph nodes — same rule the
-        libcst :func:`find_declarations` follows. Modules are never
-        returned; use :meth:`find_module` for that.
+        """First decl matching ``fqname``, falling back to the module
+        match (same walk-back rules as :meth:`find_declarations_indices`
+        but module nodes are included). Returns ``None`` when the
+        fqname can't be found anywhere.
         """
         ...
 
     def find_declarations_indices(self, fqname: str) -> list[int]:
-        """Idx-only variant of :meth:`find_declarations`.
-
-        Same walk-back rules; returns positional indices into
-        :meth:`nodes` rather than allocating ``SymbolNode`` clones — pair
-        with :class:`AddEdgeByIdx` / :class:`AddNodeByIdx` to skip the
-        ``SymbolNode -> idx`` round-trip when wiring against the matched
-        decls.
+        """Every decl matching ``fqname`` (walk-back through dotted
+        segments included). Modules are never returned; use
+        :meth:`find_module_idx` for that. Returns positional indices
+        into :meth:`nodes`.
         """
-        ...
-
-    def find_module(self, fqname: str) -> SymbolNode | None:
-        """Return the module node for the given dotted fqname, if one
-        exists in the project graph."""
         ...
 
     def find_module_idx(self, fqname: str) -> int | None:
-        """Idx-only variant of :meth:`find_module`. Same O(1) lookup,
-        returns the positional index into :meth:`nodes` (``None`` if
-        ``fqname`` doesn't name a project module).
-        """
-        ...
-
-    def module_for(self, path: str) -> SymbolNode | None:
-        """Return the module node owning ``path``, if any.
-
-        O(1) — backed by the same ``module_nodes_by_file`` index
-        :meth:`find_main_blocks` uses, so plugins don't have to scan
-        :meth:`nodes` per call.
+        """O(1) module-by-fqname lookup. Returns the positional index
+        into :meth:`nodes`, or ``None`` if ``fqname`` doesn't name a
+        project module.
         """
         ...
 
     def module_for_indices(self, path: str) -> int | None:
-        """Idx-only variant of :meth:`module_for`. Same O(1) lookup,
-        returns the positional index into :meth:`nodes` (``None`` if
-        ``path`` doesn't name a project module).
+        """O(1) path-to-module lookup. Returns the positional index
+        into :meth:`nodes`, or ``None`` if ``path`` doesn't name a
+        project module.
         """
         ...
 
     def modules_for_paths(self, paths: list[str]) -> list[int | None]:
         """Bulk form of :meth:`module_for_indices`. One ``materialize``
         check + one O(1) lookup per path; missing paths map to ``None``.
-        Lets plugins that ``module_for(path)`` once per ref row collapse
-        N FFI hops into one.
+        Lets plugins that call ``module_for(path)`` once per ref row
+        collapse N FFI hops into one.
         """
         ...
 
-    def module_surface(self, module_fqn: str) -> list[SymbolNode]:
-        """Module node + every transitive decl whose fqname lives
-        under ``module_fqn``.
-
-        Models ``importlib.import_module(module_fqn)``: the module's
-        whole top-level surface plus everything its submodules expose.
+    def module_surface_indices(self, module_fqn: str) -> list[int]:
+        """BFS over the fqname tree from ``module_fqn``: the module
+        idx + every transitive descendant idx. Models
+        ``importlib.import_module(module_fqn)``: the module's whole
+        top-level surface plus everything its submodules expose.
         Empty list when ``module_fqn`` doesn't resolve to a project
         module.
         """
         ...
 
-    def module_surface_indices(self, module_fqn: str) -> list[int]:
-        """Idx-only variant of :meth:`module_surface`. Same BFS over
-        the fqname tree; returns positional indices into :meth:`nodes`
-        rather than allocating ``SymbolNode`` clones.
-        """
-        ...
-
     def module_surfaces_indices(self, module_fqns: list[str]) -> dict[str, list[int]]:
-        """Idx-only variant of :meth:`module_surfaces`. Same single-
-        sweep scan; the per-fqname buckets carry positional indices
-        into :meth:`nodes` rather than ``SymbolNode`` clones.
-        """
-        ...
-
-    def module_surfaces(self, module_fqns: list[str]) -> dict[str, list[SymbolNode]]:
-        """Batched form of :meth:`module_surface`. Resolves every
-        fqname in ``module_fqns`` in a single scan of the internal
-        ``module_by_fqname`` and ``decl_by_fqname`` indices instead
-        of one scan per fqname.
-
-        Returns a dict keyed by input fqname; modules that don't
-        resolve map to empty lists. Duplicate inputs share the same
-        result list. Use when a plugin needs to resolve many module
-        surfaces in one shot (``LiteralListPlugin``'s ``__all__``
-        entries, ``DiscordPyPlugin``'s ``load_extensions`` args, …).
-        """
-        ...
-
-    def find_module_top_level_decls(self, module_fqn: str) -> list[SymbolNode]:
-        """``module_fqn``'s immediate top-level decls — every
-        function / class / variable / import bound at its module scope.
-
-        Models ``from module_fqn import *``: only the names that
-        statement would bind into the importing scope. Unlike
-        :meth:`module_surface`, submodules and their decls are
-        excluded — a ``from p.functions import *`` doesn't pull in
-        ``p.functions.sub.x``. Empty list when ``module_fqn`` doesn't
-        resolve to a project module.
+        """Bulk form: resolve every fqname in ``module_fqns`` in a
+        single scan instead of one scan per fqname. Returns a dict
+        keyed by input fqname; modules that don't resolve map to empty
+        lists. Duplicate inputs share the same result list.
         """
         ...
 
     def find_module_top_level_decls_indices(self, module_fqn: str) -> list[int]:
-        """Idx-only variant of :meth:`find_module_top_level_decls`.
-
-        Returns positional indices into :meth:`nodes` rather than
-        allocating ``SymbolNode`` clones — pair with
-        :class:`AddEdgeByIdx` to skip the ``SymbolNode -> idx``
-        round-trip when emitting edges to every export of a module.
-        """
-        ...
-
-    def find_module_dunder_all_exports(self, module_fqn: str) -> list[SymbolNode] | None:
-        """Decls listed in ``module_fqn``'s ``__all__``, or ``None``
-        when the module doesn't declare ``__all__``.
-
-        The visitor's ``emit_dunder_all_edges`` already wires
-        ``__all__`` → each string-listed decl as a regular edge; this
-        query walks those successor edges and filters out the default
-        ``decl -> parent_module`` edge. The distinction between "no
-        ``__all__``" (``None``) and "empty ``__all__``" (``[]``)
-        matters: callers that want CPython's ``from X import *``
-        semantics should fall back to the non-underscore decl list
-        only in the ``None`` case.
+        """``module_fqn``'s immediate top-level decls — every function
+        / class / variable / import bound at its module scope.
+        Submodules are excluded. Empty list when ``module_fqn`` isn't
+        a project module.
         """
         ...
 
     def find_module_dunder_all_exports_indices(self, module_fqn: str) -> list[int] | None:
-        """Idx-only variant of :meth:`find_module_dunder_all_exports`.
-
-        ``None`` still means "no ``__all__``"; ``[]`` means "empty /
-        unresolvable ``__all__``" — same semantics as the
-        ``SymbolNode``-returning version.
+        """Decls listed in ``module_fqn``'s ``__all__``. ``None`` means
+        "no ``__all__``"; ``[]`` means "empty / unresolvable
+        ``__all__``" — callers wanting CPython's
+        ``from X import *`` semantics fall back to the non-underscore
+        decl list only in the ``None`` case.
         """
         ...
 
@@ -746,64 +662,26 @@ class ProjectContext:
         ...
 
     # ----- Path / name filters ------------------------------------------
-
-    def decls_under(self, path_prefix: str) -> list[SymbolNode]:
-        """Every node whose ``path`` starts with the given prefix."""
-        ...
+    #
+    # Plugins use the DSL: ``query(ctx).decls()`` with the
+    # ``with_path_prefix`` / ``with_path_contains`` / ``with_simple_name_regex``
+    # predicates; ``query(ctx).matching_specs(...)`` for the
+    # OR-form entrypoint matcher. The idx-form helpers below back
+    # those DSL terminals as low-level escape hatches.
 
     def decls_under_indices(self, path_prefix: str) -> list[int]:
-        """Idx-only variant of :meth:`decls_under`. Same scan, returns
-        positional indices into :meth:`nodes` rather than allocating
-        ``SymbolNode`` clones.
-        """
-        ...
-
-    def decls_matching(self, substring: str) -> list[SymbolNode]:
-        """Every node whose ``path`` contains ``substring`` anywhere.
-
-        Useful for path-pattern plugins (``alembic/versions/``,
-        ``.ignore.py``).
+        """Every node whose ``path`` starts with ``path_prefix``.
+        Returns positional indices into :meth:`nodes`.
         """
         ...
 
     def decls_matching_indices(self, substring: str) -> list[int]:
-        """Idx-only variant of :meth:`decls_matching`. Same scan,
-        returns positional indices into :meth:`nodes`.
-        """
-        ...
-
-    def decls_matching_name(self, pattern: str) -> list[SymbolNode]:
-        """Every top-level decl whose simple name matches ``pattern``
-        (a regex).
-
-        Used by plugins that key on naming conventions —
-        :class:`ModuleDundersPlugin` (``__xxx__`` names),
-        :class:`PytestPlugin` (``test_*`` / ``Test*``), etc.
-        """
+        """Every node whose ``path`` contains ``substring`` anywhere."""
         ...
 
     def decls_matching_name_indices(self, pattern: str) -> list[int]:
-        """Idx-only variant of :meth:`decls_matching_name`. Same scan
-        and kind filter, returns positional indices into :meth:`nodes`.
-        """
-        ...
-
-    def find_nodes_matching_specs(
-        self,
-        project_root: str,
-        regexes: list[str],
-        str_specs: list[str],
-        abs_paths: list[str],
-    ) -> list[SymbolNode]:
-        """Match nodes against pre-classified path / fqname specs.
-
-        Avoids the per-node FFI hop + ``pathlib.Path`` allocation that
-        a ``for node in ctx.nodes(): ...`` loop pays. ``regexes`` are
-        anchored at the start of input (``re.Pattern.match`` semantics).
-        ``str_specs`` match exactly against the relative path OR the
-        node's fqname. ``abs_paths`` match exactly against the
-        absolute path.
-        """
+        """Every top-level decl (function / class / variable / import /
+        type_alias) whose simple name matches ``pattern`` (a regex)."""
         ...
 
     def find_nodes_matching_specs_indices(
@@ -813,9 +691,11 @@ class ProjectContext:
         str_specs: list[str],
         abs_paths: list[str],
     ) -> list[int]:
-        """Idx-only variant of :meth:`find_nodes_matching_specs`. Same
-        scan, returns positional indices into :meth:`nodes` rather than
-        allocating ``SymbolNode`` clones.
+        """OR-form spec matcher. ``regexes`` are anchored at the start
+        of input (``re.Pattern.match`` semantics) against the relative
+        path. ``str_specs`` match exactly against the relative path OR
+        the node's fqname. ``abs_paths`` match exactly against the
+        absolute path. Returns positional indices into :meth:`nodes`.
         """
         ...
 
@@ -856,24 +736,14 @@ class ProjectContext:
         """
         ...
 
-    def direct_predecessors(self, node: SymbolNode, *, skip_flags: int = 0) -> list[SymbolNode]:
-        """One-hop reverse step: every node with an edge directly into
-        ``node``.
-
-        Unlike :meth:`ancestors`, this does *not* take the transitive
-        closure — it only returns the immediate predecessors. Dedups by
-        source node, so a pair of parallel edges with different
-        :class:`EdgeFlags` between the same two nodes only produces one
-        entry. ``skip_flags`` filters edges by intersecting flag mask —
-        same semantics as :meth:`ancestors`.
-        """
-        ...
-
     def direct_predecessors_idx(self, idx: int, *, skip_flags: int = 0) -> list[int]:
-        """Idx-keyed variant of :meth:`direct_predecessors`. Takes a
-        positional index into :meth:`nodes` and returns predecessor
-        indices rather than allocating ``SymbolNode`` clones. Raises
-        :class:`IndexError` when ``idx`` is out of range.
+        """One-hop reverse step: every node with an edge directly into
+        ``idx``. Dedups by source idx, so a pair of parallel edges
+        with different :class:`EdgeFlags` between the same two nodes
+        only produces one entry. ``skip_flags`` filters edges by
+        intersecting flag mask — same semantics as
+        :meth:`ancestors_indices`. Plugins use the DSL:
+        ``native.query(ctx).from_idx(idx).direct_predecessors()``.
         """
         ...
 
@@ -958,44 +828,28 @@ class ProjectContext:
         ...
 
     # ----- Pure scans over the in-progress graph ------------------------
-
-    def find_module_dunders(self) -> list[SymbolNode]:
-        """Every top-level variable node whose name matches ``__xxx__``.
-
-        Pure scan over already-interned nodes — no ty re-query needed
-        — because the visitor's decl pass already minted one node per
-        global-scope variable binding.
-        """
-        ...
+    #
+    # Plugins use the DSL: ``query(ctx).modules().with_dunders().indices()``
+    # for module-dunder enumeration, ``query(ctx).main_blocks().index_pairs()``
+    # for ``if __name__ == "__main__":`` blocks. The idx-form helpers
+    # below back those DSL terminals.
 
     def find_module_dunders_indices(self) -> list[int]:
-        """Idx-only variant of :meth:`find_module_dunders`. Same scan,
-        returns positional indices into :meth:`nodes` rather than
-        allocating ``SymbolNode`` clones.
-        """
+        """Every top-level variable / function node whose name matches
+        ``__xxx__``. Pure scan over already-interned nodes — no ty
+        re-query needed."""
         ...
 
     # The import-of-module surface lives entirely on
     # :class:`ImportQuery`. Use ``native.query(ctx).imports().of(m)``
     # then ``.collect()`` / ``.indices()`` / ``.count()`` / ``.exists()``.
 
-    def find_main_blocks(self) -> list[tuple[SymbolNode, list[SymbolNode]]]:
-        """``(module_node, [decls inside the block])`` for every file
-        with a top-level ``if __name__ == "__main__":`` block.
-
-        The decls list contains the file's class / function / variable
-        / import nodes whose source position falls inside the block's
-        range — same shape ``MainBlockPlugin``'s libcst path computes
-        from the visitor's payload.
-        """
-        ...
-
     def find_main_blocks_indices(self) -> list[tuple[int, list[int]]]:
-        """Idx-only variant of :meth:`find_main_blocks`. Returns
-        ``(module_idx, [decl_idx])`` pairs into :meth:`nodes` rather
-        than ``SymbolNode`` clones — pair with :class:`AddNodeByIdx` to
-        emit a marker per main block without round-tripping its decls
-        through ``Py<SymbolNode>``.
+        """``(module_idx, [decl_idx])`` pairs into :meth:`nodes` for
+        every file with a top-level ``if __name__ == "__main__":``
+        block. The decls list contains the file's class / function /
+        variable / import nodes whose source position falls inside the
+        block's range.
         """
         ...
 

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -554,85 +554,14 @@ class ProjectContext:
     # ``find_calls_on_var`` methods are no longer part of the public
     # type-stub contract; use ``query(ctx)`` instead.
 
-    def find_subclasses(self, base_fqn: str, *, transitive: bool = True) -> list[SymbolNode]:
-        """Subclasses of the class addressed by ``base_fqn``.
-
-        Works for both project classes (where the fqn resolves to a
-        graph node) and external classes (``unittest.TestCase``,
-        ``pydantic.BaseModel``) via ty's module resolver +
-        ``type_hierarchy_subtypes``. ``transitive=True`` (default)
-        walks the full subclass closure; ``transitive=False`` returns
-        only direct subclasses.
-        """
-        ...
-
-    def find_subclasses_of(self, class_node: SymbolNode) -> list[SymbolNode]:
-        """Transitive subclasses of a class already in the graph.
-
-        Like :meth:`find_subclasses` but takes a ``SymbolNode`` rather
-        than a fqn — useful when you already have the seed in hand and
-        don't want to round-trip through a string. Direct subtypes
-        come from ty's ``type_hierarchy_subtypes``; results that don't
-        land in the project (stdlib / external classes) are dropped.
-        """
-        ...
-
-    def find_subclasses_of_idx(self, class_idx: int) -> list[int]:
-        """Idx-keyed variant of :meth:`find_subclasses_of`. Same lookup,
-        takes a positional index into :meth:`nodes` rather than a
-        ``SymbolNode`` reference; returns indices into :meth:`nodes`
-        instead of allocating ``SymbolNode`` clones. Raises
-        :class:`IndexError` when ``class_idx`` is out of range.
-        """
-        ...
-
-    def subclasses_of_fqn(self, fqn: str, *, transitive: bool = True) -> list[SymbolNode]:
-        """Project classes that inherit from the class identified by
-        ``fqn``. ``fqn`` may name a project or external class.
-
-        Backed by a project-wide index built once at materialize time
-        from each file's per-class resolved base list, so external
-        seeds (``flask.Flask``, ``typer.Typer``) are answered without
-        loading the framework out of the venv. ``transitive=True``
-        (default) walks the full subclass closure; ``transitive=False``
-        returns only direct subclasses.
-
-        Match shapes per base expression in a class header:
-
-        * ``Name(X)`` where ``X`` is imported via
-          ``from <module> import X [as alias]`` matches
-          ``<module>.X``;
-        * ``Attribute(Name(M).N)`` where ``M`` is bound via
-          ``import <module> [as M]`` matches ``<module>.N``;
-        * dotted ``a.b.c.N`` rooted at an imported name matches the
-          flat ``<a-upstream>.b.c.N`` fqname;
-        * a bare ``Name(X)`` referring to a class defined in the same
-          file participates in node-keyed walks.
-
-        Generic parameterizations (``class C(Foo[T])``) and other
-        non-identifier base expressions are skipped — matches the
-        libcst pipeline's behavior.
-        """
-        ...
-
-    def subclasses_of_fqn_indices(self, fqn: str, *, transitive: bool = True) -> list[int]:
-        """Idx-only variant of :meth:`subclasses_of_fqn`. Same lookup,
-        returns positional indices into :meth:`nodes` rather than
-        allocating ``SymbolNode`` clones.
-        """
-        ...
-
-    def subclasses_of_node(
-        self, class_node: SymbolNode, *, transitive: bool = True
-    ) -> list[SymbolNode]:
-        """Project classes that inherit from ``class_node``.
-
-        Sibling of :meth:`subclasses_of_fqn` for callers that already
-        hold the seed as a ``SymbolNode``. Returns an empty list when
-        ``class_node`` isn't of class kind or isn't found in the
-        project's class-by-selection index.
-        """
-        ...
+    # The subclass-walk surface lives entirely on
+    # :class:`SubclassQuery`. The point-lookup ``ctx.find_subclasses(fqn)``
+    # / ``find_subclasses_of(node)`` / ``find_subclasses_of_idx(idx)``
+    # methods that used to mirror these queries are now rust-only
+    # (called by :class:`SubclassQuery` internally). Plugin authors:
+    # use the DSL — ``native.query(ctx).subclasses().of_fqn(fqn)`` /
+    # ``.of_idx(idx)`` / ``.of_node(node)`` (legacy node-form input)
+    # with ``.collect()`` or ``.indices()`` terminals.
 
     # ----- FQN resolution ------------------------------------------------
 
@@ -1046,16 +975,9 @@ class ProjectContext:
         """
         ...
 
-    def find_imports_of(self, module_name: str) -> list[SymbolNode]:
-        """Every import-kind node whose upstream ``module`` matches.
-
-        Covers both ``import <module_name>`` and
-        ``from <module_name> import ...`` styles — both bind
-        import-kind nodes whose ``Import.module`` is the absolute
-        dotted name. Star re-exports synthesized from
-        ``from <module_name> import *`` are also included.
-        """
-        ...
+    # The import-of-module surface lives entirely on
+    # :class:`ImportQuery`. Use ``native.query(ctx).imports().of(m)``
+    # then ``.collect()`` / ``.indices()`` / ``.count()`` / ``.exists()``.
 
     def find_main_blocks(self) -> list[tuple[SymbolNode, list[SymbolNode]]]:
         """``(module_node, [decls inside the block])`` for every file
@@ -1077,15 +999,9 @@ class ProjectContext:
         """
         ...
 
-    def find_classes_defining_method(self, method_name: str) -> list[SymbolNode]:
-        """Every class that defines a method with the given name.
-
-        Walks each class's ``DefinitionKind::Class`` body for an
-        ``Stmt::FunctionDef`` whose name matches. ty's
-        ``parsed_module`` is Salsa-cached, so this is just a body scan
-        per class.
-        """
-        ...
+    # The class-defining-method surface lives on :class:`ClassQuery`.
+    # Use ``native.query(ctx).classes().defining_method(name).collect()`` /
+    # ``.indices()``.
 
     # ----- Decorator / construction shapes (syntactic walks) ------------
     #

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -1276,10 +1276,49 @@ class QueryBuilder:
     def calls(self) -> CallQuery: ...
     def subclasses(self) -> SubclassQuery: ...
     def imports(self) -> ImportQuery: ...
+    def modules(self) -> ModuleQuery: ...
     def classes(self) -> ClassQuery: ...
     def factories(self) -> FactoryQuery: ...
     def edges(self) -> EdgeQuery: ...
     def decls(self) -> DeclQuery: ...
+    def declarations(self) -> DeclarationsQuery: ...
+    def main_blocks(self) -> MainBlockQuery: ...
+    def literal_lists(self) -> LiteralListQuery: ...
+    def from_idx(self, seed_idx: int) -> TraverseQuery:
+        """Anchor a closure walk on a single seed. Returns a
+        :class:`TraverseQuery` whose terminals (``descendants`` /
+        ``ancestors`` / ``direct_predecessors``) return positional
+        indices into :meth:`ProjectContext.nodes`.
+        """
+        ...
+
+    def reachable(self, *, skip_flags: int = 0, seed_flags: int | None = None) -> list[int]:
+        """Seedless reachability terminal. Forward closure from every
+        node carrying any bit in ``seed_flags`` (default:
+        ``NodeFlags.ENTRYPOINT``), filtering edges by ``skip_flags``.
+        Returns positional indices into :meth:`ProjectContext.nodes`.
+        """
+        ...
+
+    def matching_specs(
+        self,
+        project_root: str,
+        *,
+        regexes: list[str] = ...,
+        str_specs: list[str] = ...,
+        abs_paths: list[str] = ...,
+    ) -> list[int]:
+        """OR-form spec matcher (used by
+        :class:`ExplicitEntrypointPlugin`). A node matches if any of:
+
+        * ``regexes`` contains a pattern matching the node's path
+          relative to ``project_root`` (anchored, ``re.match`` style);
+        * ``str_specs`` contains the node's relative path or fqname;
+        * ``abs_paths`` contains the node's absolute path.
+
+        Returns positional indices into :meth:`ProjectContext.nodes`.
+        """
+        ...
 
 class DecoratorQuery:
     """Find decorated top-level functions / classes. Pick exactly one
@@ -1463,6 +1502,183 @@ class ImportQuery:
 
     def __iter__(self) -> Iterator[SymbolNode]: ...
 
+class ModuleQuery:
+    """Enumerate / inspect project module nodes.
+
+    Pick exactly one filter (:meth:`with_fqn` / :meth:`with_path` /
+    :meth:`with_dunders`), optionally follow with one transform
+    (:meth:`surface` / :meth:`top_level` / :meth:`dunder_all`), then
+    drop into a terminal (:meth:`indices` / :meth:`first_idx` /
+    :meth:`dunder_all`).
+
+    Idx-only terminals — :class:`ModuleQuery` doesn't have a
+    ``.collect()`` SymbolNode form; plugins consume the idxs and
+    fetch attrs via :meth:`ProjectContext.node_attrs` /
+    :meth:`node_paths` as needed.
+    """
+
+    def with_fqn(self, fqn: str) -> ModuleQuery:
+        """Narrow to a single module by dotted fqname."""
+        ...
+
+    def with_path(self, path: str) -> ModuleQuery:
+        """Narrow to the module owning ``path``. O(1) — backed by the
+        same ``module_nodes_by_file`` index :meth:`find_main_blocks`
+        uses."""
+        ...
+
+    def with_dunders(self) -> ModuleQuery:
+        """Project-wide scan: every module-level variable named
+        ``__xxx__`` plus every PEP 562 dunder function
+        (``__getattr__`` / ``__dir__``). Terminal-friendly with
+        :meth:`indices`. Pairs with no transform.
+        """
+        ...
+
+    def surface(self) -> ModuleQuery:
+        """Transform: module + every transitive decl whose fqname
+        lives under the filtered module's fqname. Models
+        ``importlib.import_module(...)`` reachability — submodules
+        are recursed into, but a decl's sub-fqnames are not.
+        """
+        ...
+
+    def top_level(self) -> ModuleQuery:
+        """Transform: the filtered module's immediate top-level decls.
+        Models ``from <module> import *`` semantics — submodules and
+        their decls are excluded.
+        """
+        ...
+
+    def indices(self) -> list[int]:
+        """Terminal: list of matching positional indices into
+        :meth:`ProjectContext.nodes`.
+
+        * No transform + ``with_fqn`` / ``with_path``: a 0- or
+          1-element list with the matched module idx.
+        * ``surface()`` / ``top_level()``: the module + relevant
+          decls.
+        * ``with_dunders()``: every module-level dunder name in the
+          project.
+        """
+        ...
+
+    def first_idx(self) -> int | None:
+        """Terminal: first matching idx or ``None``. Convenience for
+        single-value lookups (``with_fqn`` / ``with_path`` without a
+        transform).
+        """
+        ...
+
+    def dunder_all(self) -> list[int] | None:
+        """Terminal: decls listed in the module's ``__all__``.
+
+        Returns ``None`` when the module doesn't declare ``__all__``;
+        returns ``[]`` when ``__all__`` exists but resolves to no
+        in-project decls. Requires :meth:`with_fqn`; other filters /
+        transforms are ignored. The distinction between ``None`` and
+        ``[]`` matters: CPython's ``from X import *`` semantics fall
+        back to the non-underscore decl list only in the ``None``
+        case.
+        """
+        ...
+
+    def count(self) -> int: ...
+    def __iter__(self) -> Iterator[int]: ...
+
+class TraverseQuery:
+    """Closure walks anchored at a single seed node. Built via
+    :meth:`QueryBuilder.from_idx`. All terminals return positional
+    indices into :meth:`ProjectContext.nodes`; revive rows via
+    :meth:`ProjectContext.nodes_at` if a plugin needs full
+    :class:`SymbolNode` objects. For the seedless "alive from
+    entrypoints" walk, use :meth:`QueryBuilder.reachable` instead.
+    """
+
+    def descendants(self, *, skip_flags: int = 0) -> list[int]:
+        """Terminal: forward closure from the seed. ``skip_flags`` is
+        an :class:`EdgeFlags` mask — edges whose flag mask intersects
+        are filtered out (e.g. ``EdgeFlags.DEAD_BRANCH.value``).
+        """
+        ...
+
+    def ancestors(self, *, skip_flags: int = 0) -> list[int]:
+        """Terminal: reverse closure to the seed. ``skip_flags``
+        filters edges the same way as :meth:`descendants`.
+        """
+        ...
+
+    def direct_predecessors(self, *, skip_flags: int = 0) -> list[int]:
+        """Terminal: one-hop reverse — the immediate predecessors of
+        the seed (deduped by source idx, so parallel edges with
+        different flags collapse to a single entry).
+        """
+        ...
+
+class DeclarationsQuery:
+    """Look up declarations by fully-qualified name. Built via
+    :meth:`QueryBuilder.declarations`. Requires :meth:`with_fqname`;
+    terminals are :meth:`indices` (all matching decls) and
+    :meth:`resolve_idx` (first match, with module fallback).
+
+    The walk-back rule: when the exact fqname doesn't match, dotted
+    segments are stripped from the right until an enclosing top-level
+    decl is found (``pkg.lib.Cls.method`` resolves to ``pkg.lib.Cls``
+    because methods aren't graph nodes).
+    """
+
+    def with_fqname(self, fqname: str) -> DeclarationsQuery: ...
+    def indices(self) -> list[int]:
+        """Terminal: every decl matching ``fqname`` (walk-back
+        included). Modules are never returned; use
+        :meth:`QueryBuilder.modules` for module lookup.
+        """
+        ...
+
+    def resolve_idx(self) -> int | None:
+        """Terminal: first decl matching ``fqname``, falling back to a
+        module match. Returns ``None`` when the fqname can't be found
+        anywhere.
+        """
+        ...
+
+    def count(self) -> int: ...
+    def __iter__(self) -> Iterator[int]: ...
+
+class MainBlockQuery:
+    """Enumerate every ``if __name__ == "__main__":`` block in the
+    project. Built via :meth:`QueryBuilder.main_blocks`. The only
+    terminal is :meth:`index_pairs`.
+    """
+
+    def index_pairs(self) -> list[tuple[int, list[int]]]:
+        """Terminal: ``(module_idx, [decl_idx, ...])`` pairs for every
+        file with a top-level ``if __name__ == "__main__":`` block.
+        One entry per file; ``decl_idx`` lists the top-level decls
+        whose source position falls inside the block's range.
+        """
+        ...
+
+    def count(self) -> int: ...
+    def __iter__(self) -> Iterator[tuple[int, list[int]]]: ...
+
+class LiteralListQuery:
+    """Read the entries of a module-level string-literal list / tuple
+    (typical use: ``__all__``, but works for any name). Built via
+    :meth:`QueryBuilder.literal_lists`. Requires :meth:`for_fqn`; the
+    only terminal is :meth:`entries`.
+    """
+
+    def for_fqn(self, fqn: str) -> LiteralListQuery: ...
+    def entries(self) -> list[str] | None:
+        """Terminal: the string entries bound to the configured
+        ``fqn`` at module scope (concatenated across multiple decls in
+        declaration order), or ``None`` when the name isn't a
+        module-level decl or doesn't bind a string-literal list /
+        tuple.
+        """
+        ...
+
 class ClassQuery:
     """Enumerate classes by structural property. Today the only filter
     is :meth:`defining_method` (matches classes whose body has a
@@ -1574,6 +1790,27 @@ class DeclQuery:
     def with_simple_names(self, names: str | list[str] | tuple[str, ...]) -> DeclQuery: ...
     def with_paths(self, paths: str | list[str] | tuple[str, ...]) -> DeclQuery: ...
     def with_path_regex(self, regex: str) -> DeclQuery: ...
+    def with_path_prefix(self, prefix: str) -> DeclQuery:
+        """Restrict to nodes whose absolute path starts with
+        ``prefix``. Cheaper than :meth:`with_path_regex` for simple
+        directory scoping.
+        """
+        ...
+
+    def with_path_contains(self, substring: str) -> DeclQuery:
+        """Restrict to nodes whose absolute path contains ``substring``
+        anywhere. Useful for path-pattern plugins like
+        ``alembic/versions/`` or ``.ignore.py``.
+        """
+        ...
+
+    def with_simple_name_regex(self, pattern: str) -> DeclQuery:
+        """Restrict to nodes whose trailing fqname segment matches
+        ``pattern`` (a regex). Combine with :meth:`with_kind` /
+        :meth:`with_kinds` to drop modules when you only want
+        top-level decls.
+        """
+        ...
     def with_flags(self, mask: int) -> DeclQuery:
         """Restrict to nodes whose ``flags & mask == mask`` (all bits set)."""
         ...

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -226,6 +226,23 @@ class AddEntrypoint:
 
     def __init__(self, decl: SymbolNode, *, marker: str) -> None: ...
 
+class AddEntrypointByIdx:
+    """Index-keyed variant of :class:`AddEntrypoint`. Takes a positional
+    index into :meth:`ProjectContext.nodes` instead of a ``SymbolNode``
+    reference; the apply pass reads the decl's ``fqname`` / ``path``
+    on the rust side to compose the marker, so plugins working in
+    idx-space don't pay the ``Py<SymbolNode>`` allocation just to flag
+    a seed.
+
+    Raises :class:`IndexError` at apply time when ``decl_idx`` is out
+    of range.
+    """
+
+    decl_idx: int
+    marker: str
+
+    def __init__(self, decl_idx: int, *, marker: str) -> None: ...
+
 class AddNode:
     """Mint a synthetic intermediate node, optionally wiring it with
     edges in the same op.
@@ -291,7 +308,7 @@ class AddNodeByIdx:
         edges_to_idx: Iterable[int] = ...,
     ) -> None: ...
 
-GraphOp = AddEdge | AddEdgeByIdx | AddEntrypoint | AddNode | AddNodeByIdx
+GraphOp = AddEdge | AddEdgeByIdx | AddEntrypoint | AddEntrypointByIdx | AddNode | AddNodeByIdx
 
 class CollectedOps:
     """Opaque handle to one plugin's collected graph ops.
@@ -559,6 +576,15 @@ class ProjectContext:
         """
         ...
 
+    def find_subclasses_of_idx(self, class_idx: int) -> list[int]:
+        """Idx-keyed variant of :meth:`find_subclasses_of`. Same lookup,
+        takes a positional index into :meth:`nodes` rather than a
+        ``SymbolNode`` reference; returns indices into :meth:`nodes`
+        instead of allocating ``SymbolNode`` clones. Raises
+        :class:`IndexError` when ``class_idx`` is out of range.
+        """
+        ...
+
     def subclasses_of_fqn(self, fqn: str, *, transitive: bool = True) -> list[SymbolNode]:
         """Project classes that inherit from the class identified by
         ``fqn``. ``fqn`` may name a project or external class.
@@ -585,6 +611,13 @@ class ProjectContext:
         Generic parameterizations (``class C(Foo[T])``) and other
         non-identifier base expressions are skipped — matches the
         libcst pipeline's behavior.
+        """
+        ...
+
+    def subclasses_of_fqn_indices(self, fqn: str, *, transitive: bool = True) -> list[int]:
+        """Idx-only variant of :meth:`subclasses_of_fqn`. Same lookup,
+        returns positional indices into :meth:`nodes` rather than
+        allocating ``SymbolNode`` clones.
         """
         ...
 
@@ -641,6 +674,13 @@ class ProjectContext:
     def find_module(self, fqname: str) -> SymbolNode | None:
         """Return the module node for the given dotted fqname, if one
         exists in the project graph."""
+        ...
+
+    def find_module_idx(self, fqname: str) -> int | None:
+        """Idx-only variant of :meth:`find_module`. Same O(1) lookup,
+        returns the positional index into :meth:`nodes` (``None`` if
+        ``fqname`` doesn't name a project module).
+        """
         ...
 
     def module_for(self, path: str) -> SymbolNode | None:
@@ -810,6 +850,19 @@ class ProjectContext:
         """
         ...
 
+    def find_nodes_matching_specs_indices(
+        self,
+        project_root: str,
+        regexes: list[str],
+        str_specs: list[str],
+        abs_paths: list[str],
+    ) -> list[int]:
+        """Idx-only variant of :meth:`find_nodes_matching_specs`. Same
+        scan, returns positional indices into :meth:`nodes` rather than
+        allocating ``SymbolNode`` clones.
+        """
+        ...
+
     # ----- Traversal -----------------------------------------------------
 
     def descendants(self, root: SymbolNode, *, skip_flags: int = 0) -> list[SymbolNode]:
@@ -841,6 +894,14 @@ class ProjectContext:
         :class:`EdgeFlags` between the same two nodes only produces one
         entry. ``skip_flags`` filters edges by intersecting flag mask —
         same semantics as :meth:`ancestors`.
+        """
+        ...
+
+    def direct_predecessors_idx(self, idx: int, *, skip_flags: int = 0) -> list[int]:
+        """Idx-keyed variant of :meth:`direct_predecessors`. Takes a
+        positional index into :meth:`nodes` and returns predecessor
+        indices rather than allocating ``SymbolNode`` clones. Raises
+        :class:`IndexError` when ``idx`` is out of range.
         """
         ...
 
@@ -916,6 +977,13 @@ class ProjectContext:
         Pure scan over already-interned nodes — no ty re-query needed
         — because the visitor's decl pass already minted one node per
         global-scope variable binding.
+        """
+        ...
+
+    def find_module_dunders_indices(self) -> list[int]:
+        """Idx-only variant of :meth:`find_module_dunders`. Same scan,
+        returns positional indices into :meth:`nodes` rather than
+        allocating ``SymbolNode`` clones.
         """
         ...
 
@@ -1144,14 +1212,16 @@ class CallRef:
 class DecoratorIdxRef:
     """Index-form sibling of :class:`DecoratorRef`. Same metadata
     fields, minus ``args`` / ``kwargs``; ``decorated_idx`` indexes into
-    :meth:`ProjectContext.nodes`.
+    :meth:`ProjectContext.nodes`. ``path`` is preserved because plugins
+    routinely bucket by path before any further query.
 
     Returned by :meth:`DecoratorQuery.row_indices`. Pair with
-    :meth:`ProjectContext.node_attrs` to batch-fetch any node fields
-    the plugin still needs without per-row ``borrow`` ping-pong.
+    :meth:`ProjectContext.node_attrs` to batch-fetch any other node
+    fields the plugin needs without per-row ``borrow`` ping-pong.
     """
 
     decorated_idx: int
+    path: str
     decorator_name: str | None
     decorator_owner: str | None
     decorator_via: str | None
@@ -1159,36 +1229,42 @@ class DecoratorIdxRef:
 class ConstructionIdxRef:
     """Index-form sibling of :class:`ConstructionRef`. Same metadata
     fields, minus ``args`` / ``kwargs``; ``var_idx`` indexes into
-    :meth:`ProjectContext.nodes`.
+    :meth:`ProjectContext.nodes`. ``path`` is preserved as a cheap
+    bucket key for plugins that fan out per file.
 
     Returned by :meth:`ConstructionQuery.row_indices`.
     """
 
     var_idx: int
+    path: str
     class_name: str
 
 class CallIdxRef:
     """Index-form sibling of :class:`CallRef`. Same metadata fields,
     minus ``args`` / ``kwargs``; ``owner_idx`` indexes into
-    :meth:`ProjectContext.nodes`. ``string_arg`` (the literal at the
-    configured positional index) is preserved because most call-shape
-    plugins key on it.
+    :meth:`ProjectContext.nodes`. ``path`` is the owning decl's path;
+    ``string_arg`` (the literal at the configured positional index) is
+    preserved because most call-shape plugins key on it.
 
     Returned by :meth:`CallQuery.row_indices`.
     """
 
     owner_idx: int
+    path: str
     string_arg: str
 
 class FactoryIdxRef:
     """Index-form sibling of :class:`FactoryRef`. ``decl_idx`` indexes
     into :meth:`ProjectContext.nodes`; ``kinds`` is the same sorted set
     of matched constructor bare-names the node-returning terminal emits.
+    ``path`` is preserved as a cheap bucket key for plugins that fan
+    out per file.
 
     Returned by :meth:`FactoryQuery.row_indices`.
     """
 
     decl_idx: int
+    path: str
     kinds: list[str]
 
 def query(ctx: ProjectContext) -> QueryBuilder:
@@ -1248,6 +1324,12 @@ class DecoratorQuery:
         self, via: str, attrs: str | list[str] | tuple[str, ...]
     ) -> DecoratorQuery: ...
     def in_decl(self, node: SymbolNode) -> DecoratorQuery: ...
+    def in_decl_idx(self, idx: int) -> DecoratorQuery:
+        """Idx-form sibling of :meth:`in_decl`. Pass a positional index
+        into :meth:`ProjectContext.nodes` directly so plugins working
+        in idx-space don't round-trip through a ``SymbolNode``.
+        """
+        ...
     def where_path(self, regex: str) -> DecoratorQuery: ...
     def where_kwarg(self, name: str, value: Any) -> DecoratorQuery:
         """Filter to decorator calls whose ``name=value`` kwarg matches.
@@ -1355,6 +1437,13 @@ class SubclassQuery:
 
     def of_fqn(self, fqn: str) -> SubclassQuery: ...
     def of_node(self, node: SymbolNode) -> SubclassQuery: ...
+    def of_idx(self, idx: int) -> SubclassQuery:
+        """Idx-form sibling of :meth:`of_node`. Pass a positional
+        index into :meth:`ProjectContext.nodes` directly so plugins
+        working in idx-space don't round-trip through a ``SymbolNode``.
+        """
+        ...
+
     def transitive(self, value: bool) -> SubclassQuery: ...
     def collect(self) -> list[SymbolNode]: ...
     def count(self) -> int: ...

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -1404,6 +1404,20 @@ class DecoratorQuery:
         """
         ...
 
+    def with_args(self, value: bool) -> DecoratorQuery:
+        """Opt out of rust-side ``args`` / ``kwargs`` extraction.
+
+        Defaults to ``True``. When set to ``False`` the per-row
+        :fn:`extract_call_args_kwargs` walk is skipped — the row's
+        ``args`` / ``kwargs`` getters then surface empty containers.
+        Useful for plugins that only need the row's idx + metadata
+        strings; saves rust-side allocation per matched row.
+
+        Auto-forced back to ``True`` at row-collection time when any
+        ``where_kwarg`` is set (kwarg filtering needs the data).
+        """
+        ...
+
     def collect(self) -> list[DecoratorIdxRef]: ...
     def first(self) -> DecoratorIdxRef | None: ...
     def count(self) -> int: ...
@@ -1422,6 +1436,12 @@ class ConstructionQuery:
     def where_name(self, names: str | list[str] | tuple[str, ...]) -> ConstructionQuery: ...
     def where_class(self, fqn: str, *, include_subclasses: bool = False) -> ConstructionQuery: ...
     def where_path(self, regex: str) -> ConstructionQuery: ...
+    def with_args(self, value: bool) -> ConstructionQuery:
+        """Opt out of rust-side ``args`` / ``kwargs`` extraction. See
+        :meth:`DecoratorQuery.with_args`.
+        """
+        ...
+
     def collect(self) -> list[ConstructionIdxRef]: ...
     def first(self) -> ConstructionIdxRef | None: ...
     def count(self) -> int: ...
@@ -1455,6 +1475,13 @@ class CallQuery:
         ``float`` / ``str`` / ``list`` / ``tuple``). A missing kwarg
         on the call never matches. A non-literal kwarg expression
         never matches.
+        """
+        ...
+
+    def with_args(self, value: bool) -> CallQuery:
+        """Opt out of rust-side ``args`` / ``kwargs`` extraction. See
+        :meth:`DecoratorQuery.with_args`. Auto-forced back to ``True``
+        when any ``where_kwarg`` is set.
         """
         ...
 

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -257,7 +257,41 @@ class AddNode:
         edges_to: Iterable[SymbolNode] = ...,
     ) -> None: ...
 
-GraphOp = AddEdge | AddEdgeByIdx | AddEntrypoint | AddNode
+class AddNodeByIdx:
+    """Index-keyed variant of :class:`AddNode`. Wires the freshly-minted
+    synthetic node with positional indices into ``ctx.nodes()`` instead
+    of :class:`SymbolNode` references for ``edges_from`` / ``edges_to``.
+
+    Pairs with the ``.indices()`` query terminals and
+    :meth:`ProjectContext.indices_where` so plugins that already work
+    in index space don't round-trip through ``Py<SymbolNode>`` just to
+    wire their synthetic markers. The apply pass treats it identically
+    to :class:`AddNode` once the indices land in the builder.
+
+    Raises :class:`IndexError` at apply time when any endpoint is out
+    of range. The bounds check runs *before* the new node is interned,
+    so a bad index never leaves an unconnected synthetic behind.
+    """
+
+    fqname: str
+    kind: NodeKind
+    path: str
+    flags: int
+    edges_from_idx: list[int]
+    edges_to_idx: list[int]
+
+    def __init__(
+        self,
+        fqname: str,
+        *,
+        path: str,
+        kind: NodeKind = "synthetic",
+        flags: int = 0,
+        edges_from_idx: Iterable[int] = ...,
+        edges_to_idx: Iterable[int] = ...,
+    ) -> None: ...
+
+GraphOp = AddEdge | AddEdgeByIdx | AddEntrypoint | AddNode | AddNodeByIdx
 
 class CollectedOps:
     """Opaque handle to one plugin's collected graph ops.
@@ -593,6 +627,17 @@ class ProjectContext:
         """
         ...
 
+    def find_declarations_indices(self, fqname: str) -> list[int]:
+        """Idx-only variant of :meth:`find_declarations`.
+
+        Same walk-back rules; returns positional indices into
+        :meth:`nodes` rather than allocating ``SymbolNode`` clones — pair
+        with :class:`AddEdgeByIdx` / :class:`AddNodeByIdx` to skip the
+        ``SymbolNode -> idx`` round-trip when wiring against the matched
+        decls.
+        """
+        ...
+
     def find_module(self, fqname: str) -> SymbolNode | None:
         """Return the module node for the given dotted fqname, if one
         exists in the project graph."""
@@ -607,6 +652,21 @@ class ProjectContext:
         """
         ...
 
+    def module_for_indices(self, path: str) -> int | None:
+        """Idx-only variant of :meth:`module_for`. Same O(1) lookup,
+        returns the positional index into :meth:`nodes` (``None`` if
+        ``path`` doesn't name a project module).
+        """
+        ...
+
+    def modules_for_paths(self, paths: list[str]) -> list[int | None]:
+        """Bulk form of :meth:`module_for_indices`. One ``materialize``
+        check + one O(1) lookup per path; missing paths map to ``None``.
+        Lets plugins that ``module_for(path)`` once per ref row collapse
+        N FFI hops into one.
+        """
+        ...
+
     def module_surface(self, module_fqn: str) -> list[SymbolNode]:
         """Module node + every transitive decl whose fqname lives
         under ``module_fqn``.
@@ -615,6 +675,20 @@ class ProjectContext:
         whole top-level surface plus everything its submodules expose.
         Empty list when ``module_fqn`` doesn't resolve to a project
         module.
+        """
+        ...
+
+    def module_surface_indices(self, module_fqn: str) -> list[int]:
+        """Idx-only variant of :meth:`module_surface`. Same BFS over
+        the fqname tree; returns positional indices into :meth:`nodes`
+        rather than allocating ``SymbolNode`` clones.
+        """
+        ...
+
+    def module_surfaces_indices(self, module_fqns: list[str]) -> dict[str, list[int]]:
+        """Idx-only variant of :meth:`module_surfaces`. Same single-
+        sweep scan; the per-fqname buckets carry positional indices
+        into :meth:`nodes` rather than ``SymbolNode`` clones.
         """
         ...
 
@@ -822,6 +896,18 @@ class ProjectContext:
         """
         ...
 
+    def node_attrs(self, indices: Sequence[int]) -> list[tuple[NodeKind, str, str, int]]:
+        """Batched snapshot of ``(kind, path, fqname, flags)`` per
+        index. One FFI hop instead of N per-attribute ``borrow``
+        round-trips — lets plugins that filter or partition by these
+        four fields stay GIL-free in the inner loop, which matters
+        once the plugin pass runs concurrently.
+
+        Validates bounds the same way :meth:`nodes_at` does and raises
+        :class:`IndexError` when any index is out of range.
+        """
+        ...
+
     # ----- Pure scans over the in-progress graph ------------------------
 
     def find_module_dunders(self) -> list[SymbolNode]:
@@ -852,6 +938,15 @@ class ProjectContext:
         / import nodes whose source position falls inside the block's
         range — same shape ``MainBlockPlugin``'s libcst path computes
         from the visitor's payload.
+        """
+        ...
+
+    def find_main_blocks_indices(self) -> list[tuple[int, list[int]]]:
+        """Idx-only variant of :meth:`find_main_blocks`. Returns
+        ``(module_idx, [decl_idx])`` pairs into :meth:`nodes` rather
+        than ``SymbolNode`` clones — pair with :class:`AddNodeByIdx` to
+        emit a marker per main block without round-tripping its decls
+        through ``Py<SymbolNode>``.
         """
         ...
 
@@ -1046,6 +1141,56 @@ class CallRef:
     @property
     def path(self) -> str: ...
 
+class DecoratorIdxRef:
+    """Index-form sibling of :class:`DecoratorRef`. Same metadata
+    fields, minus ``args`` / ``kwargs``; ``decorated_idx`` indexes into
+    :meth:`ProjectContext.nodes`.
+
+    Returned by :meth:`DecoratorQuery.row_indices`. Pair with
+    :meth:`ProjectContext.node_attrs` to batch-fetch any node fields
+    the plugin still needs without per-row ``borrow`` ping-pong.
+    """
+
+    decorated_idx: int
+    decorator_name: str | None
+    decorator_owner: str | None
+    decorator_via: str | None
+
+class ConstructionIdxRef:
+    """Index-form sibling of :class:`ConstructionRef`. Same metadata
+    fields, minus ``args`` / ``kwargs``; ``var_idx`` indexes into
+    :meth:`ProjectContext.nodes`.
+
+    Returned by :meth:`ConstructionQuery.row_indices`.
+    """
+
+    var_idx: int
+    class_name: str
+
+class CallIdxRef:
+    """Index-form sibling of :class:`CallRef`. Same metadata fields,
+    minus ``args`` / ``kwargs``; ``owner_idx`` indexes into
+    :meth:`ProjectContext.nodes`. ``string_arg`` (the literal at the
+    configured positional index) is preserved because most call-shape
+    plugins key on it.
+
+    Returned by :meth:`CallQuery.row_indices`.
+    """
+
+    owner_idx: int
+    string_arg: str
+
+class FactoryIdxRef:
+    """Index-form sibling of :class:`FactoryRef`. ``decl_idx`` indexes
+    into :meth:`ProjectContext.nodes`; ``kinds`` is the same sorted set
+    of matched constructor bare-names the node-returning terminal emits.
+
+    Returned by :meth:`FactoryQuery.row_indices`.
+    """
+
+    decl_idx: int
+    kinds: list[str]
+
 def query(ctx: ProjectContext) -> QueryBuilder:
     """Open a chainable query builder against ``ctx``.
 
@@ -1119,6 +1264,15 @@ class DecoratorQuery:
     def first(self) -> DecoratorRef | None: ...
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[DecoratorRef]: ...
+    def row_indices(self) -> list[DecoratorIdxRef]:
+        """Index-form row terminal. Same dispatch as :meth:`collect`,
+        but each row carries ``decorated_idx`` (a positional index into
+        :meth:`ProjectContext.nodes`) instead of a ``SymbolNode``, and
+        the ``args`` / ``kwargs`` row payloads are skipped. Pair with
+        :meth:`ProjectContext.node_attrs` for plugins that need a few
+        node fields without per-row borrow ping-pong.
+        """
+        ...
 
 class ConstructionQuery:
     """Find module-scope ``<var> = <Ctor>(...)`` sites."""
@@ -1137,6 +1291,13 @@ class ConstructionQuery:
     def first(self) -> ConstructionRef | None: ...
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[ConstructionRef]: ...
+    def row_indices(self) -> list[ConstructionIdxRef]:
+        """Index-form row terminal. Same dispatch as :meth:`collect`,
+        but each row carries ``var_idx`` (a positional index into
+        :meth:`ProjectContext.nodes`) instead of a ``SymbolNode``, and
+        the ``args`` / ``kwargs`` row payloads are skipped.
+        """
+        ...
 
 class CallQuery:
     """Find call sites with a captured positional string-literal arg.
@@ -1173,6 +1334,15 @@ class CallQuery:
     def first(self) -> CallRef | None: ...
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[CallRef]: ...
+    def row_indices(self) -> list[CallIdxRef]:
+        """Index-form row terminal. Same dispatch as :meth:`collect`,
+        but each row carries ``owner_idx`` (a positional index into
+        :meth:`ProjectContext.nodes`) instead of a ``SymbolNode``, and
+        the ``args`` / ``kwargs`` row payloads are skipped.
+        ``string_arg`` is preserved because most call-shape plugins
+        key on it.
+        """
+        ...
 
 class SubclassQuery:
     """Walk the subclass closure of a class.
@@ -1279,6 +1449,12 @@ class FactoryQuery:
     def collect(self) -> list[FactoryRef]: ...
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[FactoryRef]: ...
+    def row_indices(self) -> list[FactoryIdxRef]:
+        """Index-form row terminal. Same dispatch as :meth:`collect`;
+        each row carries ``decl_idx`` (a positional index into
+        :meth:`ProjectContext.nodes`) instead of a ``SymbolNode``.
+        """
+        ...
 
 class EdgeRef:
     """One graph edge with both endpoint nodes resolved.

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -799,7 +799,7 @@ class ProjectContext:
         """
         ...
 
-    def node_attrs(self, indices: Sequence[int]) -> list[tuple[NodeKind, str, str, int]]:
+    def node_attrs(self, indices: Sequence[int]) -> list[NodeAttrs]:
         """Batched snapshot of ``(kind, path, fqname, flags)`` per
         index. One FFI hop instead of N per-attribute ``borrow``
         round-trips — lets plugins that filter or partition by these
@@ -995,6 +995,26 @@ class ArgOpaque:
     """
 
     def __init__(self) -> None: ...
+
+class NodeAttrs:
+    """Tuple-like row returned by :meth:`ProjectContext.node_attrs`
+    and every query's ``.attrs()`` terminal.
+
+    Supports both attribute access (``attr.fqname``) and tuple
+    semantics (``kind, path, fqname, flags = attr``; ``attr[2]``;
+    ``len(attr) == 4``; ``list(attr)``). Not a `typing.NamedTuple`
+    instance, but drop-in compatible for unpacking and subscript.
+    Frozen — fields are immutable once constructed.
+    """
+
+    kind: NodeKind
+    path: str
+    fqname: str
+    flags: int
+
+    def __len__(self) -> int: ...
+    def __getitem__(self, idx: int) -> Any: ...
+    def __iter__(self) -> Iterator[Any]: ...
 
 CallArg = ArgLiteral | ArgNodeRef | ArgOpaque
 """Discriminated-union type for entries inside the lazy ``args`` /
@@ -1214,13 +1234,13 @@ class DecoratorQuery:
         ...
 
     def with_args(self, value: bool) -> DecoratorQuery:
-        """Opt out of rust-side ``args`` / ``kwargs`` extraction.
+        """Opt in to rust-side ``args`` / ``kwargs`` extraction.
 
-        Defaults to ``True``. When set to ``False`` the per-row
-        :fn:`extract_call_args_kwargs` walk is skipped — the row's
-        ``args`` / ``kwargs`` getters then surface empty containers.
-        Useful for plugins that only need the row's idx + metadata
-        strings; saves rust-side allocation per matched row.
+        Defaults to ``False`` — the per-row
+        :fn:`extract_call_args_kwargs` walk is skipped, and the
+        row's ``args`` / ``kwargs`` getters surface empty containers.
+        Pass ``True`` when a plugin actually reads ``args`` /
+        ``kwargs`` off the matched rows.
 
         Auto-forced back to ``True`` at row-collection time when any
         ``where_kwarg`` is set (kwarg filtering needs the data).
@@ -1231,6 +1251,12 @@ class DecoratorQuery:
     def first(self) -> DecoratorIdxRef | None: ...
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[DecoratorIdxRef]: ...
+    def indices_by_path(self) -> dict[str, list[int]]:
+        """Terminal — group matched ``decorated_idx`` values by their
+        owning file path. ``dict[path, list[int]]``; reads ``path``
+        straight off each row.
+        """
+        ...
 
 class ConstructionQuery:
     """Find module-scope ``<var> = <Ctor>(...)`` sites."""
@@ -1255,6 +1281,11 @@ class ConstructionQuery:
     def first(self) -> ConstructionIdxRef | None: ...
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[ConstructionIdxRef]: ...
+    def indices_by_path(self) -> dict[str, list[int]]:
+        """Terminal — group matched ``var_idx`` values by their owning
+        file path.
+        """
+        ...
 
 class CallQuery:
     """Find call sites with a captured positional string-literal arg.
@@ -1298,6 +1329,11 @@ class CallQuery:
     def first(self) -> CallIdxRef | None: ...
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[CallIdxRef]: ...
+    def indices_by_path(self) -> dict[str, list[int]]:
+        """Terminal — group matched ``owner_idx`` values by their
+        owning file path.
+        """
+        ...
 
 class SubclassQuery:
     """Walk the subclass closure of a class.
@@ -1329,6 +1365,25 @@ class SubclassQuery:
         """
         ...
 
+    def attrs(self) -> list[NodeAttrs]:
+        """Terminal — :class:`NodeAttrs` for every matched subclass,
+        in the same order :meth:`indices` returns. Avoids the
+        boilerplate of ``ctx.node_attrs(q.indices())``.
+        """
+        ...
+
+    def first_idx(self) -> int | None:
+        """Terminal — first matched subclass's positional index, or
+        ``None`` when no subclass exists.
+        """
+        ...
+
+    def indices_by_path(self) -> dict[str, list[int]]:
+        """Terminal — group matched indices by their owning file
+        path.
+        """
+        ...
+
 class ImportQuery:
     """Enumerate the ``kind="import"`` nodes that bind a name from a
     given module. Requires :meth:`of` (the upstream module name).
@@ -1351,6 +1406,25 @@ class ImportQuery:
         configured module? Short-circuits without materialising a
         Python list. Preferred over ``.count() > 0`` / ``.collect()``
         for plugin guards that just need a boolean.
+        """
+        ...
+
+    def attrs(self) -> list[NodeAttrs]:
+        """Terminal — :class:`NodeAttrs` for every matched import
+        node, in the same order :meth:`indices` returns.
+        """
+        ...
+
+    def first_idx(self) -> int | None:
+        """Terminal — first matched import node's positional index,
+        or ``None`` when no project file imports the configured
+        module.
+        """
+        ...
+
+    def indices_by_path(self) -> dict[str, list[int]]:
+        """Terminal — group matched indices by their owning file
+        path.
         """
         ...
 
@@ -1439,6 +1513,18 @@ class ModuleQuery:
 
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[int]: ...
+    def attrs(self) -> list[NodeAttrs]:
+        """Terminal — :class:`NodeAttrs` for every matched index, in
+        the same order :meth:`indices` returns. Avoids the
+        boilerplate of ``ctx.node_attrs(q.indices())``.
+        """
+        ...
+
+    def indices_by_path(self) -> dict[str, list[int]]:
+        """Terminal — group matched indices by their owning file
+        path.
+        """
+        ...
 
 class TraverseQuery:
     """Closure walks anchored at a single seed node. Built via
@@ -1498,6 +1584,25 @@ class DeclarationsQuery:
 
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[int]: ...
+    def attrs(self) -> list[NodeAttrs]:
+        """Terminal — :class:`NodeAttrs` for every matched decl, in
+        the same order :meth:`indices` returns. Modules are excluded
+        (same rule as :meth:`indices`).
+        """
+        ...
+
+    def first_idx(self) -> int | None:
+        """Terminal — first matched decl's positional index, or
+        ``None`` when no decl matches. Distinct from
+        :meth:`resolve_idx`: this one skips the module fallback.
+        """
+        ...
+
+    def indices_by_path(self) -> dict[str, list[int]]:
+        """Terminal — group matched indices by their owning file
+        path.
+        """
+        ...
 
 class MainBlockQuery:
     """Enumerate every ``if __name__ == "__main__":`` block in the
@@ -1553,6 +1658,24 @@ class ClassQuery:
         """
         ...
 
+    def attrs(self) -> list[NodeAttrs]:
+        """Terminal — :class:`NodeAttrs` for every matched class, in
+        the same order :meth:`indices` returns.
+        """
+        ...
+
+    def first_idx(self) -> int | None:
+        """Terminal — first matched class's positional index, or
+        ``None`` when no class defines the configured method.
+        """
+        ...
+
+    def indices_by_path(self) -> dict[str, list[int]]:
+        """Terminal — group matched indices by their owning file
+        path.
+        """
+        ...
+
 class FactoryQuery:
     """Walk function / class bodies for ``<Ctor>(...)`` calls where
     ``Ctor`` is imported from :meth:`of_module` and matches one of
@@ -1572,6 +1695,11 @@ class FactoryQuery:
     def collect(self) -> list[FactoryIdxRef]: ...
     def count(self) -> int: ...
     def __iter__(self) -> Iterator[FactoryIdxRef]: ...
+    def indices_by_path(self) -> dict[str, list[int]]:
+        """Terminal — group matched ``decl_idx`` values by their
+        owning file path.
+        """
+        ...
 
 class EdgeRef:
     """One graph edge with both endpoint nodes resolved.
@@ -1725,6 +1853,27 @@ class DeclQuery:
         :class:`AddEdgeByIdx`); call
         :meth:`ProjectContext.nodes_at` to materialize back to
         ``SymbolNode`` later.
+        """
+        ...
+
+    def attrs(self) -> list[NodeAttrs]:
+        """Terminal — :class:`NodeAttrs` for every surviving node, in
+        the same order :meth:`indices` returns. Avoids the
+        boilerplate of ``ctx.node_attrs(q.indices())``.
+        """
+        ...
+
+    def first_idx(self) -> int | None:
+        """Terminal — first matching node's positional index, or
+        ``None`` when no node matches. Convenience for single-value
+        lookups.
+        """
+        ...
+
+    def indices_by_path(self) -> dict[str, list[int]]:
+        """Terminal — group matched indices by their owning file
+        path. One :meth:`ProjectContext.node_paths` call internally.
+        Lets plugins fan out per-file work without re-querying.
         """
         ...
 

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -1194,98 +1194,74 @@ class ProjectContext:
 # also move the ``find_*`` methods out of ``#[pymethods]`` and inline
 # their bodies into each query's ``collect()`` directly.
 
-class DecoratorRef:
+class ArgLiteral:
+    """A literal arg / kwarg value. ``value`` is a native Python
+    primitive: ``str`` / ``int`` / ``float`` / ``bool`` / ``None`` /
+    ``bytes`` / ``list`` / ``tuple``. Nested ``list`` / ``tuple``
+    elements are themselves :class:`ArgLiteral` / :class:`ArgNodeRef`
+    / :class:`ArgOpaque` instances (the discriminated union recurses).
+    """
+
+    value: Any
+
+class ArgNodeRef:
+    """A decl reference inside an arg / kwarg position.
+
+    Materialised when the expression at that position resolves through
+    the file's imports to a project decl — e.g. ``func(SomeClass)``
+    where ``SomeClass`` is imported. ``idx`` is a positional index
+    into :meth:`ProjectContext.nodes`; pair with
+    :meth:`ProjectContext.node_attrs` (or :class:`AddEdgeByIdx`) to
+    consume it without leaving idx-space.
+    """
+
+    idx: int
+
+class ArgOpaque:
+    """An arg / kwarg expression that's neither a recognised literal
+    nor a statically-resolvable decl reference. Callers who need the
+    source text should fall back to ty's parsed module — the rust
+    extractor doesn't preserve unresolved expressions verbatim.
+    """
+
+    def __init__(self) -> None: ...
+
+CallArg = ArgLiteral | ArgNodeRef | ArgOpaque
+"""Discriminated-union type for entries inside the lazy ``args`` /
+``kwargs`` getters on :class:`DecoratorIdxRef` / :class:`ConstructionIdxRef`
+/ :class:`CallIdxRef`. Use ``isinstance`` or ``match`` to dispatch:
+
+.. code-block:: python
+
+    for arg in row.kwargs.values():
+        match arg:
+            case native.ArgLiteral(value=str() as s):
+                ...
+            case native.ArgNodeRef(idx=i):
+                ...
+            case native.ArgOpaque():
+                ...
+"""
+
+class DecoratorIdxRef:
     """One decorator application on a top-level function or class.
 
-    Field nullability follows the query shape that produced the ref:
+    Field nullability follows the query shape that produced the row:
 
-    * ``where_module + where_name`` populates ``decorated`` only;
-      ``decorator_name`` is ``None`` because the underlying walk
-      doesn't surface which of the queried names matched.
+    * ``where_module + where_name`` populates ``decorated_idx`` only.
     * ``where_owner_attr`` fills ``decorator_owner`` (the textual
       ``@<owner>.<attr>`` prefix).
     * ``where_owner_attr_via`` additionally fills ``decorator_via``
       with the middle attribute name.
 
-    ``args`` and ``kwargs`` are populated from the decorator's
-    ``Call`` form (``@dec(a, b, k=v)``). Bare-attribute decorators
-    (``@app.route`` without ``()``) get empty containers. Each value
-    is a Python literal (str / int / float / bool / None / list /
-    tuple), a :class:`SymbolNode` when the expression statically
-    resolves to a project decl, or ``None`` for any other non-literal
-    expression.
-    """
+    ``args`` and ``kwargs`` are **lazy** — accessing them walks the
+    row's rust-side ``CallArgs`` and materialises a Python ``list`` /
+    ``dict`` of :class:`ArgLiteral` / :class:`ArgNodeRef` /
+    :class:`ArgOpaque`. Plugins that never touch them pay zero Python
+    allocation cost for the args payload. Bare-attribute decorators
+    (``@app.route`` without ``()``) get empty containers.
 
-    decorated: SymbolNode
-    decorator_name: str | None
-    decorator_owner: str | None
-    decorator_via: str | None
-    args: list[Any]
-    kwargs: dict[str, Any]
-
-    @property
-    def path(self) -> str: ...
-
-class ConstructionRef:
-    """One ``<var> = <Ctor>(...)`` construction at module scope.
-
-    ``class_name`` is the upstream constructor's bare name
-    (``"Flask"`` even when imported as ``F``).
-
-    ``args`` and ``kwargs`` carry the construction's full positional /
-    keyword argument shape. Each value is a Python literal (str / int
-    / float / bool / None / list / tuple), a :class:`SymbolNode` when
-    the expression statically resolves to a project decl, or ``None``
-    for any other non-literal expression.
-    """
-
-    var: SymbolNode
-    class_name: str
-    args: list[Any]
-    kwargs: dict[str, Any]
-
-    @property
-    def path(self) -> str: ...
-
-class CallRef:
-    """One matched call site.
-
-    ``string_arg`` is the positional string literal at the index
-    passed to :meth:`CallQuery.string_arg_at`.
-
-    ``args`` and ``kwargs`` carry the call's full positional /
-    keyword argument shape. Each value is a Python literal (str /
-    int / float / bool / None / list / tuple), a :class:`SymbolNode`
-    when the expression statically resolves to a project decl, or
-    ``None`` for any other non-literal expression.
-    """
-
-    owner: SymbolNode
-    string_arg: str
-    args: list[Any]
-    kwargs: dict[str, Any]
-
-    @property
-    def path(self) -> str: ...
-
-class DecoratorIdxRef:
-    """Index-form sibling of :class:`DecoratorRef`. Same metadata
-    fields, minus ``args`` / ``kwargs``; ``decorated_idx`` indexes into
-    :meth:`ProjectContext.nodes`. ``path`` is preserved because plugins
-    routinely bucket by path before any further query.
-
-    ``args`` / ``kwargs`` are dropped on the idx form because entries
-    inside them can be :class:`SymbolNode` references that would
-    re-introduce the GIL hops the idx surface is designed to avoid.
-    Plugins that need them fall back to :meth:`DecoratorQuery.collect`;
-    plugins that only need to filter by kwarg keep using
-    :meth:`DecoratorQuery.where_kwarg`, which runs rust-side before
-    row construction either way.
-
-    Returned by :meth:`DecoratorQuery.row_indices`. Pair with
-    :meth:`ProjectContext.node_attrs` (or :meth:`node_paths` when only
-    ``path`` is needed) to batch-fetch any other node fields the
-    plugin needs without per-row ``borrow`` ping-pong.
+    Returned by :meth:`DecoratorQuery.collect`.
     """
 
     decorated_idx: int
@@ -1294,48 +1270,59 @@ class DecoratorIdxRef:
     decorator_owner: str | None
     decorator_via: str | None
 
-class ConstructionIdxRef:
-    """Index-form sibling of :class:`ConstructionRef`. Same metadata
-    fields, minus ``args`` / ``kwargs``; ``var_idx`` indexes into
-    :meth:`ProjectContext.nodes`. ``path`` is preserved as a cheap
-    bucket key for plugins that fan out per file. ``args`` /
-    ``kwargs`` are dropped for the same reason
-    :class:`DecoratorIdxRef` drops them — see its docstring.
+    @property
+    def args(self) -> list[CallArg]: ...
+    @property
+    def kwargs(self) -> dict[str, CallArg]: ...
 
-    Returned by :meth:`ConstructionQuery.row_indices`.
+class ConstructionIdxRef:
+    """One ``<var> = <Ctor>(...)`` construction at module scope.
+
+    ``class_name`` is the upstream constructor's bare name (``"Flask"``
+    even when imported as ``F``). ``args`` / ``kwargs`` are the
+    constructor call's positional / keyword arguments — lazy getters,
+    same discriminated-union shape as :class:`DecoratorIdxRef`.
+
+    Returned by :meth:`ConstructionQuery.collect`.
     """
 
     var_idx: int
     path: str
     class_name: str
 
+    @property
+    def args(self) -> list[CallArg]: ...
+    @property
+    def kwargs(self) -> dict[str, CallArg]: ...
+
 class CallIdxRef:
-    """Index-form sibling of :class:`CallRef`. Same metadata fields,
-    minus ``args`` / ``kwargs``; ``owner_idx`` indexes into
-    :meth:`ProjectContext.nodes`. ``path`` is the owning decl's path;
-    ``string_arg`` (the literal at the configured positional index)
-    is preserved because (a) most call-shape plugins key on it and
-    (b) it's a plain ``str`` with no ``SymbolNode`` content, so it
-    doesn't cost a borrow per row.
+    """One matched call site.
 
-    ``args`` / ``kwargs`` are dropped for the same reason
-    :class:`DecoratorIdxRef` drops them — see its docstring.
+    ``string_arg`` is the positional string literal at the index passed
+    to :meth:`CallQuery.string_arg_at`. ``args`` / ``kwargs`` are the
+    call's full positional / keyword arguments — lazy getters, same
+    discriminated-union shape as :class:`DecoratorIdxRef`.
 
-    Returned by :meth:`CallQuery.row_indices`.
+    Returned by :meth:`CallQuery.collect`.
     """
 
     owner_idx: int
     path: str
     string_arg: str
 
-class FactoryIdxRef:
-    """Index-form sibling of :class:`FactoryRef`. ``decl_idx`` indexes
-    into :meth:`ProjectContext.nodes`; ``kinds`` is the same sorted set
-    of matched constructor bare-names the node-returning terminal emits.
-    ``path`` is preserved as a cheap bucket key for plugins that fan
-    out per file.
+    @property
+    def args(self) -> list[CallArg]: ...
+    @property
+    def kwargs(self) -> dict[str, CallArg]: ...
 
-    Returned by :meth:`FactoryQuery.row_indices`.
+class FactoryIdxRef:
+    """One factory-function / class hit. ``decl_idx`` is the owning
+    top-level decl's positional index into :meth:`ProjectContext.nodes`;
+    ``kinds`` is the sorted set of constructor bare-names matched
+    inside its body. ``path`` is the decl's source file as a cheap
+    bucket key for per-file fan-out.
+
+    Returned by :meth:`FactoryQuery.collect`.
     """
 
     decl_idx: int
@@ -1417,19 +1404,10 @@ class DecoratorQuery:
         """
         ...
 
-    def collect(self) -> list[DecoratorRef]: ...
-    def first(self) -> DecoratorRef | None: ...
+    def collect(self) -> list[DecoratorIdxRef]: ...
+    def first(self) -> DecoratorIdxRef | None: ...
     def count(self) -> int: ...
-    def __iter__(self) -> Iterator[DecoratorRef]: ...
-    def row_indices(self) -> list[DecoratorIdxRef]:
-        """Index-form row terminal. Same dispatch as :meth:`collect`,
-        but each row carries ``decorated_idx`` (a positional index into
-        :meth:`ProjectContext.nodes`) instead of a ``SymbolNode``, and
-        the ``args`` / ``kwargs`` row payloads are skipped. Pair with
-        :meth:`ProjectContext.node_attrs` for plugins that need a few
-        node fields without per-row borrow ping-pong.
-        """
-        ...
+    def __iter__(self) -> Iterator[DecoratorIdxRef]: ...
 
 class ConstructionQuery:
     """Find module-scope ``<var> = <Ctor>(...)`` sites."""
@@ -1444,17 +1422,10 @@ class ConstructionQuery:
     def where_name(self, names: str | list[str] | tuple[str, ...]) -> ConstructionQuery: ...
     def where_class(self, fqn: str, *, include_subclasses: bool = False) -> ConstructionQuery: ...
     def where_path(self, regex: str) -> ConstructionQuery: ...
-    def collect(self) -> list[ConstructionRef]: ...
-    def first(self) -> ConstructionRef | None: ...
+    def collect(self) -> list[ConstructionIdxRef]: ...
+    def first(self) -> ConstructionIdxRef | None: ...
     def count(self) -> int: ...
-    def __iter__(self) -> Iterator[ConstructionRef]: ...
-    def row_indices(self) -> list[ConstructionIdxRef]:
-        """Index-form row terminal. Same dispatch as :meth:`collect`,
-        but each row carries ``var_idx`` (a positional index into
-        :meth:`ProjectContext.nodes`) instead of a ``SymbolNode``, and
-        the ``args`` / ``kwargs`` row payloads are skipped.
-        """
-        ...
+    def __iter__(self) -> Iterator[ConstructionIdxRef]: ...
 
 class CallQuery:
     """Find call sites with a captured positional string-literal arg.
@@ -1487,19 +1458,10 @@ class CallQuery:
         """
         ...
 
-    def collect(self) -> list[CallRef]: ...
-    def first(self) -> CallRef | None: ...
+    def collect(self) -> list[CallIdxRef]: ...
+    def first(self) -> CallIdxRef | None: ...
     def count(self) -> int: ...
-    def __iter__(self) -> Iterator[CallRef]: ...
-    def row_indices(self) -> list[CallIdxRef]:
-        """Index-form row terminal. Same dispatch as :meth:`collect`,
-        but each row carries ``owner_idx`` (a positional index into
-        :meth:`ProjectContext.nodes`) instead of a ``SymbolNode``, and
-        the ``args`` / ``kwargs`` row payloads are skipped.
-        ``string_arg`` is preserved because most call-shape plugins
-        key on it.
-        """
-        ...
+    def __iter__(self) -> Iterator[CallIdxRef]: ...
 
 class SubclassQuery:
     """Walk the subclass closure of a class.
@@ -1578,22 +1540,6 @@ class ClassQuery:
         """
         ...
 
-class FactoryRef:
-    """One result row from :class:`FactoryQuery`.
-
-    ``decl`` is the owning top-level function or class; ``kinds`` is
-    the sorted set of constructor bare-names matched inside its body
-    (multiple kinds appear when a single factory constructs more than
-    one — e.g. a function that returns a ``Flask`` after mounting
-    several ``Blueprint``\\ s).
-    """
-
-    decl: SymbolNode
-    kinds: list[str]
-
-    @property
-    def path(self) -> str: ...
-
 class FactoryQuery:
     """Walk function / class bodies for ``<Ctor>(...)`` calls where
     ``Ctor`` is imported from :meth:`of_module` and matches one of
@@ -1610,15 +1556,9 @@ class FactoryQuery:
         ...
 
     def where_name(self, names: str | list[str] | tuple[str, ...]) -> FactoryQuery: ...
-    def collect(self) -> list[FactoryRef]: ...
+    def collect(self) -> list[FactoryIdxRef]: ...
     def count(self) -> int: ...
-    def __iter__(self) -> Iterator[FactoryRef]: ...
-    def row_indices(self) -> list[FactoryIdxRef]:
-        """Index-form row terminal. Same dispatch as :meth:`collect`;
-        each row carries ``decl_idx`` (a positional index into
-        :meth:`ProjectContext.nodes`) instead of a ``SymbolNode``.
-        """
-        ...
+    def __iter__(self) -> Iterator[FactoryIdxRef]: ...
 
 class EdgeRef:
     """One graph edge with both endpoint nodes resolved.

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -430,6 +430,71 @@ class _ProgressPoller:
                 )
 
 
+class _DispatchShim:
+    """Internal: wraps a :class:`DispatchAppPlugin` with a pre-computed
+    gather slot. Implements the bare :class:`Plugin` protocol so the
+    harness can drive it through the same threaded fan-out it uses for
+    every other plugin — ``run(ctx)`` returns ``plugin.policy(ctx,
+    gathered)`` instead of calling the plugin's own ``run`` (which
+    would kick off a per-spec gather).
+
+    Used only by :meth:`Analysis.materialize_all`'s dispatch-batching
+    path; never appears in user code.
+    """
+
+    name = "DispatchShim"
+    version = 1
+
+    def __init__(self, plugin: Any, gathered: Any) -> None:
+        self._plugin = plugin
+        self._gathered = gathered
+
+    def prepare(self, project_root: Path) -> None:
+        pass
+
+    def run(self, ctx: native.ProjectContext) -> Iterator[Any]:
+        if self._gathered is None:
+            return iter(())
+        return iter(self._plugin.policy(ctx, self._gathered))
+
+
+def _schedule_with_dispatch_batching(
+    ctx: native.ProjectContext, plugins: Sequence[Any]
+) -> list[Any]:
+    """Return a per-plugin work list with every
+    :class:`DispatchAppPlugin` replaced by a :class:`_DispatchShim`
+    that closes over its slot in a single fused gather.
+
+    Position-preserving: ``len(out) == len(plugins)`` and ``out[i]`` is
+    either ``plugins[i]`` (non-dispatch) or a shim that policy-emits
+    for ``plugins[i]``. The fused gather (:func:`_gather_batched`) runs
+    here on the main thread — once for every active dispatch plugin —
+    so the subsequent per-plugin fan-out only does ``policy(ctx, …)``
+    work in worker threads.
+
+    Inactive dispatch plugins (``_is_active(ctx)`` returns ``False``)
+    get a no-op shim with ``gathered=None`` so progress accounting
+    stays one-shim-per-plugin.
+    """
+    from .plugins.decl_shapes import DispatchAppPlugin, _gather_batched
+
+    dispatch_plugins = [p for p in plugins if isinstance(p, DispatchAppPlugin)]
+    if not dispatch_plugins:
+        return list(plugins)
+
+    active = [p for p in dispatch_plugins if p._is_active(ctx)]
+    if active:
+        gathered = _gather_batched(ctx, [p.spec for p in active])
+        gathered_by_id = {id(p): g for p, g in zip(active, gathered, strict=True)}
+    else:
+        gathered_by_id = {}
+
+    return [
+        _DispatchShim(p, gathered_by_id.get(id(p))) if isinstance(p, DispatchAppPlugin) else p
+        for p in plugins
+    ]
+
+
 def _make_indicatif_callback() -> ProgressCallback:
     """Default progress callback for ``show_progress=True``.
 
@@ -606,12 +671,23 @@ class Analysis:
             )
             poller.start()
 
-        # ``DEAD_CST_PLUGINS_SERIAL=1`` (or no plugins / a single
-        # plugin) keeps the rust-side serial loop. Otherwise we drive
-        # plugins from a ``ThreadPoolExecutor`` so any plugin time
-        # spent in GIL-releasing rust queries (``find_decorated_decls``,
-        # ``find_subclasses_of_class``, ``find_handler_decorators``, ...)
-        # overlaps across workers.
+        # The plugin loop has two modes:
+        #
+        # * **Rust-side serial loop** — ``ctx.materialize()`` drives the
+        #   build pass and every registered plugin's ``run(ctx)`` in
+        #   one C call. Used when ``DEAD_CST_PLUGINS_SERIAL=1`` or
+        #   ``len(plugins) <= 1`` AND no plugin needs a between-build-
+        #   and-run hook (the dispatch-batching path does).
+        # * **Python-driven loop** — ``ctx.build_only()`` runs the
+        #   build pass; Python then drives plugin ``run(ctx)`` calls
+        #   itself, either through a :class:`ThreadPoolExecutor` (so
+        #   GIL-releasing rust queries overlap) or serially when
+        #   ``DEAD_CST_PLUGINS_SERIAL=1``. Lets the harness insert a
+        #   between-build-and-run step: detect every
+        #   :class:`DispatchAppPlugin` instance, run one fused
+        #   ``_gather_batched`` for the whole batch, and replace each
+        #   dispatch plugin with a :class:`_DispatchShim` whose
+        #   ``run(ctx)`` returns ``plugin.policy(ctx, gathered)``.
         #
         # Both paths satisfy the *frozen-graph* contract: every
         # plugin's ``run(ctx)`` observes the same base-graph state.
@@ -621,13 +697,24 @@ class Analysis:
         # and to every other plugin's queries, until the apply pass
         # runs.
         try:
-            if _serial_mode() or len(self._plugins) <= 1:
+            from .plugins.decl_shapes import DispatchAppPlugin
+
+            has_dispatch = any(isinstance(p, DispatchAppPlugin) for p in self._plugins)
+            use_rust_serial = not has_dispatch and (_serial_mode() or len(self._plugins) <= 1)
+            if use_rust_serial:
                 for plugin in self._plugins:
                     ctx.add_plugin(plugin)
                 ctx.materialize()
             else:
                 ctx.build_only()
-                workers = _plugin_worker_count(len(self._plugins))
+                scheduled = (
+                    _schedule_with_dispatch_batching(ctx, self._plugins)
+                    if has_dispatch
+                    else list(self._plugins)
+                )
+                workers = 1 if _serial_mode() else _plugin_worker_count(len(scheduled))
+                # Progress names track the *original* plugins so users see
+                # ``FlaskPlugin`` etc. — shims are an implementation detail.
                 plugin_names = [type(p).__qualname__ for p in self._plugins]
                 ctx.progress_plugins_start(plugin_names)
                 try:
@@ -646,7 +733,7 @@ class Analysis:
                     # uses those to attribute ``plugin_end`` events to
                     # the right plugin even when futures resolve out of
                     # registration order).
-                    def _run_collect(idx: int, plugin: Plugin):
+                    def _run_collect(idx: int, plugin: Any):
                         ctx.progress_plugin_started(idx)
                         try:
                             return ctx.run_plugin_collect(plugin)
@@ -659,7 +746,7 @@ class Analysis:
                         thread_name_prefix="dead-cst-plugin",
                     ) as pool:
                         futures = [
-                            pool.submit(_run_collect, idx, p) for idx, p in enumerate(self._plugins)
+                            pool.submit(_run_collect, idx, p) for idx, p in enumerate(scheduled)
                         ]
                         collected = [fut.result() for fut in futures]
                     ctx.apply_ops_batched(collected)

--- a/python/dead_cst/contrib/celery.py
+++ b/python/dead_cst/contrib/celery.py
@@ -8,7 +8,7 @@ from typing import Iterable
 
 from ..graph import NodeFlags
 from ..plugins._base import native
-from ..plugins.decl_shapes import DispatchAppPlugin
+from ..plugins.decl_shapes import DispatchAppGather, DispatchAppPlugin
 
 _SHARED_TASK_NAMES: frozenset[str] = frozenset({"shared_task"})
 
@@ -29,9 +29,14 @@ class CeleryPlugin(DispatchAppPlugin):
     app_classes: tuple[str, ...] = ("celery.Celery",)
     registration_decorators: frozenset[str] = frozenset({"task"})
 
-    def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
-        yield from DispatchAppPlugin.run(self, ctx)
-        # ``@shared_task`` is appless and not covered by DispatchAppPlugin.
+    def policy(
+        self, ctx: native.ProjectContext, gathered: DispatchAppGather
+    ) -> Iterable[native.GraphOp]:
+        # Standard dispatch policy first, then Celery's appless
+        # ``@shared_task`` fan-out. Override on ``policy`` (not ``run``)
+        # so :class:`BatchDispatchAppPlugin` honors the extension when
+        # CeleryPlugin is wrapped.
+        yield from super().policy(ctx, gathered)
         by_path: dict[str, list[int]] = {}
         for ref in (
             native.query(ctx)

--- a/python/dead_cst/contrib/celery.py
+++ b/python/dead_cst/contrib/celery.py
@@ -43,7 +43,7 @@ class CeleryPlugin(DispatchAppPlugin):
             .decorators()
             .where_module("celery")
             .where_name(list(_SHARED_TASK_NAMES))
-            .row_indices()
+            .collect()
         ):
             by_path.setdefault(ref.path, []).append(ref.decorated_idx)
         for path, target_idxs in by_path.items():

--- a/python/dead_cst/contrib/celery.py
+++ b/python/dead_cst/contrib/celery.py
@@ -34,8 +34,9 @@ class CeleryPlugin(DispatchAppPlugin):
     ) -> Iterable[native.GraphOp]:
         # Standard dispatch policy first, then Celery's appless
         # ``@shared_task`` fan-out. Override on ``policy`` (not ``run``)
-        # so :class:`BatchDispatchAppPlugin` honors the extension when
-        # CeleryPlugin is wrapped.
+        # so the harness's auto-batched gather still picks up the
+        # extension when CeleryPlugin sits alongside other dispatch
+        # plugins.
         yield from super().policy(ctx, gathered)
         by_path: dict[str, list[int]] = {}
         for ref in (

--- a/python/dead_cst/contrib/celery.py
+++ b/python/dead_cst/contrib/celery.py
@@ -32,18 +32,19 @@ class CeleryPlugin(DispatchAppPlugin):
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
         yield from DispatchAppPlugin.run(self, ctx)
         # ``@shared_task`` is appless and not covered by DispatchAppPlugin.
-        by_path: dict[str, list[native.SymbolNode]] = {}
+        by_path: dict[str, list[int]] = {}
         for ref in (
             native.query(ctx)
             .decorators()
             .where_module("celery")
             .where_name(list(_SHARED_TASK_NAMES))
+            .row_indices()
         ):
-            by_path.setdefault(ref.path, []).append(ref.decorated)
-        for path, targets in by_path.items():
-            yield native.AddNode(
+            by_path.setdefault(ref.path, []).append(ref.decorated_idx)
+        for path, target_idxs in by_path.items():
+            yield native.AddNodeByIdx(
                 fqname=f"{CELERY_SHARED_PREFIX}{Path(path).name}",
                 path=path,
                 flags=int(NodeFlags.ENTRYPOINT),
-                edges_to=targets,
+                edges_to_idx=target_idxs,
             )

--- a/python/dead_cst/contrib/click.py
+++ b/python/dead_cst/contrib/click.py
@@ -44,7 +44,7 @@ class ClickPlugin(DecoratedDeclPlugin):
             .decorators()
             .where_module(self.decorator_module)
             .where_name(list(self.decorator_names))
-            .row_indices()
+            .collect()
         )
         if dec_rows:
             dec_attrs = ctx.node_attrs([r.decorated_idx for r in dec_rows])
@@ -56,7 +56,7 @@ class ClickPlugin(DecoratedDeclPlugin):
             .constructions()
             .where_module(self.decorator_module)
             .where_name(list(self.constructor_names))
-            .row_indices()
+            .collect()
         )
         if cons_rows:
             cons_attrs = ctx.node_attrs([r.var_idx for r in cons_rows])
@@ -67,7 +67,7 @@ class ClickPlugin(DecoratedDeclPlugin):
             native.query(ctx)
             .decorators()
             .where_owner_attr(list(_REGISTRATION_DECORATORS))
-            .row_indices()
+            .collect()
         )
         # Batched fqname fetch for every handler — used both in the
         # fixpoint dispatch and for the subgroup_links key.
@@ -84,7 +84,7 @@ class ClickPlugin(DecoratedDeclPlugin):
             for h in native.query(ctx)
             .decorators()
             .where_owner_attr(list(_SUBGROUP_DECORATOR))
-            .row_indices()
+            .collect()
         }
 
         # Dedup by (owner_idx, handler_idx) — idx is globally unique.

--- a/python/dead_cst/contrib/click.py
+++ b/python/dead_cst/contrib/click.py
@@ -48,8 +48,8 @@ class ClickPlugin(DecoratedDeclPlugin):
         )
         if dec_rows:
             dec_attrs = ctx.node_attrs([r.decorated_idx for r in dec_rows])
-            for row, (_k, _p, fqname, _f) in zip(dec_rows, dec_attrs, strict=True):
-                add_group(row.decorated_idx, row.path, fqname)
+            for row, attr in zip(dec_rows, dec_attrs, strict=True):
+                add_group(row.decorated_idx, row.path, attr.fqname)
 
         cons_rows = (
             native.query(ctx)
@@ -60,8 +60,8 @@ class ClickPlugin(DecoratedDeclPlugin):
         )
         if cons_rows:
             cons_attrs = ctx.node_attrs([r.var_idx for r in cons_rows])
-            for row, (_k, _p, fqname, _f) in zip(cons_rows, cons_attrs, strict=True):
-                add_group(row.var_idx, row.path, fqname)
+            for row, attr in zip(cons_rows, cons_attrs, strict=True):
+                add_group(row.var_idx, row.path, attr.fqname)
 
         handler_rows = list(
             native.query(ctx)
@@ -74,7 +74,7 @@ class ClickPlugin(DecoratedDeclPlugin):
         handler_attrs = (
             ctx.node_attrs([h.decorated_idx for h in handler_rows]) if handler_rows else []
         )
-        handler_fqnames = [fq for (_k, _p, fq, _f) in handler_attrs]
+        handler_fqnames = [attr.fqname for attr in handler_attrs]
 
         # Set of (decorated_idx, owner_name) pairs from the subgroup
         # decorator — used inside the fixpoint to upgrade a handler to

--- a/python/dead_cst/contrib/click.py
+++ b/python/dead_cst/contrib/click.py
@@ -32,51 +32,74 @@ class ClickPlugin(DecoratedDeclPlugin):
         if not native.query(ctx).imports().of(self.decorator_module).exists():
             return
 
-        groups_by_owner: dict[tuple[str, str], list[native.SymbolNode]] = {}
+        # groups_by_owner: (path, simple_name) -> [group_idx, ...]
+        groups_by_owner: dict[tuple[str, str], list[int]] = {}
 
-        def add_group(node: native.SymbolNode) -> None:
-            simple = node.fqname.rsplit(".", 1)[-1]
-            groups_by_owner.setdefault((node.path, simple), []).append(node)
+        def add_group(node_idx: int, path: str, fqname: str) -> None:
+            simple = fqname.rsplit(".", 1)[-1]
+            groups_by_owner.setdefault((path, simple), []).append(node_idx)
 
-        for dec_ref in (
+        dec_rows = (
             native.query(ctx)
             .decorators()
             .where_module(self.decorator_module)
             .where_name(list(self.decorator_names))
-        ):
-            add_group(dec_ref.decorated)
-        for cons_ref in (
+            .row_indices()
+        )
+        if dec_rows:
+            dec_attrs = ctx.node_attrs([r.decorated_idx for r in dec_rows])
+            for row, (_k, _p, fqname, _f) in zip(dec_rows, dec_attrs, strict=True):
+                add_group(row.decorated_idx, row.path, fqname)
+
+        cons_rows = (
             native.query(ctx)
             .constructions()
             .where_module(self.decorator_module)
             .where_name(list(self.constructor_names))
-        ):
-            add_group(cons_ref.var)
+            .row_indices()
+        )
+        if cons_rows:
+            cons_attrs = ctx.node_attrs([r.var_idx for r in cons_rows])
+            for row, (_k, _p, fqname, _f) in zip(cons_rows, cons_attrs, strict=True):
+                add_group(row.var_idx, row.path, fqname)
 
-        handlers: list[tuple[str, native.SymbolNode]] = [
-            (h.decorator_owner or "", h.decorated)
-            for h in native.query(ctx).decorators().where_owner_attr(list(_REGISTRATION_DECORATORS))
-        ]
-        # Precompute (path, fqname, owner_name) triples for handlers
-        # decorated with the subgroup decorator — used inside the
-        # fixpoint to upgrade a handler to a group when its owner is
-        # already known. Querying inside the loop would be O(N²).
-        subgroup_links: set[tuple[str, str, str]] = {
-            (h.decorated.path, h.decorated.fqname, h.decorator_owner or "")
-            for h in native.query(ctx).decorators().where_owner_attr(list(_SUBGROUP_DECORATOR))
+        handler_rows = list(
+            native.query(ctx)
+            .decorators()
+            .where_owner_attr(list(_REGISTRATION_DECORATORS))
+            .row_indices()
+        )
+        # Batched fqname fetch for every handler — used both in the
+        # fixpoint dispatch and for the subgroup_links key.
+        handler_attrs = (
+            ctx.node_attrs([h.decorated_idx for h in handler_rows]) if handler_rows else []
+        )
+        handler_fqnames = [fq for (_k, _p, fq, _f) in handler_attrs]
+
+        # Set of (decorated_idx, owner_name) pairs from the subgroup
+        # decorator — used inside the fixpoint to upgrade a handler to
+        # a group when its owner is already known.
+        subgroup_links: set[tuple[int, str]] = {
+            (h.decorated_idx, h.decorator_owner or "")
+            for h in native.query(ctx)
+            .decorators()
+            .where_owner_attr(list(_SUBGROUP_DECORATOR))
+            .row_indices()
         }
 
-        emitted: set[tuple[str, str, str, str]] = set()
+        # Dedup by (owner_idx, handler_idx) — idx is globally unique.
+        emitted: set[tuple[int, int]] = set()
         changed = True
         while changed:
             changed = False
-            for owner_name, handler_func in handlers:
-                for owner in groups_by_owner.get((handler_func.path, owner_name), []):
-                    key = (owner.path, owner.fqname, handler_func.path, handler_func.fqname)
+            for h, handler_fqname in zip(handler_rows, handler_fqnames, strict=True):
+                owner_name = h.decorator_owner or ""
+                for owner_idx in groups_by_owner.get((h.path, owner_name), []):
+                    key = (owner_idx, h.decorated_idx)
                     if key in emitted:
                         continue
                     emitted.add(key)
-                    yield native.AddEdge(owner, handler_func)
-                    if (handler_func.path, handler_func.fqname, owner_name) in subgroup_links:
-                        add_group(handler_func)
+                    yield native.AddEdgeByIdx(owner_idx, h.decorated_idx)
+                    if (h.decorated_idx, owner_name) in subgroup_links:
+                        add_group(h.decorated_idx, h.path, handler_fqname)
                         changed = True

--- a/python/dead_cst/contrib/discordpy.py
+++ b/python/dead_cst/contrib/discordpy.py
@@ -46,14 +46,13 @@ class DiscordPyPlugin(Plugin):
         ):
             return
 
-        # Per-file gate: only fire on files that import discord. Fetch
-        # the import nodes' paths in a single batched node_attrs call
-        # rather than per-row borrowing.
+        # Per-file gate: only fire on files that import discord.
+        # ``node_paths`` rather than ``node_attrs`` — we only need
+        # path here; the other fields would be allocated then dropped.
         discord_paths: set[str] = set()
         for module in ("discord", "discord.ext", "discord.ext.commands"):
             idxs = native.query(ctx).imports().of(module).indices()
-            for _kind, path, _fqname, _flags in ctx.node_attrs(idxs):
-                discord_paths.add(path)
+            discord_paths.update(ctx.node_paths(idxs))
 
         # 1. Bot / Client constructions.
         bot_rows: list[native.ConstructionIdxRef] = []
@@ -108,9 +107,7 @@ class DiscordPyPlugin(Plugin):
             cog_idxs = native.query(ctx).subclasses().of_fqn(base).transitive(True).indices()
             if not cog_idxs:
                 continue
-            for cog_idx, (_k, cog_path, _fq, _f) in zip(
-                cog_idxs, ctx.node_attrs(cog_idxs), strict=True
-            ):
+            for cog_idx, cog_path in zip(cog_idxs, ctx.node_paths(cog_idxs), strict=True):
                 cogs_by_path.setdefault(cog_path, []).append(cog_idx)
 
         if cogs_by_path:
@@ -124,9 +121,7 @@ class DiscordPyPlugin(Plugin):
                 .indices()
             )
             if hook_idxs:
-                for hook_idx, (_k, hook_path, _fq, _f) in zip(
-                    hook_idxs, ctx.node_attrs(hook_idxs), strict=True
-                ):
+                for hook_idx, hook_path in zip(hook_idxs, ctx.node_paths(hook_idxs), strict=True):
                     hook_funcs_by_path.setdefault(hook_path, []).append(hook_idx)
 
             for path, cog_idxs in cogs_by_path.items():

--- a/python/dead_cst/contrib/discordpy.py
+++ b/python/dead_cst/contrib/discordpy.py
@@ -75,10 +75,10 @@ class DiscordPyPlugin(Plugin):
         bot_vars_by_file: dict[str, dict[str, int]] = {}
         if bot_rows:
             bot_attrs = ctx.node_attrs([r.var_idx for r in bot_rows])
-            for row, (_k, _p, fqname, _f) in zip(bot_rows, bot_attrs, strict=True):
+            for row, attr in zip(bot_rows, bot_attrs, strict=True):
                 if row.path not in discord_paths:
                     continue
-                simple = fqname.rsplit(".", 1)[-1]
+                simple = attr.fqname.rsplit(".", 1)[-1]
                 bot_vars_by_file.setdefault(row.path, {})[simple] = row.var_idx
                 yield native.AddEntrypointByIdx(row.var_idx, marker="<discordpy-app>")
 

--- a/python/dead_cst/contrib/discordpy.py
+++ b/python/dead_cst/contrib/discordpy.py
@@ -61,14 +61,14 @@ class DiscordPyPlugin(Plugin):
             .constructions()
             .where_module("discord.ext.commands")
             .where_name(sorted(_COMMANDS_BOT_KINDS))
-            .row_indices()
+            .collect()
         )
         bot_rows.extend(
             native.query(ctx)
             .constructions()
             .where_module("discord")
             .where_name(sorted(_DISCORD_CLIENT_KINDS))
-            .row_indices()
+            .collect()
         )
 
         # bot_vars_by_file: path -> {simple_name -> var_idx}.
@@ -83,9 +83,7 @@ class DiscordPyPlugin(Plugin):
                 yield native.AddEntrypointByIdx(row.var_idx, marker="<discordpy-app>")
 
         # 2. Single-attr decorators @<bot>.<verb>(...).
-        for h in (
-            native.query(ctx).decorators().where_owner_attr(sorted(_BOT_DECORATORS)).row_indices()
-        ):
+        for h in native.query(ctx).decorators().where_owner_attr(sorted(_BOT_DECORATORS)).collect():
             owner_idx = bot_vars_by_file.get(h.path, {}).get(h.decorator_owner or "")
             if owner_idx is not None:
                 yield native.AddEdgeByIdx(owner_idx, h.decorated_idx)
@@ -95,7 +93,7 @@ class DiscordPyPlugin(Plugin):
             native.query(ctx)
             .decorators()
             .where_owner_attr_via("tree", sorted(_TREE_DECORATORS))
-            .row_indices()
+            .collect()
         ):
             owner_idx = bot_vars_by_file.get(h.path, {}).get(h.decorator_owner or "")
             if owner_idx is not None:
@@ -141,7 +139,7 @@ class DiscordPyPlugin(Plugin):
         seen_extensions: set[str] = set()
         pending: list[tuple[str, str]] = []
         for attr in ("load_extension", "load_extensions"):
-            for cref in native.query(ctx).calls().where_attr(attr).string_arg_at(0).row_indices():
+            for cref in native.query(ctx).calls().where_attr(attr).string_arg_at(0).collect():
                 if cref.path not in discord_paths:
                     continue
                 if cref.string_arg in seen_extensions:

--- a/python/dead_cst/contrib/discordpy.py
+++ b/python/dead_cst/contrib/discordpy.py
@@ -46,78 +46,97 @@ class DiscordPyPlugin(Plugin):
         ):
             return
 
-        # Per-file gate: only fire on files that import discord.
+        # Per-file gate: only fire on files that import discord. Fetch
+        # the import nodes' paths in a single batched node_attrs call
+        # rather than per-row borrowing.
         discord_paths: set[str] = set()
         for module in ("discord", "discord.ext", "discord.ext.commands"):
-            for imp in native.query(ctx).imports().of(module).collect():
-                discord_paths.add(imp.path)
+            idxs = native.query(ctx).imports().of(module).indices()
+            for _kind, path, _fqname, _flags in ctx.node_attrs(idxs):
+                discord_paths.add(path)
 
         # 1. Bot / Client constructions.
-        bot_constructions: list[native.ConstructionRef] = []
-        bot_constructions.extend(
+        bot_rows: list[native.ConstructionIdxRef] = []
+        bot_rows.extend(
             native.query(ctx)
             .constructions()
             .where_module("discord.ext.commands")
             .where_name(sorted(_COMMANDS_BOT_KINDS))
+            .row_indices()
         )
-        bot_constructions.extend(
+        bot_rows.extend(
             native.query(ctx)
             .constructions()
             .where_module("discord")
             .where_name(sorted(_DISCORD_CLIENT_KINDS))
+            .row_indices()
         )
 
-        bot_vars_by_file: dict[str, dict[str, native.SymbolNode]] = {}
-        for cref in bot_constructions:
-            if cref.path not in discord_paths:
-                continue
-            simple = cref.var.fqname.rsplit(".", 1)[-1]
-            bot_vars_by_file.setdefault(cref.path, {})[simple] = cref.var
-            yield native.AddEntrypoint(cref.var, marker="<discordpy-app>")
+        # bot_vars_by_file: path -> {simple_name -> var_idx}.
+        bot_vars_by_file: dict[str, dict[str, int]] = {}
+        if bot_rows:
+            bot_attrs = ctx.node_attrs([r.var_idx for r in bot_rows])
+            for row, (_k, _p, fqname, _f) in zip(bot_rows, bot_attrs, strict=True):
+                if row.path not in discord_paths:
+                    continue
+                simple = fqname.rsplit(".", 1)[-1]
+                bot_vars_by_file.setdefault(row.path, {})[simple] = row.var_idx
+                yield native.AddEntrypointByIdx(row.var_idx, marker="<discordpy-app>")
 
         # 2. Single-attr decorators @<bot>.<verb>(...).
-        for h in native.query(ctx).decorators().where_owner_attr(sorted(_BOT_DECORATORS)):
-            owner_node = bot_vars_by_file.get(h.decorated.path, {}).get(h.decorator_owner or "")
-            if owner_node is not None:
-                yield native.AddEdge(owner_node, h.decorated)
+        for h in (
+            native.query(ctx).decorators().where_owner_attr(sorted(_BOT_DECORATORS)).row_indices()
+        ):
+            owner_idx = bot_vars_by_file.get(h.path, {}).get(h.decorator_owner or "")
+            if owner_idx is not None:
+                yield native.AddEdgeByIdx(owner_idx, h.decorated_idx)
 
         # 3. Two-level slash-command decorators @<bot>.tree.<verb>(...).
         for h in (
-            native.query(ctx).decorators().where_owner_attr_via("tree", sorted(_TREE_DECORATORS))
+            native.query(ctx)
+            .decorators()
+            .where_owner_attr_via("tree", sorted(_TREE_DECORATORS))
+            .row_indices()
         ):
-            owner_node = bot_vars_by_file.get(h.decorated.path, {}).get(h.decorator_owner or "")
-            if owner_node is not None:
-                yield native.AddEdge(owner_node, h.decorated)
+            owner_idx = bot_vars_by_file.get(h.path, {}).get(h.decorator_owner or "")
+            if owner_idx is not None:
+                yield native.AddEdgeByIdx(owner_idx, h.decorated_idx)
 
         # 4. Cog subclasses + module-level setup / teardown hooks.
-        cogs_by_path: dict[str, list[native.SymbolNode]] = {}
+        cogs_by_path: dict[str, list[int]] = {}
         for base in ("discord.ext.commands.Cog", "discord.ext.commands.GroupCog"):
-            for cog in native.query(ctx).subclasses().of_fqn(base).transitive(True).collect():
-                cogs_by_path.setdefault(cog.path, []).append(cog)
+            cog_idxs = native.query(ctx).subclasses().of_fqn(base).transitive(True).indices()
+            if not cog_idxs:
+                continue
+            for cog_idx, (_k, cog_path, _fq, _f) in zip(
+                cog_idxs, ctx.node_attrs(cog_idxs), strict=True
+            ):
+                cogs_by_path.setdefault(cog_path, []).append(cog_idx)
 
         if cogs_by_path:
-            hook_funcs_by_path: dict[str, list[native.SymbolNode]] = {}
-            # Push the path-set + kind + simple-name filter down into
-            # rust — saves the per-node ``rsplit`` + dict lookup in
-            # Python.
-            for n in (
+            hook_funcs_by_path: dict[str, list[int]] = {}
+            hook_idxs = (
                 native.query(ctx)
                 .decls()
                 .with_kind("function")
                 .with_paths(list(cogs_by_path.keys()))
                 .with_simple_names(["setup", "teardown"])
-                .collect()
-            ):
-                hook_funcs_by_path.setdefault(n.path, []).append(n)
+                .indices()
+            )
+            if hook_idxs:
+                for hook_idx, (_k, hook_path, _fq, _f) in zip(
+                    hook_idxs, ctx.node_attrs(hook_idxs), strict=True
+                ):
+                    hook_funcs_by_path.setdefault(hook_path, []).append(hook_idx)
 
-            for path, cogs in cogs_by_path.items():
-                targets = list(cogs) + hook_funcs_by_path.get(path, [])
+            for path, cog_idxs in cogs_by_path.items():
+                targets = list(cog_idxs) + hook_funcs_by_path.get(path, [])
                 filename = Path(path).name
-                yield native.AddNode(
+                yield native.AddNodeByIdx(
                     fqname=f"{DISCORDPY_COG_PREFIX}{filename}",
                     path=path,
                     flags=int(NodeFlags.ENTRYPOINT),
-                    edges_to=targets,
+                    edges_to_idx=targets,
                 )
 
         # 5. load_extension / load_extensions string-literal targets.
@@ -127,22 +146,22 @@ class DiscordPyPlugin(Plugin):
         seen_extensions: set[str] = set()
         pending: list[tuple[str, str]] = []
         for attr in ("load_extension", "load_extensions"):
-            for cref in native.query(ctx).calls().where_attr(attr).string_arg_at(0):
-                if cref.owner.path not in discord_paths:
+            for cref in native.query(ctx).calls().where_attr(attr).string_arg_at(0).row_indices():
+                if cref.path not in discord_paths:
                     continue
                 if cref.string_arg in seen_extensions:
                     continue
                 seen_extensions.add(cref.string_arg)
-                pending.append((cref.owner.path, cref.string_arg))
+                pending.append((cref.path, cref.string_arg))
         if pending:
-            surfaces = ctx.module_surfaces([ext for _, ext in pending])
+            surfaces = ctx.module_surfaces_indices([ext for _, ext in pending])
             for owner_path, ext_fqname in pending:
-                targets = surfaces.get(ext_fqname, [])
-                if not targets:
+                target_idxs = surfaces.get(ext_fqname, [])
+                if not target_idxs:
                     continue
-                yield native.AddNode(
+                yield native.AddNodeByIdx(
                     fqname=f"{DISCORDPY_EXTENSION_PREFIX}{ext_fqname}",
                     path=owner_path,
                     flags=int(NodeFlags.ENTRYPOINT),
-                    edges_to=targets,
+                    edges_to_idx=list(target_idxs),
                 )

--- a/python/dead_cst/contrib/mock_patch.py
+++ b/python/dead_cst/contrib/mock_patch.py
@@ -67,8 +67,10 @@ class MockPatchPlugin(Plugin):
             owners_by_fqname.setdefault(ref.string_arg, []).append((ref.owner_idx, ref.path))
 
         for fqname, owners in owners_by_fqname.items():
-            target_idxs = list(ctx.find_declarations_indices(fqname))
-            mod_idx = ctx.find_module_idx(fqname)
+            target_idxs = list(
+                native.query(ctx).declarations().with_fqname(fqname).indices()
+            )
+            mod_idx = native.query(ctx).modules().with_fqn(fqname).first_idx()
             if mod_idx is not None:
                 target_idxs.append(mod_idx)
             yield native.AddNodeByIdx(

--- a/python/dead_cst/contrib/mock_patch.py
+++ b/python/dead_cst/contrib/mock_patch.py
@@ -41,7 +41,7 @@ class MockPatchPlugin(Plugin):
                 .where_module(module)
                 .where_name("patch")
                 .string_arg_at(0)
-                .row_indices()
+                .collect()
             )
         rows.extend(
             native.query(ctx)
@@ -49,7 +49,7 @@ class MockPatchPlugin(Plugin):
             .where_owner(_MOCKER_NAME)
             .where_attr("patch")
             .string_arg_at(0)
-            .row_indices()
+            .collect()
         )
         for attr, required in _MONKEYPATCH_FQNAME_METHODS.items():
             rows.extend(
@@ -59,7 +59,7 @@ class MockPatchPlugin(Plugin):
                 .where_attr(attr)
                 .string_arg_at(0)
                 .where_required_positional(required)
-                .row_indices()
+                .collect()
             )
 
         owners_by_fqname: dict[str, list[tuple[int, str]]] = {}

--- a/python/dead_cst/contrib/mock_patch.py
+++ b/python/dead_cst/contrib/mock_patch.py
@@ -33,36 +33,47 @@ class MockPatchPlugin(Plugin):
     """Resolve string-fqname ``patch(...)`` calls to their target decl."""
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
-        refs: list[native.CallRef] = []
+        rows: list[native.CallIdxRef] = []
         for module in _MOCK_MODULES:
-            refs.extend(
-                native.query(ctx).calls().where_module(module).where_name("patch").string_arg_at(0)
+            rows.extend(
+                native.query(ctx)
+                .calls()
+                .where_module(module)
+                .where_name("patch")
+                .string_arg_at(0)
+                .row_indices()
             )
-        refs.extend(
-            native.query(ctx).calls().where_owner(_MOCKER_NAME).where_attr("patch").string_arg_at(0)
+        rows.extend(
+            native.query(ctx)
+            .calls()
+            .where_owner(_MOCKER_NAME)
+            .where_attr("patch")
+            .string_arg_at(0)
+            .row_indices()
         )
         for attr, required in _MONKEYPATCH_FQNAME_METHODS.items():
-            refs.extend(
+            rows.extend(
                 native.query(ctx)
                 .calls()
                 .where_owner(_MONKEYPATCH_NAME)
                 .where_attr(attr)
                 .string_arg_at(0)
                 .where_required_positional(required)
+                .row_indices()
             )
 
-        owners_by_fqname: dict[str, list[native.SymbolNode]] = {}
-        for ref in refs:
-            owners_by_fqname.setdefault(ref.string_arg, []).append(ref.owner)
+        owners_by_fqname: dict[str, list[tuple[int, str]]] = {}
+        for ref in rows:
+            owners_by_fqname.setdefault(ref.string_arg, []).append((ref.owner_idx, ref.path))
 
         for fqname, owners in owners_by_fqname.items():
-            targets = list(ctx.find_declarations(fqname))
-            mod = ctx.find_module(fqname)
-            if mod is not None:
-                targets.append(mod)
-            yield native.AddNode(
+            target_idxs = list(ctx.find_declarations_indices(fqname))
+            mod_idx = ctx.find_module_idx(fqname)
+            if mod_idx is not None:
+                target_idxs.append(mod_idx)
+            yield native.AddNodeByIdx(
                 fqname=f"{PATCH_TARGET_PREFIX}{fqname}",
-                path=owners[0].path,
-                edges_from=owners,
-                edges_to=targets,
+                path=owners[0][1],
+                edges_from_idx=[i for i, _p in owners],
+                edges_to_idx=target_idxs,
             )

--- a/python/dead_cst/contrib/mock_patch.py
+++ b/python/dead_cst/contrib/mock_patch.py
@@ -67,9 +67,7 @@ class MockPatchPlugin(Plugin):
             owners_by_fqname.setdefault(ref.string_arg, []).append((ref.owner_idx, ref.path))
 
         for fqname, owners in owners_by_fqname.items():
-            target_idxs = list(
-                native.query(ctx).declarations().with_fqname(fqname).indices()
-            )
+            target_idxs = list(native.query(ctx).declarations().with_fqname(fqname).indices())
             mod_idx = native.query(ctx).modules().with_fqn(fqname).first_idx()
             if mod_idx is not None:
                 target_idxs.append(mod_idx)

--- a/python/dead_cst/contrib/pytest.py
+++ b/python/dead_cst/contrib/pytest.py
@@ -25,44 +25,59 @@ class PytestPlugin(Plugin):
     """
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
-        # Rust-side fold of the ``kind in {function, class, variable}``
-        # filter; one batched node_attrs for the (kind, path, fqname)
-        # per-row reads the bucketing needs.
+        # Path-only bucketing. Most projects have far more non-test
+        # decls than test decls, so ``node_paths`` (one str per row)
+        # is ~3× cheaper than ``node_attrs`` (a 4-tuple per row) on
+        # this initial scan. We pay the per-row ``kind`` / ``fqname``
+        # cost later, but only for decls that survive the filename
+        # filter.
         idxs = native.query(ctx).decls().with_kinds(["function", "class", "variable"]).indices()
         if not idxs:
             return
-        attrs = ctx.node_attrs(idxs)
+        paths = ctx.node_paths(idxs)
 
-        # Per-path bucket: (path, [(idx, kind, fqname), ...])
-        decls_by_path: dict[str, list[tuple[int, str, str]]] = {}
-        for idx, (kind, path, fqname, _flags) in zip(idxs, attrs, strict=True):
-            decls_by_path.setdefault(path, []).append((idx, kind, fqname))
+        conftest_idxs_by_path: dict[str, list[int]] = {}
+        test_idxs_by_path: dict[str, list[int]] = {}
+        for idx, path in zip(idxs, paths, strict=True):
+            filename = Path(path).name
+            if filename == "conftest.py":
+                conftest_idxs_by_path.setdefault(path, []).append(idx)
+            elif _is_test_filename(filename):
+                test_idxs_by_path.setdefault(path, []).append(idx)
 
-        # Batched module-fqname fetch.
-        paths = list(decls_by_path.keys())
-        module_idxs = ctx.modules_for_paths(paths)
-        present = [(p, m) for p, m in zip(paths, module_idxs) if m is not None]
-        module_fqname_by_path: dict[str, str] = {}
-        if present:
-            module_attrs = ctx.node_attrs([m for _p, m in present])
-            for (path, _m), (_k, _p, module_fqname, _f) in zip(present, module_attrs, strict=True):
-                module_fqname_by_path[path] = module_fqname
+        # Filter test-file decls by ``_is_test_decl`` — needs the
+        # ``kind`` and ``fqname`` we deliberately didn't fetch above.
+        # We pay the 4-tuple node_attrs cost only for this subset.
+        test_filtered_by_path: dict[str, list[int]] = {}
+        for path, test_idxs in test_idxs_by_path.items():
+            attrs = ctx.node_attrs(test_idxs)
+            keep = [
+                idx
+                for idx, (kind, _p, fqname, _f) in zip(test_idxs, attrs, strict=True)
+                if _is_test_decl(kind, fqname)
+            ]
+            if keep:
+                test_filtered_by_path[path] = keep
 
-        for path, rows in decls_by_path.items():
+        # Module-fqname fetch — only for paths we'll actually seed
+        # (conftest + filtered tests). Skips the cost for irrelevant
+        # files entirely.
+        seed_paths = list({*conftest_idxs_by_path, *test_filtered_by_path})
+        module_fqname_by_path = _module_fqnames(ctx, seed_paths)
+        for path, conftest_idxs in conftest_idxs_by_path.items():
             module_fqname = module_fqname_by_path.get(path)
             if module_fqname is None:
                 continue
-            filename = Path(path).name
-            if filename == "conftest.py":
-                yield from _mark_seed(
-                    f"{PYTEST_CONFTEST_PREFIX}{module_fqname}", path, [i for i, _k, _f in rows]
-                )
-            elif _is_test_filename(filename):
-                test_idxs = [i for (i, kind, fqname) in rows if _is_test_decl(kind, fqname)]
-                if test_idxs:
-                    yield from _mark_seed(f"{PYTEST_TESTS_PREFIX}{module_fqname}", path, test_idxs)
+            yield from _mark_seed(f"{PYTEST_CONFTEST_PREFIX}{module_fqname}", path, conftest_idxs)
+        for path, test_idxs in test_filtered_by_path.items():
+            module_fqname = module_fqname_by_path.get(path)
+            if module_fqname is None:
+                continue
+            yield from _mark_seed(f"{PYTEST_TESTS_PREFIX}{module_fqname}", path, test_idxs)
 
-        # ``@pytest.fixture`` decorators.
+        # ``@pytest.fixture`` decorators. Bucketed per-file the same way
+        # — only fetch module fqnames for paths that have at least one
+        # fixture.
         fixtures_by_path: dict[str, list[int]] = {}
         for ref in (
             native.query(ctx)
@@ -74,19 +89,31 @@ class PytestPlugin(Plugin):
             fixtures_by_path.setdefault(ref.path, []).append(ref.decorated_idx)
 
         if fixtures_by_path:
-            f_paths = list(fixtures_by_path.keys())
-            f_module_idxs = ctx.modules_for_paths(f_paths)
-            f_present = [(p, m) for p, m in zip(f_paths, f_module_idxs) if m is not None]
-            if f_present:
-                f_module_attrs = ctx.node_attrs([m for _p, m in f_present])
-                for (path, _m), (_k, _p, module_fqname, _f) in zip(
-                    f_present, f_module_attrs, strict=True
-                ):
-                    yield from _mark_seed(
-                        f"{PYTEST_FIXTURES_PREFIX}{module_fqname}",
-                        path,
-                        fixtures_by_path[path],
-                    )
+            fixture_module_fqnames = _module_fqnames(ctx, list(fixtures_by_path.keys()))
+            for path, fixture_idxs in fixtures_by_path.items():
+                module_fqname = fixture_module_fqnames.get(path)
+                if module_fqname is None:
+                    continue
+                yield from _mark_seed(
+                    f"{PYTEST_FIXTURES_PREFIX}{module_fqname}", path, fixture_idxs
+                )
+
+
+def _module_fqnames(ctx: native.ProjectContext, paths: list[str]) -> dict[str, str]:
+    """``{path: module_fqname}`` for every path that resolves to a
+    project module. Two batched FFI hops total (``modules_for_paths`` +
+    ``node_attrs``), irrespective of ``len(paths)``."""
+    if not paths:
+        return {}
+    module_idxs = ctx.modules_for_paths(paths)
+    present = [(p, m) for p, m in zip(paths, module_idxs) if m is not None]
+    if not present:
+        return {}
+    module_attrs = ctx.node_attrs([m for _p, m in present])
+    return {
+        path: module_fqname
+        for (path, _m), (_k, _p, module_fqname, _f) in zip(present, module_attrs, strict=True)
+    }
 
 
 def _mark_seed(

--- a/python/dead_cst/contrib/pytest.py
+++ b/python/dead_cst/contrib/pytest.py
@@ -26,53 +26,89 @@ class PytestPlugin(Plugin):
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
         # Rust-side fold of the ``kind in {function, class, variable}``
-        # filter — one FFI hop, no per-node Python attribute access.
-        decls_by_path: dict[str, list[native.SymbolNode]] = {}
-        for n in native.query(ctx).decls().with_kinds(["function", "class", "variable"]).collect():
-            decls_by_path.setdefault(n.path, []).append(n)
+        # filter; one batched node_attrs for the (kind, path, fqname)
+        # per-row reads the bucketing needs.
+        idxs = native.query(ctx).decls().with_kinds(["function", "class", "variable"]).indices()
+        if not idxs:
+            return
+        attrs = ctx.node_attrs(idxs)
 
-        for path, decls in decls_by_path.items():
-            module = ctx.module_for(path)
-            if module is None:
+        # Per-path bucket: (path, [(idx, kind, fqname), ...])
+        decls_by_path: dict[str, list[tuple[int, str, str]]] = {}
+        for idx, (kind, path, fqname, _flags) in zip(idxs, attrs, strict=True):
+            decls_by_path.setdefault(path, []).append((idx, kind, fqname))
+
+        # Batched module-fqname fetch.
+        paths = list(decls_by_path.keys())
+        module_idxs = ctx.modules_for_paths(paths)
+        present = [(p, m) for p, m in zip(paths, module_idxs) if m is not None]
+        module_fqname_by_path: dict[str, str] = {}
+        if present:
+            module_attrs = ctx.node_attrs([m for _p, m in present])
+            for (path, _m), (_k, _p, module_fqname, _f) in zip(present, module_attrs, strict=True):
+                module_fqname_by_path[path] = module_fqname
+
+        for path, rows in decls_by_path.items():
+            module_fqname = module_fqname_by_path.get(path)
+            if module_fqname is None:
                 continue
             filename = Path(path).name
             if filename == "conftest.py":
-                yield from _mark_seed(f"{PYTEST_CONFTEST_PREFIX}{module.fqname}", path, decls)
+                yield from _mark_seed(
+                    f"{PYTEST_CONFTEST_PREFIX}{module_fqname}", path, [i for i, _k, _f in rows]
+                )
             elif _is_test_filename(filename):
-                test_decls = [d for d in decls if _is_test_decl(d)]
-                if test_decls:
-                    yield from _mark_seed(f"{PYTEST_TESTS_PREFIX}{module.fqname}", path, test_decls)
+                test_idxs = [i for (i, kind, fqname) in rows if _is_test_decl(kind, fqname)]
+                if test_idxs:
+                    yield from _mark_seed(f"{PYTEST_TESTS_PREFIX}{module_fqname}", path, test_idxs)
 
-        fixtures_by_path: dict[str, list[native.SymbolNode]] = {}
-        for ref in native.query(ctx).decorators().where_module("pytest").where_name("fixture"):
-            fixtures_by_path.setdefault(ref.path, []).append(ref.decorated)
-        for path, fixtures in fixtures_by_path.items():
-            module = ctx.module_for(path)
-            if module is None:
-                continue
-            yield from _mark_seed(f"{PYTEST_FIXTURES_PREFIX}{module.fqname}", path, fixtures)
+        # ``@pytest.fixture`` decorators.
+        fixtures_by_path: dict[str, list[int]] = {}
+        for ref in (
+            native.query(ctx)
+            .decorators()
+            .where_module("pytest")
+            .where_name("fixture")
+            .row_indices()
+        ):
+            fixtures_by_path.setdefault(ref.path, []).append(ref.decorated_idx)
+
+        if fixtures_by_path:
+            f_paths = list(fixtures_by_path.keys())
+            f_module_idxs = ctx.modules_for_paths(f_paths)
+            f_present = [(p, m) for p, m in zip(f_paths, f_module_idxs) if m is not None]
+            if f_present:
+                f_module_attrs = ctx.node_attrs([m for _p, m in f_present])
+                for (path, _m), (_k, _p, module_fqname, _f) in zip(
+                    f_present, f_module_attrs, strict=True
+                ):
+                    yield from _mark_seed(
+                        f"{PYTEST_FIXTURES_PREFIX}{module_fqname}",
+                        path,
+                        fixtures_by_path[path],
+                    )
 
 
 def _mark_seed(
     fqname: str,
     path: str,
-    targets: list[native.SymbolNode],
+    target_idxs: list[int],
 ) -> Iterable[native.GraphOp]:
-    if not targets:
+    if not target_idxs:
         return
-    yield native.AddNode(
+    yield native.AddNodeByIdx(
         fqname=fqname,
         path=path,
         flags=int(NodeFlags.TESTCASE),
-        edges_to=targets,
+        edges_to_idx=target_idxs,
     )
 
 
-def _is_test_decl(node: native.SymbolNode) -> bool:
-    simple = node.fqname.rsplit(".", 1)[-1]
-    if node.kind == "function" and simple.startswith("test_"):
+def _is_test_decl(kind: str, fqname: str) -> bool:
+    simple = fqname.rsplit(".", 1)[-1]
+    if kind == "function" and simple.startswith("test_"):
         return True
-    if node.kind == "class" and simple.startswith("Test"):
+    if kind == "class" and simple.startswith("Test"):
         return True
     return False
 

--- a/python/dead_cst/contrib/pytest.py
+++ b/python/dead_cst/contrib/pytest.py
@@ -80,11 +80,7 @@ class PytestPlugin(Plugin):
         # fixture.
         fixtures_by_path: dict[str, list[int]] = {}
         for ref in (
-            native.query(ctx)
-            .decorators()
-            .where_module("pytest")
-            .where_name("fixture")
-            .row_indices()
+            native.query(ctx).decorators().where_module("pytest").where_name("fixture").collect()
         ):
             fixtures_by_path.setdefault(ref.path, []).append(ref.decorated_idx)
 

--- a/python/dead_cst/contrib/pytest.py
+++ b/python/dead_cst/contrib/pytest.py
@@ -53,8 +53,8 @@ class PytestPlugin(Plugin):
             attrs = ctx.node_attrs(test_idxs)
             keep = [
                 idx
-                for idx, (kind, _p, fqname, _f) in zip(test_idxs, attrs, strict=True)
-                if _is_test_decl(kind, fqname)
+                for idx, attr in zip(test_idxs, attrs, strict=True)
+                if _is_test_decl(attr.kind, attr.fqname)
             ]
             if keep:
                 test_filtered_by_path[path] = keep
@@ -106,10 +106,7 @@ def _module_fqnames(ctx: native.ProjectContext, paths: list[str]) -> dict[str, s
     if not present:
         return {}
     module_attrs = ctx.node_attrs([m for _p, m in present])
-    return {
-        path: module_fqname
-        for (path, _m), (_k, _p, module_fqname, _f) in zip(present, module_attrs, strict=True)
-    }
+    return {path: attr.fqname for (path, _m), attr in zip(present, module_attrs, strict=True)}
 
 
 def _mark_seed(

--- a/python/dead_cst/contrib/server_config.py
+++ b/python/dead_cst/contrib/server_config.py
@@ -54,9 +54,9 @@ class ServerConfigPlugin(Plugin):
         if not present:
             return
         module_attrs = ctx.node_attrs([idx for _p, idx in present])
-        for (path, _idx), (_k, _p, module_fqname, _f) in zip(present, module_attrs, strict=True):
+        for (path, _idx), attr in zip(present, module_attrs, strict=True):
             yield native.AddNodeByIdx(
-                fqname=f"{SERVER_CONFIG_PREFIX}{module_fqname}",
+                fqname=f"{SERVER_CONFIG_PREFIX}{attr.fqname}",
                 path=path,
                 flags=int(NodeFlags.ENTRYPOINT),
                 edges_to_idx=targets_by_path[path],

--- a/python/dead_cst/contrib/server_config.py
+++ b/python/dead_cst/contrib/server_config.py
@@ -45,7 +45,7 @@ class ServerConfigPlugin(Plugin):
         )
         if not idxs:
             return
-        for idx, (_k, path, _fq, _f) in zip(idxs, ctx.node_attrs(idxs), strict=True):
+        for idx, path in zip(idxs, ctx.node_paths(idxs), strict=True):
             targets_by_path.setdefault(path, []).append(idx)
 
         paths = list(targets_by_path.keys())

--- a/python/dead_cst/contrib/server_config.py
+++ b/python/dead_cst/contrib/server_config.py
@@ -35,26 +35,29 @@ class ServerConfigPlugin(Plugin):
     filenames: tuple[str, ...] = _DEFAULT_FILENAMES
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
-        targets_by_path: dict[str, list[native.SymbolNode]] = {}
-        # Rust-side fold of the per-node basename + kind filter — saves
-        # the ``pathlib.Path(...).name`` allocation that dominates the
-        # Python-side loop on real codebases.
-        for n in (
+        targets_by_path: dict[str, list[int]] = {}
+        idxs = (
             native.query(ctx)
             .decls()
             .with_filenames(list(self.filenames))
             .with_kinds(list(_TARGET_KINDS))
-            .collect()
-        ):
-            targets_by_path.setdefault(n.path, []).append(n)
+            .indices()
+        )
+        if not idxs:
+            return
+        for idx, (_k, path, _fq, _f) in zip(idxs, ctx.node_attrs(idxs), strict=True):
+            targets_by_path.setdefault(path, []).append(idx)
 
-        for path, targets in targets_by_path.items():
-            module = ctx.module_for(path)
-            if module is None:
-                continue
-            yield native.AddNode(
-                fqname=f"{SERVER_CONFIG_PREFIX}{module.fqname}",
+        paths = list(targets_by_path.keys())
+        module_idxs = ctx.modules_for_paths(paths)
+        present = [(p, idx) for p, idx in zip(paths, module_idxs) if idx is not None]
+        if not present:
+            return
+        module_attrs = ctx.node_attrs([idx for _p, idx in present])
+        for (path, _idx), (_k, _p, module_fqname, _f) in zip(present, module_attrs, strict=True):
+            yield native.AddNodeByIdx(
+                fqname=f"{SERVER_CONFIG_PREFIX}{module_fqname}",
                 path=path,
                 flags=int(NodeFlags.ENTRYPOINT),
-                edges_to=targets,
+                edges_to_idx=targets_by_path[path],
             )

--- a/python/dead_cst/contrib/unittest.py
+++ b/python/dead_cst/contrib/unittest.py
@@ -68,11 +68,9 @@ class UnittestPlugin(Plugin):
         if not present_modules:
             return
         module_attrs = ctx.node_attrs([idx for _p, idx in present_modules])
-        for (path, _idx), (_k, _p, module_fqname, _f) in zip(
-            present_modules, module_attrs, strict=True
-        ):
+        for (path, _idx), attr in zip(present_modules, module_attrs, strict=True):
             yield native.AddNodeByIdx(
-                fqname=f"{UNITTEST_PREFIX}{module_fqname}",
+                fqname=f"{UNITTEST_PREFIX}{attr.fqname}",
                 path=path,
                 flags=flags,
                 edges_to_idx=decls_by_path[path],

--- a/python/dead_cst/contrib/unittest.py
+++ b/python/dead_cst/contrib/unittest.py
@@ -29,44 +29,51 @@ class UnittestPlugin(Plugin):
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
         # Cheap O(1) presence probe — short-circuits before paying
-        # for the path-set ``collect()`` below. If no file imports
-        # unittest, no project class can subclass ``unittest.TestCase``
-        # (you can't subclass what you haven't imported), and none of
-        # the module-level hooks would qualify either. Skip the ~50ms
-        # ``subclasses().of_fqn(...)`` walk before it forces ty to load
-        # the unittest module.
+        # for the path-set lookup below.
         if not native.query(ctx).imports().of("unittest").exists():
             return
-        importer_paths = {n.path for n in native.query(ctx).imports().of("unittest").collect()}
+        import_idxs = native.query(ctx).imports().of("unittest").indices()
+        importer_paths = {path for _k, path, _fq, _f in ctx.node_attrs(import_idxs)}
 
-        decls_by_path: dict[str, list[native.SymbolNode]] = {}
+        # decls_by_path: path -> [decl_idx, ...]
+        decls_by_path: dict[str, list[int]] = {}
         for base_fqname in _UNITTEST_BASE_FQNAMES:
-            for sub in (
-                native.query(ctx).subclasses().of_fqn(base_fqname).transitive(True).collect()
+            sub_idxs = native.query(ctx).subclasses().of_fqn(base_fqname).transitive(True).indices()
+            if not sub_idxs:
+                continue
+            for sub_idx, (_k, sub_path, _fq, _f) in zip(
+                sub_idxs, ctx.node_attrs(sub_idxs), strict=True
             ):
-                decls_by_path.setdefault(sub.path, []).append(sub)
+                decls_by_path.setdefault(sub_path, []).append(sub_idx)
 
-        # Push the ``kind == function`` + path-set + simple-name-in-set
-        # filter down into rust — folds three Python predicates into one
-        # rust pass over the node pool.
-        for node in (
+        hook_idxs = (
             native.query(ctx)
             .decls()
             .with_kind("function")
             .with_paths(list(importer_paths))
             .with_simple_names(list(_MODULE_HOOKS))
-            .collect()
-        ):
-            decls_by_path.setdefault(node.path, []).append(node)
+            .indices()
+        )
+        if hook_idxs:
+            for hook_idx, (_k, hook_path, _fq, _f) in zip(
+                hook_idxs, ctx.node_attrs(hook_idxs), strict=True
+            ):
+                decls_by_path.setdefault(hook_path, []).append(hook_idx)
 
         flags = int(NodeFlags.TESTCASE)
-        for path, decls in decls_by_path.items():
-            module = ctx.module_for(path)
-            if module is None:
-                continue
-            yield native.AddNode(
-                fqname=f"{UNITTEST_PREFIX}{module.fqname}",
+        # Batched module-fqname fetch — one node_attrs hop per path bucket.
+        paths = list(decls_by_path.keys())
+        module_idxs = ctx.modules_for_paths(paths)
+        present_modules = [(p, idx) for p, idx in zip(paths, module_idxs) if idx is not None]
+        if not present_modules:
+            return
+        module_attrs = ctx.node_attrs([idx for _p, idx in present_modules])
+        for (path, _idx), (_k, _p, module_fqname, _f) in zip(
+            present_modules, module_attrs, strict=True
+        ):
+            yield native.AddNodeByIdx(
+                fqname=f"{UNITTEST_PREFIX}{module_fqname}",
                 path=path,
                 flags=flags,
-                edges_to=decls,
+                edges_to_idx=decls_by_path[path],
             )

--- a/python/dead_cst/contrib/unittest.py
+++ b/python/dead_cst/contrib/unittest.py
@@ -33,7 +33,10 @@ class UnittestPlugin(Plugin):
         if not native.query(ctx).imports().of("unittest").exists():
             return
         import_idxs = native.query(ctx).imports().of("unittest").indices()
-        importer_paths = {path for _k, path, _fq, _f in ctx.node_attrs(import_idxs)}
+        # ``node_paths`` rather than ``node_attrs`` — we only need
+        # path here; kind / fqname / flags would be allocated then
+        # thrown away.
+        importer_paths = set(ctx.node_paths(import_idxs))
 
         # decls_by_path: path -> [decl_idx, ...]
         decls_by_path: dict[str, list[int]] = {}
@@ -41,9 +44,7 @@ class UnittestPlugin(Plugin):
             sub_idxs = native.query(ctx).subclasses().of_fqn(base_fqname).transitive(True).indices()
             if not sub_idxs:
                 continue
-            for sub_idx, (_k, sub_path, _fq, _f) in zip(
-                sub_idxs, ctx.node_attrs(sub_idxs), strict=True
-            ):
+            for sub_idx, sub_path in zip(sub_idxs, ctx.node_paths(sub_idxs), strict=True):
                 decls_by_path.setdefault(sub_path, []).append(sub_idx)
 
         hook_idxs = (
@@ -55,13 +56,12 @@ class UnittestPlugin(Plugin):
             .indices()
         )
         if hook_idxs:
-            for hook_idx, (_k, hook_path, _fq, _f) in zip(
-                hook_idxs, ctx.node_attrs(hook_idxs), strict=True
-            ):
+            for hook_idx, hook_path in zip(hook_idxs, ctx.node_paths(hook_idxs), strict=True):
                 decls_by_path.setdefault(hook_path, []).append(hook_idx)
 
         flags = int(NodeFlags.TESTCASE)
-        # Batched module-fqname fetch — one node_attrs hop per path bucket.
+        # Module-fqname fetch needs ``fqname``, so ``node_attrs`` is
+        # the right tool here — but only for the seed paths.
         paths = list(decls_by_path.keys())
         module_idxs = ctx.modules_for_paths(paths)
         present_modules = [(p, idx) for p, idx in zip(paths, module_idxs) if idx is not None]

--- a/python/dead_cst/plugins/__init__.py
+++ b/python/dead_cst/plugins/__init__.py
@@ -32,7 +32,6 @@ from ._core import (
     simple_name,
 )
 from .decl_shapes import (
-    BatchDispatchAppPlugin,
     DecoratedDeclPlugin,
     DispatchAppGather,
     DispatchAppPlugin,
@@ -47,7 +46,6 @@ from .module_dunders import ModuleDundersPlugin
 from .project_scripts import ProjectScriptsPlugin
 
 __all__ = [
-    "BatchDispatchAppPlugin",
     "DecoratedDeclPlugin",
     "DispatchAppGather",
     "DispatchAppPlugin",

--- a/python/dead_cst/plugins/__init__.py
+++ b/python/dead_cst/plugins/__init__.py
@@ -34,7 +34,9 @@ from ._core import (
 from .decl_shapes import (
     BatchDispatchAppPlugin,
     DecoratedDeclPlugin,
+    DispatchAppGather,
     DispatchAppPlugin,
+    DispatchAppSpec,
     LiteralListPlugin,
 )
 from .dynamic_import import DynamicImportFallbackPlugin
@@ -47,7 +49,9 @@ from .project_scripts import ProjectScriptsPlugin
 __all__ = [
     "BatchDispatchAppPlugin",
     "DecoratedDeclPlugin",
+    "DispatchAppGather",
     "DispatchAppPlugin",
+    "DispatchAppSpec",
     "DynamicImportFallbackPlugin",
     "EXTERNAL_DIST_PREFIX",
     "EXTERNAL_FILE_PREFIX",

--- a/python/dead_cst/plugins/__init__.py
+++ b/python/dead_cst/plugins/__init__.py
@@ -31,7 +31,12 @@ from ._core import (
     UNRESOLVED_PREFIX,
     simple_name,
 )
-from .decl_shapes import DecoratedDeclPlugin, DispatchAppPlugin, LiteralListPlugin
+from .decl_shapes import (
+    BatchDispatchAppPlugin,
+    DecoratedDeclPlugin,
+    DispatchAppPlugin,
+    LiteralListPlugin,
+)
 from .dynamic_import import DynamicImportFallbackPlugin
 from .explicit_entrypoint import ExplicitEntrypointPlugin
 from .init_subclass import InitSubclassPlugin
@@ -40,6 +45,7 @@ from .module_dunders import ModuleDundersPlugin
 from .project_scripts import ProjectScriptsPlugin
 
 __all__ = [
+    "BatchDispatchAppPlugin",
     "DecoratedDeclPlugin",
     "DispatchAppPlugin",
     "DynamicImportFallbackPlugin",

--- a/python/dead_cst/plugins/decl_shapes.py
+++ b/python/dead_cst/plugins/decl_shapes.py
@@ -177,86 +177,57 @@ class DispatchAppPlugin(Plugin):
         return out
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
-        if not (self.app_classes and self.registration_decorators):
+        if not self._is_active(ctx):
             return
-        # Cheap import-presence guard. ``_module_to_names`` triggers
-        # ``subclasses().of_fqn(...)`` for every ``app_class``, which
-        # forces ty to load the framework from the venv (parse + build
-        # SemanticIndex + walk the class hierarchy) — ~100-400ms per
-        # framework. If nothing imports the framework's root package,
-        # the project can't possibly contain an instance of an
-        # ``app_class``, so skip the work.
-        app_modules = {fqn.rpartition(".")[0] for fqn in self.app_classes if "." in fqn}
-        if not any(native.query(ctx).imports().of(m).exists() for m in app_modules if m):
-            return
-        decorator_attrs = list(self.registration_decorators)
-
         module_to_names = self._module_to_names(ctx)
         if not module_to_names:
             return
-
-        # 1. Direct constructions, deduped by var_idx (every construction
-        # site has a globally unique node index, so the same physical
-        # site that matches under two ``app_classes`` entries — e.g.
-        # one is a base of the other — collapses on idx).
-        direct_seen: set[int] = set()
-        direct: list[native.ConstructionIdxRef] = []
-        for module, names in module_to_names.items():
-            for ref in (
-                native.query(ctx)
-                .constructions()
-                .where_module(module)
-                .where_name(sorted(names))
-                .row_indices()
-            ):
-                if ref.var_idx in direct_seen:
-                    continue
-                direct_seen.add(ref.var_idx)
-                direct.append(ref)
-
-        # 2. Factory functions returning one of the listed classes,
-        # deduped by (decl_idx, kind). decl_idx is globally unique;
-        # kind is part of the key because one decl can match multiple
-        # kinds. Only relevant when we'd actually do something with the
-        # markers in step 6.
-        factory_seen: set[tuple[int, str]] = set()
-        factory_decls: list[tuple[native.FactoryIdxRef, str]] = []
-        if self.seed_as_entrypoint:
-            for module, names in module_to_names.items():
-                for fref in (
-                    native.query(ctx)
-                    .factories()
-                    .of_module(module)
-                    .where_name(sorted(names))
-                    .row_indices()
-                ):
-                    for kind in fref.kinds:
-                        key = (fref.decl_idx, kind)
-                        if key in factory_seen:
-                            continue
-                        factory_seen.add(key)
-                        factory_decls.append((fref, kind))
-
-        handlers = list(
-            native.query(ctx).decorators().where_owner_attr(decorator_attrs).row_indices()
+        direct = _fetch_direct(ctx, module_to_names)
+        factory_decls = (
+            _fetch_factory_decls(ctx, module_to_names) if self.seed_as_entrypoint else []
+        )
+        handlers = _fetch_handlers(ctx, self.registration_decorators)
+        vars_by_file = _build_vars_by_file(ctx)
+        yield from self._emit_ops(
+            ctx,
+            direct=direct,
+            factory_decls=factory_decls,
+            handlers=handlers,
+            vars_by_file=vars_by_file,
         )
 
+    def _is_active(self, ctx: native.ProjectContext) -> bool:
+        """Cheap import-presence + config-completeness guard. Skips the
+        ~100-400ms ``subclasses().of_fqn(...)`` walk when no file in the
+        project imports the framework's root package.
+        """
+        if not (self.app_classes and self.registration_decorators):
+            return False
+        app_modules = {fqn.rpartition(".")[0] for fqn in self.app_classes if "." in fqn}
+        return any(native.query(ctx).imports().of(m).exists() for m in app_modules if m)
+
+    def _emit_ops(
+        self,
+        ctx: native.ProjectContext,
+        *,
+        direct: list[native.ConstructionIdxRef],
+        factory_decls: list[tuple[native.FactoryIdxRef, str]],
+        handlers: list[native.DecoratorIdxRef],
+        vars_by_file: dict[tuple[str, str], int],
+    ) -> Iterable[native.GraphOp]:
+        """Per-plugin emission, given pre-fetched rows. Shared between
+        ``DispatchAppPlugin.run`` (single-plugin path) and
+        ``BatchDispatchAppPlugin.run`` (fused path); both fetch the
+        inputs differently then call here.
+        """
         # direct_by_owner: (path, simple_name) -> [var_idx, ...]
         direct_by_owner: dict[tuple[str, str], list[int]] = {}
+        direct_attrs: list[tuple[native.NodeKind, str, str, int]] = []
         if direct:
             direct_attrs = ctx.node_attrs([r.var_idx for r in direct])
             for ref, (_kind, _path, fqname, _flags) in zip(direct, direct_attrs, strict=True):
                 simple = fqname.rsplit(".", 1)[-1]
                 direct_by_owner.setdefault((ref.path, simple), []).append(ref.var_idx)
-
-        # vars_by_file: (path, simple_name) -> var_idx. First idx wins.
-        vars_by_file: dict[tuple[str, str], int] = {}
-        var_idxs = native.query(ctx).decls().with_kind("variable").indices()
-        if var_idxs:
-            var_attrs = ctx.node_attrs(var_idxs)
-            for idx, (_kind, path, fqname, _flags) in zip(var_idxs, var_attrs, strict=True):
-                simple = fqname.rsplit(".", 1)[-1]
-                vars_by_file.setdefault((path, simple), idx)
 
         app_prefix = self._prefix("app")
         factory_prefix = self._prefix("factory")
@@ -338,6 +309,239 @@ class DispatchAppPlugin(Plugin):
                     flags=int(NodeFlags.ENTRYPOINT),
                     edges_to_idx=[var_idx],
                 )
+
+
+# ---------------------------------------------------------------------------
+# Shared fetch helpers
+#
+# Pulled out of :class:`DispatchAppPlugin.run` so
+# :class:`BatchDispatchAppPlugin` can call them with fused inputs.
+# ---------------------------------------------------------------------------
+
+
+def _fetch_direct(
+    ctx: native.ProjectContext, module_to_names: dict[str, set[str]]
+) -> list[native.ConstructionIdxRef]:
+    """Run a construction query per distinct module (with the union of
+    requested names) and dedup by ``var_idx``. Identical observable
+    output to the per-plugin loop the legacy ``DispatchAppPlugin.run``
+    used."""
+    direct_seen: set[int] = set()
+    direct: list[native.ConstructionIdxRef] = []
+    for module, names in module_to_names.items():
+        for ref in (
+            native.query(ctx)
+            .constructions()
+            .where_module(module)
+            .where_name(sorted(names))
+            .row_indices()
+        ):
+            if ref.var_idx in direct_seen:
+                continue
+            direct_seen.add(ref.var_idx)
+            direct.append(ref)
+    return direct
+
+
+def _fetch_factory_decls(
+    ctx: native.ProjectContext, module_to_names: dict[str, set[str]]
+) -> list[tuple[native.FactoryIdxRef, str]]:
+    """Run a factory query per distinct module and dedup by
+    ``(decl_idx, kind)``."""
+    factory_seen: set[tuple[int, str]] = set()
+    factory_decls: list[tuple[native.FactoryIdxRef, str]] = []
+    for module, names in module_to_names.items():
+        for fref in (
+            native.query(ctx).factories().of_module(module).where_name(sorted(names)).row_indices()
+        ):
+            for kind in fref.kinds:
+                key = (fref.decl_idx, kind)
+                if key in factory_seen:
+                    continue
+                factory_seen.add(key)
+                factory_decls.append((fref, kind))
+    return factory_decls
+
+
+def _fetch_handlers(
+    ctx: native.ProjectContext, registration_decorators: frozenset[str]
+) -> list[native.DecoratorIdxRef]:
+    return list(
+        native.query(ctx).decorators().where_owner_attr(list(registration_decorators)).row_indices()
+    )
+
+
+def _build_vars_by_file(ctx: native.ProjectContext) -> dict[tuple[str, str], int]:
+    """One project-wide variable scan + one ``node_attrs`` batch fetch.
+    Result is plugin-agnostic, so ``BatchDispatchAppPlugin`` builds it
+    once and hands the same dict to every wrapped plugin."""
+    vars_by_file: dict[tuple[str, str], int] = {}
+    var_idxs = native.query(ctx).decls().with_kind("variable").indices()
+    if not var_idxs:
+        return vars_by_file
+    var_attrs = ctx.node_attrs(var_idxs)
+    for idx, (_kind, path, fqname, _flags) in zip(var_idxs, var_attrs, strict=True):
+        simple = fqname.rsplit(".", 1)[-1]
+        vars_by_file.setdefault((path, simple), idx)
+    return vars_by_file
+
+
+@dataclass(kw_only=True)
+class BatchDispatchAppPlugin(Plugin):
+    """Run multiple :class:`DispatchAppPlugin` instances with fused queries.
+
+    Same observable output as registering every wrapped plugin
+    individually, but the underlying construction / factory / variable
+    queries are fused so each ``par_scan_files`` runs once across the
+    union of all plugins' configs instead of once per plugin.
+
+    Fusion strategy:
+
+    * **Per-distinct-module construction & factory queries.** Two
+      plugins both targeting ``flask.Flask`` (e.g. Flask + a project-
+      level extension) share one query instead of issuing two. Result
+      rows route back to plugins by matching the row's ``class_name``
+      against each plugin's ``{module: {name}}`` map.
+    * **Shared subclass-walk cache.** Each ``app_class`` fqn's
+      transitive-subclass lookup runs at most once regardless of how
+      many plugins request it.
+    * **Single project-wide variable scan.** ``vars_by_file`` is
+      plugin-agnostic, so it's built once and reused.
+
+    Handler (``DecoratorQuery``) and emission stay per-plugin because
+    handler row routing requires knowing which plugin's
+    ``registration_decorators`` matched, and the ref API doesn't carry
+    the matched attribute name. The handler queries are cheap (each is
+    text-prefiltered before any AST parsing), so this is a fine
+    trade-off — the big AST-walk wins are in the construction /
+    factory / variable scans the fusion does collapse.
+    """
+
+    plugins: list[DispatchAppPlugin]
+    name: str = "BatchDispatchApp"
+    version: int = 1
+
+    def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
+        active = [p for p in self.plugins if p._is_active(ctx)]
+        if not active:
+            return
+
+        # Shared subclass-walk cache. ``DispatchAppPlugin._module_to_names``
+        # calls ``ctx.subclasses_of_fqn_indices(fqn)`` once per
+        # ``app_class``; two plugins that share a class would otherwise
+        # walk the same hierarchy twice. Memoise the per-fqn list of
+        # ``(sub_module, sub_name)`` pairs.
+        subclass_cache: dict[str, list[tuple[str, str]]] = {}
+
+        def _subclasses_for(fqn: str) -> list[tuple[str, str]]:
+            cached = subclass_cache.get(fqn)
+            if cached is not None:
+                return cached
+            sub_idxs = ctx.subclasses_of_fqn_indices(fqn)
+            pairs: list[tuple[str, str]] = []
+            if sub_idxs:
+                for _k, _p, sub_fqname, _f in ctx.node_attrs(sub_idxs):
+                    sub_module, _, sub_name = sub_fqname.rpartition(".")
+                    if sub_module and sub_name:
+                        pairs.append((sub_module, sub_name))
+            subclass_cache[fqn] = pairs
+            return pairs
+
+        module_to_names_per_plugin: list[dict[str, set[str]]] = []
+        for plugin in active:
+            mtn: dict[str, set[str]] = {}
+            for fqn in plugin.app_classes:
+                module, _, name = fqn.rpartition(".")
+                if module and name:
+                    mtn.setdefault(module, set()).add(name)
+            for fqn in plugin.app_classes:
+                for sub_module, sub_name in _subclasses_for(fqn):
+                    mtn.setdefault(sub_module, set()).add(sub_name)
+            module_to_names_per_plugin.append(mtn)
+
+        # Drop plugins whose ``_module_to_names`` came back empty — same
+        # short-circuit DispatchAppPlugin.run does.
+        live_indices = [i for i, mtn in enumerate(module_to_names_per_plugin) if mtn]
+        if not live_indices:
+            return
+
+        # Union of (module → names) across every live plugin — drives
+        # the fused construction & factory queries.
+        union_modules: dict[str, set[str]] = {}
+        for i in live_indices:
+            for module, names in module_to_names_per_plugin[i].items():
+                union_modules.setdefault(module, set()).update(names)
+
+        # Per-plugin direct constructions, deduped by var_idx. Each row
+        # routes to plugins whose ``mtn[module]`` contains the row's
+        # ``class_name``.
+        direct_per_plugin: dict[int, list[native.ConstructionIdxRef]] = {
+            i: [] for i in live_indices
+        }
+        direct_seen_per_plugin: dict[int, set[int]] = {i: set() for i in live_indices}
+        for module, all_names in union_modules.items():
+            for ref in (
+                native.query(ctx)
+                .constructions()
+                .where_module(module)
+                .where_name(sorted(all_names))
+                .row_indices()
+            ):
+                for i in live_indices:
+                    if ref.class_name not in module_to_names_per_plugin[i].get(module, ()):
+                        continue
+                    seen = direct_seen_per_plugin[i]
+                    if ref.var_idx in seen:
+                        continue
+                    seen.add(ref.var_idx)
+                    direct_per_plugin[i].append(ref)
+
+        # Factory queries only run for plugins with seed_as_entrypoint —
+        # but they're shared across all such plugins by module.
+        seed_indices = [i for i in live_indices if active[i].seed_as_entrypoint]
+        factory_per_plugin: dict[int, list[tuple[native.FactoryIdxRef, str]]] = {
+            i: [] for i in live_indices
+        }
+        factory_seen_per_plugin: dict[int, set[tuple[int, str]]] = {i: set() for i in live_indices}
+        if seed_indices:
+            seed_union_modules: dict[str, set[str]] = {}
+            for i in seed_indices:
+                for module, names in module_to_names_per_plugin[i].items():
+                    seed_union_modules.setdefault(module, set()).update(names)
+            for module, all_names in seed_union_modules.items():
+                for fref in (
+                    native.query(ctx)
+                    .factories()
+                    .of_module(module)
+                    .where_name(sorted(all_names))
+                    .row_indices()
+                ):
+                    for kind in fref.kinds:
+                        for i in seed_indices:
+                            if kind not in module_to_names_per_plugin[i].get(module, ()):
+                                continue
+                            key = (fref.decl_idx, kind)
+                            if key in factory_seen_per_plugin[i]:
+                                continue
+                            factory_seen_per_plugin[i].add(key)
+                            factory_per_plugin[i].append((fref, kind))
+
+        # Single project-wide variable scan — shared across every plugin.
+        vars_by_file = _build_vars_by_file(ctx)
+
+        # Per-plugin handler query + emission. Handler queries are not
+        # fused because the ref API doesn't carry which attr matched
+        # (see class docstring).
+        for i in live_indices:
+            plugin = active[i]
+            handlers = _fetch_handlers(ctx, plugin.registration_decorators)
+            yield from plugin._emit_ops(
+                ctx,
+                direct=direct_per_plugin[i],
+                factory_decls=factory_per_plugin[i],
+                handlers=handlers,
+                vars_by_file=vars_by_file,
+            )
 
 
 @dataclass(kw_only=True)

--- a/python/dead_cst/plugins/decl_shapes.py
+++ b/python/dead_cst/plugins/decl_shapes.py
@@ -101,6 +101,41 @@ class DecoratedDeclPlugin(Plugin):
             )
 
 
+@dataclass(frozen=True)
+class DispatchAppSpec:
+    """Pure-data description of what a :class:`DispatchAppPlugin` needs
+    the walker to gather. Has no behavior or policy hooks — those live
+    on the plugin's :meth:`DispatchAppPlugin.policy` method.
+
+    Fields mirror the plugin's class attributes: same semantics, just
+    repackaged so the batched walker can take a list of specs and run
+    one fused pass instead of one pass per plugin. Frozen so it's
+    hashable / cacheable.
+    """
+
+    marker_prefix: str
+    app_classes: tuple[str, ...]
+    registration_decorators: frozenset[str]
+    seed_as_entrypoint: bool
+
+
+@dataclass
+class DispatchAppGather:
+    """Pre-walked data, scoped to one plugin's spec.
+
+    Both the standalone single-plugin path and the batched fused-walk
+    path produce one of these per plugin and hand it to
+    :meth:`DispatchAppPlugin.policy`. ``vars_by_file`` is shared
+    across plugins in the batched path (it's plugin-agnostic).
+    """
+
+    spec: DispatchAppSpec
+    direct: list[native.ConstructionIdxRef]
+    factory_decls: list[tuple[native.FactoryIdxRef, str]]
+    handlers: list[native.DecoratorIdxRef]
+    vars_by_file: dict[tuple[str, str], int]
+
+
 @dataclass(kw_only=True)
 class DispatchAppPlugin(Plugin):
     """Wire ``@<instance>.<reg_decorator>(...)`` handlers to their app instance.
@@ -132,6 +167,13 @@ class DispatchAppPlugin(Plugin):
     Result-level dedup: if the same construction site is reachable
     from two ``app_classes`` entries (e.g. one is a base of the
     other), it only emits one entrypoint marker.
+
+    **Spec / policy split.** Subclasses customize behavior by
+    overriding :meth:`policy` — emission is decoupled from the
+    fetch (which is described by :attr:`spec` and performed by the
+    shared walker). The batched driver
+    :class:`BatchDispatchAppPlugin` honors policy overrides for every
+    wrapped plugin by calling each instance's :meth:`policy`.
     """
 
     marker_prefix: str
@@ -139,62 +181,32 @@ class DispatchAppPlugin(Plugin):
     registration_decorators: frozenset[str] = frozenset()
     seed_as_entrypoint: bool = True
 
+    @property
+    def spec(self) -> DispatchAppSpec:
+        """Frozen-dataclass view of this plugin's gather config.
+
+        Override-friendly: subclasses change what's gathered by
+        overriding the underlying class attributes (or this property
+        if a dynamic spec is needed). The batched walker consumes the
+        spec; it never inspects per-plugin fields directly.
+        """
+        return DispatchAppSpec(
+            marker_prefix=self.marker_prefix,
+            app_classes=self.app_classes,
+            registration_decorators=self.registration_decorators,
+            seed_as_entrypoint=self.seed_as_entrypoint,
+        )
+
     def _prefix(self, kind: str) -> str:
         return f"<{self.marker_prefix}-{kind}>:"
-
-    def _module_to_names(self, ctx: native.ProjectContext) -> dict[str, set[str]]:
-        """Expand each ``app_class`` into ``{module: {simple_name, ...}}``,
-        walking subclasses transitively. Lets module-keyed queries
-        (``where_module(...).where_name(...)``,
-        ``of_module(...).where_name(...)``) discover project / third-party
-        subclasses whose import module differs from the base class.
-
-        Subclasses are resolved by inverting the search: instead of
-        asking ty's ``find_references`` to walk down from each
-        framework class (which forces ty to load + parse the framework
-        out of the venv — ~100-400ms per framework on cold cache), we
-        do one parallel pass over project files reading each
-        ``ClassDef``'s base list and matching against the configured
-        app-class fqnames. The framework module is never loaded.
-        """
-        out: dict[str, set[str]] = {}
-        for fqn in self.app_classes:
-            module, _, name = fqn.rpartition(".")
-            if not module or not name:
-                continue
-            out.setdefault(module, set()).add(name)
-        if not self.app_classes:
-            return out
-        # One batched attr fetch per framework's subclass set.
-        for fqn in self.app_classes:
-            sub_idxs = ctx.subclasses_of_fqn_indices(fqn)
-            if not sub_idxs:
-                continue
-            for _kind, _path, sub_fqname, _flags in ctx.node_attrs(sub_idxs):
-                sub_module, _, sub_name = sub_fqname.rpartition(".")
-                if sub_module and sub_name:
-                    out.setdefault(sub_module, set()).add(sub_name)
-        return out
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
         if not self._is_active(ctx):
             return
-        module_to_names = self._module_to_names(ctx)
-        if not module_to_names:
+        gathered = _gather_one(ctx, self.spec)
+        if gathered is None:
             return
-        direct = _fetch_direct(ctx, module_to_names)
-        factory_decls = (
-            _fetch_factory_decls(ctx, module_to_names) if self.seed_as_entrypoint else []
-        )
-        handlers = _fetch_handlers(ctx, self.registration_decorators)
-        vars_by_file = _build_vars_by_file(ctx)
-        yield from self._emit_ops(
-            ctx,
-            direct=direct,
-            factory_decls=factory_decls,
-            handlers=handlers,
-            vars_by_file=vars_by_file,
-        )
+        yield from self.policy(ctx, gathered)
 
     def _is_active(self, ctx: native.ProjectContext) -> bool:
         """Cheap import-presence + config-completeness guard. Skips the
@@ -206,20 +218,25 @@ class DispatchAppPlugin(Plugin):
         app_modules = {fqn.rpartition(".")[0] for fqn in self.app_classes if "." in fqn}
         return any(native.query(ctx).imports().of(m).exists() for m in app_modules if m)
 
-    def _emit_ops(
-        self,
-        ctx: native.ProjectContext,
-        *,
-        direct: list[native.ConstructionIdxRef],
-        factory_decls: list[tuple[native.FactoryIdxRef, str]],
-        handlers: list[native.DecoratorIdxRef],
-        vars_by_file: dict[tuple[str, str], int],
+    def policy(
+        self, ctx: native.ProjectContext, gathered: DispatchAppGather
     ) -> Iterable[native.GraphOp]:
-        """Per-plugin emission, given pre-fetched rows. Shared between
-        ``DispatchAppPlugin.run`` (single-plugin path) and
-        ``BatchDispatchAppPlugin.run`` (fused path); both fetch the
-        inputs differently then call here.
+        """Emit ops from pre-gathered data. The override point for
+        subclasses that want to extend or customize emission without
+        changing what gets gathered.
+
+        Subclasses that want to add framework-specific extras should
+        ``yield from super().policy(ctx, gathered)`` first, then yield
+        their additional ops. The standalone :meth:`run` path and the
+        batched :class:`BatchDispatchAppPlugin` path both call this
+        method, so any override is honored uniformly.
         """
+        spec = gathered.spec
+        direct = gathered.direct
+        factory_decls = gathered.factory_decls
+        handlers = gathered.handlers
+        vars_by_file = gathered.vars_by_file
+
         # direct_by_owner: (path, simple_name) -> [var_idx, ...]
         direct_by_owner: dict[tuple[str, str], list[int]] = {}
         direct_attrs: list[tuple[native.NodeKind, str, str, int]] = []
@@ -229,11 +246,11 @@ class DispatchAppPlugin(Plugin):
                 simple = fqname.rsplit(".", 1)[-1]
                 direct_by_owner.setdefault((ref.path, simple), []).append(ref.var_idx)
 
-        app_prefix = self._prefix("app")
-        factory_prefix = self._prefix("factory")
+        app_prefix = f"<{spec.marker_prefix}-app>:"
+        factory_prefix = f"<{spec.marker_prefix}-factory>:"
 
         # 3. Entrypoint-promote every direct construction (when enabled).
-        if self.seed_as_entrypoint and direct:
+        if spec.seed_as_entrypoint and direct:
             # Reuse the direct_attrs computed above.
             for ref, (_kind, _path, fqname, _flags) in zip(direct, direct_attrs, strict=True):
                 yield native.AddNodeByIdx(
@@ -267,7 +284,7 @@ class DispatchAppPlugin(Plugin):
         # handler edges.
         for h in handlers:
             key = (h.path, h.decorator_owner or "")
-            if self.seed_as_entrypoint:
+            if spec.seed_as_entrypoint:
                 var_idx = vars_by_file.get(key)
                 if var_idx is not None:
                     yield native.AddEdgeByIdx(var_idx, h.decorated_idx)
@@ -288,7 +305,7 @@ class DispatchAppPlugin(Plugin):
         # doesn't reach the factory directly and stays unclassified.
         # Only ``app`` (whose direct successor *is* ``create_app``)
         # promotes.
-        if self.seed_as_entrypoint and factory_decls:
+        if spec.seed_as_entrypoint and factory_decls:
             factory_reachers: set[int] = set()
             for fref, _kind in factory_decls:
                 factory_reachers.update(ctx.direct_predecessors_idx(fref.decl_idx))
@@ -312,20 +329,55 @@ class DispatchAppPlugin(Plugin):
 
 
 # ---------------------------------------------------------------------------
-# Shared fetch helpers
+# Walker: spec → gather
 #
-# Pulled out of :class:`DispatchAppPlugin.run` so
-# :class:`BatchDispatchAppPlugin` can call them with fused inputs.
+# The "gather" half of the spec / policy split. Both the standalone
+# ``DispatchAppPlugin.run`` path and the batched
+# ``BatchDispatchAppPlugin.run`` path flow through these helpers; only
+# the fan-out shape differs.
 # ---------------------------------------------------------------------------
+
+
+def _module_to_names(
+    ctx: native.ProjectContext,
+    app_classes: tuple[str, ...],
+    subclass_cache: dict[str, list[tuple[str, str]]] | None = None,
+) -> dict[str, set[str]]:
+    """Expand each ``app_class`` fqn into ``{module: {simple_name, ...}}``,
+    walking subclasses transitively. ``subclass_cache`` (optional) lets
+    the batched walker memoise across plugins that share an app class.
+    """
+    out: dict[str, set[str]] = {}
+    for fqn in app_classes:
+        module, _, name = fqn.rpartition(".")
+        if not module or not name:
+            continue
+        out.setdefault(module, set()).add(name)
+    if not app_classes:
+        return out
+    for fqn in app_classes:
+        if subclass_cache is not None and fqn in subclass_cache:
+            pairs = subclass_cache[fqn]
+        else:
+            sub_idxs = ctx.subclasses_of_fqn_indices(fqn)
+            pairs = []
+            if sub_idxs:
+                for _kind, _path, sub_fqname, _flags in ctx.node_attrs(sub_idxs):
+                    sub_module, _, sub_name = sub_fqname.rpartition(".")
+                    if sub_module and sub_name:
+                        pairs.append((sub_module, sub_name))
+            if subclass_cache is not None:
+                subclass_cache[fqn] = pairs
+        for sub_module, sub_name in pairs:
+            out.setdefault(sub_module, set()).add(sub_name)
+    return out
 
 
 def _fetch_direct(
     ctx: native.ProjectContext, module_to_names: dict[str, set[str]]
 ) -> list[native.ConstructionIdxRef]:
     """Run a construction query per distinct module (with the union of
-    requested names) and dedup by ``var_idx``. Identical observable
-    output to the per-plugin loop the legacy ``DispatchAppPlugin.run``
-    used."""
+    requested names) and dedup by ``var_idx``."""
     direct_seen: set[int] = set()
     direct: list[native.ConstructionIdxRef] = []
     for module, names in module_to_names.items():
@@ -373,8 +425,8 @@ def _fetch_handlers(
 
 def _build_vars_by_file(ctx: native.ProjectContext) -> dict[tuple[str, str], int]:
     """One project-wide variable scan + one ``node_attrs`` batch fetch.
-    Result is plugin-agnostic, so ``BatchDispatchAppPlugin`` builds it
-    once and hands the same dict to every wrapped plugin."""
+    Result is plugin-agnostic, so the batched walker builds it once
+    and hands the same dict to every plugin's gather."""
     vars_by_file: dict[tuple[str, str], int] = {}
     var_idxs = native.query(ctx).decls().with_kind("variable").indices()
     if not var_idxs:
@@ -386,35 +438,148 @@ def _build_vars_by_file(ctx: native.ProjectContext) -> dict[tuple[str, str], int
     return vars_by_file
 
 
-@dataclass(kw_only=True)
-class BatchDispatchAppPlugin(Plugin):
-    """Run multiple :class:`DispatchAppPlugin` instances with fused queries.
+def _gather_one(ctx: native.ProjectContext, spec: DispatchAppSpec) -> DispatchAppGather | None:
+    """Standalone single-plugin gather. Returns ``None`` when the spec's
+    ``app_classes`` resolve to no usable ``{module: names}`` map —
+    matches the legacy short-circuit ``DispatchAppPlugin.run`` did."""
+    module_to_names = _module_to_names(ctx, spec.app_classes)
+    if not module_to_names:
+        return None
+    return DispatchAppGather(
+        spec=spec,
+        direct=_fetch_direct(ctx, module_to_names),
+        factory_decls=_fetch_factory_decls(ctx, module_to_names) if spec.seed_as_entrypoint else [],
+        handlers=_fetch_handlers(ctx, spec.registration_decorators),
+        vars_by_file=_build_vars_by_file(ctx),
+    )
 
-    Same observable output as registering every wrapped plugin
-    individually, but the underlying construction / factory / variable
-    queries are fused so each ``par_scan_files`` runs once across the
-    union of all plugins' configs instead of once per plugin.
+
+def _gather_batched(
+    ctx: native.ProjectContext, specs: list[DispatchAppSpec]
+) -> list[DispatchAppGather | None]:
+    """Fused walker for a batch of specs. Returns one
+    ``DispatchAppGather`` per input spec (in order), or ``None`` for
+    any spec whose ``app_classes`` resolved empty.
 
     Fusion strategy:
 
-    * **Per-distinct-module construction & factory queries.** Two
-      plugins both targeting ``flask.Flask`` (e.g. Flask + a project-
-      level extension) share one query instead of issuing two. Result
-      rows route back to plugins by matching the row's ``class_name``
-      against each plugin's ``{module: {name}}`` map.
-    * **Shared subclass-walk cache.** Each ``app_class`` fqn's
-      transitive-subclass lookup runs at most once regardless of how
-      many plugins request it.
-    * **Single project-wide variable scan.** ``vars_by_file`` is
-      plugin-agnostic, so it's built once and reused.
+    * Shared subclass-walk cache — each ``app_class`` fqn's
+      transitive lookup runs at most once across all specs.
+    * Per-distinct-module construction & factory queries — two specs
+      both targeting ``flask.Flask`` share one query; rows route back
+      to specs by matching ``class_name`` against each spec's map.
+    * Single project-wide ``vars_by_file`` scan shared across specs.
+    * Per-spec handler query (no fusion — the ref API doesn't carry
+      which attr matched, so a fused result can't route to the right
+      spec without further work).
+    """
+    if not specs:
+        return []
+    subclass_cache: dict[str, list[tuple[str, str]]] = {}
+    module_to_names_per_spec: list[dict[str, set[str]]] = [
+        _module_to_names(ctx, spec.app_classes, subclass_cache=subclass_cache) for spec in specs
+    ]
 
-    Handler (``DecoratorQuery``) and emission stay per-plugin because
-    handler row routing requires knowing which plugin's
-    ``registration_decorators`` matched, and the ref API doesn't carry
-    the matched attribute name. The handler queries are cheap (each is
-    text-prefiltered before any AST parsing), so this is a fine
-    trade-off — the big AST-walk wins are in the construction /
-    factory / variable scans the fusion does collapse.
+    # Result slot per input spec; ``None`` for empty-map specs.
+    gathered: list[DispatchAppGather | None] = [None] * len(specs)
+    live_indices = [i for i, mtn in enumerate(module_to_names_per_spec) if mtn]
+    if not live_indices:
+        return gathered
+
+    union_modules: dict[str, set[str]] = {}
+    for i in live_indices:
+        for module, names in module_to_names_per_spec[i].items():
+            union_modules.setdefault(module, set()).update(names)
+
+    # Per-spec direct constructions, deduped by var_idx.
+    direct_per_spec: list[list[native.ConstructionIdxRef]] = [[] for _ in specs]
+    direct_seen_per_spec: list[set[int]] = [set() for _ in specs]
+    for module, all_names in union_modules.items():
+        for ref in (
+            native.query(ctx)
+            .constructions()
+            .where_module(module)
+            .where_name(sorted(all_names))
+            .row_indices()
+        ):
+            for i in live_indices:
+                if ref.class_name not in module_to_names_per_spec[i].get(module, ()):
+                    continue
+                seen = direct_seen_per_spec[i]
+                if ref.var_idx in seen:
+                    continue
+                seen.add(ref.var_idx)
+                direct_per_spec[i].append(ref)
+
+    # Per-spec factory decls (only for seed_as_entrypoint specs).
+    factory_per_spec: list[list[tuple[native.FactoryIdxRef, str]]] = [[] for _ in specs]
+    factory_seen_per_spec: list[set[tuple[int, str]]] = [set() for _ in specs]
+    seed_indices = [i for i in live_indices if specs[i].seed_as_entrypoint]
+    if seed_indices:
+        seed_union_modules: dict[str, set[str]] = {}
+        for i in seed_indices:
+            for module, names in module_to_names_per_spec[i].items():
+                seed_union_modules.setdefault(module, set()).update(names)
+        for module, all_names in seed_union_modules.items():
+            for fref in (
+                native.query(ctx)
+                .factories()
+                .of_module(module)
+                .where_name(sorted(all_names))
+                .row_indices()
+            ):
+                for kind in fref.kinds:
+                    for i in seed_indices:
+                        if kind not in module_to_names_per_spec[i].get(module, ()):
+                            continue
+                        key = (fref.decl_idx, kind)
+                        if key in factory_seen_per_spec[i]:
+                            continue
+                        factory_seen_per_spec[i].add(key)
+                        factory_per_spec[i].append((fref, kind))
+
+    vars_by_file = _build_vars_by_file(ctx)
+
+    for i in live_indices:
+        gathered[i] = DispatchAppGather(
+            spec=specs[i],
+            direct=direct_per_spec[i],
+            factory_decls=factory_per_spec[i],
+            handlers=_fetch_handlers(ctx, specs[i].registration_decorators),
+            vars_by_file=vars_by_file,
+        )
+    return gathered
+
+
+@dataclass(kw_only=True)
+class BatchDispatchAppPlugin(Plugin):
+    """Run multiple :class:`DispatchAppPlugin` instances with a fused
+    gather pass + per-plugin policy.
+
+    Architecture: split each wrapped plugin into a ``spec`` (the
+    pure-data description of what to gather, see
+    :class:`DispatchAppSpec`) and a ``policy(ctx, gathered)`` method
+    (the per-plugin emission, see
+    :meth:`DispatchAppPlugin.policy`). This driver runs a fused walk
+    across every spec, then calls each plugin's :meth:`policy` with
+    its slice of the gather. Subclass overrides of :meth:`policy` are
+    honored uniformly — that's the point of the split.
+
+    Fusion strategy (in the gather phase):
+
+    * Shared subclass-walk cache — each ``app_class`` fqn's
+      transitive lookup runs at most once regardless of how many
+      specs request it.
+    * Per-distinct-module construction & factory queries. Two specs
+      both targeting ``flask.Flask`` (e.g. Flask + a project-level
+      extension) share one query; rows route back to specs by
+      matching ``class_name`` against each spec's map.
+    * Single project-wide variable scan reused across plugins.
+
+    Per-spec handler queries stay un-fused: the ref API doesn't carry
+    which attribute matched, so a fused result can't route to the
+    right spec without further work. Handler queries are
+    text-prefiltered before any AST parse, so this stays cheap.
     """
 
     plugins: list[DispatchAppPlugin]
@@ -425,123 +590,11 @@ class BatchDispatchAppPlugin(Plugin):
         active = [p for p in self.plugins if p._is_active(ctx)]
         if not active:
             return
-
-        # Shared subclass-walk cache. ``DispatchAppPlugin._module_to_names``
-        # calls ``ctx.subclasses_of_fqn_indices(fqn)`` once per
-        # ``app_class``; two plugins that share a class would otherwise
-        # walk the same hierarchy twice. Memoise the per-fqn list of
-        # ``(sub_module, sub_name)`` pairs.
-        subclass_cache: dict[str, list[tuple[str, str]]] = {}
-
-        def _subclasses_for(fqn: str) -> list[tuple[str, str]]:
-            cached = subclass_cache.get(fqn)
-            if cached is not None:
-                return cached
-            sub_idxs = ctx.subclasses_of_fqn_indices(fqn)
-            pairs: list[tuple[str, str]] = []
-            if sub_idxs:
-                for _k, _p, sub_fqname, _f in ctx.node_attrs(sub_idxs):
-                    sub_module, _, sub_name = sub_fqname.rpartition(".")
-                    if sub_module and sub_name:
-                        pairs.append((sub_module, sub_name))
-            subclass_cache[fqn] = pairs
-            return pairs
-
-        module_to_names_per_plugin: list[dict[str, set[str]]] = []
-        for plugin in active:
-            mtn: dict[str, set[str]] = {}
-            for fqn in plugin.app_classes:
-                module, _, name = fqn.rpartition(".")
-                if module and name:
-                    mtn.setdefault(module, set()).add(name)
-            for fqn in plugin.app_classes:
-                for sub_module, sub_name in _subclasses_for(fqn):
-                    mtn.setdefault(sub_module, set()).add(sub_name)
-            module_to_names_per_plugin.append(mtn)
-
-        # Drop plugins whose ``_module_to_names`` came back empty — same
-        # short-circuit DispatchAppPlugin.run does.
-        live_indices = [i for i, mtn in enumerate(module_to_names_per_plugin) if mtn]
-        if not live_indices:
-            return
-
-        # Union of (module → names) across every live plugin — drives
-        # the fused construction & factory queries.
-        union_modules: dict[str, set[str]] = {}
-        for i in live_indices:
-            for module, names in module_to_names_per_plugin[i].items():
-                union_modules.setdefault(module, set()).update(names)
-
-        # Per-plugin direct constructions, deduped by var_idx. Each row
-        # routes to plugins whose ``mtn[module]`` contains the row's
-        # ``class_name``.
-        direct_per_plugin: dict[int, list[native.ConstructionIdxRef]] = {
-            i: [] for i in live_indices
-        }
-        direct_seen_per_plugin: dict[int, set[int]] = {i: set() for i in live_indices}
-        for module, all_names in union_modules.items():
-            for ref in (
-                native.query(ctx)
-                .constructions()
-                .where_module(module)
-                .where_name(sorted(all_names))
-                .row_indices()
-            ):
-                for i in live_indices:
-                    if ref.class_name not in module_to_names_per_plugin[i].get(module, ()):
-                        continue
-                    seen = direct_seen_per_plugin[i]
-                    if ref.var_idx in seen:
-                        continue
-                    seen.add(ref.var_idx)
-                    direct_per_plugin[i].append(ref)
-
-        # Factory queries only run for plugins with seed_as_entrypoint —
-        # but they're shared across all such plugins by module.
-        seed_indices = [i for i in live_indices if active[i].seed_as_entrypoint]
-        factory_per_plugin: dict[int, list[tuple[native.FactoryIdxRef, str]]] = {
-            i: [] for i in live_indices
-        }
-        factory_seen_per_plugin: dict[int, set[tuple[int, str]]] = {i: set() for i in live_indices}
-        if seed_indices:
-            seed_union_modules: dict[str, set[str]] = {}
-            for i in seed_indices:
-                for module, names in module_to_names_per_plugin[i].items():
-                    seed_union_modules.setdefault(module, set()).update(names)
-            for module, all_names in seed_union_modules.items():
-                for fref in (
-                    native.query(ctx)
-                    .factories()
-                    .of_module(module)
-                    .where_name(sorted(all_names))
-                    .row_indices()
-                ):
-                    for kind in fref.kinds:
-                        for i in seed_indices:
-                            if kind not in module_to_names_per_plugin[i].get(module, ()):
-                                continue
-                            key = (fref.decl_idx, kind)
-                            if key in factory_seen_per_plugin[i]:
-                                continue
-                            factory_seen_per_plugin[i].add(key)
-                            factory_per_plugin[i].append((fref, kind))
-
-        # Single project-wide variable scan — shared across every plugin.
-        vars_by_file = _build_vars_by_file(ctx)
-
-        # Per-plugin handler query + emission. Handler queries are not
-        # fused because the ref API doesn't carry which attr matched
-        # (see class docstring).
-        for i in live_indices:
-            plugin = active[i]
-            handlers = _fetch_handlers(ctx, plugin.registration_decorators)
-            yield from plugin._emit_ops(
-                ctx,
-                direct=direct_per_plugin[i],
-                factory_decls=factory_per_plugin[i],
-                handlers=handlers,
-                vars_by_file=vars_by_file,
-            )
+        gathered = _gather_batched(ctx, [p.spec for p in active])
+        for plugin, g in zip(active, gathered, strict=True):
+            if g is None:
+                continue
+            yield from plugin.policy(ctx, g)
 
 
 @dataclass(kw_only=True)

--- a/python/dead_cst/plugins/decl_shapes.py
+++ b/python/dead_cst/plugins/decl_shapes.py
@@ -66,29 +66,38 @@ class DecoratedDeclPlugin(Plugin):
         def in_scope(path: str) -> bool:
             if not prefix:
                 return True
-            module = ctx.module_for(path)
-            if module is None:
+            module_idx = ctx.module_for_indices(path)
+            if module_idx is None:
                 return False
-            return module.fqname == prefix or module.fqname.startswith(prefix + ".")
+            (_kind, _path, fqname, _flags) = ctx.node_attrs([module_idx])[0]
+            return fqname == prefix or fqname.startswith(prefix + ".")
 
-        seeds_by_path: dict[str, list[native.SymbolNode]] = {}
-        for dec_ref in (
-            native.query(ctx).decorators().where_module(self.decorator_module).where_name(names)
+        seeds_by_path: dict[str, list[int]] = {}
+        for dec_row in (
+            native.query(ctx)
+            .decorators()
+            .where_module(self.decorator_module)
+            .where_name(names)
+            .row_indices()
         ):
-            if in_scope(dec_ref.path):
-                seeds_by_path.setdefault(dec_ref.path, []).append(dec_ref.decorated)
-        for cons_ref in (
-            native.query(ctx).constructions().where_module(self.decorator_module).where_name(names)
+            if in_scope(dec_row.path):
+                seeds_by_path.setdefault(dec_row.path, []).append(dec_row.decorated_idx)
+        for cons_row in (
+            native.query(ctx)
+            .constructions()
+            .where_module(self.decorator_module)
+            .where_name(names)
+            .row_indices()
         ):
-            if in_scope(cons_ref.path):
-                seeds_by_path.setdefault(cons_ref.path, []).append(cons_ref.var)
+            if in_scope(cons_row.path):
+                seeds_by_path.setdefault(cons_row.path, []).append(cons_row.var_idx)
 
-        for path, targets in seeds_by_path.items():
-            yield native.AddNode(
+        for path, target_idxs in seeds_by_path.items():
+            yield native.AddNodeByIdx(
                 fqname=f"<{self.marker_prefix}>:{Path(path).name}",
                 path=path,
                 flags=int(NodeFlags.ENTRYPOINT),
-                edges_to=targets,
+                edges_to_idx=target_idxs,
             )
 
 
@@ -156,9 +165,13 @@ class DispatchAppPlugin(Plugin):
             out.setdefault(module, set()).add(name)
         if not self.app_classes:
             return out
+        # One batched attr fetch per framework's subclass set.
         for fqn in self.app_classes:
-            for sub in ctx.subclasses_of_fqn(fqn):
-                sub_module, _, sub_name = sub.fqname.rpartition(".")
+            sub_idxs = ctx.subclasses_of_fqn_indices(fqn)
+            if not sub_idxs:
+                continue
+            for _kind, _path, sub_fqname, _flags in ctx.node_attrs(sub_idxs):
+                sub_module, _, sub_name = sub_fqname.rpartition(".")
                 if sub_module and sub_name:
                     out.setdefault(sub_module, set()).add(sub_name)
         return out
@@ -182,24 +195,32 @@ class DispatchAppPlugin(Plugin):
         if not module_to_names:
             return
 
-        # 1. Direct constructions, deduped by (path, start_line).
-        direct_seen: set[tuple[str, int]] = set()
-        direct: list = []
+        # 1. Direct constructions, deduped by var_idx (every construction
+        # site has a globally unique node index, so the same physical
+        # site that matches under two ``app_classes`` entries — e.g.
+        # one is a base of the other — collapses on idx).
+        direct_seen: set[int] = set()
+        direct: list[native.ConstructionIdxRef] = []
         for module, names in module_to_names.items():
             for ref in (
-                native.query(ctx).constructions().where_module(module).where_name(sorted(names))
+                native.query(ctx)
+                .constructions()
+                .where_module(module)
+                .where_name(sorted(names))
+                .row_indices()
             ):
-                key = (ref.var.path, ref.var.start_line)
-                if key in direct_seen:
+                if ref.var_idx in direct_seen:
                     continue
-                direct_seen.add(key)
+                direct_seen.add(ref.var_idx)
                 direct.append(ref)
 
         # 2. Factory functions returning one of the listed classes,
-        # deduped by (decl path, decl line, kind). Only relevant when
-        # we'd actually do something with the markers in step 6.
-        factory_seen: set[tuple[str, int, str]] = set()
-        factory_decls: list = []
+        # deduped by (decl_idx, kind). decl_idx is globally unique;
+        # kind is part of the key because one decl can match multiple
+        # kinds. Only relevant when we'd actually do something with the
+        # markers in step 6.
+        factory_seen: set[tuple[int, str]] = set()
+        factory_decls: list[tuple[native.FactoryIdxRef, str]] = []
         if self.seed_as_entrypoint:
             for module, names in module_to_names.items():
                 for fref in (
@@ -207,50 +228,62 @@ class DispatchAppPlugin(Plugin):
                     .factories()
                     .of_module(module)
                     .where_name(sorted(names))
-                    .collect()
+                    .row_indices()
                 ):
                     for kind in fref.kinds:
-                        key = (fref.decl.path, fref.decl.start_line, kind)
+                        key = (fref.decl_idx, kind)
                         if key in factory_seen:
                             continue
                         factory_seen.add(key)
                         factory_decls.append((fref, kind))
 
-        handlers = list(native.query(ctx).decorators().where_owner_attr(decorator_attrs))
+        handlers = list(
+            native.query(ctx).decorators().where_owner_attr(decorator_attrs).row_indices()
+        )
 
-        direct_by_owner: dict[tuple[str, str], list[native.SymbolNode]] = {}
-        for ref in direct:
-            simple = ref.var.fqname.rsplit(".", 1)[-1]
-            direct_by_owner.setdefault((ref.var.path, simple), []).append(ref.var)
+        # direct_by_owner: (path, simple_name) -> [var_idx, ...]
+        direct_by_owner: dict[tuple[str, str], list[int]] = {}
+        if direct:
+            direct_attrs = ctx.node_attrs([r.var_idx for r in direct])
+            for ref, (_kind, _path, fqname, _flags) in zip(direct, direct_attrs, strict=True):
+                simple = fqname.rsplit(".", 1)[-1]
+                direct_by_owner.setdefault((ref.path, simple), []).append(ref.var_idx)
 
-        vars_by_file: dict[tuple[str, str], native.SymbolNode] = {}
-        # Rust-side fold of the ``kind == variable`` filter — drops the
-        # FFI overhead of materialising every non-variable node.
-        for n in native.query(ctx).decls().with_kind("variable").collect():
-            simple = n.fqname.rsplit(".", 1)[-1]
-            vars_by_file.setdefault((n.path, simple), n)
+        # vars_by_file: (path, simple_name) -> var_idx. First idx wins.
+        vars_by_file: dict[tuple[str, str], int] = {}
+        var_idxs = native.query(ctx).decls().with_kind("variable").indices()
+        if var_idxs:
+            var_attrs = ctx.node_attrs(var_idxs)
+            for idx, (_kind, path, fqname, _flags) in zip(var_idxs, var_attrs, strict=True):
+                simple = fqname.rsplit(".", 1)[-1]
+                vars_by_file.setdefault((path, simple), idx)
 
         app_prefix = self._prefix("app")
         factory_prefix = self._prefix("factory")
 
         # 3. Entrypoint-promote every direct construction (when enabled).
-        if self.seed_as_entrypoint:
-            for ref in direct:
-                yield native.AddNode(
-                    fqname=f"{app_prefix}{ref.var.fqname}",
-                    path=ref.var.path,
+        if self.seed_as_entrypoint and direct:
+            # Reuse the direct_attrs computed above.
+            for ref, (_kind, _path, fqname, _flags) in zip(direct, direct_attrs, strict=True):
+                yield native.AddNodeByIdx(
+                    fqname=f"{app_prefix}{fqname}",
+                    path=ref.path,
                     flags=int(NodeFlags.ENTRYPOINT),
-                    edges_to=[ref.var],
+                    edges_to_idx=[ref.var_idx],
                 )
 
         # 4. Emit factory markers so the descendant walk in step 6 can
         # find them.
-        for fref, kind in factory_decls:
-            yield native.AddNode(
-                fqname=f"{factory_prefix}{kind}:{fref.decl.fqname}",
-                path=fref.decl.path,
-                edges_from=[fref.decl],
-            )
+        if factory_decls:
+            factory_attrs = ctx.node_attrs([fref.decl_idx for fref, _kind in factory_decls])
+            for (fref, kind), (_k, _p, decl_fqname, _f) in zip(
+                factory_decls, factory_attrs, strict=True
+            ):
+                yield native.AddNodeByIdx(
+                    fqname=f"{factory_prefix}{kind}:{decl_fqname}",
+                    path=fref.path,
+                    edges_from_idx=[fref.decl_idx],
+                )
 
         # 5. Wire decorator handlers to their owner var.
         # When seed_as_entrypoint=False (pure dispatch), only wire to
@@ -262,14 +295,14 @@ class DispatchAppPlugin(Plugin):
         # so ``app = create_app()`` factory chains also pick up
         # handler edges.
         for h in handlers:
-            key = (h.decorated.path, h.decorator_owner or "")
+            key = (h.path, h.decorator_owner or "")
             if self.seed_as_entrypoint:
-                var = vars_by_file.get(key)
-                if var is not None:
-                    yield native.AddEdge(var, h.decorated)
+                var_idx = vars_by_file.get(key)
+                if var_idx is not None:
+                    yield native.AddEdgeByIdx(var_idx, h.decorated_idx)
             else:
-                for var in direct_by_owner.get(key, []):
-                    yield native.AddEdge(var, h.decorated)
+                for var_idx in direct_by_owner.get(key, []):
+                    yield native.AddEdgeByIdx(var_idx, h.decorated_idx)
 
         # 6. Factory walk: vars whose *direct* successor is one of the
         # factory decls get entrypoint-promoted. Skipped under
@@ -285,24 +318,25 @@ class DispatchAppPlugin(Plugin):
         # Only ``app`` (whose direct successor *is* ``create_app``)
         # promotes.
         if self.seed_as_entrypoint and factory_decls:
-            factory_reachers: set[native.SymbolNode] = set()
+            factory_reachers: set[int] = set()
             for fref, _kind in factory_decls:
-                factory_reachers.update(ctx.direct_predecessors(fref.decl))
+                factory_reachers.update(ctx.direct_predecessors_idx(fref.decl_idx))
 
             classified: set[tuple[str, str]] = set()
             for h in handlers:
-                key = (h.decorated.path, h.decorator_owner or "")
+                key = (h.path, h.decorator_owner or "")
                 if key in direct_by_owner or key in classified:
                     continue
-                var = vars_by_file.get(key)
-                if var is None or var not in factory_reachers:
+                var_idx = vars_by_file.get(key)
+                if var_idx is None or var_idx not in factory_reachers:
                     continue
                 classified.add(key)
-                yield native.AddNode(
-                    fqname=f"{app_prefix}{var.fqname}",
-                    path=var.path,
+                (_kind, var_path, var_fqname, _flags) = ctx.node_attrs([var_idx])[0]
+                yield native.AddNodeByIdx(
+                    fqname=f"{app_prefix}{var_fqname}",
+                    path=var_path,
                     flags=int(NodeFlags.ENTRYPOINT),
-                    edges_to=[var],
+                    edges_to_idx=[var_idx],
                 )
 
 
@@ -343,15 +377,16 @@ class LiteralListPlugin(Plugin):
         # fqname — try both; some entries may match both (e.g.
         # ``pkg.foo`` where ``foo`` is also a re-exported decl in
         # ``pkg/__init__.py``).
-        surfaces = ctx.module_surfaces(entries)
+        surfaces = ctx.module_surfaces_indices(entries)
         for entry in entries:
-            targets: list[native.SymbolNode] = list(surfaces.get(entry, ()))
-            targets.extend(ctx.find_declarations(entry))
-            if not targets:
+            target_idxs: list[int] = list(surfaces.get(entry, ()))
+            target_idxs.extend(ctx.find_declarations_indices(entry))
+            if not target_idxs:
                 continue
-            yield native.AddNode(
+            (_kind, marker_path, _fq, _flags) = ctx.node_attrs([target_idxs[0]])[0]
+            yield native.AddNodeByIdx(
                 fqname=f"{prefix}{entry}",
-                path=targets[0].path,
+                path=marker_path,
                 flags=int(NodeFlags.ENTRYPOINT),
-                edges_to=targets,
+                edges_to_idx=target_idxs,
             )

--- a/python/dead_cst/plugins/decl_shapes.py
+++ b/python/dead_cst/plugins/decl_shapes.py
@@ -639,9 +639,7 @@ class LiteralListPlugin(Plugin):
         surfaces = ctx.module_surfaces_indices(entries)
         for entry in entries:
             target_idxs: list[int] = list(surfaces.get(entry, ()))
-            target_idxs.extend(
-                native.query(ctx).declarations().with_fqname(entry).indices()
-            )
+            target_idxs.extend(native.query(ctx).declarations().with_fqname(entry).indices())
             if not target_idxs:
                 continue
             (_kind, marker_path, _fq, _flags) = ctx.node_attrs([target_idxs[0]])[0]

--- a/python/dead_cst/plugins/decl_shapes.py
+++ b/python/dead_cst/plugins/decl_shapes.py
@@ -359,7 +359,7 @@ def _module_to_names(
         if subclass_cache is not None and fqn in subclass_cache:
             pairs = subclass_cache[fqn]
         else:
-            sub_idxs = ctx.subclasses_of_fqn_indices(fqn)
+            sub_idxs = native.query(ctx).subclasses().of_fqn(fqn).indices()
             pairs = []
             if sub_idxs:
                 for _kind, _path, sub_fqname, _flags in ctx.node_attrs(sub_idxs):

--- a/python/dead_cst/plugins/decl_shapes.py
+++ b/python/dead_cst/plugins/decl_shapes.py
@@ -123,9 +123,9 @@ class DispatchAppSpec:
 class DispatchAppGather:
     """Pre-walked data, scoped to one plugin's spec.
 
-    Both the standalone single-plugin path and the batched fused-walk
-    path produce one of these per plugin and hand it to
-    :meth:`DispatchAppPlugin.policy`. ``vars_by_file`` is shared
+    Both the standalone single-plugin path and the harness's auto-
+    batched fused-walk path produce one of these per plugin and hand
+    it to :meth:`DispatchAppPlugin.policy`. ``vars_by_file`` is shared
     across plugins in the batched path (it's plugin-agnostic).
     """
 
@@ -171,9 +171,12 @@ class DispatchAppPlugin(Plugin):
     **Spec / policy split.** Subclasses customize behavior by
     overriding :meth:`policy` — emission is decoupled from the
     fetch (which is described by :attr:`spec` and performed by the
-    shared walker). The batched driver
-    :class:`BatchDispatchAppPlugin` honors policy overrides for every
-    wrapped plugin by calling each instance's :meth:`policy`.
+    shared walker). The :class:`Analysis` harness detects every
+    registered :class:`DispatchAppPlugin` automatically and fuses
+    their specs into a single gather pass before fanning out the
+    per-plugin :meth:`policy` calls through the same
+    :class:`ThreadPoolExecutor` it uses for non-dispatch plugins,
+    so subclass overrides are honored uniformly without any wrapper.
     """
 
     marker_prefix: str
@@ -228,8 +231,8 @@ class DispatchAppPlugin(Plugin):
         Subclasses that want to add framework-specific extras should
         ``yield from super().policy(ctx, gathered)`` first, then yield
         their additional ops. The standalone :meth:`run` path and the
-        batched :class:`BatchDispatchAppPlugin` path both call this
-        method, so any override is honored uniformly.
+        harness's auto-batched gather both call this method, so any
+        override is honored uniformly.
         """
         spec = gathered.spec
         direct = gathered.direct
@@ -333,10 +336,11 @@ class DispatchAppPlugin(Plugin):
 # ---------------------------------------------------------------------------
 # Walker: spec → gather
 #
-# The "gather" half of the spec / policy split. Both the standalone
-# ``DispatchAppPlugin.run`` path and the batched
-# ``BatchDispatchAppPlugin.run`` path flow through these helpers; only
-# the fan-out shape differs.
+# The "gather" half of the spec / policy split. The standalone
+# ``DispatchAppPlugin.run`` path uses ``_gather_one``; the harness's
+# auto-batching path (``Analysis.materialize_all``) uses
+# ``_gather_batched`` to fuse the per-spec queries across every
+# registered ``DispatchAppPlugin``.
 # ---------------------------------------------------------------------------
 
 
@@ -551,52 +555,6 @@ def _gather_batched(
             vars_by_file=vars_by_file,
         )
     return gathered
-
-
-@dataclass(kw_only=True)
-class BatchDispatchAppPlugin(Plugin):
-    """Run multiple :class:`DispatchAppPlugin` instances with a fused
-    gather pass + per-plugin policy.
-
-    Architecture: split each wrapped plugin into a ``spec`` (the
-    pure-data description of what to gather, see
-    :class:`DispatchAppSpec`) and a ``policy(ctx, gathered)`` method
-    (the per-plugin emission, see
-    :meth:`DispatchAppPlugin.policy`). This driver runs a fused walk
-    across every spec, then calls each plugin's :meth:`policy` with
-    its slice of the gather. Subclass overrides of :meth:`policy` are
-    honored uniformly — that's the point of the split.
-
-    Fusion strategy (in the gather phase):
-
-    * Shared subclass-walk cache — each ``app_class`` fqn's
-      transitive lookup runs at most once regardless of how many
-      specs request it.
-    * Per-distinct-module construction & factory queries. Two specs
-      both targeting ``flask.Flask`` (e.g. Flask + a project-level
-      extension) share one query; rows route back to specs by
-      matching ``class_name`` against each spec's map.
-    * Single project-wide variable scan reused across plugins.
-
-    Per-spec handler queries stay un-fused: the ref API doesn't carry
-    which attribute matched, so a fused result can't route to the
-    right spec without further work. Handler queries are
-    text-prefiltered before any AST parse, so this stays cheap.
-    """
-
-    plugins: list[DispatchAppPlugin]
-    name: str = "BatchDispatchApp"
-    version: int = 1
-
-    def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
-        active = [p for p in self.plugins if p._is_active(ctx)]
-        if not active:
-            return
-        gathered = _gather_batched(ctx, [p.spec for p in active])
-        for plugin, g in zip(active, gathered, strict=True):
-            if g is None:
-                continue
-            yield from plugin.policy(ctx, g)
 
 
 @dataclass(kw_only=True)

--- a/python/dead_cst/plugins/decl_shapes.py
+++ b/python/dead_cst/plugins/decl_shapes.py
@@ -78,7 +78,7 @@ class DecoratedDeclPlugin(Plugin):
             .decorators()
             .where_module(self.decorator_module)
             .where_name(names)
-            .row_indices()
+            .collect()
         ):
             if in_scope(dec_row.path):
                 seeds_by_path.setdefault(dec_row.path, []).append(dec_row.decorated_idx)
@@ -87,7 +87,7 @@ class DecoratedDeclPlugin(Plugin):
             .constructions()
             .where_module(self.decorator_module)
             .where_name(names)
-            .row_indices()
+            .collect()
         ):
             if in_scope(cons_row.path):
                 seeds_by_path.setdefault(cons_row.path, []).append(cons_row.var_idx)
@@ -386,7 +386,7 @@ def _fetch_direct(
             .constructions()
             .where_module(module)
             .where_name(sorted(names))
-            .row_indices()
+            .collect()
         ):
             if ref.var_idx in direct_seen:
                 continue
@@ -404,7 +404,7 @@ def _fetch_factory_decls(
     factory_decls: list[tuple[native.FactoryIdxRef, str]] = []
     for module, names in module_to_names.items():
         for fref in (
-            native.query(ctx).factories().of_module(module).where_name(sorted(names)).row_indices()
+            native.query(ctx).factories().of_module(module).where_name(sorted(names)).collect()
         ):
             for kind in fref.kinds:
                 key = (fref.decl_idx, kind)
@@ -419,7 +419,7 @@ def _fetch_handlers(
     ctx: native.ProjectContext, registration_decorators: frozenset[str]
 ) -> list[native.DecoratorIdxRef]:
     return list(
-        native.query(ctx).decorators().where_owner_attr(list(registration_decorators)).row_indices()
+        native.query(ctx).decorators().where_owner_attr(list(registration_decorators)).collect()
     )
 
 
@@ -500,7 +500,7 @@ def _gather_batched(
             .constructions()
             .where_module(module)
             .where_name(sorted(all_names))
-            .row_indices()
+            .collect()
         ):
             for i in live_indices:
                 if ref.class_name not in module_to_names_per_spec[i].get(module, ()):
@@ -526,7 +526,7 @@ def _gather_batched(
                 .factories()
                 .of_module(module)
                 .where_name(sorted(all_names))
-                .row_indices()
+                .collect()
             ):
                 for kind in fref.kinds:
                     for i in seed_indices:

--- a/python/dead_cst/plugins/decl_shapes.py
+++ b/python/dead_cst/plugins/decl_shapes.py
@@ -69,7 +69,7 @@ class DecoratedDeclPlugin(Plugin):
             module_idx = native.query(ctx).modules().with_path(path).first_idx()
             if module_idx is None:
                 return False
-            (_kind, _path, fqname, _flags) = ctx.node_attrs([module_idx])[0]
+            fqname = ctx.node_attrs([module_idx])[0].fqname
             return fqname == prefix or fqname.startswith(prefix + ".")
 
         seeds_by_path: dict[str, list[int]] = {}
@@ -242,11 +242,11 @@ class DispatchAppPlugin(Plugin):
 
         # direct_by_owner: (path, simple_name) -> [var_idx, ...]
         direct_by_owner: dict[tuple[str, str], list[int]] = {}
-        direct_attrs: list[tuple[native.NodeKind, str, str, int]] = []
+        direct_attrs: list[native.NodeAttrs] = []
         if direct:
             direct_attrs = ctx.node_attrs([r.var_idx for r in direct])
-            for ref, (_kind, _path, fqname, _flags) in zip(direct, direct_attrs, strict=True):
-                simple = fqname.rsplit(".", 1)[-1]
+            for ref, attr in zip(direct, direct_attrs, strict=True):
+                simple = attr.fqname.rsplit(".", 1)[-1]
                 direct_by_owner.setdefault((ref.path, simple), []).append(ref.var_idx)
 
         app_prefix = f"<{spec.marker_prefix}-app>:"
@@ -255,9 +255,9 @@ class DispatchAppPlugin(Plugin):
         # 3. Entrypoint-promote every direct construction (when enabled).
         if spec.seed_as_entrypoint and direct:
             # Reuse the direct_attrs computed above.
-            for ref, (_kind, _path, fqname, _flags) in zip(direct, direct_attrs, strict=True):
+            for ref, attr in zip(direct, direct_attrs, strict=True):
                 yield native.AddNodeByIdx(
-                    fqname=f"{app_prefix}{fqname}",
+                    fqname=f"{app_prefix}{attr.fqname}",
                     path=ref.path,
                     flags=int(NodeFlags.ENTRYPOINT),
                     edges_to_idx=[ref.var_idx],
@@ -267,11 +267,9 @@ class DispatchAppPlugin(Plugin):
         # find them.
         if factory_decls:
             factory_attrs = ctx.node_attrs([fref.decl_idx for fref, _kind in factory_decls])
-            for (fref, kind), (_k, _p, decl_fqname, _f) in zip(
-                factory_decls, factory_attrs, strict=True
-            ):
+            for (fref, kind), attr in zip(factory_decls, factory_attrs, strict=True):
                 yield native.AddNodeByIdx(
-                    fqname=f"{factory_prefix}{kind}:{decl_fqname}",
+                    fqname=f"{factory_prefix}{kind}:{attr.fqname}",
                     path=fref.path,
                     edges_from_idx=[fref.decl_idx],
                 )
@@ -324,10 +322,10 @@ class DispatchAppPlugin(Plugin):
                 if var_idx is None or var_idx not in factory_reachers:
                     continue
                 classified.add(key)
-                (_kind, var_path, var_fqname, _flags) = ctx.node_attrs([var_idx])[0]
+                var_attr = ctx.node_attrs([var_idx])[0]
                 yield native.AddNodeByIdx(
-                    fqname=f"{app_prefix}{var_fqname}",
-                    path=var_path,
+                    fqname=f"{app_prefix}{var_attr.fqname}",
+                    path=var_attr.path,
                     flags=int(NodeFlags.ENTRYPOINT),
                     edges_to_idx=[var_idx],
                 )
@@ -368,8 +366,8 @@ def _module_to_names(
             sub_idxs = native.query(ctx).subclasses().of_fqn(fqn).indices()
             pairs = []
             if sub_idxs:
-                for _kind, _path, sub_fqname, _flags in ctx.node_attrs(sub_idxs):
-                    sub_module, _, sub_name = sub_fqname.rpartition(".")
+                for attr in ctx.node_attrs(sub_idxs):
+                    sub_module, _, sub_name = attr.fqname.rpartition(".")
                     if sub_module and sub_name:
                         pairs.append((sub_module, sub_name))
             if subclass_cache is not None:
@@ -438,9 +436,9 @@ def _build_vars_by_file(ctx: native.ProjectContext) -> dict[tuple[str, str], int
     if not var_idxs:
         return vars_by_file
     var_attrs = ctx.node_attrs(var_idxs)
-    for idx, (_kind, path, fqname, _flags) in zip(var_idxs, var_attrs, strict=True):
-        simple = fqname.rsplit(".", 1)[-1]
-        vars_by_file.setdefault((path, simple), idx)
+    for idx, attr in zip(var_idxs, var_attrs, strict=True):
+        simple = attr.fqname.rsplit(".", 1)[-1]
+        vars_by_file.setdefault((attr.path, simple), idx)
     return vars_by_file
 
 
@@ -600,7 +598,7 @@ class LiteralListPlugin(Plugin):
             target_idxs.extend(native.query(ctx).declarations().with_fqname(entry).indices())
             if not target_idxs:
                 continue
-            (_kind, marker_path, _fq, _flags) = ctx.node_attrs([target_idxs[0]])[0]
+            marker_path = ctx.node_attrs([target_idxs[0]])[0].path
             yield native.AddNodeByIdx(
                 fqname=f"{prefix}{entry}",
                 path=marker_path,

--- a/python/dead_cst/plugins/decl_shapes.py
+++ b/python/dead_cst/plugins/decl_shapes.py
@@ -66,7 +66,7 @@ class DecoratedDeclPlugin(Plugin):
         def in_scope(path: str) -> bool:
             if not prefix:
                 return True
-            module_idx = ctx.module_for_indices(path)
+            module_idx = native.query(ctx).modules().with_path(path).first_idx()
             if module_idx is None:
                 return False
             (_kind, _path, fqname, _flags) = ctx.node_attrs([module_idx])[0]
@@ -308,7 +308,9 @@ class DispatchAppPlugin(Plugin):
         if spec.seed_as_entrypoint and factory_decls:
             factory_reachers: set[int] = set()
             for fref, _kind in factory_decls:
-                factory_reachers.update(ctx.direct_predecessors_idx(fref.decl_idx))
+                factory_reachers.update(
+                    native.query(ctx).from_idx(fref.decl_idx).direct_predecessors()
+                )
 
             classified: set[tuple[str, str]] = set()
             for h in handlers:
@@ -622,7 +624,7 @@ class LiteralListPlugin(Plugin):
         # The visitor doesn't emit ``var -> referent`` edges for
         # non-``__all__`` string-list assignments, so the plugin can't
         # rely on a descendant walk.
-        entries = ctx.find_literal_list_entries(var_fqname)
+        entries = native.query(ctx).literal_lists().for_fqn(var_fqname).entries()
         if not entries:
             return
 
@@ -637,7 +639,9 @@ class LiteralListPlugin(Plugin):
         surfaces = ctx.module_surfaces_indices(entries)
         for entry in entries:
             target_idxs: list[int] = list(surfaces.get(entry, ()))
-            target_idxs.extend(ctx.find_declarations_indices(entry))
+            target_idxs.extend(
+                native.query(ctx).declarations().with_fqname(entry).indices()
+            )
             if not target_idxs:
                 continue
             (_kind, marker_path, _fq, _flags) = ctx.node_attrs([target_idxs[0]])[0]

--- a/python/dead_cst/plugins/dynamic_import.py
+++ b/python/dead_cst/plugins/dynamic_import.py
@@ -81,9 +81,11 @@ class DynamicImportFallbackPlugin(Plugin):
             return cached
         exports: list[int] | None = None
         if self.respect_dunder_all:
-            exports = ctx.find_module_dunder_all_exports_indices(module_fqname)
+            exports = native.query(ctx).modules().with_fqn(module_fqname).dunder_all()
         if exports is None:
-            decls_idx = ctx.find_module_top_level_decls_indices(module_fqname)
+            decls_idx = (
+                native.query(ctx).modules().with_fqn(module_fqname).top_level().indices()
+            )
             if self.include_underscore:
                 exports = decls_idx
             else:

--- a/python/dead_cst/plugins/dynamic_import.py
+++ b/python/dead_cst/plugins/dynamic_import.py
@@ -83,9 +83,7 @@ class DynamicImportFallbackPlugin(Plugin):
         if self.respect_dunder_all:
             exports = native.query(ctx).modules().with_fqn(module_fqname).dunder_all()
         if exports is None:
-            decls_idx = (
-                native.query(ctx).modules().with_fqn(module_fqname).top_level().indices()
-            )
+            decls_idx = native.query(ctx).modules().with_fqn(module_fqname).top_level().indices()
             if self.include_underscore:
                 exports = decls_idx
             else:

--- a/python/dead_cst/plugins/explicit_entrypoint.py
+++ b/python/dead_cst/plugins/explicit_entrypoint.py
@@ -43,7 +43,10 @@ class ExplicitEntrypointPlugin(Plugin):
                 abs_paths.append(str(spec))
             elif isinstance(spec, str):
                 str_specs.append(spec)
-        for idx in ctx.find_nodes_matching_specs_indices(
-            ctx.project_root, regexes, str_specs, abs_paths
+        for idx in native.query(ctx).matching_specs(
+            ctx.project_root,
+            regexes=regexes,
+            str_specs=str_specs,
+            abs_paths=abs_paths,
         ):
             yield native.AddEntrypointByIdx(idx, marker="<entrypoint>")

--- a/python/dead_cst/plugins/explicit_entrypoint.py
+++ b/python/dead_cst/plugins/explicit_entrypoint.py
@@ -43,5 +43,7 @@ class ExplicitEntrypointPlugin(Plugin):
                 abs_paths.append(str(spec))
             elif isinstance(spec, str):
                 str_specs.append(spec)
-        for node in ctx.find_nodes_matching_specs(ctx.project_root, regexes, str_specs, abs_paths):
-            yield native.AddEntrypoint(node, marker="<entrypoint>")
+        for idx in ctx.find_nodes_matching_specs_indices(
+            ctx.project_root, regexes, str_specs, abs_paths
+        ):
+            yield native.AddEntrypointByIdx(idx, marker="<entrypoint>")

--- a/python/dead_cst/plugins/init_subclass.py
+++ b/python/dead_cst/plugins/init_subclass.py
@@ -26,13 +26,11 @@ class InitSubclassPlugin(Plugin):
         # One batched attr fetch per matched parent — pulls fqname / path
         # in a single FFI hop instead of N per-attribute borrows.
         attrs = ctx.node_attrs(parent_idxs)
-        for parent_idx, (_kind, parent_path, parent_fqname, _flags) in zip(
-            parent_idxs, attrs, strict=True
-        ):
+        for parent_idx, attr in zip(parent_idxs, attrs, strict=True):
             subclass_idxs = native.query(ctx).subclasses().of_idx(parent_idx).indices()
             yield native.AddNodeByIdx(
-                fqname=f"{INIT_SUBCLASS_PREFIX}{parent_fqname}",
-                path=parent_path,
+                fqname=f"{INIT_SUBCLASS_PREFIX}{attr.fqname}",
+                path=attr.path,
                 edges_from_idx=[parent_idx],
                 edges_to_idx=subclass_idxs,
             )

--- a/python/dead_cst/plugins/init_subclass.py
+++ b/python/dead_cst/plugins/init_subclass.py
@@ -22,10 +22,17 @@ class InitSubclassPlugin(Plugin):
     """Wire subclasses of ``__init_subclass__``-defining classes through a marker."""
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
-        for parent in native.query(ctx).classes().defining_method(_INIT_SUBCLASS).collect():
-            yield native.AddNode(
-                fqname=f"{INIT_SUBCLASS_PREFIX}{parent.fqname}",
-                path=parent.path,
-                edges_from=[parent],
-                edges_to=native.query(ctx).subclasses().of_node(parent).collect(),
+        parent_idxs = native.query(ctx).classes().defining_method(_INIT_SUBCLASS).indices()
+        # One batched attr fetch per matched parent — pulls fqname / path
+        # in a single FFI hop instead of N per-attribute borrows.
+        attrs = ctx.node_attrs(parent_idxs)
+        for parent_idx, (_kind, parent_path, parent_fqname, _flags) in zip(
+            parent_idxs, attrs, strict=True
+        ):
+            subclass_idxs = native.query(ctx).subclasses().of_idx(parent_idx).indices()
+            yield native.AddNodeByIdx(
+                fqname=f"{INIT_SUBCLASS_PREFIX}{parent_fqname}",
+                path=parent_path,
+                edges_from_idx=[parent_idx],
+                edges_to_idx=subclass_idxs,
             )

--- a/python/dead_cst/plugins/main_block.py
+++ b/python/dead_cst/plugins/main_block.py
@@ -22,10 +22,18 @@ class MainBlockPlugin(Plugin):
     """
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
-        for module, block_decls in ctx.find_main_blocks():
-            yield native.AddNode(
-                fqname=f"{MAIN_BLOCK_PREFIX}{module.fqname}",
-                path=module.path,
+        pairs = ctx.find_main_blocks_indices()
+        if not pairs:
+            return
+        # Batch-fetch (fqname, path) for every matched module in one hop.
+        module_idxs = [m for (m, _decls) in pairs]
+        module_attrs = ctx.node_attrs(module_idxs)
+        for (module_idx, decl_idxs), (_kind, module_path, module_fqname, _flags) in zip(
+            pairs, module_attrs, strict=True
+        ):
+            yield native.AddNodeByIdx(
+                fqname=f"{MAIN_BLOCK_PREFIX}{module_fqname}",
+                path=module_path,
                 flags=int(NodeFlags.ENTRYPOINT),
-                edges_to=[module, *block_decls],
+                edges_to_idx=[module_idx, *decl_idxs],
             )

--- a/python/dead_cst/plugins/main_block.py
+++ b/python/dead_cst/plugins/main_block.py
@@ -22,7 +22,7 @@ class MainBlockPlugin(Plugin):
     """
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
-        pairs = ctx.find_main_blocks_indices()
+        pairs = native.query(ctx).main_blocks().index_pairs()
         if not pairs:
             return
         # Batch-fetch (fqname, path) for every matched module in one hop.

--- a/python/dead_cst/plugins/main_block.py
+++ b/python/dead_cst/plugins/main_block.py
@@ -28,12 +28,10 @@ class MainBlockPlugin(Plugin):
         # Batch-fetch (fqname, path) for every matched module in one hop.
         module_idxs = [m for (m, _decls) in pairs]
         module_attrs = ctx.node_attrs(module_idxs)
-        for (module_idx, decl_idxs), (_kind, module_path, module_fqname, _flags) in zip(
-            pairs, module_attrs, strict=True
-        ):
+        for (module_idx, decl_idxs), attr in zip(pairs, module_attrs, strict=True):
             yield native.AddNodeByIdx(
-                fqname=f"{MAIN_BLOCK_PREFIX}{module_fqname}",
-                path=module_path,
+                fqname=f"{MAIN_BLOCK_PREFIX}{attr.fqname}",
+                path=attr.path,
                 flags=int(NodeFlags.ENTRYPOINT),
                 edges_to_idx=[module_idx, *decl_idxs],
             )

--- a/python/dead_cst/plugins/module_dunders.py
+++ b/python/dead_cst/plugins/module_dunders.py
@@ -22,8 +22,8 @@ class ModuleDundersPlugin(Plugin):
     """
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
-        for target in [
-            *ctx.find_module_dunders(),
-            *native.query(ctx).imports().of("__future__").collect(),
+        for target_idx in [
+            *ctx.find_module_dunders_indices(),
+            *native.query(ctx).imports().of("__future__").indices(),
         ]:
-            yield native.AddEntrypoint(target, marker="<dunder>")
+            yield native.AddEntrypointByIdx(target_idx, marker="<dunder>")

--- a/python/dead_cst/plugins/module_dunders.py
+++ b/python/dead_cst/plugins/module_dunders.py
@@ -23,7 +23,7 @@ class ModuleDundersPlugin(Plugin):
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
         for target_idx in [
-            *ctx.find_module_dunders_indices(),
+            *native.query(ctx).modules().with_dunders().indices(),
             *native.query(ctx).imports().of("__future__").indices(),
         ]:
             yield native.AddEntrypointByIdx(target_idx, marker="<dunder>")

--- a/python/dead_cst/plugins/project_scripts.py
+++ b/python/dead_cst/plugins/project_scripts.py
@@ -47,21 +47,21 @@ class ProjectScriptsPlugin(Plugin):
         for script_name, target in scripts.items():
             module_part, _, decl_part = target.partition(":")
             fqname = f"{module_part}.{decl_part}" if decl_part else module_part
-            targets = ctx.find_declarations(fqname)
-            if not targets:
-                module_node = ctx.find_module(module_part)
-                if module_node is not None:
-                    targets = [module_node]
-            if not targets:
+            target_idxs = ctx.find_declarations_indices(fqname)
+            if not target_idxs:
+                module_idx = ctx.find_module_idx(module_part)
+                if module_idx is not None:
+                    target_idxs = [module_idx]
+            if not target_idxs:
                 logger.warning(
                     "ProjectScriptsPlugin: %s -> %r not found in symbol graph",
                     script_name,
                     target,
                 )
                 continue
-            yield native.AddNode(
+            yield native.AddNodeByIdx(
                 fqname=f"{PROJECT_SCRIPTS_PREFIX}{script_name}",
                 path=str(pyproject),
                 flags=int(NodeFlags.ENTRYPOINT),
-                edges_to=targets,
+                edges_to_idx=target_idxs,
             )

--- a/python/dead_cst/plugins/project_scripts.py
+++ b/python/dead_cst/plugins/project_scripts.py
@@ -47,9 +47,11 @@ class ProjectScriptsPlugin(Plugin):
         for script_name, target in scripts.items():
             module_part, _, decl_part = target.partition(":")
             fqname = f"{module_part}.{decl_part}" if decl_part else module_part
-            target_idxs = ctx.find_declarations_indices(fqname)
+            target_idxs = native.query(ctx).declarations().with_fqname(fqname).indices()
             if not target_idxs:
-                module_idx = ctx.find_module_idx(module_part)
+                module_idx = (
+                    native.query(ctx).modules().with_fqn(module_part).first_idx()
+                )
                 if module_idx is not None:
                     target_idxs = [module_idx]
             if not target_idxs:

--- a/python/dead_cst/plugins/project_scripts.py
+++ b/python/dead_cst/plugins/project_scripts.py
@@ -49,9 +49,7 @@ class ProjectScriptsPlugin(Plugin):
             fqname = f"{module_part}.{decl_part}" if decl_part else module_part
             target_idxs = native.query(ctx).declarations().with_fqname(fqname).indices()
             if not target_idxs:
-                module_idx = (
-                    native.query(ctx).modules().with_fqn(module_part).first_idx()
-                )
+                module_idx = native.query(ctx).modules().with_fqn(module_part).first_idx()
                 if module_idx is not None:
                     target_idxs = [module_idx]
             if not target_idxs:

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -227,6 +227,30 @@ impl AddEntrypoint {
     }
 }
 
+/// Index-keyed variant of :class:`AddEntrypoint`. Takes a positional
+/// index into ``ctx.nodes()`` instead of a ``SymbolNode`` reference;
+/// the apply pass derefs the decl on the rust side to read its
+/// ``fqname`` / ``path`` for the marker, so plugins working in
+/// idx-space don't pay the ``Py<SymbolNode>`` allocation just to flag
+/// a seed.
+///
+/// Raises :class:`IndexError` at apply time when ``decl_idx`` is out
+/// of range.
+#[pyclass(frozen, get_all)]
+pub(crate) struct AddEntrypointByIdx {
+    pub(crate) decl_idx: usize,
+    pub(crate) marker: String,
+}
+
+#[pymethods]
+impl AddEntrypointByIdx {
+    #[new]
+    #[pyo3(signature = (decl_idx, *, marker))]
+    fn new(decl_idx: usize, marker: String) -> Self {
+        Self { decl_idx, marker }
+    }
+}
+
 /// Mint a synthetic intermediate node.
 ///
 /// ``edges_from`` / ``edges_to`` wire the new node atomically — every
@@ -439,6 +463,10 @@ pub(crate) enum PreparedOp {
         decl_path: String,
         marker: String,
     },
+    EntrypointByIdx {
+        decl_idx: usize,
+        marker: String,
+    },
     Node {
         fqname: String,
         kind: &'static str,
@@ -524,6 +552,11 @@ pub(crate) fn prepare_graph_op(py: Python<'_>, op: &Bound<'_, PyAny>) -> PyResul
             decl_path: decl_ref.path.clone(),
             marker: add_ep.marker.clone(),
         }
+    } else if let Ok(add_ep_idx) = op.extract::<PyRef<AddEntrypointByIdx>>() {
+        PreparedOp::EntrypointByIdx {
+            decl_idx: add_ep_idx.decl_idx,
+            marker: add_ep_idx.marker.clone(),
+        }
     } else if let Ok(add_node) = op.extract::<PyRef<AddNode>>() {
         let edges_from: Vec<NodeKey> = add_node
             .edges_from
@@ -554,8 +587,8 @@ pub(crate) fn prepare_graph_op(py: Python<'_>, op: &Bound<'_, PyAny>) -> PyResul
         }
     } else {
         return Err(PyValueError::new_err(format!(
-            "expected a GraphOp (AddEdge / AddEdgeByIdx / AddEntrypoint / AddNode / AddNodeByIdx), \
-             got {:?}",
+            "expected a GraphOp (AddEdge / AddEdgeByIdx / AddEntrypoint / \
+             AddEntrypointByIdx / AddNode / AddNodeByIdx), got {:?}",
             op.get_type().name()?,
         )));
     };
@@ -635,6 +668,24 @@ fn apply_prepared(
             marker,
         } => {
             let decl_idx = lookup_idx_by_key(&outputs.builder, &decl, "decl")?;
+            let marker_fqname = format!("{marker}:{decl_fqname}");
+            let marker_idx = outputs.builder.intern_node(
+                py,
+                synthetic_node(marker_fqname, "synthetic", decl_path, NODE_FLAG_ENTRYPOINT),
+            )?;
+            outputs.builder.add_edge(marker_idx, decl_idx, 0);
+            Ok(())
+        }
+        PreparedOp::EntrypointByIdx { decl_idx, marker } => {
+            let len = outputs.builder.nodes.len();
+            check_idx_in_range(len, decl_idx, "AddEntrypointByIdx", "decl_idx")?;
+            // Read fqname / path off the existing node — same shape
+            // the ``AddEntrypoint`` arm gets from the prepare step,
+            // but without a ``Py<SymbolNode>`` round-trip.
+            let (decl_fqname, decl_path) = {
+                let node = outputs.builder.nodes[decl_idx].borrow(py);
+                (node.fqname.clone(), node.path.clone())
+            };
             let marker_fqname = format!("{marker}:{decl_fqname}");
             let marker_idx = outputs.builder.intern_node(
                 py,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6,7 +6,7 @@
 
 use std::sync::OnceLock;
 
-use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::exceptions::{PyIndexError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use ruff_db::files::File;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -276,6 +276,60 @@ impl AddNode {
     }
 }
 
+/// Index-keyed variant of :class:`AddNode`. Wires the freshly-minted
+/// synthetic node with positional indices into ``ctx.nodes()`` instead
+/// of ``SymbolNode`` references for ``edges_from`` / ``edges_to``.
+///
+/// Pairs with the ``.indices()`` query terminals and
+/// :meth:`ProjectContext.indices_where` so plugins that work in index
+/// space don't have to round-trip through ``Py<SymbolNode>`` just to
+/// wire their synthetic markers. The apply pass treats it identically
+/// to :class:`AddNode` once the indices land in the builder.
+///
+/// Raises :class:`IndexError` at apply time when any endpoint is out
+/// of range for the current graph snapshot (pre-intern, so the new
+/// node is not created if any endpoint check fails).
+#[pyclass(frozen, get_all)]
+pub(crate) struct AddNodeByIdx {
+    pub(crate) fqname: String,
+    pub(crate) kind: &'static str,
+    pub(crate) path: String,
+    pub(crate) flags: u32,
+    pub(crate) edges_from_idx: Vec<usize>,
+    pub(crate) edges_to_idx: Vec<usize>,
+}
+
+#[pymethods]
+impl AddNodeByIdx {
+    #[new]
+    #[pyo3(signature = (
+        fqname,
+        *,
+        path,
+        kind = "synthetic",
+        flags = 0,
+        edges_from_idx = Vec::new(),
+        edges_to_idx = Vec::new(),
+    ))]
+    fn new(
+        fqname: String,
+        path: String,
+        kind: &str,
+        flags: u32,
+        edges_from_idx: Vec<usize>,
+        edges_to_idx: Vec<usize>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            fqname,
+            kind: intern_kind(kind)?,
+            path,
+            flags,
+            edges_from_idx,
+            edges_to_idx,
+        })
+    }
+}
+
 pub(crate) fn not_materialized(op: &str) -> PyErr {
     PyRuntimeError::new_err(format!(
         "ProjectContext.{op}() called outside an active materialize() — \
@@ -393,6 +447,14 @@ pub(crate) enum PreparedOp {
         edges_from: Vec<NodeKey>,
         edges_to: Vec<NodeKey>,
     },
+    NodeByIdx {
+        fqname: String,
+        kind: &'static str,
+        path: String,
+        flags: u32,
+        edges_from_idx: Vec<usize>,
+        edges_to_idx: Vec<usize>,
+    },
 }
 
 /// Opaque Python handle wrapping a plugin's pre-prepared op queue.
@@ -481,9 +543,19 @@ pub(crate) fn prepare_graph_op(py: Python<'_>, op: &Bound<'_, PyAny>) -> PyResul
             edges_from,
             edges_to,
         }
+    } else if let Ok(add_node_idx) = op.extract::<PyRef<AddNodeByIdx>>() {
+        PreparedOp::NodeByIdx {
+            fqname: add_node_idx.fqname.clone(),
+            kind: add_node_idx.kind,
+            path: add_node_idx.path.clone(),
+            flags: add_node_idx.flags,
+            edges_from_idx: add_node_idx.edges_from_idx.clone(),
+            edges_to_idx: add_node_idx.edges_to_idx.clone(),
+        }
     } else {
         return Err(PyValueError::new_err(format!(
-            "expected a GraphOp (AddEdge / AddEdgeByIdx / AddEntrypoint / AddNode), got {:?}",
+            "expected a GraphOp (AddEdge / AddEdgeByIdx / AddEntrypoint / AddNode / AddNodeByIdx), \
+             got {:?}",
             op.get_type().name()?,
         )));
     };
@@ -551,16 +623,8 @@ fn apply_prepared(
             flags,
         } => {
             let len = outputs.builder.nodes.len();
-            if src_idx >= len {
-                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                    "AddEdgeByIdx: src_idx {src_idx} out of range (len={len})"
-                )));
-            }
-            if dst_idx >= len {
-                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                    "AddEdgeByIdx: dst_idx {dst_idx} out of range (len={len})"
-                )));
-            }
+            check_idx_in_range(len, src_idx, "AddEdgeByIdx", "src_idx")?;
+            check_idx_in_range(len, dst_idx, "AddEdgeByIdx", "dst_idx")?;
             outputs.builder.add_edge(src_idx, dst_idx, flags);
             Ok(())
         }
@@ -587,20 +651,96 @@ fn apply_prepared(
             edges_from,
             edges_to,
         } => {
+            // Resolve endpoint keys to indices *before* minting the
+            // node — a missing key then surfaces as a clean
+            // ``ValueError`` without leaving an unconnected synthetic
+            // behind in the graph. Same pre-validation discipline as
+            // the ``NodeByIdx`` arm below.
+            let from_idxs = resolve_edge_keys(&outputs.builder, &edges_from, "edges_from")?;
+            let to_idxs = resolve_edge_keys(&outputs.builder, &edges_to, "edges_to")?;
             let node_idx = outputs
                 .builder
                 .intern_node(py, synthetic_node(fqname, kind, path, flags))?;
-            for src in &edges_from {
-                let src_idx = lookup_idx_by_key(&outputs.builder, src, "edges_from")?;
-                outputs.builder.add_edge(src_idx, node_idx, 0);
-            }
-            for dst in &edges_to {
-                let dst_idx = lookup_idx_by_key(&outputs.builder, dst, "edges_to")?;
-                outputs.builder.add_edge(node_idx, dst_idx, 0);
-            }
+            wire_synthetic_edges(&mut outputs.builder, node_idx, &from_idxs, &to_idxs);
+            Ok(())
+        }
+        PreparedOp::NodeByIdx {
+            fqname,
+            kind,
+            path,
+            flags,
+            edges_from_idx,
+            edges_to_idx,
+        } => {
+            // Bounds-check every endpoint *before* minting the new
+            // node so that a bad index doesn't leave an unconnected
+            // synthetic in the graph. The check uses the pre-intern
+            // node count: callers cannot reference an idx that
+            // doesn't yet exist (including the about-to-be-minted
+            // node).
+            let len = outputs.builder.nodes.len();
+            check_idx_slice_in_range(len, &edges_from_idx, "AddNodeByIdx", "edges_from_idx")?;
+            check_idx_slice_in_range(len, &edges_to_idx, "AddNodeByIdx", "edges_to_idx")?;
+            let node_idx = outputs
+                .builder
+                .intern_node(py, synthetic_node(fqname, kind, path, flags))?;
+            wire_synthetic_edges(
+                &mut outputs.builder,
+                node_idx,
+                &edges_from_idx,
+                &edges_to_idx,
+            );
             Ok(())
         }
     }
+}
+
+/// Wire a freshly-minted synthetic node into the graph: every entry
+/// of ``edges_from_idx`` becomes ``source -> node``, every entry of
+/// ``edges_to_idx`` becomes ``node -> target``. Endpoints are already
+/// validated indices.
+fn wire_synthetic_edges(
+    builder: &mut GraphBuilder,
+    node_idx: usize,
+    edges_from_idx: &[usize],
+    edges_to_idx: &[usize],
+) {
+    for &src_idx in edges_from_idx {
+        builder.add_edge(src_idx, node_idx, 0);
+    }
+    for &dst_idx in edges_to_idx {
+        builder.add_edge(node_idx, dst_idx, 0);
+    }
+}
+
+/// Resolve every endpoint key to its builder-side index, propagating
+/// the first lookup failure as a ``ValueError`` with the matching
+/// ``side`` label.
+fn resolve_edge_keys(builder: &GraphBuilder, keys: &[NodeKey], side: &str) -> PyResult<Vec<usize>> {
+    keys.iter()
+        .map(|k| lookup_idx_by_key(builder, k, side))
+        .collect()
+}
+
+/// Bounds-check a single index against the builder's current node
+/// count, surfacing an ``IndexError`` matching the existing
+/// ``AddEdgeByIdx`` style.
+fn check_idx_in_range(len: usize, idx: usize, op: &str, side: &str) -> PyResult<()> {
+    if idx >= len {
+        return Err(PyIndexError::new_err(format!(
+            "{op}: {side} {idx} out of range (len={len})"
+        )));
+    }
+    Ok(())
+}
+
+/// Bounds-check every index in a slice. Returns on the first
+/// out-of-range index with the matching ``IndexError``.
+fn check_idx_slice_in_range(len: usize, idxs: &[usize], op: &str, side: &str) -> PyResult<()> {
+    for &idx in idxs {
+        check_idx_in_range(len, idx, op, side)?;
+    }
+    Ok(())
 }
 
 /// Resolve a `SymbolNode` reference to its builder-side index for an

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -258,7 +258,8 @@ impl AddEntrypointByIdx {
 /// element of ``edges_to`` a ``this -> target`` edge — so a plugin
 /// doesn't need a separate handle to reference the freshly-minted node
 /// from subsequent ops. Set ``flags = NodeFlags.ENTRYPOINT`` to make
-/// the node a seed (``AddEntrypoint`` is the single-target sugar).
+/// the node a seed (``AddEntrypoint`` / ``AddEntrypointByIdx`` are the
+/// single-target sugar).
 #[pyclass(frozen, get_all)]
 pub(crate) struct AddNode {
     pub(crate) fqname: String,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -254,11 +254,6 @@ pub(crate) type DeclKey = (File, ScopedPlaceId, (u32, u32));
 
 pub(crate) type DeclIndex = FxHashMap<DeclKey, usize>;
 
-/// Return type of `ProjectContext.find_main_blocks`: one entry per
-/// file with a top-level ``if __name__ == "__main__":`` block, paired
-/// with the decls that fall inside it.
-pub(crate) type MainBlock = (Py<SymbolNode>, Vec<Py<SymbolNode>>);
-
 /// Bit values stamped into [`SymbolNode::flags`]. Mirrors
 /// `dead_cst.graph.NodeFlags` exactly so plugin code can mix
 /// rust-emitted and libcst-emitted nodes.

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1121,6 +1121,67 @@ pub(crate) struct ArgNodeRef {
 #[pyclass(frozen)]
 pub(crate) struct ArgOpaque;
 
+/// Tuple-like result row returned by
+/// :meth:`ProjectContext.node_attrs` and the per-query
+/// ``.attrs()`` terminals.
+///
+/// Supports both attribute access (``attr.fqname``) and tuple
+/// semantics (``kind, path, fqname, flags = attr``; ``attr[2]``;
+/// ``len(attr) == 4``). Not a `typing.NamedTuple` instance, but
+/// drop-in compatible for unpacking and subscript access. Frozen —
+/// fields are immutable once constructed.
+#[pyclass(frozen, get_all)]
+pub(crate) struct NodeAttrs {
+    pub(crate) kind: String,
+    pub(crate) path: String,
+    pub(crate) fqname: String,
+    pub(crate) flags: u32,
+}
+
+#[pymethods]
+impl NodeAttrs {
+    fn __len__(&self) -> usize {
+        4
+    }
+
+    fn __getitem__(&self, idx: isize, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let n: isize = 4;
+        let i = if idx < 0 { idx + n } else { idx };
+        if !(0..n).contains(&i) {
+            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                "NodeAttrs index {idx} out of range (len=4)"
+            )));
+        }
+        Ok(match i {
+            0 => self.kind.clone().into_py(py),
+            1 => self.path.clone().into_py(py),
+            2 => self.fqname.clone().into_py(py),
+            3 => self.flags.into_py(py),
+            _ => unreachable!(),
+        })
+    }
+
+    fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let tup = pyo3::types::PyTuple::new_bound(
+            py,
+            &[
+                slf.kind.clone().into_py(py),
+                slf.path.clone().into_py(py),
+                slf.fqname.clone().into_py(py),
+                slf.flags.into_py(py),
+            ],
+        );
+        Ok(tup.call_method0("__iter__")?.into())
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "NodeAttrs(kind={:?}, path={:?}, fqname={:?}, flags={})",
+            self.kind, self.path, self.fqname, self.flags
+        )
+    }
+}
+
 #[pymethods]
 impl ArgOpaque {
     #[new]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1498,6 +1498,10 @@ where
     pub(crate) arg_index: usize,
     pub(crate) file_imports: &'a FxHashMap<String, String>,
     pub(crate) decl_by_fqname: &'a FxHashMap<String, Vec<usize>>,
+    /// When ``false``, every result row gets a default-constructed
+    /// (empty) :struct:`CallArgs`. The caller pays for the rust-side
+    /// arg / kwarg walk only when ``extract_args = true``.
+    pub(crate) extract_args: bool,
     pub(crate) results: Vec<(String, CallArgs)>,
 }
 
@@ -1509,8 +1513,11 @@ where
         if let Expr::Call(call) = expr {
             if (self.predicate)(call) {
                 if let Some(value) = nth_positional_string(call, self.arg_index) {
-                    let call_args =
-                        extract_call_args_kwargs(call, self.file_imports, self.decl_by_fqname);
+                    let call_args = if self.extract_args {
+                        extract_call_args_kwargs(call, self.file_imports, self.decl_by_fqname)
+                    } else {
+                        CallArgs::default()
+                    };
                     self.results.push((value, call_args));
                 }
             }
@@ -1532,6 +1539,8 @@ pub(crate) struct AttrCallFinder<'a> {
     pub(crate) arg_index: usize,
     pub(crate) file_imports: &'a FxHashMap<String, String>,
     pub(crate) decl_by_fqname: &'a FxHashMap<String, Vec<usize>>,
+    /// See :struct:`StringArgCallFinder` — same gate.
+    pub(crate) extract_args: bool,
     pub(crate) results: Vec<(String, CallArgs)>,
 }
 
@@ -1543,11 +1552,15 @@ impl<'ast, 'a> Visitor<'ast> for AttrCallFinder<'a> {
                     if let Some(arg) = call.arguments.args.get(self.arg_index) {
                         let hits = string_or_string_collection(arg);
                         if !hits.is_empty() {
-                            let call_args = extract_call_args_kwargs(
-                                call,
-                                self.file_imports,
-                                self.decl_by_fqname,
-                            );
+                            let call_args = if self.extract_args {
+                                extract_call_args_kwargs(
+                                    call,
+                                    self.file_imports,
+                                    self.decl_by_fqname,
+                                )
+                            } else {
+                                CallArgs::default()
+                            };
                             for s in hits {
                                 self.results.push((s, call_args.clone()));
                             }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1059,9 +1059,9 @@ pub(crate) fn nth_positional_string(
 ///
 /// ``Unknown`` is reported when the expression is neither a recognized
 /// literal nor a name/attribute that resolves through the file's
-/// imports to a project decl. It surfaces to Python as ``None`` —
-/// callers who care about the difference between "literal None" and
-/// "unresolvable" should also inspect the original source.
+/// imports to a project decl. Python-side it surfaces as
+/// :class:`ArgOpaque` so callers can distinguish "literal ``None``"
+/// from "unresolvable expression".
 #[derive(Clone, Debug)]
 pub(crate) enum ArgValue {
     None,
@@ -1069,6 +1069,7 @@ pub(crate) enum ArgValue {
     Int(i64),
     Float(f64),
     Str(String),
+    Bytes(Vec<u8>),
     List(Vec<ArgValue>),
     Tuple(Vec<ArgValue>),
     DeclRef(usize),
@@ -1079,6 +1080,154 @@ pub(crate) enum ArgValue {
 pub(crate) struct CallArgs {
     pub(crate) args: Vec<ArgValue>,
     pub(crate) kwargs: FxHashMap<String, ArgValue>,
+}
+
+// ---------------------------------------------------------------------------
+// Python-side discriminated union for ``args`` / ``kwargs`` entries.
+//
+// The rust :enum:`ArgValue` carries everything needed; the Python
+// surface flattens it into a three-way tagged union — :class:`ArgLiteral`
+// (any Python literal), :class:`ArgNodeRef` (resolved decl, carrying
+// just the positional index), :class:`ArgOpaque` (non-literal /
+// non-resolvable). Plugin code uses ``match arg:`` or
+// ``isinstance(arg, ArgLiteral)`` to dispatch.
+//
+// The pyclasses are materialised lazily by the per-ref ``args`` /
+// ``kwargs`` getters — see :class:`DecoratorIdxRef` etc. Plugins that
+// never read ``args`` / ``kwargs`` pay zero Python allocation cost.
+// ---------------------------------------------------------------------------
+
+/// A literal arg / kwarg value. ``value`` is a native Python primitive:
+/// ``str`` / ``int`` / ``float`` / ``bool`` / ``None`` / ``bytes`` /
+/// ``list`` / ``tuple``. Nested collections are recursively native too.
+#[pyclass(frozen, get_all)]
+pub(crate) struct ArgLiteral {
+    pub(crate) value: Py<PyAny>,
+}
+
+/// A decl reference inside an arg / kwarg position — e.g. ``func(some_class)``
+/// where ``some_class`` resolves through the file's imports to a project
+/// decl. ``idx`` is a positional index into ``ctx.nodes()``.
+#[pyclass(frozen, get_all)]
+pub(crate) struct ArgNodeRef {
+    pub(crate) idx: usize,
+}
+
+/// An arg / kwarg expression that's neither a recognised literal nor a
+/// statically-resolvable decl reference (e.g. a function call result,
+/// a complex expression, a name we can't pin to a decl). Carries no
+/// payload — callers who need the source text should fall back to ty's
+/// parsed module.
+#[pyclass(frozen)]
+pub(crate) struct ArgOpaque;
+
+#[pymethods]
+impl ArgOpaque {
+    #[new]
+    fn new() -> Self {
+        Self
+    }
+
+    fn __repr__(&self) -> &'static str {
+        "ArgOpaque()"
+    }
+}
+
+/// Materialize a single :enum:`ArgValue` into the Python discriminated
+/// union (``ArgLiteral`` / ``ArgNodeRef`` / ``ArgOpaque``). Allocates
+/// one pyclass per call; the lazy ``args`` / ``kwargs`` getters on the
+/// ref types call this per-entry on demand.
+pub(crate) fn arg_value_to_py_arg(py: Python<'_>, v: &ArgValue) -> PyResult<Py<PyAny>> {
+    let py_obj: Py<PyAny> = match v {
+        ArgValue::None => Py::new(py, ArgLiteral { value: py.None() })?.into_py(py),
+        ArgValue::Bool(b) => Py::new(
+            py,
+            ArgLiteral {
+                value: b.into_py(py),
+            },
+        )?
+        .into_py(py),
+        ArgValue::Int(i) => Py::new(
+            py,
+            ArgLiteral {
+                value: i.into_py(py),
+            },
+        )?
+        .into_py(py),
+        ArgValue::Float(f) => Py::new(
+            py,
+            ArgLiteral {
+                value: f.into_py(py),
+            },
+        )?
+        .into_py(py),
+        ArgValue::Str(s) => Py::new(
+            py,
+            ArgLiteral {
+                value: s.into_py(py),
+            },
+        )?
+        .into_py(py),
+        ArgValue::Bytes(b) => Py::new(
+            py,
+            ArgLiteral {
+                value: pyo3::types::PyBytes::new_bound(py, b).into_py(py),
+            },
+        )?
+        .into_py(py),
+        // ``List`` / ``Tuple`` recurse through ``arg_value_to_py_arg``
+        // so nested ``DeclRef`` / ``Unknown`` entries surface as
+        // ``ArgNodeRef`` / ``ArgOpaque`` inside the literal container.
+        // The outer ``ArgLiteral.value`` is therefore a Python
+        // ``list`` / ``tuple`` whose elements are themselves
+        // ``ArgLiteral | ArgNodeRef | ArgOpaque``.
+        ArgValue::List(items) => {
+            let py_items: PyResult<Vec<Py<PyAny>>> =
+                items.iter().map(|v| arg_value_to_py_arg(py, v)).collect();
+            Py::new(
+                py,
+                ArgLiteral {
+                    value: pyo3::types::PyList::new_bound(py, py_items?).into_py(py),
+                },
+            )?
+            .into_py(py)
+        }
+        ArgValue::Tuple(items) => {
+            let py_items: PyResult<Vec<Py<PyAny>>> =
+                items.iter().map(|v| arg_value_to_py_arg(py, v)).collect();
+            Py::new(
+                py,
+                ArgLiteral {
+                    value: pyo3::types::PyTuple::new_bound(py, py_items?).into_py(py),
+                },
+            )?
+            .into_py(py)
+        }
+        ArgValue::DeclRef(idx) => Py::new(py, ArgNodeRef { idx: *idx })?.into_py(py),
+        ArgValue::Unknown => Py::new(py, ArgOpaque)?.into_py(py),
+    };
+    Ok(py_obj)
+}
+
+/// Materialize a ``Vec<ArgValue>`` into a Python ``list[ArgLiteral |
+/// ArgNodeRef | ArgOpaque]``. Used by per-ref ``args`` getters.
+pub(crate) fn arg_values_to_py_list(py: Python<'_>, values: &[ArgValue]) -> PyResult<Py<PyAny>> {
+    let items: PyResult<Vec<Py<PyAny>>> =
+        values.iter().map(|v| arg_value_to_py_arg(py, v)).collect();
+    Ok(pyo3::types::PyList::new_bound(py, items?).into_py(py))
+}
+
+/// Materialize a ``FxHashMap<String, ArgValue>`` into a Python
+/// ``dict[str, ArgLiteral | ArgNodeRef | ArgOpaque]``.
+pub(crate) fn arg_kwargs_to_py_dict(
+    py: Python<'_>,
+    kwargs: &FxHashMap<String, ArgValue>,
+) -> PyResult<Py<PyAny>> {
+    let out = pyo3::types::PyDict::new_bound(py);
+    for (k, v) in kwargs {
+        out.set_item(k, arg_value_to_py_arg(py, v)?)?;
+    }
+    Ok(out.into_py(py))
 }
 
 /// Resolve a dotted Name / Attribute chain to a project decl index
@@ -1115,6 +1264,7 @@ pub(crate) fn extract_arg_value(
         Expr::NoneLiteral(_) => ArgValue::None,
         Expr::BooleanLiteral(b) => ArgValue::Bool(b.value),
         Expr::StringLiteral(s) => ArgValue::Str(s.value.to_str().to_string()),
+        Expr::BytesLiteral(b) => ArgValue::Bytes(b.value.bytes().collect()),
         Expr::NumberLiteral(n) => match &n.value {
             ruff_python_ast::Number::Int(i) => match i.as_i64() {
                 Some(v) => ArgValue::Int(v),
@@ -1186,59 +1336,6 @@ pub(crate) fn extract_call_args_kwargs(
     CallArgs { args, kwargs }
 }
 
-/// Materialize one ``ArgValue`` into a Python object. ``DeclRef``
-/// resolves through the build's ``Py<SymbolNode>`` pool.
-pub(crate) fn arg_value_to_py(py: Python<'_>, v: &ArgValue, nodes: &[Py<SymbolNode>]) -> PyObject {
-    match v {
-        ArgValue::None => py.None(),
-        ArgValue::Bool(b) => b.into_py(py),
-        ArgValue::Int(i) => i.into_py(py),
-        ArgValue::Float(f) => f.into_py(py),
-        ArgValue::Str(s) => s.into_py(py),
-        ArgValue::List(items) => {
-            let py_items: Vec<PyObject> = items
-                .iter()
-                .map(|v| arg_value_to_py(py, v, nodes))
-                .collect();
-            pyo3::types::PyList::new_bound(py, py_items).into_py(py)
-        }
-        ArgValue::Tuple(items) => {
-            let py_items: Vec<PyObject> = items
-                .iter()
-                .map(|v| arg_value_to_py(py, v, nodes))
-                .collect();
-            pyo3::types::PyTuple::new_bound(py, py_items).into_py(py)
-        }
-        ArgValue::DeclRef(idx) => match nodes.get(*idx) {
-            Some(node) => node.clone_ref(py).into_py(py),
-            None => py.None(),
-        },
-        ArgValue::Unknown => py.None(),
-    }
-}
-
-/// Convert a list of ``ArgValue`` to a `Vec<Py<PyAny>>` ready for a
-/// frozen pyclass field.
-pub(crate) fn args_to_py_vec(
-    py: Python<'_>,
-    args: &[ArgValue],
-    nodes: &[Py<SymbolNode>],
-) -> Vec<Py<PyAny>> {
-    args.iter().map(|v| arg_value_to_py(py, v, nodes)).collect()
-}
-
-/// Convert a kwargs map to ``FxHashMap<String, Py<PyAny>>``.
-pub(crate) fn kwargs_to_py_map(
-    py: Python<'_>,
-    kwargs: &FxHashMap<String, ArgValue>,
-    nodes: &[Py<SymbolNode>],
-) -> FxHashMap<String, Py<PyAny>> {
-    kwargs
-        .iter()
-        .map(|(k, v)| (k.clone(), arg_value_to_py(py, v, nodes)))
-        .collect()
-}
-
 /// A user-supplied kwarg matcher. Only literal-value equality is
 /// supported; ``SymbolNode``-valued matchers are rejected at
 /// ``where_kwarg`` call time.
@@ -1259,6 +1356,7 @@ pub(crate) fn arg_value_eq_literal(a: &ArgValue, b: &ArgValue) -> bool {
         (ArgValue::Int(x), ArgValue::Float(y)) => (*x as f64) == *y,
         (ArgValue::Float(x), ArgValue::Int(y)) => *x == (*y as f64),
         (ArgValue::Str(x), ArgValue::Str(y)) => x == y,
+        (ArgValue::Bytes(x), ArgValue::Bytes(y)) => x == y,
         (ArgValue::List(xs), ArgValue::List(ys))
         | (ArgValue::Tuple(xs), ArgValue::Tuple(ys))
         | (ArgValue::List(xs), ArgValue::Tuple(ys))
@@ -1314,6 +1412,9 @@ pub(crate) fn py_to_arg_value(value: &Bound<'_, PyAny>) -> PyResult<ArgValue> {
     if let Ok(s) = value.extract::<String>() {
         return Ok(ArgValue::Str(s));
     }
+    if let Ok(b) = value.downcast::<pyo3::types::PyBytes>() {
+        return Ok(ArgValue::Bytes(b.as_bytes().to_vec()));
+    }
     if let Ok(list) = value.downcast::<pyo3::types::PyList>() {
         let mut out = Vec::with_capacity(list.len());
         for item in list.iter() {
@@ -1329,7 +1430,8 @@ pub(crate) fn py_to_arg_value(value: &Bound<'_, PyAny>) -> PyResult<ArgValue> {
         return Ok(ArgValue::Tuple(out));
     }
     Err(PyValueError::new_err(format!(
-        "where_kwarg value must be a literal (None / bool / int / float / str / list / tuple); got {}",
+        "where_kwarg value must be a literal \
+         (None / bool / int / float / str / bytes / list / tuple); got {}",
         value.get_type().name()?,
     )))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,15 +42,15 @@ mod query;
 
 use pyo3::prelude::*;
 
-use crate::builder::{AddEdge, AddEdgeByIdx, AddEntrypoint, AddNode, CollectedOps};
+use crate::builder::{AddEdge, AddEdgeByIdx, AddEntrypoint, AddNode, AddNodeByIdx, CollectedOps};
 use crate::graph::{EdgeFlags, Import, NativeGraph, NodeFlags, SymbolNode};
 use crate::io::{read_graph, write_graph, GraphMetadata};
 use crate::progress::ProgressHandle;
 use crate::project::{Project, ProjectContext};
 use crate::query::{
-    CallQuery, CallRef, ClassQuery, ConstructionQuery, ConstructionRef, DeclQuery, DecoratorQuery,
-    DecoratorRef, EdgeQuery, EdgeRef, FactoryQuery, FactoryRef, ImportQuery, QueryBuilder,
-    SubclassQuery,
+    CallIdxRef, CallQuery, CallRef, ClassQuery, ConstructionIdxRef, ConstructionQuery,
+    ConstructionRef, DeclQuery, DecoratorIdxRef, DecoratorQuery, DecoratorRef, EdgeQuery, EdgeRef,
+    FactoryIdxRef, FactoryQuery, FactoryRef, ImportQuery, QueryBuilder, SubclassQuery,
 };
 
 // ---------------------------------------------------------------------------
@@ -77,12 +77,16 @@ fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<AddEdgeByIdx>()?;
     m.add_class::<AddEntrypoint>()?;
     m.add_class::<AddNode>()?;
+    m.add_class::<AddNodeByIdx>()?;
     m.add_class::<CollectedOps>()?;
     m.add_class::<NodeFlags>()?;
     m.add_class::<EdgeFlags>()?;
     m.add_class::<DecoratorRef>()?;
+    m.add_class::<DecoratorIdxRef>()?;
     m.add_class::<ConstructionRef>()?;
+    m.add_class::<ConstructionIdxRef>()?;
     m.add_class::<CallRef>()?;
+    m.add_class::<CallIdxRef>()?;
     m.add_class::<QueryBuilder>()?;
     m.add_class::<DecoratorQuery>()?;
     m.add_class::<ConstructionQuery>()?;
@@ -92,6 +96,7 @@ fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ClassQuery>()?;
     m.add_class::<FactoryQuery>()?;
     m.add_class::<FactoryRef>()?;
+    m.add_class::<FactoryIdxRef>()?;
     m.add_class::<EdgeQuery>()?;
     m.add_class::<EdgeRef>()?;
     m.add_class::<DeclQuery>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,13 +46,14 @@ use crate::builder::{
     AddEdge, AddEdgeByIdx, AddEntrypoint, AddEntrypointByIdx, AddNode, AddNodeByIdx, CollectedOps,
 };
 use crate::graph::{EdgeFlags, Import, NativeGraph, NodeFlags, SymbolNode};
+use crate::helpers::{ArgLiteral, ArgNodeRef, ArgOpaque};
 use crate::io::{read_graph, write_graph, GraphMetadata};
 use crate::progress::ProgressHandle;
 use crate::project::{Project, ProjectContext};
 use crate::query::{
-    CallIdxRef, CallQuery, CallRef, ClassQuery, ConstructionIdxRef, ConstructionQuery,
-    ConstructionRef, DeclQuery, DecoratorIdxRef, DecoratorQuery, DecoratorRef, EdgeQuery, EdgeRef,
-    FactoryIdxRef, FactoryQuery, FactoryRef, ImportQuery, QueryBuilder, SubclassQuery,
+    CallIdxRef, CallQuery, ClassQuery, ConstructionIdxRef, ConstructionQuery, DeclQuery,
+    DecoratorIdxRef, DecoratorQuery, EdgeQuery, EdgeRef, FactoryIdxRef, FactoryQuery, ImportQuery,
+    QueryBuilder, SubclassQuery,
 };
 
 // ---------------------------------------------------------------------------
@@ -84,12 +85,12 @@ fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<CollectedOps>()?;
     m.add_class::<NodeFlags>()?;
     m.add_class::<EdgeFlags>()?;
-    m.add_class::<DecoratorRef>()?;
     m.add_class::<DecoratorIdxRef>()?;
-    m.add_class::<ConstructionRef>()?;
     m.add_class::<ConstructionIdxRef>()?;
-    m.add_class::<CallRef>()?;
     m.add_class::<CallIdxRef>()?;
+    m.add_class::<ArgLiteral>()?;
+    m.add_class::<ArgNodeRef>()?;
+    m.add_class::<ArgOpaque>()?;
     m.add_class::<QueryBuilder>()?;
     m.add_class::<DecoratorQuery>()?;
     m.add_class::<ConstructionQuery>()?;
@@ -98,7 +99,6 @@ fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ImportQuery>()?;
     m.add_class::<ClassQuery>()?;
     m.add_class::<FactoryQuery>()?;
-    m.add_class::<FactoryRef>()?;
     m.add_class::<FactoryIdxRef>()?;
     m.add_class::<EdgeQuery>()?;
     m.add_class::<EdgeRef>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,9 @@ use crate::progress::ProgressHandle;
 use crate::project::{Project, ProjectContext};
 use crate::query::{
     CallIdxRef, CallQuery, ClassQuery, ConstructionIdxRef, ConstructionQuery, DeclQuery,
-    DecoratorIdxRef, DecoratorQuery, EdgeQuery, EdgeRef, FactoryIdxRef, FactoryQuery, ImportQuery,
-    QueryBuilder, SubclassQuery,
+    DeclarationsQuery, DecoratorIdxRef, DecoratorQuery, EdgeQuery, EdgeRef, FactoryIdxRef,
+    FactoryQuery, ImportQuery, LiteralListQuery, MainBlockQuery, ModuleQuery, QueryBuilder,
+    SubclassQuery, TraverseQuery,
 };
 
 // ---------------------------------------------------------------------------
@@ -97,12 +98,17 @@ fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<CallQuery>()?;
     m.add_class::<SubclassQuery>()?;
     m.add_class::<ImportQuery>()?;
+    m.add_class::<ModuleQuery>()?;
     m.add_class::<ClassQuery>()?;
     m.add_class::<FactoryQuery>()?;
     m.add_class::<FactoryIdxRef>()?;
     m.add_class::<EdgeQuery>()?;
     m.add_class::<EdgeRef>()?;
     m.add_class::<DeclQuery>()?;
+    m.add_class::<DeclarationsQuery>()?;
+    m.add_class::<MainBlockQuery>()?;
+    m.add_class::<LiteralListQuery>()?;
+    m.add_class::<TraverseQuery>()?;
     m.add_class::<GraphMetadata>()?;
     m.add_class::<ProgressHandle>()?;
     m.add_function(wrap_pyfunction!(query_fn, m)?)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ use crate::builder::{
     AddEdge, AddEdgeByIdx, AddEntrypoint, AddEntrypointByIdx, AddNode, AddNodeByIdx, CollectedOps,
 };
 use crate::graph::{EdgeFlags, Import, NativeGraph, NodeFlags, SymbolNode};
-use crate::helpers::{ArgLiteral, ArgNodeRef, ArgOpaque};
+use crate::helpers::{ArgLiteral, ArgNodeRef, ArgOpaque, NodeAttrs};
 use crate::io::{read_graph, write_graph, GraphMetadata};
 use crate::progress::ProgressHandle;
 use crate::project::{Project, ProjectContext};
@@ -92,6 +92,7 @@ fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ArgLiteral>()?;
     m.add_class::<ArgNodeRef>()?;
     m.add_class::<ArgOpaque>()?;
+    m.add_class::<NodeAttrs>()?;
     m.add_class::<QueryBuilder>()?;
     m.add_class::<DecoratorQuery>()?;
     m.add_class::<ConstructionQuery>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,9 @@ mod query;
 
 use pyo3::prelude::*;
 
-use crate::builder::{AddEdge, AddEdgeByIdx, AddEntrypoint, AddNode, AddNodeByIdx, CollectedOps};
+use crate::builder::{
+    AddEdge, AddEdgeByIdx, AddEntrypoint, AddEntrypointByIdx, AddNode, AddNodeByIdx, CollectedOps,
+};
 use crate::graph::{EdgeFlags, Import, NativeGraph, NodeFlags, SymbolNode};
 use crate::io::{read_graph, write_graph, GraphMetadata};
 use crate::progress::ProgressHandle;
@@ -76,6 +78,7 @@ fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<AddEdge>()?;
     m.add_class::<AddEdgeByIdx>()?;
     m.add_class::<AddEntrypoint>()?;
+    m.add_class::<AddEntrypointByIdx>()?;
     m.add_class::<AddNode>()?;
     m.add_class::<AddNodeByIdx>()?;
     m.add_class::<CollectedOps>()?;

--- a/src/project.rs
+++ b/src/project.rs
@@ -34,7 +34,7 @@ use crate::builder::{
 };
 use crate::file_payload::{file_to_edges, file_to_nodes, FileEdges, NodeKind, NodeRef};
 use crate::file_ref_edges::{file_to_ref_edges, FileRefEdges};
-use crate::graph::{intern_kind, DeclIndex, Import, MainBlock, NativeGraph, SymbolNode};
+use crate::graph::{intern_kind, DeclIndex, Import, NativeGraph, SymbolNode};
 use crate::helpers::{
     call_callee_matches_var, class_body_defines_method, collect_all_imports_local,
     collect_modules_imports_local, decorators_match_imports, extract_call_args_kwargs,
@@ -1598,19 +1598,8 @@ impl ProjectContext {
     /// and module-scope PEP 562 dunder functions (``__getattr__``,
     /// ``__dir__``) — both are observable to import / attribute-access
     /// machinery and must be kept alive even when no source reference
-    /// points at them.
-    pub(crate) fn find_module_dunders(&self, py: Python<'_>) -> PyResult<Vec<Py<SymbolNode>>> {
-        let indices = self.find_module_dunders_indices(py)?;
-        let outputs = self.materialized("find_module_dunders")?;
-        Ok(indices
-            .into_iter()
-            .map(|i| outputs.builder.nodes[i].clone_ref(py))
-            .collect())
-    }
-
-    /// Idx-only variant of :meth:`find_module_dunders`. Same scan,
-    /// returns positional indices into ``ctx.nodes()`` rather than
-    /// allocating ``Py<SymbolNode>`` clones.
+    /// points at them. Plugins use the DSL form:
+    /// ``native.query(ctx).modules().with_dunders().indices()``.
     pub(crate) fn find_module_dunders_indices(&self, py: Python<'_>) -> PyResult<Vec<usize>> {
         let outputs = self.materialized("find_module_dunders_indices")?;
         let mut out = Vec::new();
@@ -1642,31 +1631,6 @@ impl ProjectContext {
     ///   OR the node's fqname.
     /// * `abs_paths` — exact equality match against the node's
     ///   absolute path.
-    pub(crate) fn find_nodes_matching_specs(
-        &self,
-        py: Python<'_>,
-        project_root: &str,
-        regexes: Vec<String>,
-        str_specs: Vec<String>,
-        abs_paths: Vec<String>,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let indices = self.find_nodes_matching_specs_indices(
-            py,
-            project_root,
-            regexes,
-            str_specs,
-            abs_paths,
-        )?;
-        let outputs = self.materialized("find_nodes_matching_specs")?;
-        Ok(indices
-            .into_iter()
-            .map(|i| outputs.builder.nodes[i].clone_ref(py))
-            .collect())
-    }
-
-    /// Idx-only variant of :meth:`find_nodes_matching_specs`. Same scan,
-    /// returns positional indices into ``ctx.nodes()`` rather than
-    /// allocating ``Py<SymbolNode>`` clones.
     pub(crate) fn find_nodes_matching_specs_indices(
         &self,
         py: Python<'_>,
@@ -1805,44 +1769,16 @@ impl ProjectContext {
     /// aren't represented as their own graph nodes — same rule the
     /// libcst :func:`find_declarations` follows. Modules are never
     /// returned; use :meth:`find_module` for that.
-    pub(crate) fn find_declarations(
-        &self,
-        py: Python<'_>,
-        fqname: &str,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.materialized("find_declarations")?;
-        let indices = find_declarations_indices_in(&outputs, fqname);
-        Ok(indices
-            .into_iter()
-            .map(|i| outputs.builder.nodes[i].clone_ref(py))
-            .collect())
-    }
-
-    /// Idx-only variant of :meth:`find_declarations`. Same walk-back
-    /// rules, returns positional indices into ``ctx.nodes()`` rather
-    /// than allocating ``Py<SymbolNode>`` clones.
+    /// Indices for every project decl whose fqname matches (walk-back
+    /// included). Plugins use the DSL:
+    /// ``native.query(ctx).declarations().with_fqname(fqn).indices()``.
     pub(crate) fn find_declarations_indices(&self, fqname: &str) -> PyResult<Vec<usize>> {
         let outputs = self.materialized("find_declarations_indices")?;
         Ok(find_declarations_indices_in(&outputs, fqname))
     }
 
-    /// Return the module node for the given dotted fqname, if it
-    /// exists in the project graph.
-    pub(crate) fn find_module(
-        &self,
-        py: Python<'_>,
-        fqname: &str,
-    ) -> PyResult<Option<Py<SymbolNode>>> {
-        let outputs = self.materialized("find_module")?;
-        Ok(outputs
-            .module_by_fqname
-            .get(fqname)
-            .map(|&idx| outputs.builder.nodes[idx].clone_ref(py)))
-    }
-
-    /// Idx-only variant of :meth:`find_module`. Same O(1) lookup,
-    /// returns the positional index into ``ctx.nodes()`` (``None`` if
-    /// ``fqname`` doesn't name a project module).
+    /// O(1) module-by-fqname lookup. Plugins use the DSL:
+    /// ``native.query(ctx).modules().with_fqn(fqn).first_idx()``.
     pub(crate) fn find_module_idx(&self, fqname: &str) -> PyResult<Option<usize>> {
         let outputs = self.materialized("find_module_idx")?;
         Ok(outputs.module_by_fqname.get(fqname).copied())
@@ -1851,21 +1787,8 @@ impl ProjectContext {
 
 #[pymethods]
 impl ProjectContext {
-    /// Return the module node owning ``path``, if any. O(1) — backed
-    /// by the same ``module_nodes_by_file`` index `find_main_blocks`
-    /// uses, so plugins don't have to scan ``nodes()`` per call.
-    pub(crate) fn module_for(
-        &self,
-        py: Python<'_>,
-        path: &str,
-    ) -> PyResult<Option<Py<SymbolNode>>> {
-        let outputs = self.materialized("module_for")?;
-        Ok(module_for_idx_in(&outputs, path).map(|idx| outputs.builder.nodes[idx].clone_ref(py)))
-    }
-
-    /// Idx-only variant of :meth:`module_for`. Same O(1) lookup,
-    /// returns the positional index into ``ctx.nodes()`` (``None`` if
-    /// ``path`` doesn't name a project module).
+    /// O(1) path-to-module lookup. Plugins use the DSL:
+    /// ``native.query(ctx).modules().with_path(path).first_idx()``.
     pub(crate) fn module_for_indices(&self, path: &str) -> PyResult<Option<usize>> {
         let outputs = self.materialized("module_for_indices")?;
         Ok(module_for_idx_in(&outputs, path))
@@ -1891,14 +1814,6 @@ impl ProjectContext {
     /// decl (``pkg.lib.Cls.method`` resolves to ``pkg.lib.Cls`` because
     /// methods don't get their own graph nodes). Returns ``None`` when
     /// the fqname can't be found anywhere — never raises.
-    pub(crate) fn resolve(&self, py: Python<'_>, fqname: &str) -> PyResult<Option<Py<SymbolNode>>> {
-        let outputs = self.materialized("resolve")?;
-        Ok(resolve_idx_in(&outputs, fqname).map(|i| outputs.builder.nodes[i].clone_ref(py)))
-    }
-
-    /// Idx-only variant of :meth:`resolve`. Same walk-back rules,
-    /// returns the positional index into ``ctx.nodes()`` (``None``
-    /// when the fqname can't be found anywhere).
     pub(crate) fn resolve_idx(&self, fqname: &str) -> PyResult<Option<usize>> {
         let outputs = self.materialized("resolve_idx")?;
         Ok(resolve_idx_in(&outputs, fqname))
@@ -1918,22 +1833,9 @@ impl ProjectContext {
     /// ``pkg.foo`` but its synthetic sub-fqnames (``pkg.foo.MyClass.method``)
     /// are not surfaced; nested defs aren't graph nodes anyway, and the
     /// "module surface" contract is per-module.
-    pub(crate) fn module_surface(
-        &self,
-        py: Python<'_>,
-        module_fqn: &str,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.materialized("module_surface")?;
-        let indices = module_surface_indices_in(&outputs, py, module_fqn);
-        Ok(indices
-            .into_iter()
-            .map(|i| outputs.builder.nodes[i].clone_ref(py))
-            .collect())
-    }
-
-    /// Idx-only variant of :meth:`module_surface`. Same BFS over the
-    /// fqname tree; returns positional indices into ``ctx.nodes()``
-    /// instead of allocating ``Py<SymbolNode>`` clones.
+    /// BFS over the fqname tree from ``module_fqn``: the module idx
+    /// + every transitive descendant idx. Plugins use the DSL:
+    /// ``native.query(ctx).modules().with_fqn(fqn).surface().indices()``.
     pub(crate) fn module_surface_indices(
         &self,
         py: Python<'_>,
@@ -1943,40 +1845,17 @@ impl ProjectContext {
         Ok(module_surface_indices_in(&outputs, py, module_fqn))
     }
 
-    /// Batched form of :meth:`module_surface`. Resolves every fqname
-    /// in ``module_fqns`` in a single scan of ``module_by_fqname`` +
-    /// ``decl_by_fqname`` instead of one scan per fqname. The N
-    /// per-call materialize-lookup + N scans collapse to one of each.
-    /// Returns a dict keyed by input fqname; missing modules map to
-    /// empty lists. Duplicate inputs share the same result list.
-    /// Idx-only variant of :meth:`module_surfaces`. Same single-sweep
-    /// scan; the per-fqname buckets carry positional indices into
-    /// ``ctx.nodes()`` instead of allocated ``Py<SymbolNode>`` clones.
+    /// Bulk form: resolve every fqname in ``module_fqns`` in a single
+    /// scan. Returns a dict keyed by input fqname; missing modules
+    /// map to empty lists. No DSL equivalent — the bulk shape is the
+    /// reason this exists (one materialize check + one scan instead
+    /// of N).
     pub(crate) fn module_surfaces_indices(
         &self,
         module_fqns: Vec<String>,
     ) -> PyResult<FxHashMap<String, Vec<usize>>> {
         let outputs = self.materialized("module_surfaces_indices")?;
         Ok(module_surfaces_indices_in(&outputs, &module_fqns))
-    }
-
-    pub(crate) fn module_surfaces(
-        &self,
-        py: Python<'_>,
-        module_fqns: Vec<String>,
-    ) -> PyResult<FxHashMap<String, Vec<Py<SymbolNode>>>> {
-        let outputs = self.materialized("module_surfaces")?;
-        let idx_buckets = module_surfaces_indices_in(&outputs, &module_fqns);
-        let mut buckets: FxHashMap<String, Vec<Py<SymbolNode>>> =
-            FxHashMap::with_capacity_and_hasher(idx_buckets.len(), Default::default());
-        for (key, idxs) in idx_buckets {
-            let nodes = idxs
-                .into_iter()
-                .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
-                .collect();
-            buckets.insert(key, nodes);
-        }
-        Ok(buckets)
     }
 }
 
@@ -1991,22 +1870,9 @@ impl ProjectContext {
     /// excluded — a `from p.functions import *` doesn't pull in
     /// `p.functions.sub.x`. Empty list when ``module_fqn`` doesn't
     /// resolve to a project module.
-    pub(crate) fn find_module_top_level_decls(
-        &self,
-        py: Python<'_>,
-        module_fqn: &str,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let indices = self.find_module_top_level_decls_indices(py, module_fqn)?;
-        let outputs = self.materialized("find_module_top_level_decls")?;
-        Ok(indices
-            .into_iter()
-            .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
-            .collect())
-    }
-
-    /// Idx-only variant of :meth:`find_module_top_level_decls`. Same
-    /// scan, returns positional indices into ``ctx.nodes()`` rather
-    /// than allocating ``Py<SymbolNode>`` clones.
+    /// One-level lookup via the ``children_by_parent`` fqname tree;
+    /// excludes module children. Plugins use the DSL:
+    /// ``native.query(ctx).modules().with_fqn(fqn).top_level().indices()``.
     pub(crate) fn find_module_top_level_decls_indices(
         &self,
         py: Python<'_>,
@@ -2047,30 +1913,11 @@ impl ProjectContext {
     /// that want CPython's ``from X import *`` semantics should fall
     /// back to the non-underscore decl list only in the ``None``
     /// case.
-    pub(crate) fn find_module_dunder_all_exports(
-        &self,
-        py: Python<'_>,
-        module_fqn: &str,
-    ) -> PyResult<Option<Vec<Py<SymbolNode>>>> {
-        let Some(indices) = self.find_module_dunder_all_exports_indices(module_fqn)? else {
-            return Ok(None);
-        };
-        let outputs = self.materialized("find_module_dunder_all_exports")?;
-        Ok(Some(
-            indices
-                .into_iter()
-                .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
-                .collect(),
-        ))
-    }
-
-    /// Idx-only variant of :meth:`find_module_dunder_all_exports`.
-    /// Same lookup, returns positional indices into ``ctx.nodes()``
-    /// rather than allocating ``Py<SymbolNode>`` clones. ``None``
-    /// still means "no ``__all__``"; ``Some([])`` means "empty /
-    /// unresolvable ``__all__``" (callers wanting CPython's
-    /// ``from X import *`` semantics fall back to the non-underscore
-    /// decl list only in the ``None`` case).
+    /// Read the entries from ``{module_fqn}.__all__``'s string-literal
+    /// RHS and resolve each name in the module's scope. ``None`` means
+    /// "no ``__all__``"; ``Some([])`` means "empty / unresolvable".
+    /// Plugins use the DSL:
+    /// ``native.query(ctx).modules().with_fqn(fqn).dunder_all()``.
     pub(crate) fn find_module_dunder_all_exports_indices(
         &self,
         module_fqn: &str,
@@ -2149,23 +1996,8 @@ impl ProjectContext {
 
 #[pymethods]
 impl ProjectContext {
-    /// Every node whose ``path`` starts with the given prefix.
-    pub(crate) fn decls_under(
-        &self,
-        py: Python<'_>,
-        path_prefix: &str,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let indices = self.decls_under_indices(py, path_prefix)?;
-        let outputs = self.materialized("decls_under")?;
-        Ok(indices
-            .into_iter()
-            .map(|i| outputs.builder.nodes[i].clone_ref(py))
-            .collect())
-    }
-
-    /// Idx-only variant of :meth:`decls_under`. Same scan, returns
-    /// positional indices into ``ctx.nodes()`` rather than allocating
-    /// ``Py<SymbolNode>`` clones.
+    /// Every node whose ``path`` starts with ``path_prefix``. Plugins
+    /// use the DSL: ``native.query(ctx).decls().with_path_prefix(p)``.
     pub(crate) fn decls_under_indices(
         &self,
         py: Python<'_>,
@@ -2183,22 +2015,8 @@ impl ProjectContext {
     }
 
     /// Every node whose ``path`` contains ``substring`` anywhere.
-    /// Useful for path-pattern plugins (``alembic/versions/``, ``.ignore.py``).
-    pub(crate) fn decls_matching(
-        &self,
-        py: Python<'_>,
-        substring: &str,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let indices = self.decls_matching_indices(py, substring)?;
-        let outputs = self.materialized("decls_matching")?;
-        Ok(indices
-            .into_iter()
-            .map(|i| outputs.builder.nodes[i].clone_ref(py))
-            .collect())
-    }
-
-    /// Idx-only variant of :meth:`decls_matching`. Same scan, returns
-    /// positional indices into ``ctx.nodes()``.
+    /// Plugins use the DSL:
+    /// ``native.query(ctx).decls().with_path_contains(s)``.
     pub(crate) fn decls_matching_indices(
         &self,
         py: Python<'_>,
@@ -2215,25 +2033,10 @@ impl ProjectContext {
             .collect())
     }
 
-    /// Every top-level decl whose simple name matches ``regex``.
-    /// Fills the gap the screenshot's API doesn't cover — needed by
-    /// :class:`ModuleDundersPlugin` (``__xxx__`` names),
-    /// :class:`PytestPlugin` (``test_*`` / ``Test*``), etc.
-    pub(crate) fn decls_matching_name(
-        &self,
-        py: Python<'_>,
-        pattern: &str,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let indices = self.decls_matching_name_indices(py, pattern)?;
-        let outputs = self.materialized("decls_matching_name")?;
-        Ok(indices
-            .into_iter()
-            .map(|i| outputs.builder.nodes[i].clone_ref(py))
-            .collect())
-    }
-
-    /// Idx-only variant of :meth:`decls_matching_name`. Same scan and
-    /// kind filter, returns positional indices into ``ctx.nodes()``.
+    /// Every top-level decl (function / class / variable / import /
+    /// type_alias) whose simple name matches ``pattern``. Plugins use
+    /// the DSL — compose
+    /// ``decls().with_simple_name_regex(p).with_kinds([...])``.
     pub(crate) fn decls_matching_name_indices(
         &self,
         py: Python<'_>,
@@ -2345,32 +2148,10 @@ impl ProjectContext {
     }
 
     /// One-hop reverse step: every node with an edge directly into
-    /// ``node`` (i.e. the immediate predecessors, *not* the transitive
-    /// closure :meth:`ancestors` returns). ``skip_flags`` filters edges
-    /// by intersecting flag mask — same semantics as :meth:`ancestors`.
-    ///
-    /// Dedups by source index, so a pair of parallel edges with
-    /// different ``EdgeFlags`` between the same two nodes only produces
-    /// one entry in the result. Result order is unspecified.
-    #[pyo3(signature = (node, *, skip_flags = 0))]
-    pub(crate) fn direct_predecessors(
-        &self,
-        py: Python<'_>,
-        node: &SymbolNode,
-        skip_flags: u32,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.materialized("direct_predecessors")?;
-        let idx = lookup_idx(&outputs.builder, node, "node")?;
-        let indices = direct_predecessors_idxs_in(&outputs, idx, skip_flags);
-        Ok(indices
-            .into_iter()
-            .map(|i| outputs.builder.nodes[i].clone_ref(py))
-            .collect())
-    }
-
-    /// Idx-keyed variant of :meth:`direct_predecessors`. Takes a
-    /// positional index into ``ctx.nodes()``; returns predecessor
-    /// indices rather than allocating ``Py<SymbolNode>`` clones.
+    /// ``idx``. ``skip_flags`` filters edges by intersecting flag
+    /// mask — same semantics as :meth:`ancestors_indices`. Dedups by
+    /// source index. Plugins use the DSL:
+    /// ``native.query(ctx).from_idx(idx).direct_predecessors()``.
     #[pyo3(signature = (idx, *, skip_flags = 0))]
     pub(crate) fn direct_predecessors_idx(
         &self,
@@ -2414,34 +2195,12 @@ impl ProjectContext {
 
 #[pymethods]
 impl ProjectContext {
-    /// Return ``(module_node, [decls inside the block])`` for every
-    /// file with a top-level ``if __name__ == "__main__":`` block.
-    ///
-    /// The decls list contains the file's class / function / variable
-    /// / import nodes whose source position falls inside the block's
-    /// range — same shape ``MainBlockPlugin``'s libcst path computes
-    /// from the visitor's payload.
-    pub(crate) fn find_main_blocks(&self, py: Python<'_>) -> PyResult<Vec<MainBlock>> {
-        let indexed = self.find_main_blocks_indices()?;
-        let outputs = self.materialized("find_main_blocks")?;
-        Ok(indexed
-            .into_iter()
-            .map(|(module_idx, decl_idxs)| {
-                let module = outputs.builder.nodes[module_idx].clone_ref(py);
-                let decls = decl_idxs
-                    .into_iter()
-                    .map(|i| outputs.builder.nodes[i].clone_ref(py))
-                    .collect();
-                (module, decls)
-            })
-            .collect())
-    }
-
-    /// Idx-only variant of :meth:`find_main_blocks`. Returns
-    /// ``(module_idx, [decl_idx])`` pairs into ``ctx.nodes()`` rather
-    /// than allocating ``Py<SymbolNode>`` clones. Same single-pass
-    /// ``__main__`` substring filter + ``find_main_block_range`` +
-    /// global-index bucketing as the node form.
+    /// Return ``(module_idx, [decl_idx])`` pairs into ``ctx.nodes()``
+    /// for every file with a top-level ``if __name__ == "__main__":``
+    /// block. The decls list contains the file's class / function /
+    /// variable / import nodes whose source position falls inside the
+    /// block's range. Plugins use the DSL:
+    /// ``native.query(ctx).main_blocks().index_pairs()``.
     pub(crate) fn find_main_blocks_indices(&self) -> PyResult<Vec<(usize, Vec<usize>)>> {
         let outputs = self.materialized("find_main_blocks_indices")?;
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -2515,6 +2515,7 @@ impl ProjectContext {
         decorator_modules: &[String],
         decorator_names: Vec<String>,
         path_regex: Option<&str>,
+        extract_args: bool,
     ) -> PyResult<Vec<(usize, CallArgs)>> {
         let outputs = self.materialized("find_decorated_decls")?;
         let path_re = _compile_path_regex(path_regex)?;
@@ -2564,9 +2565,13 @@ impl ProjectContext {
                     };
                     let key = (file, range_key(func.name.range()));
                     if let Some(&idx) = decl_by_name_range.get(&key) {
-                        let call_args = call_form
-                            .map(|c| extract_call_args_kwargs(c, &file_imports, decl_by_fqname))
-                            .unwrap_or_default();
+                        let call_args = if extract_args {
+                            call_form
+                                .map(|c| extract_call_args_kwargs(c, &file_imports, decl_by_fqname))
+                                .unwrap_or_default()
+                        } else {
+                            CallArgs::default()
+                        };
                         local.push((idx, call_args));
                     }
                 }
@@ -2598,6 +2603,7 @@ impl ProjectContext {
         modules: &[String],
         ctor_names: Vec<String>,
         path_regex: Option<&str>,
+        extract_args: bool,
     ) -> PyResult<Vec<(usize, String, CallArgs)>> {
         let outputs = self.materialized("find_instance_constructions")?;
         let path_re = _compile_path_regex(path_regex)?;
@@ -2641,8 +2647,11 @@ impl ProjectContext {
                     {
                         let key = (file, range_key(target_range));
                         if let Some(&idx) = decl_by_name_range.get(&key) {
-                            let call_args =
-                                extract_call_args_kwargs(call, &file_imports, decl_by_fqname);
+                            let call_args = if extract_args {
+                                extract_call_args_kwargs(call, &file_imports, decl_by_fqname)
+                            } else {
+                                CallArgs::default()
+                            };
                             local.push((idx, matched, call_args));
                         }
                     }
@@ -2668,6 +2677,7 @@ impl ProjectContext {
         py: Python<'_>,
         decorator_attrs: Vec<String>,
         path_regex: Option<&str>,
+        extract_args: bool,
     ) -> PyResult<Vec<(String, usize, CallArgs)>> {
         let outputs = self.materialized("find_handler_decorators")?;
         let path_re = _compile_path_regex(path_regex)?;
@@ -2719,9 +2729,15 @@ impl ProjectContext {
                         }
                         let key = (file, range_key(func.name.range()));
                         if let Some(&idx) = decl_by_name_range.get(&key) {
-                            let call_args = call_form
-                                .map(|c| extract_call_args_kwargs(c, &file_imports, decl_by_fqname))
-                                .unwrap_or_default();
+                            let call_args = if extract_args {
+                                call_form
+                                    .map(|c| {
+                                        extract_call_args_kwargs(c, &file_imports, decl_by_fqname)
+                                    })
+                                    .unwrap_or_default()
+                            } else {
+                                CallArgs::default()
+                            };
                             local.push((owner_name, idx, call_args));
                         }
                     }
@@ -2745,6 +2761,7 @@ impl ProjectContext {
         via_attr: &str,
         decorator_attrs: Vec<String>,
         path_regex: Option<&str>,
+        extract_args: bool,
     ) -> PyResult<Vec<(String, usize, CallArgs)>> {
         let outputs = self.materialized("find_handler_decorators_via")?;
         let path_re = _compile_path_regex(path_regex)?;
@@ -2799,9 +2816,15 @@ impl ProjectContext {
                         }
                         let key = (file, range_key(func.name.range()));
                         if let Some(&idx) = decl_by_name_range.get(&key) {
-                            let call_args = call_form
-                                .map(|c| extract_call_args_kwargs(c, &file_imports, decl_by_fqname))
-                                .unwrap_or_default();
+                            let call_args = if extract_args {
+                                call_form
+                                    .map(|c| {
+                                        extract_call_args_kwargs(c, &file_imports, decl_by_fqname)
+                                    })
+                                    .unwrap_or_default()
+                            } else {
+                                CallArgs::default()
+                            };
                             local.push((owner_name, idx, call_args));
                         }
                     }
@@ -2831,6 +2854,7 @@ impl ProjectContext {
         attr: &str,
         arg_index: usize,
         path_regex: Option<&str>,
+        extract_args: bool,
     ) -> PyResult<Vec<(usize, String, CallArgs)>> {
         let outputs = self.materialized("find_calls_on_attr")?;
         let path_re = _compile_path_regex(path_regex)?;
@@ -2863,6 +2887,7 @@ impl ProjectContext {
                         arg_index,
                         file_imports: &file_imports,
                         decl_by_fqname,
+                        extract_args,
                         results: Vec::new(),
                     };
                     finder.visit_stmt(stmt);
@@ -2971,6 +2996,7 @@ impl ProjectContext {
         name: &str,
         arg_index: usize,
         path_regex: Option<&str>,
+        extract_args: bool,
     ) -> PyResult<Vec<(usize, String, CallArgs)>> {
         let outputs = self.materialized("find_calls_to_imported")?;
         let path_re = _compile_path_regex(path_regex)?;
@@ -3019,6 +3045,7 @@ impl ProjectContext {
                         arg_index,
                         file_imports: &file_imports,
                         decl_by_fqname,
+                        extract_args,
                         results: Vec::new(),
                     };
                     finder.visit_stmt(stmt);
@@ -3053,6 +3080,7 @@ impl ProjectContext {
         arg_index: usize,
         required_positional: Option<usize>,
         path_regex: Option<&str>,
+        extract_args: bool,
     ) -> PyResult<Vec<(usize, String, CallArgs)>> {
         let outputs = self.materialized("find_calls_on_var")?;
         let path_re = _compile_path_regex(path_regex)?;
@@ -3090,6 +3118,7 @@ impl ProjectContext {
                         arg_index,
                         file_imports: &file_imports,
                         decl_by_fqname,
+                        extract_args,
                         results: Vec::new(),
                     };
                     finder.visit_stmt(stmt);
@@ -3458,6 +3487,7 @@ impl ProjectContext {
         py: Python<'_>,
         decorator_fqn: &str,
         path_regex: Option<&str>,
+        extract_args: bool,
     ) -> PyResult<Vec<(usize, CallArgs)>> {
         let Some((module, name)) = decorator_fqn.rsplit_once('.') else {
             return Err(PyValueError::new_err(format!(
@@ -3465,7 +3495,13 @@ impl ProjectContext {
             )));
         };
         let modules = [module.to_string()];
-        self.find_decorated_decls(py, &modules, vec![name.to_string()], path_regex)
+        self.find_decorated_decls(
+            py,
+            &modules,
+            vec![name.to_string()],
+            path_regex,
+            extract_args,
+        )
     }
 
     #[allow(clippy::type_complexity)]
@@ -3475,6 +3511,7 @@ impl ProjectContext {
         class_fqn: &str,
         include_subclasses: bool,
         path_regex: Option<&str>,
+        extract_args: bool,
     ) -> PyResult<Vec<(usize, CallArgs)>> {
         let Some((module, name)) = class_fqn.rsplit_once('.') else {
             return Err(PyValueError::new_err(format!(
@@ -3497,7 +3534,8 @@ impl ProjectContext {
             }
         }
         let modules = [module.to_string()];
-        let triples = self.find_instance_constructions(py, &modules, ctors, path_regex)?;
+        let triples =
+            self.find_instance_constructions(py, &modules, ctors, path_regex, extract_args)?;
         Ok(triples
             .into_iter()
             .map(|(idx, _name, call_args)| (idx, call_args))
@@ -3511,9 +3549,10 @@ impl ProjectContext {
         instance: &SymbolNode,
         method_names: Vec<String>,
         path_regex: Option<&str>,
+        extract_args: bool,
     ) -> PyResult<Vec<(usize, CallArgs)>> {
         let instance_simple = instance.fqname.rsplit('.').next().unwrap_or("").to_string();
-        let handlers = self.find_handler_decorators(py, method_names, path_regex)?;
+        let handlers = self.find_handler_decorators(py, method_names, path_regex, extract_args)?;
         let outputs = self.materialized("find_decorations_on")?;
         let mut out: Vec<(usize, CallArgs)> = Vec::new();
         for (owner_name, handler_idx, call_args) in handlers {

--- a/src/project.rs
+++ b/src/project.rs
@@ -1883,21 +1883,15 @@ impl ProjectContext {
     /// the fqname can't be found anywhere — never raises.
     pub(crate) fn resolve(&self, py: Python<'_>, fqname: &str) -> PyResult<Option<Py<SymbolNode>>> {
         let outputs = self.materialized("resolve")?;
-        let mut prefix = fqname;
-        loop {
-            if let Some(idxs) = outputs.decl_by_fqname.get(prefix) {
-                if let Some(&idx) = idxs.first() {
-                    return Ok(Some(outputs.builder.nodes[idx].clone_ref(py)));
-                }
-            }
-            if let Some(&idx) = outputs.module_by_fqname.get(prefix) {
-                return Ok(Some(outputs.builder.nodes[idx].clone_ref(py)));
-            }
-            match prefix.rsplit_once('.') {
-                Some((parent, _)) => prefix = parent,
-                None => return Ok(None),
-            }
-        }
+        Ok(resolve_idx_in(&outputs, fqname).map(|i| outputs.builder.nodes[i].clone_ref(py)))
+    }
+
+    /// Idx-only variant of :meth:`resolve`. Same walk-back rules,
+    /// returns the positional index into ``ctx.nodes()`` (``None``
+    /// when the fqname can't be found anywhere).
+    pub(crate) fn resolve_idx(&self, fqname: &str) -> PyResult<Option<usize>> {
+        let outputs = self.materialized("resolve_idx")?;
+        Ok(resolve_idx_in(&outputs, fqname))
     }
 
     /// Return the module node + every transitive decl whose fqname
@@ -2151,13 +2145,30 @@ impl ProjectContext {
         py: Python<'_>,
         path_prefix: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
+        let indices = self.decls_under_indices(py, path_prefix)?;
         let outputs = self.materialized("decls_under")?;
+        Ok(indices
+            .into_iter()
+            .map(|i| outputs.builder.nodes[i].clone_ref(py))
+            .collect())
+    }
+
+    /// Idx-only variant of :meth:`decls_under`. Same scan, returns
+    /// positional indices into ``ctx.nodes()`` rather than allocating
+    /// ``Py<SymbolNode>`` clones.
+    pub(crate) fn decls_under_indices(
+        &self,
+        py: Python<'_>,
+        path_prefix: &str,
+    ) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("decls_under_indices")?;
         Ok(outputs
             .builder
             .nodes
             .iter()
-            .filter(|n| n.borrow(py).path.starts_with(path_prefix))
-            .map(|n| n.clone_ref(py))
+            .enumerate()
+            .filter(|(_i, n)| n.borrow(py).path.starts_with(path_prefix))
+            .map(|(i, _n)| i)
             .collect())
     }
 
@@ -2168,13 +2179,29 @@ impl ProjectContext {
         py: Python<'_>,
         substring: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
+        let indices = self.decls_matching_indices(py, substring)?;
         let outputs = self.materialized("decls_matching")?;
+        Ok(indices
+            .into_iter()
+            .map(|i| outputs.builder.nodes[i].clone_ref(py))
+            .collect())
+    }
+
+    /// Idx-only variant of :meth:`decls_matching`. Same scan, returns
+    /// positional indices into ``ctx.nodes()``.
+    pub(crate) fn decls_matching_indices(
+        &self,
+        py: Python<'_>,
+        substring: &str,
+    ) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("decls_matching_indices")?;
         Ok(outputs
             .builder
             .nodes
             .iter()
-            .filter(|n| n.borrow(py).path.contains(substring))
-            .map(|n| n.clone_ref(py))
+            .enumerate()
+            .filter(|(_i, n)| n.borrow(py).path.contains(substring))
+            .map(|(i, _n)| i)
             .collect())
     }
 
@@ -2187,10 +2214,25 @@ impl ProjectContext {
         py: Python<'_>,
         pattern: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let regex = self.compile_regex(pattern)?;
+        let indices = self.decls_matching_name_indices(py, pattern)?;
         let outputs = self.materialized("decls_matching_name")?;
-        let mut out = Vec::new();
-        for node_py in &outputs.builder.nodes {
+        Ok(indices
+            .into_iter()
+            .map(|i| outputs.builder.nodes[i].clone_ref(py))
+            .collect())
+    }
+
+    /// Idx-only variant of :meth:`decls_matching_name`. Same scan and
+    /// kind filter, returns positional indices into ``ctx.nodes()``.
+    pub(crate) fn decls_matching_name_indices(
+        &self,
+        py: Python<'_>,
+        pattern: &str,
+    ) -> PyResult<Vec<usize>> {
+        let regex = self.compile_regex(pattern)?;
+        let outputs = self.materialized("decls_matching_name_indices")?;
+        let mut out: Vec<usize> = Vec::new();
+        for (idx, node_py) in outputs.builder.nodes.iter().enumerate() {
             let node = node_py.borrow(py);
             if !matches!(
                 node.kind,
@@ -2200,7 +2242,7 @@ impl ProjectContext {
             }
             let simple = node.fqname.rsplit('.').next().unwrap_or("");
             if regex.is_match(simple) {
-                out.push(node_py.clone_ref(py));
+                out.push(idx);
             }
         }
         Ok(out)
@@ -2227,6 +2269,30 @@ impl ProjectContext {
         )
     }
 
+    /// Idx-keyed variant of :meth:`descendants`. Takes a positional
+    /// index into ``ctx.nodes()`` and returns descendant indices
+    /// rather than allocating ``Py<SymbolNode>`` clones. Raises
+    /// :class:`IndexError` when ``root_idx`` is out of range.
+    #[pyo3(signature = (root_idx, *, skip_flags = 0))]
+    pub(crate) fn descendants_indices(
+        &self,
+        root_idx: usize,
+        skip_flags: u32,
+    ) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("descendants_indices")?;
+        let len = outputs.builder.nodes.len();
+        if root_idx >= len {
+            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                "descendants_indices: root_idx {root_idx} out of range (len={len})"
+            )));
+        }
+        Ok(
+            bfs(&outputs.builder, [root_idx], Direction::Forward, skip_flags)
+                .into_iter()
+                .collect(),
+        )
+    }
+
     /// Reverse closure: every node that can reach ``decl`` by following
     /// graph edges. Used for ``why-alive`` and blast-radius scoping.
     #[pyo3(signature = (decl, *, skip_flags = 0))]
@@ -2242,6 +2308,30 @@ impl ProjectContext {
             .into_iter()
             .map(|i| outputs.builder.nodes[i].clone_ref(py))
             .collect())
+    }
+
+    /// Idx-keyed variant of :meth:`ancestors`. Takes a positional
+    /// index into ``ctx.nodes()`` and returns ancestor indices rather
+    /// than allocating ``Py<SymbolNode>`` clones. Raises
+    /// :class:`IndexError` when ``decl_idx`` is out of range.
+    #[pyo3(signature = (decl_idx, *, skip_flags = 0))]
+    pub(crate) fn ancestors_indices(
+        &self,
+        decl_idx: usize,
+        skip_flags: u32,
+    ) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("ancestors_indices")?;
+        let len = outputs.builder.nodes.len();
+        if decl_idx >= len {
+            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                "ancestors_indices: decl_idx {decl_idx} out of range (len={len})"
+            )));
+        }
+        Ok(
+            bfs(&outputs.builder, [decl_idx], Direction::Reverse, skip_flags)
+                .into_iter()
+                .collect(),
+        )
     }
 
     /// One-hop reverse step: every node with an edge directly into
@@ -3287,6 +3377,28 @@ fn module_surfaces_indices_in(
         }
     }
     buckets
+}
+
+/// Shared walk-back lookup for :meth:`ProjectContext::resolve` and
+/// :meth:`resolve_idx`. Tries an exact decl match first, then an
+/// exact module match, then strips dotted segments. Returns the
+/// idx of the first hit or ``None``.
+fn resolve_idx_in(outputs: &BuildOutputs, fqname: &str) -> Option<usize> {
+    let mut prefix = fqname;
+    loop {
+        if let Some(idxs) = outputs.decl_by_fqname.get(prefix) {
+            if let Some(&idx) = idxs.first() {
+                return Some(idx);
+            }
+        }
+        if let Some(&idx) = outputs.module_by_fqname.get(prefix) {
+            return Some(idx);
+        }
+        match prefix.rsplit_once('.') {
+            Some((parent, _)) => prefix = parent,
+            None => return None,
+        }
+    }
 }
 
 /// `path -> module-node idx`, shared by :meth:`ProjectContext::module_for`,

--- a/src/project.rs
+++ b/src/project.rs
@@ -4074,6 +4074,11 @@ impl ProjectContext {
     /// ``borrow`` round-trips — lets plugins that filter / partition by
     /// these four fields stay GIL-free in the inner loop.
     ///
+    /// When a plugin only needs ``path`` (the common "bucket by file"
+    /// case), prefer :meth:`node_paths` — it skips the per-row
+    /// ``kind`` / ``fqname`` / ``flags`` clones that ``node_attrs`` would
+    /// allocate but the plugin would throw away.
+    ///
     /// Validates bounds the same way :meth:`nodes_at` does and raises
     /// :class:`IndexError` when any index is out of range.
     pub(crate) fn node_attrs(
@@ -4097,6 +4102,29 @@ impl ProjectContext {
                 node.fqname.clone(),
                 node.flags,
             ));
+        }
+        Ok(out)
+    }
+
+    /// Batched ``path``-only snapshot for each index in ``indices``.
+    /// Same FFI shape as :meth:`node_attrs` but allocates only one
+    /// ``str`` per row instead of ``(kind, path, fqname, flags)`` —
+    /// roughly 3× fewer Python allocations on the common "bucket by
+    /// file" path that doesn't need the other three fields.
+    ///
+    /// Validates bounds and raises :class:`IndexError` when any index
+    /// is out of range. Mirrors the contract of :meth:`node_attrs`.
+    pub(crate) fn node_paths(&self, py: Python<'_>, indices: Vec<usize>) -> PyResult<Vec<String>> {
+        let outputs = self.materialized("node_paths")?;
+        let len = outputs.builder.nodes.len();
+        let mut out: Vec<String> = Vec::with_capacity(indices.len());
+        for idx in indices {
+            if idx >= len {
+                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                    "node index {idx} out of range (len={len})"
+                )));
+            }
+            out.push(outputs.builder.nodes[idx].borrow(py).path.clone());
         }
         Ok(out)
     }

--- a/src/project.rs
+++ b/src/project.rs
@@ -162,11 +162,11 @@ pub(crate) struct BuildOutputs {
     /// this map.
     pub(crate) children_by_node: FxHashMap<usize, Vec<usize>>,
     /// Project-wide class hierarchy keyed by parent fqname (project or
-    /// external). `base_fqn -> [direct subclass class_idx]`. Lets
-    /// ``subclasses_of_fqn`` answer the "any project classes extending
-    /// ``flask.Flask``?" question in O(1) without re-walking the AST
-    /// or re-resolving imports. Built alongside ``children_by_node``
-    /// from the per-file ``class_bases`` payload.
+    /// external). `base_fqn -> [direct subclass class_idx]`. Built
+    /// alongside ``children_by_node`` from the per-file ``class_bases``
+    /// payload. Retained for the upcoming DSL ``subclasses().of_fqn()``
+    /// O(1) fast path; not yet wired into the current path.
+    #[allow(dead_code)]
     pub(crate) children_by_fqn: FxHashMap<String, Vec<usize>>,
 }
 
@@ -3081,7 +3081,7 @@ impl ProjectContext {
     /// has 3. Pass ``None`` to accept any positional-arg count.
     ///
     /// Returns ``(owning_decl, string_literal_arg)`` pairs.
-    #[allow(clippy::type_complexity)]
+    #[allow(clippy::type_complexity, clippy::too_many_arguments)]
     pub(crate) fn find_calls_on_var(
         &self,
         py: Python<'_>,
@@ -3224,30 +3224,10 @@ impl ProjectContext {
     }
 }
 
-// ``find_subclasses_of`` / ``_indices`` / ``_idx`` back
-// :class:`SubclassQuery`. NOT exposed to Python — plugin authors use
-// the DSL: ``native.query(ctx).subclasses().of_idx(idx).indices()``
-// or ``of_fqn(fqn)``.
-impl ProjectContext {
-    /// Return every transitive subclass of the given class node.
-    ///
-    /// Direct subtypes come from ty's `type_hierarchy_subtypes`; we BFS
-    /// to collect the transitive closure. Results that don't land in
-    /// the project (stdlib / external classes) are dropped.
-    pub(crate) fn find_subclasses_of(
-        &self,
-        py: Python<'_>,
-        class_node: &SymbolNode,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let indices = self.find_subclasses_of_indices(class_node)?;
-        let outputs = self.materialized("find_subclasses_of")?;
-        Ok(indices
-            .into_iter()
-            .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
-            .collect())
-    }
-}
-
+// ``find_subclasses_of_indices`` / ``_idx`` back :class:`SubclassQuery`.
+// NOT exposed to Python — plugin authors use the DSL:
+// ``native.query(ctx).subclasses().of_idx(idx).indices()`` or
+// ``of_fqn(fqn)``.
 impl ProjectContext {
     /// Idx-only variant of :meth:`find_subclasses_of`. Same lookup,
     /// returns positional indices into ``ctx.nodes()`` rather than
@@ -3726,117 +3706,6 @@ impl ProjectContext {
             }
         }
         Ok(out_idx.into_iter().collect())
-    }
-}
-
-// ``subclasses_of_fqn`` / ``_indices`` / ``subclasses_of_node`` back
-// the project-only subclass-walk path inside :class:`SubclassQuery`.
-// NOT exposed to Python — plugin authors use the DSL.
-impl ProjectContext {
-    /// Project classes that inherit (directly or transitively) from
-    /// the class identified by ``fqn``. ``fqn`` may name a project
-    /// class (e.g. ``pkg.module.MyBase``) or an external one
-    /// (``flask.Flask``, ``typer.Typer``); the lookup is keyed against
-    /// the pre-built ``children_by_fqn`` index (populated at
-    /// materialize time from per-file `class_bases` payloads — see
-    /// `file_payload::ResolvedBase`), so the framework module is
-    /// never loaded out of the venv.
-    ///
-    /// ``transitive=True`` (default) walks the subclass closure via
-    /// ``children_by_node``; ``transitive=False`` returns only direct
-    /// hits. Match shapes per base expression in the class header
-    /// follow the [`ResolvedBase`](crate::file_payload::ResolvedBase)
-    /// contract:
-    ///
-    /// * ``Name(X)`` where ``X`` is imported via
-    ///   ``from <module> import X [as alias]`` → matches when
-    ///   ``<module>.X`` equals ``fqn``.
-    /// * ``Attribute(Name(M).N)`` where ``M`` is bound via
-    ///   ``import <module> [as M]`` → matches when ``<module>.N``
-    ///   equals ``fqn``.
-    /// * ``Name(X)`` referring to a class earlier in the same file →
-    ///   matches when the in-project resolution lands the parent's
-    ///   own fqname or graph idx.
-    ///
-    /// Generics (``class X(Foo[T])``) and other non-identifier
-    /// expressions are skipped — matches the libcst pipeline.
-    pub(crate) fn subclasses_of_fqn(
-        &self,
-        py: Python<'_>,
-        fqn: &str,
-        transitive: bool,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let indices = self.subclasses_of_fqn_indices(fqn, transitive)?;
-        let outputs = self.materialized("subclasses_of_fqn")?;
-        Ok(indices
-            .into_iter()
-            .map(|i| outputs.builder.nodes[i].clone_ref(py))
-            .collect())
-    }
-
-    /// Idx-only variant of :meth:`subclasses_of_fqn`. Same lookup,
-    /// returns positional indices into ``ctx.nodes()`` rather than
-    /// allocating ``Py<SymbolNode>`` clones.
-    pub(crate) fn subclasses_of_fqn_indices(
-        &self,
-        fqn: &str,
-        transitive: bool,
-    ) -> PyResult<Vec<usize>> {
-        let outputs = self.materialized("subclasses_of_fqn_indices")?;
-        let Some(direct) = outputs.children_by_fqn.get(fqn) else {
-            return Ok(Vec::new());
-        };
-        let mut visited: FxHashSet<usize> = direct.iter().copied().collect();
-        if transitive {
-            for &d in direct {
-                for idx in transitive_subclasses_via_index(d, &outputs.children_by_node) {
-                    visited.insert(idx);
-                }
-            }
-        }
-        Ok(visited.into_iter().collect())
-    }
-
-    /// Project classes that inherit (directly or transitively) from
-    /// ``class_node``. O(1) probe in ``children_by_node`` plus BFS for
-    /// the transitive walk. Returns an empty vec when ``class_node``
-    /// isn't a class kind. Symmetric to :meth:`subclasses_of_fqn` for
-    /// callers that already hold the seed as a `SymbolNode`.
-    pub(crate) fn subclasses_of_node(
-        &self,
-        py: Python<'_>,
-        class_node: &SymbolNode,
-        transitive: bool,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        if class_node.kind != "class" {
-            return Ok(Vec::new());
-        }
-        let outputs = self.materialized("subclasses_of_node")?;
-        let Some((seed_file, seed_range)) = locate_class_def(
-            &self.db,
-            &outputs.path_to_file,
-            &class_node.path,
-            class_node,
-        ) else {
-            return Ok(Vec::new());
-        };
-        let rk = (seed_range.start().to_u32(), seed_range.end().to_u32());
-        let Some(&seed_idx) = outputs.class_by_selection.get(&(seed_file, rk)) else {
-            return Ok(Vec::new());
-        };
-        let out_idx = if transitive {
-            transitive_subclasses_via_index(seed_idx, &outputs.children_by_node)
-        } else {
-            outputs
-                .children_by_node
-                .get(&seed_idx)
-                .cloned()
-                .unwrap_or_default()
-        };
-        Ok(out_idx
-            .into_iter()
-            .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
-            .collect())
     }
 }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -3769,10 +3769,10 @@ impl ProjectContext {
         &self,
         py: Python<'_>,
         indices: Vec<usize>,
-    ) -> PyResult<Vec<(String, String, String, u32)>> {
+    ) -> PyResult<Vec<crate::helpers::NodeAttrs>> {
         let outputs = self.materialized("node_attrs")?;
         let len = outputs.builder.nodes.len();
-        let mut out: Vec<(String, String, String, u32)> = Vec::with_capacity(indices.len());
+        let mut out: Vec<crate::helpers::NodeAttrs> = Vec::with_capacity(indices.len());
         for idx in indices {
             if idx >= len {
                 return Err(pyo3::exceptions::PyIndexError::new_err(format!(
@@ -3780,12 +3780,12 @@ impl ProjectContext {
                 )));
             }
             let node = outputs.builder.nodes[idx].borrow(py);
-            out.push((
-                node.kind.to_string(),
-                node.path.clone(),
-                node.fqname.clone(),
-                node.flags,
-            ));
+            out.push(crate::helpers::NodeAttrs {
+                kind: node.kind.to_string(),
+                path: node.path.clone(),
+                fqname: node.fqname.clone(),
+                flags: node.flags,
+            });
         }
         Ok(out)
     }

--- a/src/project.rs
+++ b/src/project.rs
@@ -1600,15 +1600,27 @@ impl ProjectContext {
     /// machinery and must be kept alive even when no source reference
     /// points at them.
     pub(crate) fn find_module_dunders(&self, py: Python<'_>) -> PyResult<Vec<Py<SymbolNode>>> {
+        let indices = self.find_module_dunders_indices(py)?;
         let outputs = self.materialized("find_module_dunders")?;
+        Ok(indices
+            .into_iter()
+            .map(|i| outputs.builder.nodes[i].clone_ref(py))
+            .collect())
+    }
+
+    /// Idx-only variant of :meth:`find_module_dunders`. Same scan,
+    /// returns positional indices into ``ctx.nodes()`` rather than
+    /// allocating ``Py<SymbolNode>`` clones.
+    pub(crate) fn find_module_dunders_indices(&self, py: Python<'_>) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("find_module_dunders_indices")?;
         let mut out = Vec::new();
-        for node_py in &outputs.builder.nodes {
+        for (idx, node_py) in outputs.builder.nodes.iter().enumerate() {
             let node = node_py.borrow(py);
             if !matches!(node.kind, "variable" | "function") {
                 continue;
             }
             if is_dunder_name(&node.fqname) {
-                out.push(node_py.clone_ref(py));
+                out.push(idx);
             }
         }
         Ok(out)
@@ -1638,6 +1650,31 @@ impl ProjectContext {
         str_specs: Vec<String>,
         abs_paths: Vec<String>,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
+        let indices = self.find_nodes_matching_specs_indices(
+            py,
+            project_root,
+            regexes,
+            str_specs,
+            abs_paths,
+        )?;
+        let outputs = self.materialized("find_nodes_matching_specs")?;
+        Ok(indices
+            .into_iter()
+            .map(|i| outputs.builder.nodes[i].clone_ref(py))
+            .collect())
+    }
+
+    /// Idx-only variant of :meth:`find_nodes_matching_specs`. Same scan,
+    /// returns positional indices into ``ctx.nodes()`` rather than
+    /// allocating ``Py<SymbolNode>`` clones.
+    pub(crate) fn find_nodes_matching_specs_indices(
+        &self,
+        py: Python<'_>,
+        project_root: &str,
+        regexes: Vec<String>,
+        str_specs: Vec<String>,
+        abs_paths: Vec<String>,
+    ) -> PyResult<Vec<usize>> {
         let compiled: Vec<regex::Regex> = regexes
             .iter()
             .map(|p| {
@@ -1655,27 +1692,25 @@ impl ProjectContext {
         let str_set: FxHashSet<&str> = str_specs.iter().map(String::as_str).collect();
         let abs_set: FxHashSet<&str> = abs_paths.iter().map(String::as_str).collect();
 
-        let outputs = self.materialized("find_nodes_matching_specs")?;
-        let mut out = Vec::new();
-        for node_py in &outputs.builder.nodes {
+        let outputs = self.materialized("find_nodes_matching_specs_indices")?;
+        let mut out: Vec<usize> = Vec::new();
+        for (idx, node_py) in outputs.builder.nodes.iter().enumerate() {
             let node = node_py.borrow(py);
             let path = node.path.as_str();
             if abs_set.contains(path) {
-                out.push(node_py.clone_ref(py));
+                out.push(idx);
                 continue;
             }
-            // Mirror Python's ``path.relative_to(root)`` ⇒ ``str(...)``
-            // with the ``except ValueError: rel = node.path`` fallback.
             let rel = path
                 .strip_prefix(project_root)
                 .map(|s| s.trim_start_matches(['/', '\\']))
                 .unwrap_or(path);
             if str_set.contains(rel) || str_set.contains(node.fqname.as_str()) {
-                out.push(node_py.clone_ref(py));
+                out.push(idx);
                 continue;
             }
             if compiled.iter().any(|r| r.is_match(rel)) {
-                out.push(node_py.clone_ref(py));
+                out.push(idx);
             }
         }
         Ok(out)
@@ -1793,6 +1828,14 @@ impl ProjectContext {
             .module_by_fqname
             .get(fqname)
             .map(|&idx| outputs.builder.nodes[idx].clone_ref(py)))
+    }
+
+    /// Idx-only variant of :meth:`find_module`. Same O(1) lookup,
+    /// returns the positional index into ``ctx.nodes()`` (``None`` if
+    /// ``fqname`` doesn't name a project module).
+    pub(crate) fn find_module_idx(&self, fqname: &str) -> PyResult<Option<usize>> {
+        let outputs = self.materialized("find_module_idx")?;
+        Ok(outputs.module_by_fqname.get(fqname).copied())
     }
 }
 
@@ -2218,17 +2261,30 @@ impl ProjectContext {
     ) -> PyResult<Vec<Py<SymbolNode>>> {
         let outputs = self.materialized("direct_predecessors")?;
         let idx = lookup_idx(&outputs.builder, node, "node")?;
-        let mut seen: FxHashSet<usize> = FxHashSet::default();
-        let mut out: Vec<Py<SymbolNode>> = Vec::new();
-        for &(src, flags) in &outputs.builder.reverse_adj[idx] {
-            if flags & skip_flags != 0 {
-                continue;
-            }
-            if seen.insert(src) {
-                out.push(outputs.builder.nodes[src].clone_ref(py));
-            }
+        let indices = direct_predecessors_idxs_in(&outputs, idx, skip_flags);
+        Ok(indices
+            .into_iter()
+            .map(|i| outputs.builder.nodes[i].clone_ref(py))
+            .collect())
+    }
+
+    /// Idx-keyed variant of :meth:`direct_predecessors`. Takes a
+    /// positional index into ``ctx.nodes()``; returns predecessor
+    /// indices rather than allocating ``Py<SymbolNode>`` clones.
+    #[pyo3(signature = (idx, *, skip_flags = 0))]
+    pub(crate) fn direct_predecessors_idx(
+        &self,
+        idx: usize,
+        skip_flags: u32,
+    ) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("direct_predecessors_idx")?;
+        let len = outputs.builder.nodes.len();
+        if idx >= len {
+            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                "direct_predecessors_idx: idx {idx} out of range (len={len})"
+            )));
         }
-        Ok(out)
+        Ok(direct_predecessors_idxs_in(&outputs, idx, skip_flags))
     }
 
     /// Forward closure from every node carrying any bit in
@@ -3088,6 +3144,65 @@ impl ProjectContext {
     }
 }
 
+#[pymethods]
+impl ProjectContext {
+    /// Idx-keyed variant of :meth:`find_subclasses_of_indices` —
+    /// resolves the seed class by positional index into ``ctx.nodes()``
+    /// rather than taking a ``Py<SymbolNode>`` reference. Bounds-checks
+    /// the index and raises :class:`IndexError` when out of range.
+    pub(crate) fn find_subclasses_of_idx(
+        &self,
+        py: Python<'_>,
+        class_idx: usize,
+    ) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("find_subclasses_of_idx")?;
+        let len = outputs.builder.nodes.len();
+        if class_idx >= len {
+            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                "find_subclasses_of_idx: class_idx {class_idx} out of range (len={len})"
+            )));
+        }
+        // Snapshot the node fields the inner helper reads — same shape
+        // it gets when called from the node-form ``find_subclasses_of``.
+        let class_node = outputs.builder.nodes[class_idx].borrow(py);
+        if class_node.kind != "class" {
+            return Ok(Vec::new());
+        }
+        if let Some((seed_file, seed_range)) = locate_class_def(
+            &self.db,
+            &outputs.path_to_file,
+            &class_node.path,
+            &class_node,
+        ) {
+            let rk = (seed_range.start().to_u32(), seed_range.end().to_u32());
+            if let Some(&seed_idx) = outputs.class_by_selection.get(&(seed_file, rk)) {
+                return Ok(transitive_subclasses_via_index(
+                    seed_idx,
+                    &outputs.children_by_node,
+                ));
+            }
+        }
+        Ok(Vec::new())
+    }
+}
+
+/// Shared one-hop reverse-adjacency walk used by
+/// :meth:`ProjectContext::direct_predecessors` and
+/// :meth:`direct_predecessors_idx`.
+fn direct_predecessors_idxs_in(outputs: &BuildOutputs, idx: usize, skip_flags: u32) -> Vec<usize> {
+    let mut seen: FxHashSet<usize> = FxHashSet::default();
+    let mut out: Vec<usize> = Vec::new();
+    for &(src, flags) in &outputs.builder.reverse_adj[idx] {
+        if flags & skip_flags != 0 {
+            continue;
+        }
+        if seen.insert(src) {
+            out.push(src);
+        }
+    }
+    out
+}
+
 /// Shared BFS used by :meth:`ProjectContext::module_surface` and
 /// :meth:`module_surface_indices` — the module index, then every
 /// transitive child node (modules recursed into; non-module decls
@@ -3484,7 +3599,24 @@ impl ProjectContext {
         fqn: &str,
         transitive: bool,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
+        let indices = self.subclasses_of_fqn_indices(fqn, transitive)?;
         let outputs = self.materialized("subclasses_of_fqn")?;
+        Ok(indices
+            .into_iter()
+            .map(|i| outputs.builder.nodes[i].clone_ref(py))
+            .collect())
+    }
+
+    /// Idx-only variant of :meth:`subclasses_of_fqn`. Same lookup,
+    /// returns positional indices into ``ctx.nodes()`` rather than
+    /// allocating ``Py<SymbolNode>`` clones.
+    #[pyo3(signature = (fqn, *, transitive = true))]
+    pub(crate) fn subclasses_of_fqn_indices(
+        &self,
+        fqn: &str,
+        transitive: bool,
+    ) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("subclasses_of_fqn_indices")?;
         let Some(direct) = outputs.children_by_fqn.get(fqn) else {
             return Ok(Vec::new());
         };
@@ -3496,10 +3628,7 @@ impl ProjectContext {
                 }
             }
         }
-        Ok(visited
-            .into_iter()
-            .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
-            .collect())
+        Ok(visited.into_iter().collect())
     }
 
     /// Project classes that inherit (directly or transitively) from

--- a/src/project.rs
+++ b/src/project.rs
@@ -1766,20 +1766,19 @@ impl ProjectContext {
         fqname: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
         let outputs = self.materialized("find_declarations")?;
-        // Try exact match first, then strip trailing segments.
-        let mut prefix = fqname;
-        loop {
-            if let Some(idxs) = outputs.decl_by_fqname.get(prefix) {
-                return Ok(idxs
-                    .iter()
-                    .map(|&i| outputs.builder.nodes[i].clone_ref(py))
-                    .collect());
-            }
-            match prefix.rsplit_once('.') {
-                Some((parent, _)) => prefix = parent,
-                None => return Ok(Vec::new()),
-            }
-        }
+        let indices = find_declarations_indices_in(&outputs, fqname);
+        Ok(indices
+            .into_iter()
+            .map(|i| outputs.builder.nodes[i].clone_ref(py))
+            .collect())
+    }
+
+    /// Idx-only variant of :meth:`find_declarations`. Same walk-back
+    /// rules, returns positional indices into ``ctx.nodes()`` rather
+    /// than allocating ``Py<SymbolNode>`` clones.
+    pub(crate) fn find_declarations_indices(&self, fqname: &str) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("find_declarations_indices")?;
+        Ok(find_declarations_indices_in(&outputs, fqname))
     }
 
     /// Return the module node for the given dotted fqname, if it
@@ -1808,13 +1807,28 @@ impl ProjectContext {
         path: &str,
     ) -> PyResult<Option<Py<SymbolNode>>> {
         let outputs = self.materialized("module_for")?;
-        let Some(&file) = outputs.path_to_file.get(path) else {
-            return Ok(None);
-        };
-        let Some(&idx) = outputs.module_nodes_by_file.get(&file) else {
-            return Ok(None);
-        };
-        Ok(Some(outputs.builder.nodes[idx].clone_ref(py)))
+        Ok(module_for_idx_in(&outputs, path).map(|idx| outputs.builder.nodes[idx].clone_ref(py)))
+    }
+
+    /// Idx-only variant of :meth:`module_for`. Same O(1) lookup,
+    /// returns the positional index into ``ctx.nodes()`` (``None`` if
+    /// ``path`` doesn't name a project module).
+    pub(crate) fn module_for_indices(&self, path: &str) -> PyResult<Option<usize>> {
+        let outputs = self.materialized("module_for_indices")?;
+        Ok(module_for_idx_in(&outputs, path))
+    }
+
+    /// Bulk form of :meth:`module_for_indices`. One materialize check
+    /// + one ``path_to_file`` / ``module_nodes_by_file`` lookup per
+    /// path; missing paths map to ``None``. Lets plugins that
+    /// ``module_for(path)`` once per ref row collapse N FFI hops into
+    /// one.
+    pub(crate) fn modules_for_paths(&self, paths: Vec<String>) -> PyResult<Vec<Option<usize>>> {
+        let outputs = self.materialized("modules_for_paths")?;
+        Ok(paths
+            .iter()
+            .map(|p| module_for_idx_in(&outputs, p))
+            .collect())
     }
 
     /// Resolve a dotted FQN to either a declaration or a module node.
@@ -1863,39 +1877,23 @@ impl ProjectContext {
         module_fqn: &str,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
         let outputs = self.materialized("module_surface")?;
-        let Some(&module_idx) = outputs.module_by_fqname.get(module_fqn) else {
-            return Ok(Vec::new());
-        };
-        let mut out = vec![outputs.builder.nodes[module_idx].clone_ref(py)];
-        // BFS over the fqname tree. Recurse only into module children:
-        // a decl ``pkg.foo.MyClass`` doesn't have submodule descendants,
-        // so chasing its sub-fqnames would just be wasted lookups.
-        // Queue holds owned ``String``s because ``children_by_parent``
-        // keys are owned strings and ``SymbolNode.fqname`` lives behind
-        // a ``PyRef`` guard that can't be held across iterations.
-        let mut queue: std::collections::VecDeque<String> =
-            std::collections::VecDeque::from([module_fqn.to_string()]);
-        while let Some(parent) = queue.pop_front() {
-            let Some(children) = outputs.children_by_parent.get(parent.as_str()) else {
-                continue;
-            };
-            for &child_idx in children {
-                let child_py = &outputs.builder.nodes[child_idx];
-                let child = child_py.borrow(py);
-                let is_module = child.kind == "module";
-                let child_fqname = if is_module {
-                    Some(child.fqname.clone())
-                } else {
-                    None
-                };
-                drop(child);
-                out.push(child_py.clone_ref(py));
-                if let Some(fqn) = child_fqname {
-                    queue.push_back(fqn);
-                }
-            }
-        }
-        Ok(out)
+        let indices = module_surface_indices_in(&outputs, py, module_fqn);
+        Ok(indices
+            .into_iter()
+            .map(|i| outputs.builder.nodes[i].clone_ref(py))
+            .collect())
+    }
+
+    /// Idx-only variant of :meth:`module_surface`. Same BFS over the
+    /// fqname tree; returns positional indices into ``ctx.nodes()``
+    /// instead of allocating ``Py<SymbolNode>`` clones.
+    pub(crate) fn module_surface_indices(
+        &self,
+        py: Python<'_>,
+        module_fqn: &str,
+    ) -> PyResult<Vec<usize>> {
+        let outputs = self.materialized("module_surface_indices")?;
+        Ok(module_surface_indices_in(&outputs, py, module_fqn))
     }
 
     /// Batched form of :meth:`module_surface`. Resolves every fqname
@@ -1904,60 +1902,32 @@ impl ProjectContext {
     /// per-call materialize-lookup + N scans collapse to one of each.
     /// Returns a dict keyed by input fqname; missing modules map to
     /// empty lists. Duplicate inputs share the same result list.
+    /// Idx-only variant of :meth:`module_surfaces`. Same single-sweep
+    /// scan; the per-fqname buckets carry positional indices into
+    /// ``ctx.nodes()`` instead of allocated ``Py<SymbolNode>`` clones.
+    pub(crate) fn module_surfaces_indices(
+        &self,
+        module_fqns: Vec<String>,
+    ) -> PyResult<FxHashMap<String, Vec<usize>>> {
+        let outputs = self.materialized("module_surfaces_indices")?;
+        Ok(module_surfaces_indices_in(&outputs, &module_fqns))
+    }
+
     pub(crate) fn module_surfaces(
         &self,
         py: Python<'_>,
         module_fqns: Vec<String>,
     ) -> PyResult<FxHashMap<String, Vec<Py<SymbolNode>>>> {
         let outputs = self.materialized("module_surfaces")?;
-        // Deduplicate the requested fqnames + pre-stage each one's
-        // (prefix, output vec) so a single map iteration can drop
-        // matches into the right bucket. Skip fqnames that don't name
-        // a project module — same per-call short-circuit as the
-        // singular ``module_surface``.
+        let idx_buckets = module_surfaces_indices_in(&outputs, &module_fqns);
         let mut buckets: FxHashMap<String, Vec<Py<SymbolNode>>> =
-            FxHashMap::with_capacity_and_hasher(module_fqns.len(), Default::default());
-        let mut prefixes: Vec<(String, String)> = Vec::with_capacity(module_fqns.len());
-        for fqn in &module_fqns {
-            if buckets.contains_key(fqn) {
-                continue;
-            }
-            let Some(&module_idx) = outputs.module_by_fqname.get(fqn) else {
-                buckets.insert(fqn.clone(), Vec::new());
-                continue;
-            };
-            buckets.insert(
-                fqn.clone(),
-                vec![outputs.builder.nodes[module_idx].clone_ref(py)],
-            );
-            prefixes.push((fqn.clone(), format!("{fqn}.")));
-        }
-        if prefixes.is_empty() {
-            return Ok(buckets);
-        }
-        // Single sweep over each map; per-fqname row goes into every
-        // bucket whose prefix matches. K small (≤ inputs), so the
-        // nested-loop ``starts_with`` is fine — a prefix trie would
-        // only help for K in the hundreds.
-        for (fqname, &idx) in &outputs.module_by_fqname {
-            for (key, prefix) in &prefixes {
-                if fqname.starts_with(prefix) {
-                    buckets
-                        .get_mut(key)
-                        .expect("seeded above")
-                        .push(outputs.builder.nodes[idx].clone_ref(py));
-                }
-            }
-        }
-        for (fqname, idxs) in &outputs.decl_by_fqname {
-            for (key, prefix) in &prefixes {
-                if fqname.starts_with(prefix) {
-                    let bucket = buckets.get_mut(key).expect("seeded above");
-                    for &idx in idxs {
-                        bucket.push(outputs.builder.nodes[idx].clone_ref(py));
-                    }
-                }
-            }
+            FxHashMap::with_capacity_and_hasher(idx_buckets.len(), Default::default());
+        for (key, idxs) in idx_buckets {
+            let nodes = idxs
+                .into_iter()
+                .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
+                .collect();
+            buckets.insert(key, nodes);
         }
         Ok(buckets)
     }
@@ -2296,7 +2266,28 @@ impl ProjectContext {
     /// range — same shape ``MainBlockPlugin``'s libcst path computes
     /// from the visitor's payload.
     pub(crate) fn find_main_blocks(&self, py: Python<'_>) -> PyResult<Vec<MainBlock>> {
+        let indexed = self.find_main_blocks_indices()?;
         let outputs = self.materialized("find_main_blocks")?;
+        Ok(indexed
+            .into_iter()
+            .map(|(module_idx, decl_idxs)| {
+                let module = outputs.builder.nodes[module_idx].clone_ref(py);
+                let decls = decl_idxs
+                    .into_iter()
+                    .map(|i| outputs.builder.nodes[i].clone_ref(py))
+                    .collect();
+                (module, decls)
+            })
+            .collect())
+    }
+
+    /// Idx-only variant of :meth:`find_main_blocks`. Returns
+    /// ``(module_idx, [decl_idx])`` pairs into ``ctx.nodes()`` rather
+    /// than allocating ``Py<SymbolNode>`` clones. Same single-pass
+    /// ``__main__`` substring filter + ``find_main_block_range`` +
+    /// global-index bucketing as the node form.
+    pub(crate) fn find_main_blocks_indices(&self) -> PyResult<Vec<(usize, Vec<usize>)>> {
+        let outputs = self.materialized("find_main_blocks_indices")?;
 
         // First pass: identify files that actually contain a top-level
         // ``if __name__ == "__main__":`` block. The cheap ``__main__``
@@ -2341,17 +2332,17 @@ impl ProjectContext {
             }
         }
 
-        let mut out: Vec<MainBlock> = Vec::with_capacity(hits.len());
+        let mut out: Vec<(usize, Vec<usize>)> = Vec::with_capacity(hits.len());
         for (file, module_idx, (block_start, block_end)) in hits {
-            let mut decls: Vec<Py<SymbolNode>> = Vec::new();
+            let mut decl_idxs: Vec<usize> = Vec::new();
             if let Some(file_decls) = decls_by_file.get(&file) {
                 for &(start, end, idx) in file_decls {
                     if start >= block_start && end <= block_end {
-                        decls.push(outputs.builder.nodes[idx].clone_ref(py));
+                        decl_idxs.push(idx);
                     }
                 }
             }
-            out.push((outputs.builder.nodes[module_idx].clone_ref(py), decls));
+            out.push((module_idx, decl_idxs));
         }
         Ok(out)
     }
@@ -2378,7 +2369,7 @@ impl ProjectContext {
         decorator_modules: &[String],
         decorator_names: Vec<String>,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, CallArgs)>> {
+    ) -> PyResult<Vec<(usize, CallArgs)>> {
         let outputs = self.materialized("find_decorated_decls")?;
         let path_re = _compile_path_regex(path_regex)?;
         let names: FxHashSet<&str> = decorator_names.iter().map(String::as_str).collect();
@@ -2436,10 +2427,8 @@ impl ProjectContext {
                 local
             })
         });
-        Ok(pairs
-            .into_iter()
-            .map(|(idx, call_args)| (outputs.builder.nodes[idx].clone_ref(py), call_args))
-            .collect())
+        drop(outputs);
+        Ok(pairs)
     }
 
     /// Find top-level ``<var> = <Ctor>(...)`` constructions where
@@ -2463,7 +2452,7 @@ impl ProjectContext {
         modules: &[String],
         ctor_names: Vec<String>,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, String, CallArgs)>> {
+    ) -> PyResult<Vec<(usize, String, CallArgs)>> {
         let outputs = self.materialized("find_instance_constructions")?;
         let path_re = _compile_path_regex(path_regex)?;
         let allowed: FxHashSet<&str> = ctor_names.iter().map(String::as_str).collect();
@@ -2515,13 +2504,8 @@ impl ProjectContext {
                 local
             })
         });
-        let out: Vec<(Py<SymbolNode>, String, CallArgs)> = pairs
-            .into_iter()
-            .map(|(idx, name, call_args)| {
-                (outputs.builder.nodes[idx].clone_ref(py), name, call_args)
-            })
-            .collect();
-        Ok(out)
+        drop(outputs);
+        Ok(pairs)
     }
 
     /// Find top-level functions decorated with ``@<owner>.<attr>(...)``
@@ -2538,7 +2522,7 @@ impl ProjectContext {
         py: Python<'_>,
         decorator_attrs: Vec<String>,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(String, Py<SymbolNode>, CallArgs)>> {
+    ) -> PyResult<Vec<(String, usize, CallArgs)>> {
         let outputs = self.materialized("find_handler_decorators")?;
         let path_re = _compile_path_regex(path_regex)?;
         let attrs: FxHashSet<&str> = decorator_attrs.iter().map(String::as_str).collect();
@@ -2599,12 +2583,8 @@ impl ProjectContext {
                 local
             })
         });
-        Ok(triples
-            .into_iter()
-            .map(|(name, idx, call_args)| {
-                (name, outputs.builder.nodes[idx].clone_ref(py), call_args)
-            })
-            .collect())
+        drop(outputs);
+        Ok(triples)
     }
 
     /// Like ``find_handler_decorators`` but matches the two-level form
@@ -2619,7 +2599,7 @@ impl ProjectContext {
         via_attr: &str,
         decorator_attrs: Vec<String>,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(String, Py<SymbolNode>, CallArgs)>> {
+    ) -> PyResult<Vec<(String, usize, CallArgs)>> {
         let outputs = self.materialized("find_handler_decorators_via")?;
         let path_re = _compile_path_regex(path_regex)?;
         let attrs: FxHashSet<&str> = decorator_attrs.iter().map(String::as_str).collect();
@@ -2683,12 +2663,8 @@ impl ProjectContext {
                 local
             })
         });
-        Ok(triples
-            .into_iter()
-            .map(|(name, idx, call_args)| {
-                (name, outputs.builder.nodes[idx].clone_ref(py), call_args)
-            })
-            .collect())
+        drop(outputs);
+        Ok(triples)
     }
 
     /// Find calls of the form ``<expr>.<attr>(...)`` regardless of
@@ -2709,7 +2685,7 @@ impl ProjectContext {
         attr: &str,
         arg_index: usize,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, String, CallArgs)>> {
+    ) -> PyResult<Vec<(usize, String, CallArgs)>> {
         let outputs = self.materialized("find_calls_on_attr")?;
         let path_re = _compile_path_regex(path_regex)?;
         let decl_by_name_range = &outputs.decl_by_name_range;
@@ -2751,10 +2727,8 @@ impl ProjectContext {
                 local
             })
         });
-        Ok(triples
-            .into_iter()
-            .map(|(idx, arg, call_args)| (outputs.builder.nodes[idx].clone_ref(py), arg, call_args))
-            .collect())
+        drop(outputs);
+        Ok(triples)
     }
 }
 
@@ -2774,7 +2748,7 @@ impl ProjectContext {
         py: Python<'_>,
         modules: &[String],
         ctor_names: Vec<String>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, Vec<String>)>> {
+    ) -> PyResult<Vec<(usize, Vec<String>)>> {
         let outputs = self.materialized("find_factory_decls")?;
         let allowed: FxHashSet<&str> = ctor_names.iter().map(String::as_str).collect();
         let needle_strs: Vec<&str> = ctor_names.iter().map(String::as_str).collect();
@@ -2830,10 +2804,8 @@ impl ProjectContext {
                 local
             })
         });
-        Ok(pairs
-            .into_iter()
-            .map(|(idx, kinds)| (outputs.builder.nodes[idx].clone_ref(py), kinds))
-            .collect())
+        drop(outputs);
+        Ok(pairs)
     }
 }
 
@@ -2853,7 +2825,7 @@ impl ProjectContext {
         name: &str,
         arg_index: usize,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, String, CallArgs)>> {
+    ) -> PyResult<Vec<(usize, String, CallArgs)>> {
         let outputs = self.materialized("find_calls_to_imported")?;
         let path_re = _compile_path_regex(path_regex)?;
         let allowed: FxHashSet<&str> = [name].into_iter().collect();
@@ -2911,10 +2883,8 @@ impl ProjectContext {
                 local
             })
         });
-        Ok(triples
-            .into_iter()
-            .map(|(idx, arg, call_args)| (outputs.builder.nodes[idx].clone_ref(py), arg, call_args))
-            .collect())
+        drop(outputs);
+        Ok(triples)
     }
 
     /// Find ``<owner>.<attr>(...)`` calls where ``owner`` is the textual
@@ -2937,7 +2907,7 @@ impl ProjectContext {
         arg_index: usize,
         required_positional: Option<usize>,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, String, CallArgs)>> {
+    ) -> PyResult<Vec<(usize, String, CallArgs)>> {
         let outputs = self.materialized("find_calls_on_var")?;
         let path_re = _compile_path_regex(path_regex)?;
         let decl_by_name_range = &outputs.decl_by_name_range;
@@ -2984,10 +2954,8 @@ impl ProjectContext {
                 local
             })
         });
-        Ok(triples
-            .into_iter()
-            .map(|(idx, arg, call_args)| (outputs.builder.nodes[idx].clone_ref(py), arg, call_args))
-            .collect())
+        drop(outputs);
+        Ok(triples)
     }
 }
 
@@ -3120,6 +3088,117 @@ impl ProjectContext {
     }
 }
 
+/// Shared BFS used by :meth:`ProjectContext::module_surface` and
+/// :meth:`module_surface_indices` — the module index, then every
+/// transitive child node (modules recursed into; non-module decls
+/// surfaced but not chased for sub-fqnames).
+fn module_surface_indices_in(
+    outputs: &BuildOutputs,
+    py: Python<'_>,
+    module_fqn: &str,
+) -> Vec<usize> {
+    let Some(&module_idx) = outputs.module_by_fqname.get(module_fqn) else {
+        return Vec::new();
+    };
+    let mut out: Vec<usize> = vec![module_idx];
+    let mut queue: std::collections::VecDeque<String> =
+        std::collections::VecDeque::from([module_fqn.to_string()]);
+    while let Some(parent) = queue.pop_front() {
+        let Some(children) = outputs.children_by_parent.get(parent.as_str()) else {
+            continue;
+        };
+        for &child_idx in children {
+            let child_py = &outputs.builder.nodes[child_idx];
+            let child = child_py.borrow(py);
+            let is_module = child.kind == "module";
+            let child_fqname = if is_module {
+                Some(child.fqname.clone())
+            } else {
+                None
+            };
+            drop(child);
+            out.push(child_idx);
+            if let Some(fqn) = child_fqname {
+                queue.push_back(fqn);
+            }
+        }
+    }
+    out
+}
+
+/// Shared bulk-resolution loop used by
+/// :meth:`ProjectContext::module_surfaces` and
+/// :meth:`module_surfaces_indices`: dedupe the input fqnames, seed
+/// each requested bucket with its module idx (if any), then sweep
+/// ``module_by_fqname`` + ``decl_by_fqname`` once and drop matches
+/// into every bucket whose prefix lights up.
+fn module_surfaces_indices_in(
+    outputs: &BuildOutputs,
+    module_fqns: &[String],
+) -> FxHashMap<String, Vec<usize>> {
+    let mut buckets: FxHashMap<String, Vec<usize>> =
+        FxHashMap::with_capacity_and_hasher(module_fqns.len(), Default::default());
+    let mut prefixes: Vec<(String, String)> = Vec::with_capacity(module_fqns.len());
+    for fqn in module_fqns {
+        if buckets.contains_key(fqn) {
+            continue;
+        }
+        let Some(&module_idx) = outputs.module_by_fqname.get(fqn) else {
+            buckets.insert(fqn.clone(), Vec::new());
+            continue;
+        };
+        buckets.insert(fqn.clone(), vec![module_idx]);
+        prefixes.push((fqn.clone(), format!("{fqn}.")));
+    }
+    if prefixes.is_empty() {
+        return buckets;
+    }
+    // Single sweep — K small (≤ inputs), so the nested ``starts_with``
+    // is fine. Mirrors the original ``module_surfaces`` body, just
+    // staying in idx-space.
+    for (fqname, &idx) in &outputs.module_by_fqname {
+        for (key, prefix) in &prefixes {
+            if fqname.starts_with(prefix) {
+                buckets.get_mut(key).expect("seeded above").push(idx);
+            }
+        }
+    }
+    for (fqname, idxs) in &outputs.decl_by_fqname {
+        for (key, prefix) in &prefixes {
+            if fqname.starts_with(prefix) {
+                let bucket = buckets.get_mut(key).expect("seeded above");
+                bucket.extend(idxs.iter().copied());
+            }
+        }
+    }
+    buckets
+}
+
+/// `path -> module-node idx`, shared by :meth:`ProjectContext::module_for`,
+/// :meth:`module_for_indices`, and :meth:`modules_for_paths`. Returns
+/// ``None`` when the path doesn't name a project module.
+fn module_for_idx_in(outputs: &BuildOutputs, path: &str) -> Option<usize> {
+    let &file = outputs.path_to_file.get(path)?;
+    outputs.module_nodes_by_file.get(&file).copied()
+}
+
+/// Walk-back lookup shared by :meth:`ProjectContext::find_declarations`
+/// and :meth:`ProjectContext::find_declarations_indices` — try an exact
+/// match first, then strip trailing dotted segments until either a
+/// decl bucket lands or no parent remains.
+fn find_declarations_indices_in(outputs: &BuildOutputs, fqname: &str) -> Vec<usize> {
+    let mut prefix = fqname;
+    loop {
+        if let Some(idxs) = outputs.decl_by_fqname.get(prefix) {
+            return idxs.clone();
+        }
+        match prefix.rsplit_once('.') {
+            Some((parent, _)) => prefix = parent,
+            None => return Vec::new(),
+        }
+    }
+}
+
 /// BFS from `seed_idx` through `children_by_node`. Returns the
 /// transitive closure (excluding the seed itself).
 fn transitive_subclasses_via_index(
@@ -3152,7 +3231,7 @@ impl ProjectContext {
         py: Python<'_>,
         decorator_fqn: &str,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, CallArgs)>> {
+    ) -> PyResult<Vec<(usize, CallArgs)>> {
         let Some((module, name)) = decorator_fqn.rsplit_once('.') else {
             return Err(PyValueError::new_err(format!(
                 "expected a dotted decorator fqn (e.g. 'pytest.fixture'), got {decorator_fqn:?}"
@@ -3169,7 +3248,7 @@ impl ProjectContext {
         class_fqn: &str,
         include_subclasses: bool,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, CallArgs)>> {
+    ) -> PyResult<Vec<(usize, CallArgs)>> {
         let Some((module, name)) = class_fqn.rsplit_once('.') else {
             return Err(PyValueError::new_err(format!(
                 "expected a dotted class fqn, got {class_fqn:?}"
@@ -3194,7 +3273,7 @@ impl ProjectContext {
         let triples = self.find_instance_constructions(py, &modules, ctors, path_regex)?;
         Ok(triples
             .into_iter()
-            .map(|(node, _name, call_args)| (node, call_args))
+            .map(|(idx, _name, call_args)| (idx, call_args))
             .collect())
     }
 
@@ -3205,18 +3284,19 @@ impl ProjectContext {
         instance: &SymbolNode,
         method_names: Vec<String>,
         path_regex: Option<&str>,
-    ) -> PyResult<Vec<(Py<SymbolNode>, CallArgs)>> {
+    ) -> PyResult<Vec<(usize, CallArgs)>> {
         let instance_simple = instance.fqname.rsplit('.').next().unwrap_or("").to_string();
         let handlers = self.find_handler_decorators(py, method_names, path_regex)?;
-        let mut out = Vec::new();
-        for (owner_name, handler, call_args) in handlers {
+        let outputs = self.materialized("find_decorations_on")?;
+        let mut out: Vec<(usize, CallArgs)> = Vec::new();
+        for (owner_name, handler_idx, call_args) in handlers {
             if owner_name != instance_simple {
                 continue;
             }
-            if handler.borrow(py).path != instance.path {
+            if outputs.builder.nodes[handler_idx].borrow(py).path != instance.path {
                 continue;
             }
-            out.push((handler, call_args));
+            out.push((handler_idx, call_args));
         }
         Ok(out)
     }
@@ -3744,6 +3824,38 @@ impl ProjectContext {
                 )));
             }
             out.push(outputs.builder.nodes[idx].clone_ref(py));
+        }
+        Ok(out)
+    }
+
+    /// Batched snapshot of ``(kind, path, fqname, flags)`` for each
+    /// index in ``indices``. One FFI hop instead of N per-attribute
+    /// ``borrow`` round-trips — lets plugins that filter / partition by
+    /// these four fields stay GIL-free in the inner loop.
+    ///
+    /// Validates bounds the same way :meth:`nodes_at` does and raises
+    /// :class:`IndexError` when any index is out of range.
+    pub(crate) fn node_attrs(
+        &self,
+        py: Python<'_>,
+        indices: Vec<usize>,
+    ) -> PyResult<Vec<(String, String, String, u32)>> {
+        let outputs = self.materialized("node_attrs")?;
+        let len = outputs.builder.nodes.len();
+        let mut out: Vec<(String, String, String, u32)> = Vec::with_capacity(indices.len());
+        for idx in indices {
+            if idx >= len {
+                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                    "node index {idx} out of range (len={len})"
+                )));
+            }
+            let node = outputs.builder.nodes[idx].borrow(py);
+            out.push((
+                node.kind.to_string(),
+                node.path.clone(),
+                node.fqname.clone(),
+                node.flags,
+            ));
         }
         Ok(out)
     }

--- a/src/project.rs
+++ b/src/project.rs
@@ -1715,7 +1715,14 @@ impl ProjectContext {
         }
         Ok(out)
     }
+}
 
+// ``find_imports_of`` / ``_indices`` / ``imports_of_count`` /
+// ``has_imports_of`` back :class:`ImportQuery` and its ``.count()`` /
+// ``.exists()`` shortcuts. NOT exposed to Python — plugin authors use
+// the DSL: ``native.query(ctx).imports().of(module).indices()`` /
+// ``.count()`` / ``.exists()``.
+impl ProjectContext {
     /// Return every import-kind node whose upstream `module` matches.
     ///
     /// Covers both `import <module_name>` and
@@ -1785,7 +1792,10 @@ impl ProjectContext {
             .get(module_name)
             .is_some_and(|v| !v.is_empty()))
     }
+}
 
+#[pymethods]
+impl ProjectContext {
     /// Return every declaration (function / class / variable / import)
     /// whose fully qualified name matches ``fqname``, walking back
     /// through dotted segments to find the enclosing top-level decl
@@ -3134,7 +3144,9 @@ impl ProjectContext {
     }
 }
 
-#[pymethods]
+// ``find_classes_defining_method`` is the rust-side helper backing
+// :class:`ClassQuery`. It's NOT exposed to Python — plugin authors use
+// the DSL: ``native.query(ctx).classes().defining_method(name).collect()``.
 impl ProjectContext {
     /// Every class that defines a method with the given name.
     ///
@@ -3212,7 +3224,10 @@ impl ProjectContext {
     }
 }
 
-#[pymethods]
+// ``find_subclasses_of`` / ``_indices`` / ``_idx`` back
+// :class:`SubclassQuery`. NOT exposed to Python — plugin authors use
+// the DSL: ``native.query(ctx).subclasses().of_idx(idx).indices()``
+// or ``of_fqn(fqn)``.
 impl ProjectContext {
     /// Return every transitive subclass of the given class node.
     ///
@@ -3263,7 +3278,6 @@ impl ProjectContext {
     }
 }
 
-#[pymethods]
 impl ProjectContext {
     /// Idx-keyed variant of :meth:`find_subclasses_of_indices` —
     /// resolves the seed class by positional index into ``ctx.nodes()``
@@ -3568,7 +3582,9 @@ impl ProjectContext {
     }
 }
 
-#[pymethods]
+// ``find_subclasses`` + ``_indices`` back :class:`SubclassQuery`.
+// NOT exposed to Python — plugin authors use the DSL:
+// ``native.query(ctx).subclasses().of_fqn(fqn).collect()``.
 impl ProjectContext {
     /// Subclasses of the class addressed by ``base_fqn``.
     ///
@@ -3578,7 +3594,6 @@ impl ProjectContext {
     /// ``type_hierarchy_subtypes``. ``transitive=True`` (default)
     /// walks the full subclass closure; ``transitive=False`` returns
     /// only direct subclasses.
-    #[pyo3(signature = (base_fqn, *, transitive = true))]
     pub(crate) fn find_subclasses(
         &self,
         py: Python<'_>,
@@ -3714,7 +3729,9 @@ impl ProjectContext {
     }
 }
 
-#[pymethods]
+// ``subclasses_of_fqn`` / ``_indices`` / ``subclasses_of_node`` back
+// the project-only subclass-walk path inside :class:`SubclassQuery`.
+// NOT exposed to Python — plugin authors use the DSL.
 impl ProjectContext {
     /// Project classes that inherit (directly or transitively) from
     /// the class identified by ``fqn``. ``fqn`` may name a project
@@ -3743,7 +3760,6 @@ impl ProjectContext {
     ///
     /// Generics (``class X(Foo[T])``) and other non-identifier
     /// expressions are skipped — matches the libcst pipeline.
-    #[pyo3(signature = (fqn, *, transitive = true))]
     pub(crate) fn subclasses_of_fqn(
         &self,
         py: Python<'_>,
@@ -3761,7 +3777,6 @@ impl ProjectContext {
     /// Idx-only variant of :meth:`subclasses_of_fqn`. Same lookup,
     /// returns positional indices into ``ctx.nodes()`` rather than
     /// allocating ``Py<SymbolNode>`` clones.
-    #[pyo3(signature = (fqn, *, transitive = true))]
     pub(crate) fn subclasses_of_fqn_indices(
         &self,
         fqn: &str,
@@ -3787,7 +3802,6 @@ impl ProjectContext {
     /// the transitive walk. Returns an empty vec when ``class_node``
     /// isn't a class kind. Symmetric to :meth:`subclasses_of_fqn` for
     /// callers that already hold the seed as a `SymbolNode`.
-    #[pyo3(signature = (class_node, *, transitive = true))]
     pub(crate) fn subclasses_of_node(
         &self,
         py: Python<'_>,
@@ -3824,7 +3838,10 @@ impl ProjectContext {
             .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
             .collect())
     }
+}
 
+#[pymethods]
+impl ProjectContext {
     /// Return `(decl_node, comment_text)` for every comment in the
     /// project that matches `pattern` (a regex), paired with the next
     /// declaration that follows it in the same file.

--- a/src/query.rs
+++ b/src/query.rs
@@ -120,10 +120,12 @@ impl CallRef {
 
 /// Index-form sibling of :class:`DecoratorRef`. Same metadata fields,
 /// minus ``args`` / ``kwargs``; ``decorated_idx`` indexes into
-/// ``ctx.nodes()``.
+/// ``ctx.nodes()``. ``path`` is preserved because plugins routinely
+/// bucket by path before any further query.
 #[pyclass(frozen, get_all)]
 pub(crate) struct DecoratorIdxRef {
     pub(crate) decorated_idx: usize,
+    pub(crate) path: String,
     pub(crate) decorator_name: Option<String>,
     pub(crate) decorator_owner: Option<String>,
     pub(crate) decorator_via: Option<String>,
@@ -131,28 +133,34 @@ pub(crate) struct DecoratorIdxRef {
 
 /// Index-form sibling of :class:`ConstructionRef`. Same metadata
 /// fields, minus ``args`` / ``kwargs``; ``var_idx`` indexes into
-/// ``ctx.nodes()``.
+/// ``ctx.nodes()``. ``path`` is preserved as a cheap bucket key for
+/// plugins that fan out per file.
 #[pyclass(frozen, get_all)]
 pub(crate) struct ConstructionIdxRef {
     pub(crate) var_idx: usize,
+    pub(crate) path: String,
     pub(crate) class_name: String,
 }
 
 /// Index-form sibling of :class:`CallRef`. Same metadata fields,
 /// minus ``args`` / ``kwargs``; ``owner_idx`` indexes into
-/// ``ctx.nodes()``.
+/// ``ctx.nodes()``. ``path`` is the owning decl's path.
 #[pyclass(frozen, get_all)]
 pub(crate) struct CallIdxRef {
     pub(crate) owner_idx: usize,
+    pub(crate) path: String,
     pub(crate) string_arg: String,
 }
 
 /// Index-form sibling of :class:`FactoryRef`. ``decl_idx`` indexes
 /// into ``ctx.nodes()``; ``kinds`` is the same sorted set of matched
 /// constructor bare-names the node-returning terminal emits.
+/// ``path`` is preserved as a cheap bucket key for plugins that fan
+/// out per file.
 #[pyclass(frozen, get_all)]
 pub(crate) struct FactoryIdxRef {
     pub(crate) decl_idx: usize,
+    pub(crate) path: String,
     pub(crate) kinds: Vec<String>,
 }
 
@@ -456,6 +464,7 @@ pub(crate) struct DecoratorQuery {
     pub(crate) owner_attrs: Option<Vec<String>>,
     pub(crate) via_attr: Option<String>,
     pub(crate) in_decl: Option<Py<SymbolNode>>,
+    pub(crate) in_decl_idx: Option<usize>,
     pub(crate) path_regex: Option<String>,
     pub(crate) kwarg_matchers: Vec<(String, KwargMatcher)>,
 }
@@ -470,6 +479,7 @@ impl DecoratorQuery {
             owner_attrs: None,
             via_attr: None,
             in_decl: None,
+            in_decl_idx: None,
             path_regex: None,
             kwarg_matchers: Vec::new(),
         }
@@ -518,6 +528,10 @@ impl DecoratorQuery {
     }
     fn in_decl<'py>(mut slf: PyRefMut<'py, Self>, node: Py<SymbolNode>) -> PyRefMut<'py, Self> {
         slf.in_decl = Some(node);
+        slf
+    }
+    fn in_decl_idx<'py>(mut slf: PyRefMut<'py, Self>, idx: usize) -> PyRefMut<'py, Self> {
+        slf.in_decl_idx = Some(idx);
         slf
     }
     fn where_path<'py>(mut slf: PyRefMut<'py, Self>, regex: String) -> PyRefMut<'py, Self> {
@@ -634,6 +648,38 @@ impl DecoratorQuery {
                     call_args,
                 });
             }
+        } else if let Some(in_decl_idx) = self.in_decl_idx {
+            let names = self.names.as_ref().ok_or_else(|| {
+                PyValueError::new_err("DecoratorQuery.in_decl_idx(...) requires .where_name(...)")
+            })?;
+            let outputs = ctx.materialized("DecoratorQuery.in_decl_idx")?;
+            let len = outputs.builder.nodes.len();
+            if in_decl_idx >= len {
+                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                    "DecoratorQuery.in_decl_idx: idx {in_decl_idx} out of range (len={len})"
+                )));
+            }
+            let in_decl_ref = outputs.builder.nodes[in_decl_idx].borrow(py);
+            let decls = ctx.find_decorations_on(py, &in_decl_ref, names.clone(), path_regex)?;
+            let owner_simple = in_decl_ref
+                .fqname
+                .rsplit('.')
+                .next()
+                .unwrap_or("")
+                .to_string();
+            drop(in_decl_ref);
+            for (decorated_idx, call_args) in decls {
+                if !call_args_match_kwargs(&call_args, kwarg_matchers) {
+                    continue;
+                }
+                out.push(DecoratorRowIdx {
+                    decorated_idx,
+                    decorator_name: None,
+                    decorator_owner: Some(owner_simple.clone()),
+                    decorator_via: None,
+                    call_args,
+                });
+            }
         } else if let Some(fqn) = &self.callee_fqn {
             let decls = ctx.find_decorated(py, fqn, path_regex)?;
             for (decorated_idx, call_args) in decls {
@@ -666,7 +712,8 @@ impl DecoratorQuery {
             return Err(PyValueError::new_err(
                 "DecoratorQuery requires one of: where_callee(...); \
                  where_module(...) + where_name(...); where_owner_attr(...); \
-                 where_owner_attr_via(via, attrs); or in_decl(node) + where_name(...)",
+                 where_owner_attr_via(via, attrs); in_decl(node) + where_name(...); \
+                 or in_decl_idx(idx) + where_name(...)",
             ));
         }
         Ok(out)
@@ -685,19 +732,24 @@ impl DecoratorQuery {
     /// :class:`AddNodeByIdx` to stay GIL-light end-to-end.
     fn row_indices(&self, py: Python<'_>) -> PyResult<Vec<Py<DecoratorIdxRef>>> {
         let rows = self.decorator_rows(py)?;
-        rows.into_iter()
-            .map(|row| {
-                Py::new(
-                    py,
-                    DecoratorIdxRef {
-                        decorated_idx: row.decorated_idx,
-                        decorator_name: row.decorator_name,
-                        decorator_owner: row.decorator_owner,
-                        decorator_via: row.decorator_via,
-                    },
-                )
-            })
-            .collect()
+        let ctx = self.ctx.borrow(py);
+        let outputs = ctx.materialized("DecoratorQuery.row_indices")?;
+        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let mut out: Vec<Py<DecoratorIdxRef>> = Vec::with_capacity(rows.len());
+        for row in rows {
+            let path = nodes[row.decorated_idx].borrow(py).path.clone();
+            out.push(Py::new(
+                py,
+                DecoratorIdxRef {
+                    decorated_idx: row.decorated_idx,
+                    path,
+                    decorator_name: row.decorator_name,
+                    decorator_owner: row.decorator_owner,
+                    decorator_via: row.decorator_via,
+                },
+            )?);
+        }
+        Ok(out)
     }
 }
 
@@ -841,17 +893,22 @@ impl ConstructionQuery {
     /// ``args`` / ``kwargs`` row payloads are skipped.
     fn row_indices(&self, py: Python<'_>) -> PyResult<Vec<Py<ConstructionIdxRef>>> {
         let rows = self.construction_rows(py)?;
-        rows.into_iter()
-            .map(|row| {
-                Py::new(
-                    py,
-                    ConstructionIdxRef {
-                        var_idx: row.var_idx,
-                        class_name: row.class_name,
-                    },
-                )
-            })
-            .collect()
+        let ctx = self.ctx.borrow(py);
+        let outputs = ctx.materialized("ConstructionQuery.row_indices")?;
+        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let mut out: Vec<Py<ConstructionIdxRef>> = Vec::with_capacity(rows.len());
+        for row in rows {
+            let path = nodes[row.var_idx].borrow(py).path.clone();
+            out.push(Py::new(
+                py,
+                ConstructionIdxRef {
+                    var_idx: row.var_idx,
+                    path,
+                    class_name: row.class_name,
+                },
+            )?);
+        }
+        Ok(out)
     }
 }
 
@@ -1034,17 +1091,22 @@ impl CallQuery {
     /// because most call-shape plugins key on it.
     fn row_indices(&self, py: Python<'_>) -> PyResult<Vec<Py<CallIdxRef>>> {
         let rows = self.call_rows(py)?;
-        rows.into_iter()
-            .map(|row| {
-                Py::new(
-                    py,
-                    CallIdxRef {
-                        owner_idx: row.owner_idx,
-                        string_arg: row.string_arg,
-                    },
-                )
-            })
-            .collect()
+        let ctx = self.ctx.borrow(py);
+        let outputs = ctx.materialized("CallQuery.row_indices")?;
+        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let mut out: Vec<Py<CallIdxRef>> = Vec::with_capacity(rows.len());
+        for row in rows {
+            let path = nodes[row.owner_idx].borrow(py).path.clone();
+            out.push(Py::new(
+                py,
+                CallIdxRef {
+                    owner_idx: row.owner_idx,
+                    path,
+                    string_arg: row.string_arg,
+                },
+            )?);
+        }
+        Ok(out)
     }
 }
 
@@ -1056,14 +1118,17 @@ impl CallQuery {
 /// * ``of_fqn(fqn)`` — base by dotted name (external classes ok —
 ///   ``unittest.TestCase`` etc.).
 /// * ``of_node(class_node)`` — base by project-local class node.
+/// * ``of_idx(class_idx)`` — base by positional index into
+///   ``ctx.nodes()`` (idx-form sibling of ``of_node``).
 /// ``transitive(bool)`` controls whether the BFS walks past the
-/// direct subclass frontier (default ``True``; for ``of_node`` the
-/// BFS is always transitive).
+/// direct subclass frontier (default ``True``; for ``of_node`` /
+/// ``of_idx`` the BFS is always transitive).
 #[pyclass(unsendable)]
 pub(crate) struct SubclassQuery {
     pub(crate) ctx: Py<ProjectContext>,
     pub(crate) base_fqn: Option<String>,
     pub(crate) base_node: Option<Py<SymbolNode>>,
+    pub(crate) base_idx: Option<usize>,
     pub(crate) transitive: bool,
 }
 
@@ -1073,6 +1138,7 @@ impl SubclassQuery {
             ctx,
             base_fqn: None,
             base_node: None,
+            base_idx: None,
             transitive: true,
         }
     }
@@ -1088,22 +1154,23 @@ impl SubclassQuery {
         slf.base_node = Some(node);
         slf
     }
+    fn of_idx<'py>(mut slf: PyRefMut<'py, Self>, idx: usize) -> PyRefMut<'py, Self> {
+        slf.base_idx = Some(idx);
+        slf
+    }
     fn transitive<'py>(mut slf: PyRefMut<'py, Self>, value: bool) -> PyRefMut<'py, Self> {
         slf.transitive = value;
         slf
     }
 
     fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<SymbolNode>>> {
+        let indices = self.indices(py)?;
         let ctx = self.ctx.borrow(py);
-        if let Some(fqn) = &self.base_fqn {
-            ctx.find_subclasses(py, fqn, self.transitive)
-        } else if let Some(node) = &self.base_node {
-            ctx.find_subclasses_of(py, &node.borrow(py))
-        } else {
-            Err(PyValueError::new_err(
-                "SubclassQuery requires .of_fqn(...) or .of_node(...)",
-            ))
-        }
+        let outputs = ctx.materialized("SubclassQuery.collect")?;
+        Ok(indices
+            .into_iter()
+            .map(|i| outputs.builder.nodes[i].clone_ref(py))
+            .collect())
     }
 
     /// Index-returning terminal. Same lookup as :meth:`collect`, but
@@ -1115,9 +1182,11 @@ impl SubclassQuery {
             ctx.find_subclasses_indices(py, fqn, self.transitive)
         } else if let Some(node) = &self.base_node {
             ctx.find_subclasses_of_indices(&node.borrow(py))
+        } else if let Some(idx) = self.base_idx {
+            ctx.find_subclasses_of_idx(py, idx)
         } else {
             Err(PyValueError::new_err(
-                "SubclassQuery requires .of_fqn(...) or .of_node(...)",
+                "SubclassQuery requires .of_fqn(...), .of_node(...), or .of_idx(...)",
             ))
         }
     }
@@ -1335,10 +1404,22 @@ impl FactoryQuery {
     /// node-returning terminal emits.
     fn row_indices(&self, py: Python<'_>) -> PyResult<Vec<Py<FactoryIdxRef>>> {
         let pairs = self.factory_rows(py)?;
-        pairs
-            .into_iter()
-            .map(|(decl_idx, kinds)| Py::new(py, FactoryIdxRef { decl_idx, kinds }))
-            .collect()
+        let ctx = self.ctx.borrow(py);
+        let outputs = ctx.materialized("FactoryQuery.row_indices")?;
+        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let mut out: Vec<Py<FactoryIdxRef>> = Vec::with_capacity(pairs.len());
+        for (decl_idx, kinds) in pairs {
+            let path = nodes[decl_idx].borrow(py).path.clone();
+            out.push(Py::new(
+                py,
+                FactoryIdxRef {
+                    decl_idx,
+                    path,
+                    kinds,
+                },
+            )?);
+        }
+        Ok(out)
     }
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -7,7 +7,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::PyClass;
 use ruff_db::files::File;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use ty_project::Db as ProjectDb;
 
 use crate::graph::SymbolNode;
@@ -435,6 +435,23 @@ where
     result.into_inner().unwrap_or_default()
 }
 
+/// Bucket a list of node indices by their owning path. Shared by
+/// every Tier-1 query's ``.indices_by_path()`` terminal. One
+/// :meth:`ProjectContext.node_paths` lookup fans the indices into
+/// per-path bins.
+pub(crate) fn _bucket_indices_by_path(
+    ctx: &ProjectContext,
+    py: Python<'_>,
+    indices: Vec<usize>,
+) -> PyResult<FxHashMap<String, Vec<usize>>> {
+    let paths = ctx.node_paths(py, indices.clone())?;
+    let mut buckets: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+    for (idx, path) in indices.into_iter().zip(paths.into_iter()) {
+        buckets.entry(path).or_default().push(idx);
+    }
+    Ok(buckets)
+}
+
 pub(crate) fn _to_iter(py: Python<'_>, items: Vec<Py<impl PyClass>>) -> PyResult<PyObject> {
     let list = pyo3::types::PyList::new_bound(py, items);
     let iter_obj = list.call_method0("__iter__")?;
@@ -535,7 +552,7 @@ impl DecoratorQuery {
             in_decl_idx: None,
             path_regex: None,
             kwarg_matchers: Vec::new(),
-            with_args: true,
+            with_args: false,
         }
     }
 }
@@ -593,14 +610,14 @@ impl DecoratorQuery {
         slf
     }
 
-    /// Opt out of rust-side ``args`` / ``kwargs`` extraction.
-    /// ``with_args(False)`` skips the per-row
-    /// :fn:`extract_call_args_kwargs` walk; row ``args`` / ``kwargs``
-    /// getters then surface empty containers. Useful for plugins that
-    /// only need the row's idx + metadata strings — saves rust-side
-    /// allocation per matched row. Forced back to ``True`` at row-
-    /// collection time when any ``where_kwarg`` is set (kwarg filtering
-    /// needs the data).
+    /// Opt in to rust-side ``args`` / ``kwargs`` extraction.
+    /// Defaults to ``False`` — the per-row
+    /// :fn:`extract_call_args_kwargs` walk is skipped, and row
+    /// ``args`` / ``kwargs`` getters surface empty containers.
+    /// Pass ``True`` when a plugin actually reads ``args`` /
+    /// ``kwargs`` off the matched rows. Forced back to ``True`` at
+    /// row-collection time when any ``where_kwarg`` is set (kwarg
+    /// filtering needs the data).
     fn with_args<'py>(mut slf: PyRefMut<'py, Self>, value: bool) -> PyRefMut<'py, Self> {
         slf.with_args = value;
         slf
@@ -653,6 +670,23 @@ impl DecoratorQuery {
             )?);
         }
         Ok(out)
+    }
+
+    /// Terminal — group matched ``decorated_idx`` values by their
+    /// owning file path. Reads ``path`` straight off each row (no
+    /// extra :meth:`ProjectContext.node_paths` lookup). Useful for
+    /// plugins that fan out per-file work without re-querying.
+    fn indices_by_path(&self, py: Python<'_>) -> PyResult<FxHashMap<String, Vec<usize>>> {
+        let rows = self.decorator_rows(py)?;
+        let ctx = self.ctx.borrow(py);
+        let outputs = ctx.materialized("DecoratorQuery.indices_by_path")?;
+        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let mut buckets: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+        for row in rows {
+            let path = nodes[row.decorated_idx].borrow(py).path.clone();
+            buckets.entry(path).or_default().push(row.decorated_idx);
+        }
+        Ok(buckets)
     }
 }
 
@@ -837,7 +871,7 @@ impl ConstructionQuery {
             class_fqn: None,
             include_subclasses: false,
             path_regex: None,
-            with_args: true,
+            with_args: false,
         }
     }
 }
@@ -875,8 +909,9 @@ impl ConstructionQuery {
         slf
     }
 
-    /// Opt out of rust-side ``args`` / ``kwargs`` extraction; see
-    /// :meth:`DecoratorQuery.with_args` for the trade-off.
+    /// Opt in to rust-side ``args`` / ``kwargs`` extraction; see
+    /// :meth:`DecoratorQuery.with_args` for the contract. Defaults
+    /// to ``False``.
     fn with_args<'py>(mut slf: PyRefMut<'py, Self>, value: bool) -> PyRefMut<'py, Self> {
         slf.with_args = value;
         slf
@@ -907,6 +942,22 @@ impl ConstructionQuery {
             )?);
         }
         Ok(out)
+    }
+
+    /// Terminal — group matched ``var_idx`` values by their owning
+    /// file path. Reads ``path`` straight off each row (no extra
+    /// :meth:`ProjectContext.node_paths` lookup).
+    fn indices_by_path(&self, py: Python<'_>) -> PyResult<FxHashMap<String, Vec<usize>>> {
+        let rows = self.construction_rows(py)?;
+        let ctx = self.ctx.borrow(py);
+        let outputs = ctx.materialized("ConstructionQuery.indices_by_path")?;
+        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let mut buckets: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+        for row in rows {
+            let path = nodes[row.var_idx].borrow(py).path.clone();
+            buckets.entry(path).or_default().push(row.var_idx);
+        }
+        Ok(buckets)
     }
 }
 
@@ -998,7 +1049,7 @@ impl CallQuery {
             required_positional: None,
             path_regex: None,
             kwarg_matchers: Vec::new(),
-            with_args: true,
+            with_args: false,
         }
     }
 }
@@ -1092,6 +1143,22 @@ impl CallQuery {
             )?);
         }
         Ok(out)
+    }
+
+    /// Terminal — group matched ``owner_idx`` values by their owning
+    /// file path. Reads ``path`` straight off each row (no extra
+    /// :meth:`ProjectContext.node_paths` lookup).
+    fn indices_by_path(&self, py: Python<'_>) -> PyResult<FxHashMap<String, Vec<usize>>> {
+        let rows = self.call_rows(py)?;
+        let ctx = self.ctx.borrow(py);
+        let outputs = ctx.materialized("CallQuery.indices_by_path")?;
+        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let mut buckets: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+        for row in rows {
+            let path = nodes[row.owner_idx].borrow(py).path.clone();
+            buckets.entry(path).or_default().push(row.owner_idx);
+        }
+        Ok(buckets)
     }
 }
 
@@ -1229,6 +1296,27 @@ impl SubclassQuery {
             ))
         }
     }
+
+    /// Terminal — :class:`NodeAttrs` for every matched subclass, in
+    /// the same order :meth:`indices` returns.
+    fn attrs(&self, py: Python<'_>) -> PyResult<Vec<crate::helpers::NodeAttrs>> {
+        let indices = self.indices(py)?;
+        let ctx = self.ctx.borrow(py);
+        ctx.node_attrs(py, indices)
+    }
+
+    /// Terminal — first matched subclass's positional index, or
+    /// ``None`` when no subclass exists.
+    fn first_idx(&self, py: Python<'_>) -> PyResult<Option<usize>> {
+        Ok(self.indices(py)?.into_iter().next())
+    }
+
+    /// Terminal — group matched indices by their owning file path.
+    fn indices_by_path(&self, py: Python<'_>) -> PyResult<FxHashMap<String, Vec<usize>>> {
+        let indices = self.indices(py)?;
+        let ctx = self.ctx.borrow(py);
+        _bucket_indices_by_path(&ctx, py, indices)
+    }
 }
 
 impl_query_methods!(no_first SubclassQuery);
@@ -1283,6 +1371,27 @@ impl ImportQuery {
     /// length of the pre-built index entry directly.
     fn count(&self, py: Python<'_>) -> PyResult<usize> {
         Ok(self.ctx.borrow(py).imports_of_count(self.module_or_err()?))
+    }
+
+    /// Terminal — :class:`NodeAttrs` for every matched import node,
+    /// in the same order :meth:`indices` returns.
+    fn attrs(&self, py: Python<'_>) -> PyResult<Vec<crate::helpers::NodeAttrs>> {
+        let indices = self.indices(py)?;
+        let ctx = self.ctx.borrow(py);
+        ctx.node_attrs(py, indices)
+    }
+
+    /// Terminal — first matched import node's positional index, or
+    /// ``None`` when no project file imports the configured module.
+    fn first_idx(&self, py: Python<'_>) -> PyResult<Option<usize>> {
+        Ok(self.indices(py)?.into_iter().next())
+    }
+
+    /// Terminal — group matched indices by their owning file path.
+    fn indices_by_path(&self, py: Python<'_>) -> PyResult<FxHashMap<String, Vec<usize>>> {
+        let indices = self.indices(py)?;
+        let ctx = self.ctx.borrow(py);
+        _bucket_indices_by_path(&ctx, py, indices)
     }
 }
 
@@ -1418,6 +1527,24 @@ impl ModuleQuery {
     fn count(&self, py: Python<'_>) -> PyResult<usize> {
         Ok(self.indices(py)?.len())
     }
+
+    /// Terminal — :class:`NodeAttrs` for every matched index, in the
+    /// same order :meth:`indices` returns. Avoids the boilerplate of
+    /// ``ctx.node_attrs(q.indices())``.
+    fn attrs(&self, py: Python<'_>) -> PyResult<Vec<crate::helpers::NodeAttrs>> {
+        let indices = self.indices(py)?;
+        let ctx = self.ctx.borrow(py);
+        ctx.node_attrs(py, indices)
+    }
+
+    /// Terminal — group matched indices by their owning file path.
+    /// Returns ``dict[path, list[int]]``; one
+    /// :meth:`ProjectContext.node_paths` call internally.
+    fn indices_by_path(&self, py: Python<'_>) -> PyResult<FxHashMap<String, Vec<usize>>> {
+        let indices = self.indices(py)?;
+        let ctx = self.ctx.borrow(py);
+        _bucket_indices_by_path(&ctx, py, indices)
+    }
 }
 
 impl ModuleQuery {
@@ -1432,7 +1559,7 @@ impl ModuleQuery {
                 return Ok(None);
             };
             let attrs = ctx.node_attrs(py, vec![idx])?;
-            return Ok(attrs.into_iter().next().map(|(_k, _p, fqname, _f)| fqname));
+            return Ok(attrs.into_iter().next().map(|a| a.fqname));
         }
         Err(PyValueError::new_err(
             "ModuleQuery requires one of: .with_fqn(...), .with_path(...), .with_dunders()",
@@ -1484,6 +1611,27 @@ impl ClassQuery {
             .as_deref()
             .ok_or_else(|| PyValueError::new_err("ClassQuery requires .defining_method(name)"))?;
         ctx.find_classes_defining_method_indices(py, name)
+    }
+
+    /// Terminal — :class:`NodeAttrs` for every matched class, in the
+    /// same order :meth:`indices` returns.
+    fn attrs(&self, py: Python<'_>) -> PyResult<Vec<crate::helpers::NodeAttrs>> {
+        let indices = self.indices(py)?;
+        let ctx = self.ctx.borrow(py);
+        ctx.node_attrs(py, indices)
+    }
+
+    /// Terminal — first matched class's positional index, or ``None``
+    /// when no class defines the configured method.
+    fn first_idx(&self, py: Python<'_>) -> PyResult<Option<usize>> {
+        Ok(self.indices(py)?.into_iter().next())
+    }
+
+    /// Terminal — group matched indices by their owning file path.
+    fn indices_by_path(&self, py: Python<'_>) -> PyResult<FxHashMap<String, Vec<usize>>> {
+        let indices = self.indices(py)?;
+        let ctx = self.ctx.borrow(py);
+        _bucket_indices_by_path(&ctx, py, indices)
     }
 }
 
@@ -1554,6 +1702,22 @@ impl FactoryQuery {
             )?);
         }
         Ok(out)
+    }
+
+    /// Terminal — group matched ``decl_idx`` values by their owning
+    /// file path. Reads ``path`` straight off each row (no extra
+    /// :meth:`ProjectContext.node_paths` lookup).
+    fn indices_by_path(&self, py: Python<'_>) -> PyResult<FxHashMap<String, Vec<usize>>> {
+        let pairs = self.factory_rows(py)?;
+        let ctx = self.ctx.borrow(py);
+        let outputs = ctx.materialized("FactoryQuery.indices_by_path")?;
+        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let mut buckets: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+        for (decl_idx, _kinds) in pairs {
+            let path = nodes[decl_idx].borrow(py).path.clone();
+            buckets.entry(path).or_default().push(decl_idx);
+        }
+        Ok(buckets)
     }
 }
 
@@ -2153,6 +2317,34 @@ impl DeclQuery {
         }
         Ok(out)
     }
+
+    /// Terminal — :class:`NodeAttrs` (``kind`` / ``path`` / ``fqname``
+    /// / ``flags``) for every surviving node, in the same order
+    /// :meth:`indices` returns. Avoids the boilerplate of
+    /// ``ctx.node_attrs(q.indices())``.
+    fn attrs(&self, py: Python<'_>) -> PyResult<Vec<crate::helpers::NodeAttrs>> {
+        let indices = self.indices(py)?;
+        let ctx = self.ctx.borrow(py);
+        ctx.node_attrs(py, indices)
+    }
+
+    /// Terminal — first matching node's positional index, or ``None``
+    /// when no node matches. Convenience for single-value lookups
+    /// (e.g. fqname-prefix queries that should match at most one
+    /// decl).
+    fn first_idx(&self, py: Python<'_>) -> PyResult<Option<usize>> {
+        Ok(self.indices(py)?.into_iter().next())
+    }
+
+    /// Terminal — group matched indices by their owning file path.
+    /// Returns ``dict[path, list[int]]``; one
+    /// :meth:`ProjectContext.node_paths` call internally. Lets
+    /// plugins fan out per-file work without re-querying.
+    fn indices_by_path(&self, py: Python<'_>) -> PyResult<FxHashMap<String, Vec<usize>>> {
+        let indices = self.indices(py)?;
+        let ctx = self.ctx.borrow(py);
+        _bucket_indices_by_path(&ctx, py, indices)
+    }
 }
 
 impl_query_methods!(no_first DeclQuery);
@@ -2281,6 +2473,31 @@ impl DeclarationsQuery {
 
     fn count(&self, py: Python<'_>) -> PyResult<usize> {
         Ok(self.indices(py)?.len())
+    }
+
+    /// Terminal — :class:`NodeAttrs` for every matched decl, in the
+    /// same order :meth:`indices` returns. Modules are excluded (same
+    /// rule as :meth:`indices`); use :meth:`resolve_idx` +
+    /// :meth:`ProjectContext.node_attrs` if you need the module
+    /// fallback's attrs.
+    fn attrs(&self, py: Python<'_>) -> PyResult<Vec<crate::helpers::NodeAttrs>> {
+        let indices = self.indices(py)?;
+        let ctx = self.ctx.borrow(py);
+        ctx.node_attrs(py, indices)
+    }
+
+    /// Terminal — first matched decl's positional index, or ``None``
+    /// when no decl matches. Distinct from :meth:`resolve_idx`: this
+    /// one skips the module fallback.
+    fn first_idx(&self, py: Python<'_>) -> PyResult<Option<usize>> {
+        Ok(self.indices(py)?.into_iter().next())
+    }
+
+    /// Terminal — group matched indices by their owning file path.
+    fn indices_by_path(&self, py: Python<'_>) -> PyResult<FxHashMap<String, Vec<usize>>> {
+        let indices = self.indices(py)?;
+        let ctx = self.ctx.borrow(py);
+        _bucket_indices_by_path(&ctx, py, indices)
     }
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,170 +1,150 @@
 //! The chainable query DSL exposed to Python via `ProjectContext.query()`.
-//! Result types (`DecoratorRef`/`ConstructionRef`/`CallRef`/`FactoryRef`),
-//! the `QueryBuilder` entry point, and the per-stream `Query` builders.
+//! Result types (`DecoratorIdxRef` / `ConstructionIdxRef` / `CallIdxRef`
+//! / `FactoryIdxRef` / `EdgeRef`), the `QueryBuilder` entry point, and
+//! the per-stream `Query` builders.
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::PyClass;
 use ruff_db::files::File;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 use ty_project::Db as ProjectDb;
 
 use crate::graph::SymbolNode;
 use crate::helpers::{
-    args_to_py_vec, call_args_match_kwargs, file_path_string, kwarg_matcher_from_py,
-    kwargs_to_py_map, KwargMatcher,
+    call_args_match_kwargs, file_path_string, kwarg_matcher_from_py, KwargMatcher,
 };
 use crate::project::ProjectContext;
 
+// ---------------------------------------------------------------------------
+// Result row types
+//
+// One pyclass per query stream; all idx-based. Each carries a
+// positional index into ``ctx.nodes()`` for the row's "node identity"
+// field (``decorated_idx`` / ``var_idx`` / ``owner_idx`` / ``decl_idx``),
+// the row's owning ``path`` as a cheap bucket key, and any
+// query-shape-specific metadata strings (``decorator_owner`` etc.).
+//
+// ``DecoratorIdxRef`` / ``ConstructionIdxRef`` / ``CallIdxRef`` also
+// expose ``args`` / ``kwargs`` lazy getters that walk the row's
+// rust-side :struct:`CallArgs` and produce a Python ``list`` / ``dict``
+// of :class:`ArgLiteral` / :class:`ArgNodeRef` / :class:`ArgOpaque`.
+// The walk runs on every access — plugins that never read args/kwargs
+// pay zero Python allocation cost; plugins that read them pay only
+// for what they touch.
+// ---------------------------------------------------------------------------
+
 /// One decorator application on a top-level function or class.
 ///
-/// Field nullability follows the query shape that produced the ref:
-/// * ``where_module + where_name`` populates ``decorated`` only.
+/// Field nullability follows the query shape that produced the row:
+/// * ``where_module + where_name`` populates ``decorated_idx`` only.
 /// * ``where_owner_attr`` fills ``decorator_owner`` (the textual
 ///   ``@<owner>.<attr>`` prefix).
 /// * ``where_owner_attr_via`` additionally fills ``decorator_via``
 ///   with the middle attribute name.
-#[pyclass(frozen, get_all)]
-pub(crate) struct DecoratorRef {
-    pub(crate) decorated: Py<SymbolNode>,
+#[pyclass]
+pub(crate) struct DecoratorIdxRef {
+    #[pyo3(get)]
+    pub(crate) decorated_idx: usize,
+    #[pyo3(get)]
+    pub(crate) path: String,
+    #[pyo3(get)]
     pub(crate) decorator_name: Option<String>,
+    #[pyo3(get)]
     pub(crate) decorator_owner: Option<String>,
+    #[pyo3(get)]
     pub(crate) decorator_via: Option<String>,
-    /// Positional arguments of the decorator's ``Call`` form. Empty
-    /// for bare attribute decorators (``@app.route`` without ``()``).
-    /// Each entry is a Python literal, a :class:`SymbolNode` (when the
-    /// expression resolves to a project decl), or ``None``.
-    pub(crate) args: Vec<Py<PyAny>>,
-    /// Keyword arguments of the decorator's ``Call`` form. Same value
-    /// shape as ``args``.
-    pub(crate) kwargs: FxHashMap<String, Py<PyAny>>,
+    pub(crate) call_args: crate::helpers::CallArgs,
 }
 
 #[pymethods]
-impl DecoratorRef {
-    /// File path of the decorated decl. Read off ``decorated.path`` —
-    /// surfaced as a top-level attribute for ergonomics in path-keyed
-    /// dispatch.
+impl DecoratorIdxRef {
+    /// Positional arguments of the decorator's ``Call`` form, lazily
+    /// materialised on access. Empty for bare attribute decorators
+    /// (``@app.route`` without ``()``). Each entry is one of
+    /// :class:`ArgLiteral`, :class:`ArgNodeRef`, or :class:`ArgOpaque`.
     #[getter]
-    fn path(&self, py: Python<'_>) -> String {
-        self.decorated.borrow(py).path.clone()
+    fn args(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        crate::helpers::arg_values_to_py_list(py, &self.call_args.args)
+    }
+
+    /// Keyword arguments of the decorator's ``Call`` form, lazily
+    /// materialised on access. Same value shape as :meth:`args`.
+    #[getter]
+    fn kwargs(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        crate::helpers::arg_kwargs_to_py_dict(py, &self.call_args.kwargs)
     }
 }
 
 /// One ``<var> = <Ctor>(...)`` construction at module scope.
 ///
-/// ``class_name`` is the upstream constructor's bare name
-/// (``"Flask"`` even when imported as ``F``).
-///
-/// ``args`` and ``kwargs`` carry the construction's full positional /
-/// keyword argument shape (same Python-side value shape as
-/// :class:`CallRef`).
-#[pyclass(frozen, get_all)]
-pub(crate) struct ConstructionRef {
-    pub(crate) var: Py<SymbolNode>,
+/// ``class_name`` is the upstream constructor's bare name (``"Flask"``
+/// even when imported as ``F``).
+#[pyclass]
+pub(crate) struct ConstructionIdxRef {
+    #[pyo3(get)]
+    pub(crate) var_idx: usize,
+    #[pyo3(get)]
+    pub(crate) path: String,
+    #[pyo3(get)]
     pub(crate) class_name: String,
-    /// Positional arguments of the constructor call. Each entry is a
-    /// Python literal, a :class:`SymbolNode` (when the expression
-    /// resolves to a project decl), or ``None``.
-    pub(crate) args: Vec<Py<PyAny>>,
-    /// Keyword arguments of the constructor call. Same value shape as
-    /// ``args``.
-    pub(crate) kwargs: FxHashMap<String, Py<PyAny>>,
+    pub(crate) call_args: crate::helpers::CallArgs,
 }
 
 #[pymethods]
-impl ConstructionRef {
+impl ConstructionIdxRef {
+    /// Positional arguments of the constructor call, lazily
+    /// materialised on access. Each entry is one of
+    /// :class:`ArgLiteral`, :class:`ArgNodeRef`, or :class:`ArgOpaque`.
     #[getter]
-    fn path(&self, py: Python<'_>) -> String {
-        self.var.borrow(py).path.clone()
+    fn args(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        crate::helpers::arg_values_to_py_list(py, &self.call_args.args)
+    }
+
+    /// Keyword arguments of the constructor call, lazily materialised
+    /// on access. Same value shape as :meth:`args`.
+    #[getter]
+    fn kwargs(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        crate::helpers::arg_kwargs_to_py_dict(py, &self.call_args.kwargs)
     }
 }
 
 /// One matched call site. ``string_arg`` is the literal at the
 /// positional index passed to :meth:`CallQuery.string_arg_at`.
-#[pyclass(frozen, get_all)]
-pub(crate) struct CallRef {
-    pub(crate) owner: Py<SymbolNode>,
+#[pyclass]
+pub(crate) struct CallIdxRef {
+    #[pyo3(get)]
+    pub(crate) owner_idx: usize,
+    #[pyo3(get)]
+    pub(crate) path: String,
+    #[pyo3(get)]
     pub(crate) string_arg: String,
-    /// Positional arguments of the matched call, one entry per source
-    /// positional arg. Each entry is a Python literal, a
-    /// :class:`SymbolNode` (when the expression resolves to a project
-    /// decl), or ``None``.
-    pub(crate) args: Vec<Py<PyAny>>,
-    /// Keyword arguments of the matched call. Same value shape as
-    /// ``args``.
-    pub(crate) kwargs: FxHashMap<String, Py<PyAny>>,
+    pub(crate) call_args: crate::helpers::CallArgs,
 }
 
 #[pymethods]
-impl CallRef {
+impl CallIdxRef {
+    /// Positional arguments of the matched call, lazily materialised
+    /// on access. One entry per source positional arg; each is one of
+    /// :class:`ArgLiteral`, :class:`ArgNodeRef`, or :class:`ArgOpaque`.
     #[getter]
-    fn path(&self, py: Python<'_>) -> String {
-        self.owner.borrow(py).path.clone()
+    fn args(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        crate::helpers::arg_values_to_py_list(py, &self.call_args.args)
+    }
+
+    /// Keyword arguments of the matched call, lazily materialised on
+    /// access. Same value shape as :meth:`args`.
+    #[getter]
+    fn kwargs(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        crate::helpers::arg_kwargs_to_py_dict(py, &self.call_args.kwargs)
     }
 }
 
-// ---------------------------------------------------------------------------
-// Index-form result rows
-//
-// Lean siblings of the ref types: same dispatch, but every
-// ``SymbolNode`` field is replaced with a positional index into
-// ``ctx.nodes()`` and the costly ``args`` / ``kwargs`` row payloads
-// are dropped — both because they're expensive to materialise and
-// because entries inside them can be ``SymbolNode`` references that
-// would re-introduce the GIL hops the idx surface is designed to
-// avoid. Plugins that need ``args`` / ``kwargs`` access fall back to
-// the node-form ``.collect()`` terminals; plugins that only need to
-// filter by kwarg keep using ``.where_kwarg(...)``, which operates
-// rust-side before row construction either way.
-//
-// Returned by the ``.row_indices()`` terminals on
-// :class:`DecoratorQuery` / :class:`ConstructionQuery` /
-// :class:`CallQuery` / :class:`FactoryQuery`. Pair with
-// :meth:`ProjectContext.node_attrs` (or :meth:`node_paths` when only
-// ``path`` is needed) to batch-fetch any node fields the plugin still
-// needs without per-row ``borrow`` ping-pong.
-// ---------------------------------------------------------------------------
-
-/// Index-form sibling of :class:`DecoratorRef`. Same metadata fields,
-/// minus ``args`` / ``kwargs``; ``decorated_idx`` indexes into
-/// ``ctx.nodes()``. ``path`` is preserved because plugins routinely
-/// bucket by path before any further query.
-#[pyclass(frozen, get_all)]
-pub(crate) struct DecoratorIdxRef {
-    pub(crate) decorated_idx: usize,
-    pub(crate) path: String,
-    pub(crate) decorator_name: Option<String>,
-    pub(crate) decorator_owner: Option<String>,
-    pub(crate) decorator_via: Option<String>,
-}
-
-/// Index-form sibling of :class:`ConstructionRef`. Same metadata
-/// fields, minus ``args`` / ``kwargs``; ``var_idx`` indexes into
-/// ``ctx.nodes()``. ``path`` is preserved as a cheap bucket key for
-/// plugins that fan out per file.
-#[pyclass(frozen, get_all)]
-pub(crate) struct ConstructionIdxRef {
-    pub(crate) var_idx: usize,
-    pub(crate) path: String,
-    pub(crate) class_name: String,
-}
-
-/// Index-form sibling of :class:`CallRef`. Same metadata fields,
-/// minus ``args`` / ``kwargs``; ``owner_idx`` indexes into
-/// ``ctx.nodes()``. ``path`` is the owning decl's path.
-#[pyclass(frozen, get_all)]
-pub(crate) struct CallIdxRef {
-    pub(crate) owner_idx: usize,
-    pub(crate) path: String,
-    pub(crate) string_arg: String,
-}
-
-/// Index-form sibling of :class:`FactoryRef`. ``decl_idx`` indexes
-/// into ``ctx.nodes()``; ``kinds`` is the same sorted set of matched
-/// constructor bare-names the node-returning terminal emits.
-/// ``path`` is preserved as a cheap bucket key for plugins that fan
-/// out per file.
+/// One factory-function / class hit from :class:`FactoryQuery`.
+/// ``decl_idx`` is the owning top-level decl's positional index into
+/// ``ctx.nodes()``; ``kinds`` is the sorted set of constructor
+/// bare-names matched inside its body. ``path`` is the decl's source
+/// file as a cheap bucket key for per-file fan-out.
 #[pyclass(frozen, get_all)]
 pub(crate) struct FactoryIdxRef {
     pub(crate) decl_idx: usize,
@@ -564,37 +544,43 @@ impl DecoratorQuery {
         Ok(slf)
     }
 
-    fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<DecoratorRef>>> {
+    /// Materialise every matched decorator row.
+    ///
+    /// Each row is a :class:`DecoratorIdxRef`: the ``decorated``
+    /// position is given as ``decorated_idx`` (a positional index into
+    /// ``ctx.nodes()``); ``path`` is the owning decl's file; the
+    /// query-shape-specific metadata strings (``decorator_owner`` etc.)
+    /// follow the predicate that produced the row; and ``args`` /
+    /// ``kwargs`` are lazy getters that walk the row's pre-extracted
+    /// :struct:`CallArgs` on access.
+    fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<DecoratorIdxRef>>> {
         let rows = self.decorator_rows(py)?;
         let ctx = self.ctx.borrow(py);
         let outputs = ctx.materialized("DecoratorQuery.collect")?;
         let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
-        let mut refs: Vec<Py<DecoratorRef>> = Vec::with_capacity(rows.len());
+        let mut out: Vec<Py<DecoratorIdxRef>> = Vec::with_capacity(rows.len());
         for row in rows {
-            let args = args_to_py_vec(py, &row.call_args.args, nodes);
-            let kwargs = kwargs_to_py_map(py, &row.call_args.kwargs, nodes);
-            refs.push(Py::new(
+            let path = nodes[row.decorated_idx].borrow(py).path.clone();
+            out.push(Py::new(
                 py,
-                DecoratorRef {
-                    decorated: nodes[row.decorated_idx].clone_ref(py),
+                DecoratorIdxRef {
+                    decorated_idx: row.decorated_idx,
+                    path,
                     decorator_name: row.decorator_name,
                     decorator_owner: row.decorator_owner,
                     decorator_via: row.decorator_via,
-                    args,
-                    kwargs,
+                    call_args: row.call_args,
                 },
             )?);
         }
-        Ok(refs)
+        Ok(out)
     }
 }
 
 /// Idx-form intermediate produced by :meth:`DecoratorQuery::decorator_rows`.
-/// Carries the same metadata as :class:`DecoratorRef` minus the
-/// ``Py<SymbolNode>`` allocation — the node identity is just an index
-/// into ``ctx.nodes()``. ``call_args`` is kept so kwarg filtering and
-/// ``collect()``'s ``args`` / ``kwargs`` materialization can both share
-/// the same upstream.
+/// Carries the same metadata as :class:`DecoratorIdxRef` plus the
+/// ``call_args`` upstream that kwarg filtering and the per-ref
+/// ``args`` / ``kwargs`` getters both consume.
 struct DecoratorRowIdx {
     decorated_idx: usize,
     decorator_name: Option<String>,
@@ -604,10 +590,9 @@ struct DecoratorRowIdx {
 }
 
 impl DecoratorQuery {
-    /// Shared dispatch used by both terminals (:meth:`collect` and
-    /// :meth:`row_indices`). Stays in idx-space throughout so
-    /// ``row_indices`` can skip the ``Py<SymbolNode>`` and
-    /// ``args_to_py_vec`` allocations entirely.
+    /// Shared idx-space dispatch backing :meth:`collect`. Applies the
+    /// kwarg-matcher filter rust-side before row construction so the
+    /// terminal stays GIL-light.
     fn decorator_rows(&self, py: Python<'_>) -> PyResult<Vec<DecoratorRowIdx>> {
         let ctx = self.ctx.borrow(py);
         let path_regex = self.path_regex.as_deref();
@@ -728,38 +713,7 @@ impl DecoratorQuery {
     }
 }
 
-impl_query_methods!(with_first DecoratorQuery, DecoratorRef);
-
-#[pymethods]
-impl DecoratorQuery {
-    /// Index-form row terminal. Same dispatch as :meth:`collect`, but
-    /// each row carries ``decorated_idx`` (a positional index into
-    /// ``ctx.nodes()``) instead of a ``Py<SymbolNode>``, and the
-    /// ``args`` / ``kwargs`` row payloads are skipped. Pairs with
-    /// :meth:`ProjectContext.node_attrs` and :class:`AddEdgeByIdx` /
-    /// :class:`AddNodeByIdx` to stay GIL-light end-to-end.
-    fn row_indices(&self, py: Python<'_>) -> PyResult<Vec<Py<DecoratorIdxRef>>> {
-        let rows = self.decorator_rows(py)?;
-        let ctx = self.ctx.borrow(py);
-        let outputs = ctx.materialized("DecoratorQuery.row_indices")?;
-        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
-        let mut out: Vec<Py<DecoratorIdxRef>> = Vec::with_capacity(rows.len());
-        for row in rows {
-            let path = nodes[row.decorated_idx].borrow(py).path.clone();
-            out.push(Py::new(
-                py,
-                DecoratorIdxRef {
-                    decorated_idx: row.decorated_idx,
-                    path,
-                    decorator_name: row.decorator_name,
-                    decorator_owner: row.decorator_owner,
-                    decorator_via: row.decorator_via,
-                },
-            )?);
-        }
-        Ok(out)
-    }
-}
+impl_query_methods!(with_first DecoratorQuery, DecoratorIdxRef);
 
 /// Find module-scope ``<var> = <Ctor>(...)`` sites. Pick exactly one
 /// of ``where_module + where_name`` or
@@ -824,26 +778,31 @@ impl ConstructionQuery {
         slf
     }
 
-    fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<ConstructionRef>>> {
+    /// Materialise every matched construction row. Each row is a
+    /// :class:`ConstructionIdxRef`: ``var_idx`` is the construction's
+    /// positional index into ``ctx.nodes()``; ``path`` is the owning
+    /// file; ``class_name`` is the upstream constructor's bare name;
+    /// ``args`` / ``kwargs`` are lazy getters over the row's
+    /// pre-extracted :struct:`CallArgs`.
+    fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<ConstructionIdxRef>>> {
         let rows = self.construction_rows(py)?;
         let ctx = self.ctx.borrow(py);
         let outputs = ctx.materialized("ConstructionQuery.collect")?;
         let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
-        let mut refs: Vec<Py<ConstructionRef>> = Vec::with_capacity(rows.len());
+        let mut out: Vec<Py<ConstructionIdxRef>> = Vec::with_capacity(rows.len());
         for row in rows {
-            let args = args_to_py_vec(py, &row.call_args.args, nodes);
-            let kwargs = kwargs_to_py_map(py, &row.call_args.kwargs, nodes);
-            refs.push(Py::new(
+            let path = nodes[row.var_idx].borrow(py).path.clone();
+            out.push(Py::new(
                 py,
-                ConstructionRef {
-                    var: nodes[row.var_idx].clone_ref(py),
+                ConstructionIdxRef {
+                    var_idx: row.var_idx,
+                    path,
                     class_name: row.class_name,
-                    args,
-                    kwargs,
+                    call_args: row.call_args,
                 },
             )?);
         }
-        Ok(refs)
+        Ok(out)
     }
 }
 
@@ -891,34 +850,7 @@ impl ConstructionQuery {
     }
 }
 
-impl_query_methods!(with_first ConstructionQuery, ConstructionRef);
-
-#[pymethods]
-impl ConstructionQuery {
-    /// Index-form row terminal. Same dispatch as :meth:`collect`, but
-    /// each row carries ``var_idx`` (a positional index into
-    /// ``ctx.nodes()``) instead of a ``Py<SymbolNode>``, and the
-    /// ``args`` / ``kwargs`` row payloads are skipped.
-    fn row_indices(&self, py: Python<'_>) -> PyResult<Vec<Py<ConstructionIdxRef>>> {
-        let rows = self.construction_rows(py)?;
-        let ctx = self.ctx.borrow(py);
-        let outputs = ctx.materialized("ConstructionQuery.row_indices")?;
-        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
-        let mut out: Vec<Py<ConstructionIdxRef>> = Vec::with_capacity(rows.len());
-        for row in rows {
-            let path = nodes[row.var_idx].borrow(py).path.clone();
-            out.push(Py::new(
-                py,
-                ConstructionIdxRef {
-                    var_idx: row.var_idx,
-                    path,
-                    class_name: row.class_name,
-                },
-            )?);
-        }
-        Ok(out)
-    }
-}
+impl_query_methods!(with_first ConstructionQuery, ConstructionIdxRef);
 
 /// Find call sites whose positional string-literal at the configured
 /// index is captured. :meth:`string_arg_at` is required. Pick one of:
@@ -1013,26 +945,31 @@ impl CallQuery {
         Ok(slf)
     }
 
-    fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<CallRef>>> {
+    /// Materialise every matched call row. Each row is a
+    /// :class:`CallIdxRef`: ``owner_idx`` is the owning decl's
+    /// positional index into ``ctx.nodes()``; ``path`` is the owning
+    /// file; ``string_arg`` is the literal at the configured
+    /// positional index; ``args`` / ``kwargs`` are lazy getters over
+    /// the row's pre-extracted :struct:`CallArgs`.
+    fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<CallIdxRef>>> {
         let rows = self.call_rows(py)?;
         let ctx = self.ctx.borrow(py);
         let outputs = ctx.materialized("CallQuery.collect")?;
         let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
-        let mut refs: Vec<Py<CallRef>> = Vec::with_capacity(rows.len());
+        let mut out: Vec<Py<CallIdxRef>> = Vec::with_capacity(rows.len());
         for row in rows {
-            let args = args_to_py_vec(py, &row.call_args.args, nodes);
-            let kwargs = kwargs_to_py_map(py, &row.call_args.kwargs, nodes);
-            refs.push(Py::new(
+            let path = nodes[row.owner_idx].borrow(py).path.clone();
+            out.push(Py::new(
                 py,
-                CallRef {
-                    owner: nodes[row.owner_idx].clone_ref(py),
+                CallIdxRef {
+                    owner_idx: row.owner_idx,
+                    path,
                     string_arg: row.string_arg,
-                    args,
-                    kwargs,
+                    call_args: row.call_args,
                 },
             )?);
         }
-        Ok(refs)
+        Ok(out)
     }
 }
 
@@ -1087,36 +1024,7 @@ impl CallQuery {
     }
 }
 
-impl_query_methods!(with_first CallQuery, CallRef);
-
-#[pymethods]
-impl CallQuery {
-    /// Index-form row terminal. Same dispatch as :meth:`collect`, but
-    /// each row carries ``owner_idx`` (a positional index into
-    /// ``ctx.nodes()``) instead of a ``Py<SymbolNode>``, and the
-    /// ``args`` / ``kwargs`` row payloads are skipped. ``string_arg``
-    /// — the literal at the configured positional index — is preserved
-    /// because most call-shape plugins key on it.
-    fn row_indices(&self, py: Python<'_>) -> PyResult<Vec<Py<CallIdxRef>>> {
-        let rows = self.call_rows(py)?;
-        let ctx = self.ctx.borrow(py);
-        let outputs = ctx.materialized("CallQuery.row_indices")?;
-        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
-        let mut out: Vec<Py<CallIdxRef>> = Vec::with_capacity(rows.len());
-        for row in rows {
-            let path = nodes[row.owner_idx].borrow(py).path.clone();
-            out.push(Py::new(
-                py,
-                CallIdxRef {
-                    owner_idx: row.owner_idx,
-                    path,
-                    string_arg: row.string_arg,
-                },
-            )?);
-        }
-        Ok(out)
-    }
-}
+impl_query_methods!(with_first CallQuery, CallIdxRef);
 
 // ---------------------------------------------------------------------------
 // Subclass / Import / Class / Factory queries
@@ -1307,22 +1215,6 @@ impl ClassQuery {
 impl_query_methods!(no_first ClassQuery);
 
 /// One result row from :class:`FactoryQuery`. ``decl`` is the
-/// owning top-level function or class; ``kinds`` is the sorted set
-/// of constructor bare-names matched inside its body.
-#[pyclass(frozen, get_all)]
-pub(crate) struct FactoryRef {
-    pub(crate) decl: Py<SymbolNode>,
-    pub(crate) kinds: Vec<String>,
-}
-
-#[pymethods]
-impl FactoryRef {
-    #[getter]
-    fn path(&self, py: Python<'_>) -> String {
-        self.decl.borrow(py).path.clone()
-    }
-}
-
 /// Walk function / class bodies for ``<Ctor>(...)`` calls where
 /// ``Ctor`` is imported from ``of_module(...)`` and matches one of
 /// ``where_name(...)``. Both filters are required.
@@ -1364,56 +1256,15 @@ impl FactoryQuery {
         slf.names = Some(_extract_str_or_list(py, names)?);
         Ok(slf)
     }
-    fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<FactoryRef>>> {
+    /// Materialise every matched factory row. Each row is a
+    /// :class:`FactoryIdxRef`: ``decl_idx`` is the owning decl's
+    /// positional index into ``ctx.nodes()``; ``path`` is the owning
+    /// file; ``kinds`` is the sorted set of constructor bare-names
+    /// matched inside its body.
+    fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<FactoryIdxRef>>> {
         let pairs = self.factory_rows(py)?;
         let ctx = self.ctx.borrow(py);
         let outputs = ctx.materialized("FactoryQuery.collect")?;
-        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
-        pairs
-            .into_iter()
-            .map(|(decl_idx, kinds)| {
-                Py::new(
-                    py,
-                    FactoryRef {
-                        decl: nodes[decl_idx].clone_ref(py),
-                        kinds,
-                    },
-                )
-            })
-            .collect()
-    }
-}
-
-impl FactoryQuery {
-    /// Shared dispatch used by both terminals (:meth:`collect` and
-    /// :meth:`row_indices`). Stays in idx-space throughout.
-    fn factory_rows(&self, py: Python<'_>) -> PyResult<Vec<(usize, Vec<String>)>> {
-        let ctx = self.ctx.borrow(py);
-        let modules = self
-            .modules
-            .as_ref()
-            .ok_or_else(|| PyValueError::new_err("FactoryQuery requires .of_module(...)"))?;
-        let names = self
-            .names
-            .clone()
-            .ok_or_else(|| PyValueError::new_err("FactoryQuery requires .where_name(...)"))?;
-        ctx.find_factory_decls(py, modules, names)
-    }
-}
-
-impl_query_methods!(no_first FactoryQuery);
-
-#[pymethods]
-impl FactoryQuery {
-    /// Index-form row terminal. Same dispatch as :meth:`collect`;
-    /// each row carries ``decl_idx`` (a positional index into
-    /// ``ctx.nodes()``) instead of a ``Py<SymbolNode>``. ``kinds`` is
-    /// the same sorted set of matched constructor bare-names the
-    /// node-returning terminal emits.
-    fn row_indices(&self, py: Python<'_>) -> PyResult<Vec<Py<FactoryIdxRef>>> {
-        let pairs = self.factory_rows(py)?;
-        let ctx = self.ctx.borrow(py);
-        let outputs = ctx.materialized("FactoryQuery.row_indices")?;
         let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
         let mut out: Vec<Py<FactoryIdxRef>> = Vec::with_capacity(pairs.len());
         for (decl_idx, kinds) in pairs {
@@ -1430,6 +1281,24 @@ impl FactoryQuery {
         Ok(out)
     }
 }
+
+impl FactoryQuery {
+    /// Shared idx-space dispatch backing :meth:`collect`.
+    fn factory_rows(&self, py: Python<'_>) -> PyResult<Vec<(usize, Vec<String>)>> {
+        let ctx = self.ctx.borrow(py);
+        let modules = self
+            .modules
+            .as_ref()
+            .ok_or_else(|| PyValueError::new_err("FactoryQuery requires .of_module(...)"))?;
+        let names = self
+            .names
+            .clone()
+            .ok_or_else(|| PyValueError::new_err("FactoryQuery requires .where_name(...)"))?;
+        ctx.find_factory_decls(py, modules, names)
+    }
+}
+
+impl_query_methods!(no_first FactoryQuery);
 
 // ---------------------------------------------------------------------------
 // EdgeQuery — filtered enumeration over the in-progress graph's edges

--- a/src/query.rs
+++ b/src/query.rs
@@ -455,6 +455,13 @@ pub(crate) struct DecoratorQuery {
     pub(crate) in_decl_idx: Option<usize>,
     pub(crate) path_regex: Option<String>,
     pub(crate) kwarg_matchers: Vec<(String, KwargMatcher)>,
+    /// User-controlled args/kwargs extraction gate. Defaults to
+    /// ``true``; flip with ``.with_args(false)`` to skip the rust-side
+    /// :fn:`extract_call_args_kwargs` walk when the plugin doesn't
+    /// read row ``args`` / ``kwargs``. Auto-forced back to ``true``
+    /// at row-collection time when any ``where_kwarg`` is set, since
+    /// kwarg filtering needs the data.
+    pub(crate) with_args: bool,
 }
 
 impl DecoratorQuery {
@@ -470,6 +477,7 @@ impl DecoratorQuery {
             in_decl_idx: None,
             path_regex: None,
             kwarg_matchers: Vec::new(),
+            with_args: true,
         }
     }
 }
@@ -527,12 +535,25 @@ impl DecoratorQuery {
         slf
     }
 
+    /// Opt out of rust-side ``args`` / ``kwargs`` extraction.
+    /// ``with_args(False)`` skips the per-row
+    /// :fn:`extract_call_args_kwargs` walk; row ``args`` / ``kwargs``
+    /// getters then surface empty containers. Useful for plugins that
+    /// only need the row's idx + metadata strings — saves rust-side
+    /// allocation per matched row. Forced back to ``True`` at row-
+    /// collection time when any ``where_kwarg`` is set (kwarg filtering
+    /// needs the data).
+    fn with_args<'py>(mut slf: PyRefMut<'py, Self>, value: bool) -> PyRefMut<'py, Self> {
+        slf.with_args = value;
+        slf
+    }
+
     /// Add a kwarg matcher. Multiple calls AND together.
     ///
     /// ``value`` must be a Python literal (``None`` / ``bool`` /
-    /// ``int`` / ``float`` / ``str`` / ``list`` / ``tuple``). Passing
-    /// any other type — including a :class:`SymbolNode` — raises
-    /// ``ValueError``.
+    /// ``int`` / ``float`` / ``str`` / ``bytes`` / ``list`` /
+    /// ``tuple``). Passing any other type — including a
+    /// :class:`SymbolNode` — raises ``ValueError``.
     fn where_kwarg<'py>(
         mut slf: PyRefMut<'py, Self>,
         name: String,
@@ -597,12 +618,22 @@ impl DecoratorQuery {
         let ctx = self.ctx.borrow(py);
         let path_regex = self.path_regex.as_deref();
         let kwarg_matchers = &self.kwarg_matchers;
+        // ``with_args(False)`` skips the rust-side extraction, but
+        // kwarg filtering needs ``CallArgs`` populated — force it back
+        // to ``true`` when any matcher is set.
+        let extract_args = self.with_args || !kwarg_matchers.is_empty();
         let mut out: Vec<DecoratorRowIdx> = Vec::new();
         if let Some(owner_attrs) = &self.owner_attrs {
             let triples = if let Some(via) = &self.via_attr {
-                ctx.find_handler_decorators_via(py, via, owner_attrs.clone(), path_regex)?
+                ctx.find_handler_decorators_via(
+                    py,
+                    via,
+                    owner_attrs.clone(),
+                    path_regex,
+                    extract_args,
+                )?
             } else {
-                ctx.find_handler_decorators(py, owner_attrs.clone(), path_regex)?
+                ctx.find_handler_decorators(py, owner_attrs.clone(), path_regex, extract_args)?
             };
             for (owner_name, decorated_idx, call_args) in triples {
                 if !call_args_match_kwargs(&call_args, kwarg_matchers) {
@@ -621,7 +652,8 @@ impl DecoratorQuery {
                 PyValueError::new_err("DecoratorQuery.in_decl(...) requires .where_name(...)")
             })?;
             let in_decl_ref = in_decl_node.borrow(py);
-            let decls = ctx.find_decorations_on(py, &in_decl_ref, names.clone(), path_regex)?;
+            let decls =
+                ctx.find_decorations_on(py, &in_decl_ref, names.clone(), path_regex, extract_args)?;
             let owner_simple = in_decl_ref
                 .fqname
                 .rsplit('.')
@@ -653,7 +685,8 @@ impl DecoratorQuery {
                 )));
             }
             let in_decl_ref = outputs.builder.nodes[in_decl_idx].borrow(py);
-            let decls = ctx.find_decorations_on(py, &in_decl_ref, names.clone(), path_regex)?;
+            let decls =
+                ctx.find_decorations_on(py, &in_decl_ref, names.clone(), path_regex, extract_args)?;
             let owner_simple = in_decl_ref
                 .fqname
                 .rsplit('.')
@@ -674,7 +707,7 @@ impl DecoratorQuery {
                 });
             }
         } else if let Some(fqn) = &self.callee_fqn {
-            let decls = ctx.find_decorated(py, fqn, path_regex)?;
+            let decls = ctx.find_decorated(py, fqn, path_regex, extract_args)?;
             for (decorated_idx, call_args) in decls {
                 if !call_args_match_kwargs(&call_args, kwarg_matchers) {
                     continue;
@@ -688,7 +721,8 @@ impl DecoratorQuery {
                 });
             }
         } else if let (Some(modules), Some(names)) = (&self.modules, &self.names) {
-            let decls = ctx.find_decorated_decls(py, modules, names.clone(), path_regex)?;
+            let decls =
+                ctx.find_decorated_decls(py, modules, names.clone(), path_regex, extract_args)?;
             for (decorated_idx, call_args) in decls {
                 if !call_args_match_kwargs(&call_args, kwarg_matchers) {
                     continue;
@@ -730,6 +764,10 @@ pub(crate) struct ConstructionQuery {
     pub(crate) class_fqn: Option<String>,
     pub(crate) include_subclasses: bool,
     pub(crate) path_regex: Option<String>,
+    /// See :class:`DecoratorQuery::with_args`. Defaults to ``true``.
+    /// :class:`ConstructionQuery` doesn't have its own
+    /// ``where_kwarg`` (yet), so this isn't auto-forced.
+    pub(crate) with_args: bool,
 }
 
 impl ConstructionQuery {
@@ -741,6 +779,7 @@ impl ConstructionQuery {
             class_fqn: None,
             include_subclasses: false,
             path_regex: None,
+            with_args: true,
         }
     }
 }
@@ -775,6 +814,13 @@ impl ConstructionQuery {
     }
     fn where_path<'py>(mut slf: PyRefMut<'py, Self>, regex: String) -> PyRefMut<'py, Self> {
         slf.path_regex = Some(regex);
+        slf
+    }
+
+    /// Opt out of rust-side ``args`` / ``kwargs`` extraction; see
+    /// :meth:`DecoratorQuery.with_args` for the trade-off.
+    fn with_args<'py>(mut slf: PyRefMut<'py, Self>, value: bool) -> PyRefMut<'py, Self> {
+        slf.with_args = value;
         slf
     }
 
@@ -814,14 +860,15 @@ struct ConstructionRowIdx {
 }
 
 impl ConstructionQuery {
-    /// Shared dispatch used by both terminals (:meth:`collect` and
-    /// :meth:`row_indices`). Stays in idx-space throughout.
+    /// Shared idx-space dispatch backing :meth:`collect`.
     fn construction_rows(&self, py: Python<'_>) -> PyResult<Vec<ConstructionRowIdx>> {
         let ctx = self.ctx.borrow(py);
         let path_regex = self.path_regex.as_deref();
+        let extract_args = self.with_args;
         let mut out: Vec<ConstructionRowIdx> = Vec::new();
         if let Some(fqn) = &self.class_fqn {
-            let pairs = ctx.find_constructions(py, fqn, self.include_subclasses, path_regex)?;
+            let pairs =
+                ctx.find_constructions(py, fqn, self.include_subclasses, path_regex, extract_args)?;
             let cls_name = fqn.rsplit('.').next().unwrap_or("").to_string();
             for (var_idx, call_args) in pairs {
                 out.push(ConstructionRowIdx {
@@ -831,8 +878,13 @@ impl ConstructionQuery {
                 });
             }
         } else if let (Some(modules), Some(names)) = (&self.modules, &self.names) {
-            let triples =
-                ctx.find_instance_constructions(py, modules, names.clone(), path_regex)?;
+            let triples = ctx.find_instance_constructions(
+                py,
+                modules,
+                names.clone(),
+                path_regex,
+                extract_args,
+            )?;
             for (var_idx, name, call_args) in triples {
                 out.push(ConstructionRowIdx {
                     var_idx,
@@ -871,6 +923,9 @@ pub(crate) struct CallQuery {
     pub(crate) required_positional: Option<usize>,
     pub(crate) path_regex: Option<String>,
     pub(crate) kwarg_matchers: Vec<(String, KwargMatcher)>,
+    /// See :class:`DecoratorQuery::with_args`. Auto-forced to ``true``
+    /// when any ``where_kwarg`` is set.
+    pub(crate) with_args: bool,
 }
 
 impl CallQuery {
@@ -885,6 +940,7 @@ impl CallQuery {
             required_positional: None,
             path_regex: None,
             kwarg_matchers: Vec::new(),
+            with_args: true,
         }
     }
 }
@@ -928,12 +984,20 @@ impl CallQuery {
         slf
     }
 
+    /// Opt out of rust-side ``args`` / ``kwargs`` extraction; see
+    /// :meth:`DecoratorQuery.with_args` for the trade-off. Auto-forced
+    /// back to ``true`` when any ``where_kwarg`` is set.
+    fn with_args<'py>(mut slf: PyRefMut<'py, Self>, value: bool) -> PyRefMut<'py, Self> {
+        slf.with_args = value;
+        slf
+    }
+
     /// Add a kwarg matcher. Multiple calls AND together.
     ///
     /// ``value`` must be a Python literal (``None`` / ``bool`` /
-    /// ``int`` / ``float`` / ``str`` / ``list`` / ``tuple``). Passing
-    /// any other type — including a :class:`SymbolNode` — raises
-    /// ``ValueError``.
+    /// ``int`` / ``float`` / ``str`` / ``bytes`` / ``list`` /
+    /// ``tuple``). Passing any other type — including a
+    /// :class:`SymbolNode` — raises ``ValueError``.
     fn where_kwarg<'py>(
         mut slf: PyRefMut<'py, Self>,
         name: String,
@@ -981,16 +1045,16 @@ struct CallRowIdx {
 }
 
 impl CallQuery {
-    /// Shared dispatch used by both terminals (:meth:`collect` and
-    /// :meth:`row_indices`). Stays in idx-space throughout.
+    /// Shared idx-space dispatch backing :meth:`collect`.
     fn call_rows(&self, py: Python<'_>) -> PyResult<Vec<CallRowIdx>> {
         let ctx = self.ctx.borrow(py);
         let arg_index = self
             .arg_index
             .ok_or_else(|| PyValueError::new_err("CallQuery: .string_arg_at(index) is required"))?;
         let path_regex = self.path_regex.as_deref();
+        let extract_args = self.with_args || !self.kwarg_matchers.is_empty();
         let triples = if let (Some(modules), Some(name)) = (&self.modules, &self.name) {
-            ctx.find_calls_to_imported(py, modules, name, arg_index, path_regex)?
+            ctx.find_calls_to_imported(py, modules, name, arg_index, path_regex, extract_args)?
         } else if let (Some(owner), Some(attr)) = (&self.owner, &self.attr) {
             ctx.find_calls_on_var(
                 py,
@@ -999,9 +1063,10 @@ impl CallQuery {
                 arg_index,
                 self.required_positional,
                 path_regex,
+                extract_args,
             )?
         } else if let Some(attr) = &self.attr {
-            ctx.find_calls_on_attr(py, attr, arg_index, path_regex)?
+            ctx.find_calls_on_attr(py, attr, arg_index, path_regex, extract_args)?
         } else {
             return Err(PyValueError::new_err(
                 "CallQuery requires one of: where_module(...) + where_name(...); \

--- a/src/query.rs
+++ b/src/query.rs
@@ -105,6 +105,58 @@ impl CallRef {
 }
 
 // ---------------------------------------------------------------------------
+// Index-form result rows
+//
+// Lean siblings of the ref types: same dispatch, but every
+// ``SymbolNode`` field is replaced with a positional index into
+// ``ctx.nodes()`` and the costly ``args`` / ``kwargs`` row payloads
+// are dropped. Returned by the ``.row_indices()`` terminals on
+// :class:`DecoratorQuery` / :class:`ConstructionQuery` /
+// :class:`CallQuery` / :class:`FactoryQuery`. Pair with
+// :meth:`ProjectContext.node_attrs` to batch-fetch any
+// ``(kind, path, fqname, flags)`` the plugin still needs without
+// per-row ``borrow`` ping-pong.
+// ---------------------------------------------------------------------------
+
+/// Index-form sibling of :class:`DecoratorRef`. Same metadata fields,
+/// minus ``args`` / ``kwargs``; ``decorated_idx`` indexes into
+/// ``ctx.nodes()``.
+#[pyclass(frozen, get_all)]
+pub(crate) struct DecoratorIdxRef {
+    pub(crate) decorated_idx: usize,
+    pub(crate) decorator_name: Option<String>,
+    pub(crate) decorator_owner: Option<String>,
+    pub(crate) decorator_via: Option<String>,
+}
+
+/// Index-form sibling of :class:`ConstructionRef`. Same metadata
+/// fields, minus ``args`` / ``kwargs``; ``var_idx`` indexes into
+/// ``ctx.nodes()``.
+#[pyclass(frozen, get_all)]
+pub(crate) struct ConstructionIdxRef {
+    pub(crate) var_idx: usize,
+    pub(crate) class_name: String,
+}
+
+/// Index-form sibling of :class:`CallRef`. Same metadata fields,
+/// minus ``args`` / ``kwargs``; ``owner_idx`` indexes into
+/// ``ctx.nodes()``.
+#[pyclass(frozen, get_all)]
+pub(crate) struct CallIdxRef {
+    pub(crate) owner_idx: usize,
+    pub(crate) string_arg: String,
+}
+
+/// Index-form sibling of :class:`FactoryRef`. ``decl_idx`` indexes
+/// into ``ctx.nodes()``; ``kinds`` is the same sorted set of matched
+/// constructor bare-names the node-returning terminal emits.
+#[pyclass(frozen, get_all)]
+pub(crate) struct FactoryIdxRef {
+    pub(crate) decl_idx: usize,
+    pub(crate) kinds: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
 // Builder query API: builders
 // ---------------------------------------------------------------------------
 
@@ -491,38 +543,71 @@ impl DecoratorQuery {
     }
 
     fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<DecoratorRef>>> {
+        let rows = self.decorator_rows(py)?;
         let ctx = self.ctx.borrow(py);
-        let path_regex = self.path_regex.as_deref();
-        let mut refs: Vec<Py<DecoratorRef>> = Vec::new();
-        // Cache a snapshot of the build's node pool for arg materialization.
-        // Keep the borrow alive for the duration of the loop so we don't
-        // reborrow on every iteration.
         let outputs = ctx.materialized("DecoratorQuery.collect")?;
         let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let mut refs: Vec<Py<DecoratorRef>> = Vec::with_capacity(rows.len());
+        for row in rows {
+            let args = args_to_py_vec(py, &row.call_args.args, nodes);
+            let kwargs = kwargs_to_py_map(py, &row.call_args.kwargs, nodes);
+            refs.push(Py::new(
+                py,
+                DecoratorRef {
+                    decorated: nodes[row.decorated_idx].clone_ref(py),
+                    decorator_name: row.decorator_name,
+                    decorator_owner: row.decorator_owner,
+                    decorator_via: row.decorator_via,
+                    args,
+                    kwargs,
+                },
+            )?);
+        }
+        Ok(refs)
+    }
+}
+
+/// Idx-form intermediate produced by :meth:`DecoratorQuery::decorator_rows`.
+/// Carries the same metadata as :class:`DecoratorRef` minus the
+/// ``Py<SymbolNode>`` allocation — the node identity is just an index
+/// into ``ctx.nodes()``. ``call_args`` is kept so kwarg filtering and
+/// ``collect()``'s ``args`` / ``kwargs`` materialization can both share
+/// the same upstream.
+struct DecoratorRowIdx {
+    decorated_idx: usize,
+    decorator_name: Option<String>,
+    decorator_owner: Option<String>,
+    decorator_via: Option<String>,
+    call_args: crate::helpers::CallArgs,
+}
+
+impl DecoratorQuery {
+    /// Shared dispatch used by both terminals (:meth:`collect` and
+    /// :meth:`row_indices`). Stays in idx-space throughout so
+    /// ``row_indices`` can skip the ``Py<SymbolNode>`` and
+    /// ``args_to_py_vec`` allocations entirely.
+    fn decorator_rows(&self, py: Python<'_>) -> PyResult<Vec<DecoratorRowIdx>> {
+        let ctx = self.ctx.borrow(py);
+        let path_regex = self.path_regex.as_deref();
         let kwarg_matchers = &self.kwarg_matchers;
+        let mut out: Vec<DecoratorRowIdx> = Vec::new();
         if let Some(owner_attrs) = &self.owner_attrs {
             let triples = if let Some(via) = &self.via_attr {
                 ctx.find_handler_decorators_via(py, via, owner_attrs.clone(), path_regex)?
             } else {
                 ctx.find_handler_decorators(py, owner_attrs.clone(), path_regex)?
             };
-            for (owner_name, decorated, call_args) in triples {
+            for (owner_name, decorated_idx, call_args) in triples {
                 if !call_args_match_kwargs(&call_args, kwarg_matchers) {
                     continue;
                 }
-                let args = args_to_py_vec(py, &call_args.args, nodes);
-                let kwargs = kwargs_to_py_map(py, &call_args.kwargs, nodes);
-                refs.push(Py::new(
-                    py,
-                    DecoratorRef {
-                        decorated,
-                        decorator_name: None,
-                        decorator_owner: Some(owner_name),
-                        decorator_via: self.via_attr.clone(),
-                        args,
-                        kwargs,
-                    },
-                )?);
+                out.push(DecoratorRowIdx {
+                    decorated_idx,
+                    decorator_name: None,
+                    decorator_owner: Some(owner_name),
+                    decorator_via: self.via_attr.clone(),
+                    call_args,
+                });
             }
         } else if let Some(in_decl_node) = &self.in_decl {
             let names = self.names.as_ref().ok_or_else(|| {
@@ -537,63 +622,45 @@ impl DecoratorQuery {
                 .unwrap_or("")
                 .to_string();
             drop(in_decl_ref);
-            for (d, call_args) in decls {
+            for (decorated_idx, call_args) in decls {
                 if !call_args_match_kwargs(&call_args, kwarg_matchers) {
                     continue;
                 }
-                let args = args_to_py_vec(py, &call_args.args, nodes);
-                let kwargs = kwargs_to_py_map(py, &call_args.kwargs, nodes);
-                refs.push(Py::new(
-                    py,
-                    DecoratorRef {
-                        decorated: d,
-                        decorator_name: None,
-                        decorator_owner: Some(owner_simple.clone()),
-                        decorator_via: None,
-                        args,
-                        kwargs,
-                    },
-                )?);
+                out.push(DecoratorRowIdx {
+                    decorated_idx,
+                    decorator_name: None,
+                    decorator_owner: Some(owner_simple.clone()),
+                    decorator_via: None,
+                    call_args,
+                });
             }
         } else if let Some(fqn) = &self.callee_fqn {
             let decls = ctx.find_decorated(py, fqn, path_regex)?;
-            for (d, call_args) in decls {
+            for (decorated_idx, call_args) in decls {
                 if !call_args_match_kwargs(&call_args, kwarg_matchers) {
                     continue;
                 }
-                let args = args_to_py_vec(py, &call_args.args, nodes);
-                let kwargs = kwargs_to_py_map(py, &call_args.kwargs, nodes);
-                refs.push(Py::new(
-                    py,
-                    DecoratorRef {
-                        decorated: d,
-                        decorator_name: None,
-                        decorator_owner: None,
-                        decorator_via: None,
-                        args,
-                        kwargs,
-                    },
-                )?);
+                out.push(DecoratorRowIdx {
+                    decorated_idx,
+                    decorator_name: None,
+                    decorator_owner: None,
+                    decorator_via: None,
+                    call_args,
+                });
             }
         } else if let (Some(modules), Some(names)) = (&self.modules, &self.names) {
             let decls = ctx.find_decorated_decls(py, modules, names.clone(), path_regex)?;
-            for (d, call_args) in decls {
+            for (decorated_idx, call_args) in decls {
                 if !call_args_match_kwargs(&call_args, kwarg_matchers) {
                     continue;
                 }
-                let args = args_to_py_vec(py, &call_args.args, nodes);
-                let kwargs = kwargs_to_py_map(py, &call_args.kwargs, nodes);
-                refs.push(Py::new(
-                    py,
-                    DecoratorRef {
-                        decorated: d,
-                        decorator_name: None,
-                        decorator_owner: None,
-                        decorator_via: None,
-                        args,
-                        kwargs,
-                    },
-                )?);
+                out.push(DecoratorRowIdx {
+                    decorated_idx,
+                    decorator_name: None,
+                    decorator_owner: None,
+                    decorator_via: None,
+                    call_args,
+                });
             }
         } else {
             return Err(PyValueError::new_err(
@@ -602,11 +669,37 @@ impl DecoratorQuery {
                  where_owner_attr_via(via, attrs); or in_decl(node) + where_name(...)",
             ));
         }
-        Ok(refs)
+        Ok(out)
     }
 }
 
 impl_query_methods!(with_first DecoratorQuery, DecoratorRef);
+
+#[pymethods]
+impl DecoratorQuery {
+    /// Index-form row terminal. Same dispatch as :meth:`collect`, but
+    /// each row carries ``decorated_idx`` (a positional index into
+    /// ``ctx.nodes()``) instead of a ``Py<SymbolNode>``, and the
+    /// ``args`` / ``kwargs`` row payloads are skipped. Pairs with
+    /// :meth:`ProjectContext.node_attrs` and :class:`AddEdgeByIdx` /
+    /// :class:`AddNodeByIdx` to stay GIL-light end-to-end.
+    fn row_indices(&self, py: Python<'_>) -> PyResult<Vec<Py<DecoratorIdxRef>>> {
+        let rows = self.decorator_rows(py)?;
+        rows.into_iter()
+            .map(|row| {
+                Py::new(
+                    py,
+                    DecoratorIdxRef {
+                        decorated_idx: row.decorated_idx,
+                        decorator_name: row.decorator_name,
+                        decorator_owner: row.decorator_owner,
+                        decorator_via: row.decorator_via,
+                    },
+                )
+            })
+            .collect()
+    }
+}
 
 /// Find module-scope ``<var> = <Ctor>(...)`` sites. Pick exactly one
 /// of ``where_module + where_name`` or
@@ -672,42 +765,61 @@ impl ConstructionQuery {
     }
 
     fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<ConstructionRef>>> {
+        let rows = self.construction_rows(py)?;
         let ctx = self.ctx.borrow(py);
-        let path_regex = self.path_regex.as_deref();
-        let mut refs: Vec<Py<ConstructionRef>> = Vec::new();
         let outputs = ctx.materialized("ConstructionQuery.collect")?;
         let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let mut refs: Vec<Py<ConstructionRef>> = Vec::with_capacity(rows.len());
+        for row in rows {
+            let args = args_to_py_vec(py, &row.call_args.args, nodes);
+            let kwargs = kwargs_to_py_map(py, &row.call_args.kwargs, nodes);
+            refs.push(Py::new(
+                py,
+                ConstructionRef {
+                    var: nodes[row.var_idx].clone_ref(py),
+                    class_name: row.class_name,
+                    args,
+                    kwargs,
+                },
+            )?);
+        }
+        Ok(refs)
+    }
+}
+
+/// Idx-form intermediate produced by :meth:`ConstructionQuery::construction_rows`.
+struct ConstructionRowIdx {
+    var_idx: usize,
+    class_name: String,
+    call_args: crate::helpers::CallArgs,
+}
+
+impl ConstructionQuery {
+    /// Shared dispatch used by both terminals (:meth:`collect` and
+    /// :meth:`row_indices`). Stays in idx-space throughout.
+    fn construction_rows(&self, py: Python<'_>) -> PyResult<Vec<ConstructionRowIdx>> {
+        let ctx = self.ctx.borrow(py);
+        let path_regex = self.path_regex.as_deref();
+        let mut out: Vec<ConstructionRowIdx> = Vec::new();
         if let Some(fqn) = &self.class_fqn {
             let pairs = ctx.find_constructions(py, fqn, self.include_subclasses, path_regex)?;
             let cls_name = fqn.rsplit('.').next().unwrap_or("").to_string();
-            for (d, call_args) in pairs {
-                let args = args_to_py_vec(py, &call_args.args, nodes);
-                let kwargs = kwargs_to_py_map(py, &call_args.kwargs, nodes);
-                refs.push(Py::new(
-                    py,
-                    ConstructionRef {
-                        var: d,
-                        class_name: cls_name.clone(),
-                        args,
-                        kwargs,
-                    },
-                )?);
+            for (var_idx, call_args) in pairs {
+                out.push(ConstructionRowIdx {
+                    var_idx,
+                    class_name: cls_name.clone(),
+                    call_args,
+                });
             }
         } else if let (Some(modules), Some(names)) = (&self.modules, &self.names) {
             let triples =
                 ctx.find_instance_constructions(py, modules, names.clone(), path_regex)?;
-            for (var, name, call_args) in triples {
-                let args = args_to_py_vec(py, &call_args.args, nodes);
-                let kwargs = kwargs_to_py_map(py, &call_args.kwargs, nodes);
-                refs.push(Py::new(
-                    py,
-                    ConstructionRef {
-                        var,
-                        class_name: name,
-                        args,
-                        kwargs,
-                    },
-                )?);
+            for (var_idx, name, call_args) in triples {
+                out.push(ConstructionRowIdx {
+                    var_idx,
+                    class_name: name,
+                    call_args,
+                });
             }
         } else {
             return Err(PyValueError::new_err(
@@ -715,11 +827,33 @@ impl ConstructionQuery {
                  or where_module(...) + where_name(...)",
             ));
         }
-        Ok(refs)
+        Ok(out)
     }
 }
 
 impl_query_methods!(with_first ConstructionQuery, ConstructionRef);
+
+#[pymethods]
+impl ConstructionQuery {
+    /// Index-form row terminal. Same dispatch as :meth:`collect`, but
+    /// each row carries ``var_idx`` (a positional index into
+    /// ``ctx.nodes()``) instead of a ``Py<SymbolNode>``, and the
+    /// ``args`` / ``kwargs`` row payloads are skipped.
+    fn row_indices(&self, py: Python<'_>) -> PyResult<Vec<Py<ConstructionIdxRef>>> {
+        let rows = self.construction_rows(py)?;
+        rows.into_iter()
+            .map(|row| {
+                Py::new(
+                    py,
+                    ConstructionIdxRef {
+                        var_idx: row.var_idx,
+                        class_name: row.class_name,
+                    },
+                )
+            })
+            .collect()
+    }
+}
 
 /// Find call sites whose positional string-literal at the configured
 /// index is captured. :meth:`string_arg_at` is required. Pick one of:
@@ -815,6 +949,39 @@ impl CallQuery {
     }
 
     fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<CallRef>>> {
+        let rows = self.call_rows(py)?;
+        let ctx = self.ctx.borrow(py);
+        let outputs = ctx.materialized("CallQuery.collect")?;
+        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let mut refs: Vec<Py<CallRef>> = Vec::with_capacity(rows.len());
+        for row in rows {
+            let args = args_to_py_vec(py, &row.call_args.args, nodes);
+            let kwargs = kwargs_to_py_map(py, &row.call_args.kwargs, nodes);
+            refs.push(Py::new(
+                py,
+                CallRef {
+                    owner: nodes[row.owner_idx].clone_ref(py),
+                    string_arg: row.string_arg,
+                    args,
+                    kwargs,
+                },
+            )?);
+        }
+        Ok(refs)
+    }
+}
+
+/// Idx-form intermediate produced by :meth:`CallQuery::call_rows`.
+struct CallRowIdx {
+    owner_idx: usize,
+    string_arg: String,
+    call_args: crate::helpers::CallArgs,
+}
+
+impl CallQuery {
+    /// Shared dispatch used by both terminals (:meth:`collect` and
+    /// :meth:`row_indices`). Stays in idx-space throughout.
+    fn call_rows(&self, py: Python<'_>) -> PyResult<Vec<CallRowIdx>> {
         let ctx = self.ctx.borrow(py);
         let arg_index = self
             .arg_index
@@ -839,31 +1006,47 @@ impl CallQuery {
                  where_owner(...) + where_attr(...); or where_attr(...)",
             ));
         };
-        let outputs = ctx.materialized("CallQuery.collect")?;
-        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
         let kwarg_matchers = &self.kwarg_matchers;
-        let mut refs: Vec<Py<CallRef>> = Vec::new();
-        for (owner_node, s, call_args) in triples {
+        let mut out: Vec<CallRowIdx> = Vec::new();
+        for (owner_idx, string_arg, call_args) in triples {
             if !call_args_match_kwargs(&call_args, kwarg_matchers) {
                 continue;
             }
-            let args = args_to_py_vec(py, &call_args.args, nodes);
-            let kwargs = kwargs_to_py_map(py, &call_args.kwargs, nodes);
-            refs.push(Py::new(
-                py,
-                CallRef {
-                    owner: owner_node,
-                    string_arg: s,
-                    args,
-                    kwargs,
-                },
-            )?);
+            out.push(CallRowIdx {
+                owner_idx,
+                string_arg,
+                call_args,
+            });
         }
-        Ok(refs)
+        Ok(out)
     }
 }
 
 impl_query_methods!(with_first CallQuery, CallRef);
+
+#[pymethods]
+impl CallQuery {
+    /// Index-form row terminal. Same dispatch as :meth:`collect`, but
+    /// each row carries ``owner_idx`` (a positional index into
+    /// ``ctx.nodes()``) instead of a ``Py<SymbolNode>``, and the
+    /// ``args`` / ``kwargs`` row payloads are skipped. ``string_arg``
+    /// — the literal at the configured positional index — is preserved
+    /// because most call-shape plugins key on it.
+    fn row_indices(&self, py: Python<'_>) -> PyResult<Vec<Py<CallIdxRef>>> {
+        let rows = self.call_rows(py)?;
+        rows.into_iter()
+            .map(|row| {
+                Py::new(
+                    py,
+                    CallIdxRef {
+                        owner_idx: row.owner_idx,
+                        string_arg: row.string_arg,
+                    },
+                )
+            })
+            .collect()
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Subclass / Import / Class / Factory queries
@@ -1105,6 +1288,29 @@ impl FactoryQuery {
         Ok(slf)
     }
     fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<FactoryRef>>> {
+        let pairs = self.factory_rows(py)?;
+        let ctx = self.ctx.borrow(py);
+        let outputs = ctx.materialized("FactoryQuery.collect")?;
+        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        pairs
+            .into_iter()
+            .map(|(decl_idx, kinds)| {
+                Py::new(
+                    py,
+                    FactoryRef {
+                        decl: nodes[decl_idx].clone_ref(py),
+                        kinds,
+                    },
+                )
+            })
+            .collect()
+    }
+}
+
+impl FactoryQuery {
+    /// Shared dispatch used by both terminals (:meth:`collect` and
+    /// :meth:`row_indices`). Stays in idx-space throughout.
+    fn factory_rows(&self, py: Python<'_>) -> PyResult<Vec<(usize, Vec<String>)>> {
         let ctx = self.ctx.borrow(py);
         let modules = self
             .modules
@@ -1114,15 +1320,27 @@ impl FactoryQuery {
             .names
             .clone()
             .ok_or_else(|| PyValueError::new_err("FactoryQuery requires .where_name(...)"))?;
-        let pairs = ctx.find_factory_decls(py, modules, names)?;
-        pairs
-            .into_iter()
-            .map(|(decl, kinds)| Py::new(py, FactoryRef { decl, kinds }))
-            .collect()
+        ctx.find_factory_decls(py, modules, names)
     }
 }
 
 impl_query_methods!(no_first FactoryQuery);
+
+#[pymethods]
+impl FactoryQuery {
+    /// Index-form row terminal. Same dispatch as :meth:`collect`;
+    /// each row carries ``decl_idx`` (a positional index into
+    /// ``ctx.nodes()``) instead of a ``Py<SymbolNode>``. ``kinds`` is
+    /// the same sorted set of matched constructor bare-names the
+    /// node-returning terminal emits.
+    fn row_indices(&self, py: Python<'_>) -> PyResult<Vec<Py<FactoryIdxRef>>> {
+        let pairs = self.factory_rows(py)?;
+        pairs
+            .into_iter()
+            .map(|(decl_idx, kinds)| Py::new(py, FactoryIdxRef { decl_idx, kinds }))
+            .collect()
+    }
+}
 
 // ---------------------------------------------------------------------------
 // EdgeQuery — filtered enumeration over the in-progress graph's edges

--- a/src/query.rs
+++ b/src/query.rs
@@ -185,6 +185,9 @@ impl QueryBuilder {
     fn imports(&self, py: Python<'_>) -> ImportQuery {
         ImportQuery::new(self.ctx.clone_ref(py))
     }
+    fn modules(&self, py: Python<'_>) -> ModuleQuery {
+        ModuleQuery::new(self.ctx.clone_ref(py))
+    }
     fn classes(&self, py: Python<'_>) -> ClassQuery {
         ClassQuery::new(self.ctx.clone_ref(py))
     }
@@ -196,6 +199,61 @@ impl QueryBuilder {
     }
     fn decls(&self, py: Python<'_>) -> DeclQuery {
         DeclQuery::new(self.ctx.clone_ref(py))
+    }
+    fn declarations(&self, py: Python<'_>) -> DeclarationsQuery {
+        DeclarationsQuery::new(self.ctx.clone_ref(py))
+    }
+    fn main_blocks(&self, py: Python<'_>) -> MainBlockQuery {
+        MainBlockQuery::new(self.ctx.clone_ref(py))
+    }
+    fn literal_lists(&self, py: Python<'_>) -> LiteralListQuery {
+        LiteralListQuery::new(self.ctx.clone_ref(py))
+    }
+    #[allow(clippy::wrong_self_convention)]
+    fn from_idx(&self, py: Python<'_>, seed_idx: usize) -> TraverseQuery {
+        TraverseQuery::new(self.ctx.clone_ref(py), seed_idx)
+    }
+
+    /// Terminal — seedless reachability over the graph. Forward
+    /// closure from every node carrying any bit in ``seed_flags``
+    /// (default: ``NodeFlags.ENTRYPOINT``), filtering edges by
+    /// ``skip_flags``. Returns indices into ``ctx.nodes()``.
+    #[pyo3(signature = (*, skip_flags = 0, seed_flags = None))]
+    fn reachable(
+        &self,
+        py: Python<'_>,
+        skip_flags: u32,
+        seed_flags: Option<u32>,
+    ) -> PyResult<Vec<usize>> {
+        let ctx = self.ctx.borrow(py);
+        match seed_flags {
+            Some(sf) => ctx.reachable_indices(py, skip_flags, sf),
+            None => ctx.reachable_indices(py, skip_flags, crate::helpers::NODE_FLAG_ENTRYPOINT),
+        }
+    }
+
+    /// Terminal — OR-form spec matcher used by
+    /// :class:`ExplicitEntrypointPlugin`. A node matches if any of:
+    ///
+    /// * ``regexes`` contains a pattern matching the node's path
+    ///   *relative to ``project_root``* (anchored at start of input,
+    ///   like ``re.match``).
+    /// * ``str_specs`` contains the node's relative path OR its
+    ///   fqname.
+    /// * ``abs_paths`` contains the node's absolute path.
+    ///
+    /// Returns indices into ``ctx.nodes()``.
+    #[pyo3(signature = (project_root, *, regexes = Vec::new(), str_specs = Vec::new(), abs_paths = Vec::new()))]
+    fn matching_specs(
+        &self,
+        py: Python<'_>,
+        project_root: &str,
+        regexes: Vec<String>,
+        str_specs: Vec<String>,
+        abs_paths: Vec<String>,
+    ) -> PyResult<Vec<usize>> {
+        let ctx = self.ctx.borrow(py);
+        ctx.find_nodes_matching_specs_indices(py, project_root, regexes, str_specs, abs_paths)
     }
 }
 
@@ -1230,6 +1288,158 @@ impl ImportQuery {
 
 impl_query_methods!(iter_only ImportQuery);
 
+/// Enumerate / inspect project module nodes. Pick exactly one filter
+/// (``with_fqn`` / ``with_path`` / ``with_dunders``), optionally
+/// follow with one transform (``surface`` / ``top_level`` /
+/// ``dunder_all``), then drop into a terminal (``.indices()`` /
+/// ``.first_idx()``).
+///
+/// * ``with_fqn(fqn)`` — narrow to a single module by dotted fqname.
+/// * ``with_path(path)`` — narrow to the module owning ``path``.
+/// * ``with_dunders()`` — project-wide scan of module-level ``__xxx__``
+///   variables and PEP 562 dunder functions (``__getattr__`` /
+///   ``__dir__``).
+///
+/// Transforms:
+///
+/// * ``surface()`` — module + every transitive decl under its fqname
+///   tree. Models ``importlib.import_module(...)`` reachability.
+/// * ``top_level()`` — module's immediate top-level decls
+///   (``from module import *`` semantics).
+/// * ``dunder_all()`` — decls listed in the module's ``__all__``.
+///   Terminal-shaped: returns ``list[int] | None`` (``None`` when
+///   the module doesn't declare ``__all__``).
+#[pyclass(unsendable)]
+pub(crate) struct ModuleQuery {
+    pub(crate) ctx: Py<ProjectContext>,
+    pub(crate) fqn: Option<String>,
+    pub(crate) path: Option<String>,
+    pub(crate) all_dunders: bool,
+    pub(crate) transform: ModuleTransform,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ModuleTransform {
+    None,
+    Surface,
+    TopLevel,
+}
+
+impl ModuleQuery {
+    fn new(ctx: Py<ProjectContext>) -> Self {
+        Self {
+            ctx,
+            fqn: None,
+            path: None,
+            all_dunders: false,
+            transform: ModuleTransform::None,
+        }
+    }
+}
+
+#[pymethods]
+impl ModuleQuery {
+    fn with_fqn<'py>(mut slf: PyRefMut<'py, Self>, fqn: String) -> PyRefMut<'py, Self> {
+        slf.fqn = Some(fqn);
+        slf
+    }
+    fn with_path<'py>(mut slf: PyRefMut<'py, Self>, path: String) -> PyRefMut<'py, Self> {
+        slf.path = Some(path);
+        slf
+    }
+    fn with_dunders<'py>(mut slf: PyRefMut<'py, Self>) -> PyRefMut<'py, Self> {
+        slf.all_dunders = true;
+        slf
+    }
+    fn surface<'py>(mut slf: PyRefMut<'py, Self>) -> PyRefMut<'py, Self> {
+        slf.transform = ModuleTransform::Surface;
+        slf
+    }
+    fn top_level<'py>(mut slf: PyRefMut<'py, Self>) -> PyRefMut<'py, Self> {
+        slf.transform = ModuleTransform::TopLevel;
+        slf
+    }
+
+    /// Terminal — list of matching node indices into ``ctx.nodes()``.
+    ///
+    /// * No transform + ``with_fqn`` / ``with_path``: the matched
+    ///   module idx, as a 0- or 1-element list.
+    /// * ``surface()`` / ``top_level()``: the module + relevant decls.
+    /// * ``with_dunders()``: every project-wide module-level dunder
+    ///   name (``surface`` / ``top_level`` are ignored here — dunders
+    ///   are a flat scan).
+    fn indices(&self, py: Python<'_>) -> PyResult<Vec<usize>> {
+        let ctx = self.ctx.borrow(py);
+        if self.all_dunders {
+            return ctx.find_module_dunders_indices(py);
+        }
+        let fqn = self.resolve_fqn(py, &ctx)?;
+        let Some(fqn) = fqn else {
+            return Ok(Vec::new());
+        };
+        match self.transform {
+            ModuleTransform::None => Ok(ctx
+                .find_module_idx(&fqn)?
+                .map(|i| vec![i])
+                .unwrap_or_default()),
+            ModuleTransform::Surface => ctx.module_surface_indices(py, &fqn),
+            ModuleTransform::TopLevel => ctx.find_module_top_level_decls_indices(py, &fqn),
+        }
+    }
+
+    /// Terminal — first matching idx or ``None``. Convenience for
+    /// single-value lookups (``with_fqn`` / ``with_path`` without a
+    /// transform). For multi-result transforms (``surface`` /
+    /// ``top_level`` / ``with_dunders``) this returns the first row in
+    /// arbitrary order — use ``.indices()`` instead.
+    fn first_idx(&self, py: Python<'_>) -> PyResult<Option<usize>> {
+        Ok(self.indices(py)?.into_iter().next())
+    }
+
+    /// Terminal — decls listed in the module's ``__all__``, or
+    /// ``None`` when the module doesn't declare ``__all__``. Requires
+    /// ``with_fqn(fqn)``; ``with_path`` / ``with_dunders`` / transforms
+    /// are ignored.
+    fn dunder_all(&self, py: Python<'_>) -> PyResult<Option<Vec<usize>>> {
+        let ctx = self.ctx.borrow(py);
+        let fqn = self.fqn.as_deref().ok_or_else(|| {
+            PyValueError::new_err("ModuleQuery.dunder_all() requires .with_fqn(fqn)")
+        })?;
+        ctx.find_module_dunder_all_exports_indices(fqn)
+    }
+
+    /// Iterate over matched indices. Same shape as :meth:`indices`.
+    fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let idxs = self.indices(py)?;
+        let list = pyo3::types::PyList::new_bound(py, idxs);
+        Ok(list.call_method0("__iter__")?.into())
+    }
+
+    fn count(&self, py: Python<'_>) -> PyResult<usize> {
+        Ok(self.indices(py)?.len())
+    }
+}
+
+impl ModuleQuery {
+    /// Resolve the query's filter to a dotted fqname.
+    fn resolve_fqn(&self, py: Python<'_>, ctx: &ProjectContext) -> PyResult<Option<String>> {
+        if let Some(ref fqn) = self.fqn {
+            return Ok(Some(fqn.clone()));
+        }
+        if let Some(ref path) = self.path {
+            // Map path → module idx → fqname via node_attrs.
+            let Some(idx) = ctx.module_for_indices(path)? else {
+                return Ok(None);
+            };
+            let attrs = ctx.node_attrs(py, vec![idx])?;
+            return Ok(attrs.into_iter().next().map(|(_k, _p, fqname, _f)| fqname));
+        }
+        Err(PyValueError::new_err(
+            "ModuleQuery requires one of: .with_fqn(...), .with_path(...), .with_dunders()",
+        ))
+    }
+}
+
 /// Enumerate classes by structural property. Today the only filter
 /// is ``defining_method(name)`` (matches classes whose body has a
 /// ``FunctionDef`` with that name); easy to extend later.
@@ -1536,8 +1746,11 @@ pub(crate) struct DeclQuery {
     pub(crate) kinds: Option<Vec<String>>,
     pub(crate) filenames: Option<Vec<String>>,
     pub(crate) simple_names: Option<Vec<String>>,
+    pub(crate) simple_name_regex: Option<String>,
     pub(crate) paths: Option<Vec<String>>,
     pub(crate) path_regex: Option<String>,
+    pub(crate) path_prefix: Option<String>,
+    pub(crate) path_contains: Option<String>,
     pub(crate) flags_mask: Option<u32>,
     pub(crate) flags_match_any: bool,
     pub(crate) fqname_prefix: Option<String>,
@@ -1567,8 +1780,11 @@ impl DeclQuery {
             kinds: None,
             filenames: None,
             simple_names: None,
+            simple_name_regex: None,
             paths: None,
             path_regex: None,
+            path_prefix: None,
+            path_contains: None,
             flags_mask: None,
             flags_match_any: false,
             fqname_prefix: None,
@@ -1638,6 +1854,35 @@ impl DeclQuery {
     /// Restrict to nodes whose absolute path matches ``regex``.
     fn with_path_regex<'py>(mut slf: PyRefMut<'py, Self>, regex: String) -> PyRefMut<'py, Self> {
         slf.path_regex = Some(regex);
+        slf
+    }
+    /// Restrict to nodes whose absolute path starts with ``prefix``.
+    /// Cheaper than :meth:`with_path_regex` for simple directory
+    /// scoping — folds the per-node ``str.starts_with`` loop into the
+    /// query's single rust pass.
+    fn with_path_prefix<'py>(mut slf: PyRefMut<'py, Self>, prefix: String) -> PyRefMut<'py, Self> {
+        slf.path_prefix = Some(prefix);
+        slf
+    }
+    /// Restrict to nodes whose absolute path contains ``substring``
+    /// anywhere. Useful for path-pattern plugins (``alembic/versions/``,
+    /// ``.ignore.py``).
+    fn with_path_contains<'py>(
+        mut slf: PyRefMut<'py, Self>,
+        substring: String,
+    ) -> PyRefMut<'py, Self> {
+        slf.path_contains = Some(substring);
+        slf
+    }
+    /// Restrict to nodes whose trailing fqname segment matches
+    /// ``pattern`` (a regex). Use with :meth:`with_kind` /
+    /// :meth:`with_kinds` to drop modules from the result set when
+    /// you only want top-level decls.
+    fn with_simple_name_regex<'py>(
+        mut slf: PyRefMut<'py, Self>,
+        pattern: String,
+    ) -> PyRefMut<'py, Self> {
+        slf.simple_name_regex = Some(pattern);
         slf
     }
     /// Restrict to nodes whose ``flags & mask == mask`` (all bits in
@@ -1739,6 +1984,12 @@ impl DeclQuery {
         let ctx = self.ctx.borrow(py);
         let outputs = ctx.materialized("DeclQuery.indices")?;
         let path_regex = _compile_path_regex(self.path_regex.as_deref())?;
+        let simple_name_regex = match self.simple_name_regex.as_deref() {
+            None => None,
+            Some(p) => Some(regex::Regex::new(p).map_err(|e| {
+                PyValueError::new_err(format!("invalid simple-name regex {p:?}: {e}"))
+            })?),
+        };
 
         // Pre-compute hashsets for predicates that take lists. Singular
         // forms reuse the same vec (length 1) so the hashset cost is
@@ -1841,6 +2092,26 @@ impl DeclQuery {
                     continue;
                 }
             }
+            // simple-name regex
+            if let Some(re) = &simple_name_regex {
+                let fq = node.fqname.as_str();
+                let simple = fq.rsplit_once('.').map(|(_, n)| n).unwrap_or(fq);
+                if !re.is_match(simple) {
+                    continue;
+                }
+            }
+            // path prefix
+            if let Some(prefix) = &self.path_prefix {
+                if !node.path.starts_with(prefix.as_str()) {
+                    continue;
+                }
+            }
+            // path substring
+            if let Some(needle) = &self.path_contains {
+                if !node.path.contains(needle.as_str()) {
+                    continue;
+                }
+            }
             // flags mask
             if let Some(mask) = self.flags_mask {
                 if self.flags_match_any {
@@ -1885,6 +2156,221 @@ impl DeclQuery {
 }
 
 impl_query_methods!(no_first DeclQuery);
+
+// ---------------------------------------------------------------------------
+// TraverseQuery — seeded closure walks
+// ---------------------------------------------------------------------------
+
+/// Closure walks over the graph anchored at a single seed node. Built
+/// via :meth:`QueryBuilder.from_idx`. Terminals: :meth:`descendants`,
+/// :meth:`ancestors`, :meth:`direct_predecessors`. Each takes a
+/// keyword-only ``skip_flags`` mask (default ``0``) that filters out
+/// edges whose flag mask intersects — pass ``EdgeFlags.DEAD_BRANCH.value``
+/// for strict reachability.
+///
+/// All terminals return positional indices into ``ctx.nodes()``; revive
+/// rows via :meth:`ProjectContext.nodes_at` if a plugin needs full
+/// :class:`SymbolNode` objects.
+///
+/// For the seedless "alive from entrypoints" closure, use the top-level
+/// :meth:`QueryBuilder.reachable` form instead.
+#[pyclass(unsendable)]
+pub(crate) struct TraverseQuery {
+    pub(crate) ctx: Py<ProjectContext>,
+    pub(crate) seed: usize,
+}
+
+impl TraverseQuery {
+    fn new(ctx: Py<ProjectContext>, seed: usize) -> Self {
+        Self { ctx, seed }
+    }
+}
+
+#[pymethods]
+impl TraverseQuery {
+    /// Forward closure: every node reachable from the seed by
+    /// following edges. ``skip_flags`` filters out edges whose flag
+    /// mask intersects. Returns indices into ``ctx.nodes()``.
+    #[pyo3(signature = (*, skip_flags = 0))]
+    fn descendants(&self, py: Python<'_>, skip_flags: u32) -> PyResult<Vec<usize>> {
+        let ctx = self.ctx.borrow(py);
+        ctx.descendants_indices(self.seed, skip_flags)
+    }
+
+    /// Reverse closure: every node that can reach the seed by
+    /// following edges. ``skip_flags`` filters the same way as
+    /// :meth:`descendants`. Returns indices into ``ctx.nodes()``.
+    #[pyo3(signature = (*, skip_flags = 0))]
+    fn ancestors(&self, py: Python<'_>, skip_flags: u32) -> PyResult<Vec<usize>> {
+        let ctx = self.ctx.borrow(py);
+        ctx.ancestors_indices(self.seed, skip_flags)
+    }
+
+    /// One-hop reverse: the immediate predecessors of the seed (deduped
+    /// by source index, so parallel edges with different flags collapse
+    /// to a single entry). ``skip_flags`` filters edges the same way as
+    /// :meth:`ancestors`.
+    #[pyo3(signature = (*, skip_flags = 0))]
+    fn direct_predecessors(&self, py: Python<'_>, skip_flags: u32) -> PyResult<Vec<usize>> {
+        let ctx = self.ctx.borrow(py);
+        ctx.direct_predecessors_idx(self.seed, skip_flags)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DeclarationsQuery — fqname lookup with optional module fallback
+// ---------------------------------------------------------------------------
+
+/// Look up declarations by fully-qualified name. Built via
+/// :meth:`QueryBuilder.declarations`. Requires :meth:`with_fqname`;
+/// terminals are :meth:`indices` (all matching decls) and
+/// :meth:`resolve_idx` (first match, with module fallback).
+///
+/// Both terminals share the walk-back rule: if the exact fqname
+/// doesn't match, dotted segments are stripped from the right until an
+/// enclosing top-level decl is found (``pkg.lib.Cls.method`` resolves
+/// to ``pkg.lib.Cls`` because methods aren't graph nodes).
+#[pyclass(unsendable)]
+pub(crate) struct DeclarationsQuery {
+    pub(crate) ctx: Py<ProjectContext>,
+    pub(crate) fqname: Option<String>,
+}
+
+impl DeclarationsQuery {
+    fn new(ctx: Py<ProjectContext>) -> Self {
+        Self { ctx, fqname: None }
+    }
+}
+
+#[pymethods]
+impl DeclarationsQuery {
+    fn with_fqname<'py>(mut slf: PyRefMut<'py, Self>, fqname: String) -> PyRefMut<'py, Self> {
+        slf.fqname = Some(fqname);
+        slf
+    }
+
+    /// Terminal — every decl matching ``fqname`` (walk-back included).
+    /// Modules are never returned; use :meth:`QueryBuilder.modules`
+    /// for module lookup. Returns indices into ``ctx.nodes()``.
+    fn indices(&self, py: Python<'_>) -> PyResult<Vec<usize>> {
+        let ctx = self.ctx.borrow(py);
+        let fqname = self.fqname.as_deref().ok_or_else(|| {
+            PyValueError::new_err("DeclarationsQuery requires .with_fqname(fqname)")
+        })?;
+        ctx.find_declarations_indices(fqname)
+    }
+
+    /// Terminal — first decl matching ``fqname``, falling back to a
+    /// module match. Same walk-back rules as :meth:`indices` but
+    /// includes module nodes in the lookup. Returns ``None`` when the
+    /// fqname can't be found anywhere.
+    fn resolve_idx(&self, py: Python<'_>) -> PyResult<Option<usize>> {
+        let ctx = self.ctx.borrow(py);
+        let fqname = self.fqname.as_deref().ok_or_else(|| {
+            PyValueError::new_err("DeclarationsQuery requires .with_fqname(fqname)")
+        })?;
+        ctx.resolve_idx(fqname)
+    }
+
+    /// Iterate over matched indices. Same shape as :meth:`indices`.
+    fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let idxs = self.indices(py)?;
+        let list = pyo3::types::PyList::new_bound(py, idxs);
+        Ok(list.call_method0("__iter__")?.into())
+    }
+
+    fn count(&self, py: Python<'_>) -> PyResult<usize> {
+        Ok(self.indices(py)?.len())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MainBlockQuery — project-wide ``if __name__ == "__main__":`` blocks
+// ---------------------------------------------------------------------------
+
+/// Enumerate every ``if __name__ == "__main__":`` block in the project.
+/// Built via :meth:`QueryBuilder.main_blocks`. The only terminal is
+/// :meth:`index_pairs`, returning ``(module_idx, [decl_idx, ...])``
+/// pairs into ``ctx.nodes()`` — one entry per file that has a main
+/// block, with ``decl_idx`` listing the top-level decls inside the
+/// block.
+#[pyclass(unsendable)]
+pub(crate) struct MainBlockQuery {
+    pub(crate) ctx: Py<ProjectContext>,
+}
+
+impl MainBlockQuery {
+    fn new(ctx: Py<ProjectContext>) -> Self {
+        Self { ctx }
+    }
+}
+
+#[pymethods]
+impl MainBlockQuery {
+    /// Terminal — ``(module_idx, [decl_idx, ...])`` pairs for every
+    /// file with a top-level ``if __name__ == "__main__":`` block.
+    /// Same scan as :meth:`ProjectContext.find_main_blocks_indices`,
+    /// returns indices into ``ctx.nodes()``.
+    fn index_pairs(&self, py: Python<'_>) -> PyResult<Vec<(usize, Vec<usize>)>> {
+        let ctx = self.ctx.borrow(py);
+        ctx.find_main_blocks_indices()
+    }
+
+    /// Iterate over ``(module_idx, [decl_idx, ...])`` pairs.
+    fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let pairs = self.index_pairs(py)?;
+        let list = pyo3::types::PyList::new_bound(py, pairs);
+        Ok(list.call_method0("__iter__")?.into())
+    }
+
+    fn count(&self, py: Python<'_>) -> PyResult<usize> {
+        Ok(self.index_pairs(py)?.len())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LiteralListQuery — per-variable string literal list lookup
+// ---------------------------------------------------------------------------
+
+/// Read the entries of a module-level string-literal list / tuple
+/// (typical use: ``__all__``, but works for any name). Built via
+/// :meth:`QueryBuilder.literal_lists`. Requires :meth:`for_fqn`; the
+/// only terminal is :meth:`entries`.
+///
+/// Returns the concatenation of entries from every matching decl,
+/// preserving declaration order. Returns ``None`` when the fqname
+/// isn't a module-level name or doesn't bind a string-literal list.
+#[pyclass(unsendable)]
+pub(crate) struct LiteralListQuery {
+    pub(crate) ctx: Py<ProjectContext>,
+    pub(crate) fqn: Option<String>,
+}
+
+impl LiteralListQuery {
+    fn new(ctx: Py<ProjectContext>) -> Self {
+        Self { ctx, fqn: None }
+    }
+}
+
+#[pymethods]
+impl LiteralListQuery {
+    fn for_fqn<'py>(mut slf: PyRefMut<'py, Self>, fqn: String) -> PyRefMut<'py, Self> {
+        slf.fqn = Some(fqn);
+        slf
+    }
+
+    /// Terminal — the list of string entries bound to ``fqn`` at
+    /// module scope, or ``None`` when no matching binding declares a
+    /// string-literal list / tuple.
+    fn entries(&self, py: Python<'_>) -> PyResult<Option<Vec<String>>> {
+        let ctx = self.ctx.borrow(py);
+        let fqn = self
+            .fqn
+            .as_deref()
+            .ok_or_else(|| PyValueError::new_err("LiteralListQuery requires .for_fqn(fqn)"))?;
+        ctx.find_literal_list_entries(fqn)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/query.rs
+++ b/src/query.rs
@@ -110,12 +110,20 @@ impl CallRef {
 // Lean siblings of the ref types: same dispatch, but every
 // ``SymbolNode`` field is replaced with a positional index into
 // ``ctx.nodes()`` and the costly ``args`` / ``kwargs`` row payloads
-// are dropped. Returned by the ``.row_indices()`` terminals on
+// are dropped — both because they're expensive to materialise and
+// because entries inside them can be ``SymbolNode`` references that
+// would re-introduce the GIL hops the idx surface is designed to
+// avoid. Plugins that need ``args`` / ``kwargs`` access fall back to
+// the node-form ``.collect()`` terminals; plugins that only need to
+// filter by kwarg keep using ``.where_kwarg(...)``, which operates
+// rust-side before row construction either way.
+//
+// Returned by the ``.row_indices()`` terminals on
 // :class:`DecoratorQuery` / :class:`ConstructionQuery` /
 // :class:`CallQuery` / :class:`FactoryQuery`. Pair with
-// :meth:`ProjectContext.node_attrs` to batch-fetch any
-// ``(kind, path, fqname, flags)`` the plugin still needs without
-// per-row ``borrow`` ping-pong.
+// :meth:`ProjectContext.node_attrs` (or :meth:`node_paths` when only
+// ``path`` is needed) to batch-fetch any node fields the plugin still
+// needs without per-row ``borrow`` ping-pong.
 // ---------------------------------------------------------------------------
 
 /// Index-form sibling of :class:`DecoratorRef`. Same metadata fields,

--- a/tests/prototype/test_inverted_edge_example.py
+++ b/tests/prototype/test_inverted_edge_example.py
@@ -60,7 +60,13 @@ class HandlerByKwargPlugin:
     def run(self, ctx: "native.ProjectContext") -> Iterable["native.GraphOp"]:
         from dead_cst import _native as native
 
-        refs = native.query(ctx).decorators().where_owner_attr([self.decorator_attr]).collect()
+        refs = (
+            native.query(ctx)
+            .decorators()
+            .where_owner_attr([self.decorator_attr])
+            .with_args(True)
+            .collect()
+        )
         for ref in refs:
             if ref.decorator_owner != self.decorator_owner:
                 continue

--- a/tests/prototype/test_inverted_edge_example.py
+++ b/tests/prototype/test_inverted_edge_example.py
@@ -65,9 +65,9 @@ class HandlerByKwargPlugin:
             if ref.decorator_owner != self.decorator_owner:
                 continue
             target = ref.kwargs.get(self.kwarg_name)
-            if target is None or not hasattr(target, "fqname"):
+            if not isinstance(target, native.ArgNodeRef):
                 continue
-            yield native.AddEdge(target, ref.decorated)
+            yield native.AddEdgeByIdx(target.idx, ref.decorated_idx)
 
 
 def _edges(graph: "native.NativeGraph") -> set[str]:

--- a/tests/prototype/test_kwarg_matchers.py
+++ b/tests/prototype/test_kwarg_matchers.py
@@ -71,10 +71,11 @@ def test_where_kwarg_matches_list_literal(make_ctx):
             .collect()
         )
         any_route = native.query(ctx).decorators().where_owner_attr(["route"]).collect()
+        nodes = ctx.nodes()
         return {
-            "get": [r.decorated.fqname for r in get_refs],
-            "post": [r.decorated.fqname for r in post_refs],
-            "any": [r.decorated.fqname for r in any_route],
+            "get": [nodes[r.decorated_idx].fqname for r in get_refs],
+            "post": [nodes[r.decorated_idx].fqname for r in post_refs],
+            "any": [nodes[r.decorated_idx].fqname for r in any_route],
         }
 
     ctx = make_ctx(
@@ -140,17 +141,37 @@ def test_where_kwarg_missing_kwarg_never_matches(make_ctx):
     assert plugin.result == []
 
 
+def _unwrap_arg(arg):
+    """Helper: peel off the ``ArgLiteral`` / ``ArgNodeRef`` /
+    ``ArgOpaque`` wrapper to compare against raw Python values. Used by
+    the assertion-level tests below.
+    """
+    if isinstance(arg, native.ArgLiteral):
+        v = arg.value
+        if isinstance(v, list):
+            return [_unwrap_arg(x) for x in v]
+        if isinstance(v, tuple):
+            return tuple(_unwrap_arg(x) for x in v)
+        return v
+    if isinstance(arg, native.ArgNodeRef):
+        return ("node", arg.idx)
+    if isinstance(arg, native.ArgOpaque):
+        return ("opaque",)
+    raise TypeError(f"unexpected arg shape: {type(arg)!r}")
+
+
 def test_decorator_ref_args_kwargs_populated(make_ctx):
     """``@app.route("/x", methods=["GET"], strict_slashes=False)``
-    surfaces both ``args`` and ``kwargs`` on the matched ref."""
+    surfaces both ``args`` and ``kwargs`` as the discriminated-union
+    shape on the matched ref."""
 
     def capture(ctx):
         refs = native.query(ctx).decorators().where_owner_attr(["route"]).collect()
         assert len(refs) == 1
         ref = refs[0]
         return {
-            "args": list(ref.args),
-            "kwargs": dict(ref.kwargs),
+            "args": [_unwrap_arg(a) for a in ref.args],
+            "kwargs": {k: _unwrap_arg(v) for k, v in ref.kwargs.items()},
         }
 
     ctx = make_ctx(
@@ -208,19 +229,23 @@ def test_decorator_ref_args_kwargs_empty_for_bare_decorator(make_ctx):
 
 
 def test_kwarg_payload_surfaces_nativenode_for_imported_symbol(make_ctx):
-    """``@register(handler=ImportedClass)`` exposes ImportedClass as a
-    SymbolNode in ``ref.kwargs["handler"]`` so plugins can anchor inverted
-    edges off the resolved decl."""
+    """``@register(handler=ImportedClass)`` exposes ImportedClass as an
+    :class:`ArgNodeRef` in ``ref.kwargs["handler"]`` so plugins can
+    anchor inverted edges off the resolved decl."""
 
     def capture(ctx):
         refs = native.query(ctx).decorators().where_owner_attr(["register"]).collect()
+        nodes = ctx.nodes()
         out = []
         for r in refs:
             handler = r.kwargs.get("handler")
+            handler_fqname = None
+            if isinstance(handler, native.ArgNodeRef):
+                handler_fqname = nodes[handler.idx].fqname
             out.append(
                 {
-                    "decorated": r.decorated.fqname,
-                    "handler_fqname": getattr(handler, "fqname", None),
+                    "decorated": nodes[r.decorated_idx].fqname,
+                    "handler_fqname": handler_fqname,
                 }
             )
         return out
@@ -347,7 +372,7 @@ def test_call_query_where_kwarg_multiple_and_together(make_ctx):
 
 def test_call_ref_args_kwargs_populated(make_ctx):
     """``mocker.patch("X", autospec=True, foo=1)`` surfaces all args
-    and kwargs on the matched ref."""
+    and kwargs on the matched ref (as the discriminated-union shape)."""
 
     def capture(ctx):
         refs = (
@@ -362,8 +387,8 @@ def test_call_ref_args_kwargs_populated(make_ctx):
         ref = refs[0]
         return {
             "string_arg": ref.string_arg,
-            "args": list(ref.args),
-            "kwargs": dict(ref.kwargs),
+            "args": [_unwrap_arg(a) for a in ref.args],
+            "kwargs": {k: _unwrap_arg(v) for k, v in ref.kwargs.items()},
         }
 
     ctx = make_ctx(

--- a/tests/prototype/test_kwarg_matchers.py
+++ b/tests/prototype/test_kwarg_matchers.py
@@ -417,8 +417,9 @@ def test_where_kwarg_with_nativenode_raises(make_ctx):
     captured: list[Exception] = []
 
     def capture(ctx):
-        mod = ctx.find_module("tests")
-        assert mod is not None
+        mod_idx = native.query(ctx).modules().with_fqn("tests").first_idx()
+        assert mod_idx is not None
+        mod = ctx.nodes_at([mod_idx])[0]
         try:
             (
                 native.query(ctx)

--- a/tests/prototype/test_kwarg_matchers.py
+++ b/tests/prototype/test_kwarg_matchers.py
@@ -166,7 +166,7 @@ def test_decorator_ref_args_kwargs_populated(make_ctx):
     shape on the matched ref."""
 
     def capture(ctx):
-        refs = native.query(ctx).decorators().where_owner_attr(["route"]).collect()
+        refs = native.query(ctx).decorators().where_owner_attr(["route"]).with_args(True).collect()
         assert len(refs) == 1
         ref = refs[0]
         return {
@@ -234,7 +234,9 @@ def test_kwarg_payload_surfaces_nativenode_for_imported_symbol(make_ctx):
     anchor inverted edges off the resolved decl."""
 
     def capture(ctx):
-        refs = native.query(ctx).decorators().where_owner_attr(["register"]).collect()
+        refs = (
+            native.query(ctx).decorators().where_owner_attr(["register"]).with_args(True).collect()
+        )
         nodes = ctx.nodes()
         out = []
         for r in refs:
@@ -381,6 +383,7 @@ def test_call_ref_args_kwargs_populated(make_ctx):
             .where_owner("mocker")
             .where_attr("patch")
             .string_arg_at(0)
+            .with_args(True)
             .collect()
         )
         assert len(refs) == 1

--- a/tests/prototype/test_plugin_protocol.py
+++ b/tests/prototype/test_plugin_protocol.py
@@ -70,7 +70,7 @@ def test_plugin_runs_once_per_project(make_ctx):
         name = "counter"
 
         def run(self, ctx: native.ProjectContext) -> None:
-            calls.append(len(ctx.find_module_dunders()))
+            calls.append(len(native.query(ctx).modules().with_dunders().indices()))
 
     ctx = make_ctx(
         {
@@ -265,7 +265,7 @@ def test_query_outside_materialize_raises(make_ctx):
     """Calling a query method on an un-materialized context errors clearly."""
     ctx = make_ctx({"mod.py": "x = 1\n"})
     with pytest.raises(RuntimeError, match="find_module_dunders"):
-        ctx.find_module_dunders()
+        native.query(ctx).modules().with_dunders().indices()
 
 
 def test_materialize_is_idempotent(make_ctx):

--- a/tests/test_module_surface.py
+++ b/tests/test_module_surface.py
@@ -1,16 +1,17 @@
-"""Tests for the fqname-tree-backed ``ProjectContext.module_surface``
-and ``find_module_top_level_decls`` queries, and the matching
-``DeclQuery.with_fqname_under`` DSL predicate.
+"""Tests for the fqname-tree-backed ``ModuleQuery.surface`` /
+``ModuleQuery.top_level`` DSL terminals and the matching
+``DeclQuery.with_fqname_under`` predicate.
 
 All three are backed by ``BuildOutputs.children_by_parent``, a parent
 fqname -> [child node idx] index built in ``build_fqname_indices``.
 The behavior contracts these tests pin:
 
-* ``module_surface(M)``: module ``M`` plus every transitive descendant
-  in the fqname tree. Decls under ``M`` are included but their
-  sub-fqnames (synthetic method-of-class names, etc.) are NOT recursed
-  into — the BFS only steps through module children.
-* ``find_module_top_level_decls(M)``: just the immediate top-level
+* ``modules().with_fqn(M).surface()``: module ``M`` plus every
+  transitive descendant in the fqname tree. Decls under ``M`` are
+  included but their sub-fqnames (synthetic method-of-class names,
+  etc.) are NOT recursed into — the BFS only steps through module
+  children.
+* ``modules().with_fqn(M).top_level()``: just the immediate top-level
   decls (non-module children of ``M``). Submodules are excluded.
 * ``DeclQuery.with_fqname_under(P)``: ``P`` itself plus every
   segment-bounded descendant. Distinct from
@@ -22,8 +23,18 @@ from __future__ import annotations
 from dead_cst import _native as native
 
 
+def _surface_fqnames(ctx, fqn: str) -> set[str]:
+    idxs = native.query(ctx).modules().with_fqn(fqn).surface().indices()
+    return {n.fqname for n in ctx.nodes_at(idxs)}
+
+
+def _top_level_fqnames(ctx, fqn: str) -> set[str]:
+    idxs = native.query(ctx).modules().with_fqn(fqn).top_level().indices()
+    return {n.fqname for n in ctx.nodes_at(idxs)}
+
+
 # ---------------------------------------------------------------------------
-# module_surface
+# ModuleQuery.surface
 # ---------------------------------------------------------------------------
 
 
@@ -39,9 +50,12 @@ def test_module_surface_returns_module_and_all_decls(build_decl_graph):
             """,
         }
     )
-    surface = ctx.module_surface("pkg.mod")
-    fqnames = {n.fqname for n in surface}
-    assert fqnames == {"pkg.mod", "pkg.mod.foo", "pkg.mod.bar", "pkg.mod.X"}
+    assert _surface_fqnames(ctx, "pkg.mod") == {
+        "pkg.mod",
+        "pkg.mod.foo",
+        "pkg.mod.bar",
+        "pkg.mod.X",
+    }
 
 
 def test_module_surface_includes_transitive_submodules(build_decl_graph):
@@ -55,14 +69,13 @@ def test_module_surface_includes_transitive_submodules(build_decl_graph):
             "pkg/sub/b.py": "def g(): ...\n",
         }
     )
-    surface = ctx.module_surface("pkg")
-    fqnames = {n.fqname for n in surface}
+    fqnames = _surface_fqnames(ctx, "pkg")
     assert {"pkg", "pkg.a", "pkg.a.f", "pkg.sub", "pkg.sub.b", "pkg.sub.b.g"} <= fqnames
 
 
 def test_module_surface_segment_bounded(build_decl_graph):
-    """``module_surface(pkg.foo)`` must NOT pick up ``pkg.foobar`` —
-    the old linear-prefix-scan would have. The fqname-tree BFS is
+    """``surface(pkg.foo)`` must NOT pick up ``pkg.foobar`` — the old
+    linear-prefix-scan would have. The fqname-tree BFS is
     segment-bounded by construction."""
     ctx = build_decl_graph(
         {
@@ -71,8 +84,7 @@ def test_module_surface_segment_bounded(build_decl_graph):
             "pkg/foobar.py": "Y = 2\n",
         }
     )
-    surface = ctx.module_surface("pkg.foo")
-    fqnames = {n.fqname for n in surface}
+    fqnames = _surface_fqnames(ctx, "pkg.foo")
     assert "pkg.foo" in fqnames
     assert "pkg.foo.X" in fqnames
     assert "pkg.foobar" not in fqnames
@@ -81,7 +93,7 @@ def test_module_surface_segment_bounded(build_decl_graph):
 
 def test_module_surface_unknown_module_returns_empty(build_decl_graph):
     ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): ...\n"})
-    assert ctx.module_surface("does.not.exist") == []
+    assert native.query(ctx).modules().with_fqn("does.not.exist").surface().indices() == []
 
 
 def test_module_surface_does_not_recurse_into_decls(build_decl_graph):
@@ -99,19 +111,17 @@ def test_module_surface_does_not_recurse_into_decls(build_decl_graph):
             """,
         }
     )
-    surface = ctx.module_surface("pkg.mod")
-    fqnames = {n.fqname for n in surface}
     # The Klass node is in; its method nodes don't exist (nested defs
     # are deliberately not graph nodes per the architecture invariant).
-    assert fqnames == {"pkg.mod", "pkg.mod.Klass"}
+    assert _surface_fqnames(ctx, "pkg.mod") == {"pkg.mod", "pkg.mod.Klass"}
 
 
 # ---------------------------------------------------------------------------
-# find_module_top_level_decls
+# ModuleQuery.top_level
 # ---------------------------------------------------------------------------
 
 
-def test_find_top_level_decls_excludes_submodules(build_decl_graph):
+def test_top_level_excludes_submodules(build_decl_graph):
     """``from pkg import *`` doesn't pull in submodules — top-level
     decls only."""
     ctx = build_decl_graph(
@@ -120,14 +130,13 @@ def test_find_top_level_decls_excludes_submodules(build_decl_graph):
             "pkg/sub.py": "def f(): ...\n",
         }
     )
-    decls = ctx.find_module_top_level_decls("pkg")
-    fqnames = {n.fqname for n in decls}
+    fqnames = _top_level_fqnames(ctx, "pkg")
     # X is top-level; sub (a submodule) is NOT included.
     assert "pkg.X" in fqnames
     assert "pkg.sub" not in fqnames
 
 
-def test_find_top_level_decls_does_not_descend(build_decl_graph):
+def test_top_level_does_not_descend(build_decl_graph):
     """Transitive decls (``pkg.sub.x`` when querying ``pkg``) are
     excluded — only immediate children."""
     ctx = build_decl_graph(
@@ -137,15 +146,14 @@ def test_find_top_level_decls_does_not_descend(build_decl_graph):
             "pkg/sub/inner.py": "def deep(): ...\n",
         }
     )
-    decls = ctx.find_module_top_level_decls("pkg")
-    fqnames = {n.fqname for n in decls}
+    fqnames = _top_level_fqnames(ctx, "pkg")
     assert "pkg.sub.inner" not in fqnames
     assert "pkg.sub.inner.deep" not in fqnames
 
 
-def test_find_top_level_decls_segment_bounded(build_decl_graph):
-    """Same segment-bounded guarantee as ``module_surface``: the
-    sibling ``pkg.foobar`` is not pulled in by querying ``pkg.foo``."""
+def test_top_level_segment_bounded(build_decl_graph):
+    """Same segment-bounded guarantee as ``surface``: the sibling
+    ``pkg.foobar`` is not pulled in by querying ``pkg.foo``."""
     ctx = build_decl_graph(
         {
             "pkg/__init__.py": "",
@@ -153,16 +161,15 @@ def test_find_top_level_decls_segment_bounded(build_decl_graph):
             "pkg/foobar.py": "B = 2\n",
         }
     )
-    decls = ctx.find_module_top_level_decls("pkg.foo")
-    fqnames = {n.fqname for n in decls}
+    fqnames = _top_level_fqnames(ctx, "pkg.foo")
     assert "pkg.foo.A" in fqnames
     assert "pkg.foobar" not in fqnames
     assert "pkg.foobar.B" not in fqnames
 
 
-def test_find_top_level_decls_unknown_module_returns_empty(build_decl_graph):
+def test_top_level_unknown_module_returns_empty(build_decl_graph):
     ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): ...\n"})
-    assert ctx.find_module_top_level_decls("does.not.exist") == []
+    assert native.query(ctx).modules().with_fqn("does.not.exist").top_level().indices() == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plugins/test_batch_dispatch_app.py
+++ b/tests/test_plugins/test_batch_dispatch_app.py
@@ -70,9 +70,7 @@ def test_batch_matches_individual_for_flask_fastapi(build_plugin_graph, reachabl
     assert individual == batched
 
 
-def test_batch_matches_individual_for_seed_and_dispatch_mix(
-    build_plugin_graph, reachable_fqnames
-):
+def test_batch_matches_individual_for_seed_and_dispatch_mix(build_plugin_graph, reachable_fqnames):
     files = {
         "app/__init__.py": "",
         "app/flask_app.py": """
@@ -189,3 +187,130 @@ def test_batch_with_one_plugin_matches_individual(build_plugin_graph, reachable_
         build_plugin_graph(files, [BatchDispatchAppPlugin(plugins=[flask_plugin()])])
     )
     assert individual == batched
+
+
+# ---------------------------------------------------------------------------
+# spec / policy split — subclass overrides of policy() must be honored
+# uniformly by both the standalone DispatchAppPlugin.run path and the
+# batched BatchDispatchAppPlugin.run path. This is the bit the previous
+# "compose existing plugins" design got wrong: it called
+# ``plugin._emit_ops`` rather than letting subclasses override behavior.
+# ---------------------------------------------------------------------------
+
+
+def test_subclass_policy_override_honored_by_batch(build_plugin_graph, reachable_fqnames):
+    """A subclass that extends ``policy`` to emit additional ops should
+    have those extra ops fire whether it's invoked standalone OR
+    wrapped in ``BatchDispatchAppPlugin``. This is the regression the
+    spec/policy split fixes — the previous batch design only invoked
+    the standard policy and skipped subclass extensions.
+    """
+    from collections.abc import Iterable
+    from dataclasses import dataclass
+
+    from dead_cst import _native as native
+    from dead_cst.plugins import DispatchAppGather, DispatchAppPlugin
+
+    @dataclass
+    class FlaskPlusMarker(DispatchAppPlugin):
+        """Flask spec + an extra synthetic node per discovered app."""
+
+        marker_prefix: str = "flask_plus"
+        app_classes: tuple[str, ...] = ("flask.Flask",)
+        registration_decorators: frozenset[str] = frozenset({"route"})
+
+        def policy(
+            self, ctx: native.ProjectContext, gathered: DispatchAppGather
+        ) -> Iterable[native.GraphOp]:
+            yield from super().policy(ctx, gathered)
+            # Subclass extension: mint a uniquely-named marker per
+            # direct construction so we can prove the override fired.
+            for ref in gathered.direct:
+                yield native.AddNodeByIdx(
+                    fqname=f"<flask-plus-extra>:{ref.var_idx}",
+                    path=ref.path,
+                )
+
+    files = {
+        "app/__init__.py": "",
+        "app/main.py": """
+        from flask import Flask
+
+        app = Flask(__name__)
+
+        @app.route("/x")
+        def x(): pass
+        """,
+    }
+
+    def _extra_fqnames(ctx) -> set[str]:
+        return {n.fqname for n in ctx.nodes() if n.fqname.startswith("<flask-plus-extra>:")}
+
+    standalone_ctx = build_plugin_graph(files, [FlaskPlusMarker()])
+    batched_ctx = build_plugin_graph(files, [BatchDispatchAppPlugin(plugins=[FlaskPlusMarker()])])
+
+    standalone_extras = _extra_fqnames(standalone_ctx)
+    batched_extras = _extra_fqnames(batched_ctx)
+
+    # Both paths must emit the same set of extension markers.
+    assert standalone_extras
+    assert standalone_extras == batched_extras
+    # And the underlying dispatch reachability must still match.
+    assert reachable_fqnames(standalone_ctx) == reachable_fqnames(batched_ctx)
+
+
+def test_celery_shared_task_fires_in_batch(build_plugin_graph, reachable_fqnames):
+    """CeleryPlugin's ``@shared_task`` fan-out lives in its policy()
+    override. Wrapping it in BatchDispatchAppPlugin must still trigger
+    that fan-out — the original 'compose existing plugins' design
+    skipped subclass run() overrides; the spec/policy split fixes it.
+    """
+    files = {
+        "app/__init__.py": "",
+        "app/tasks.py": """
+        from celery import shared_task
+
+        @shared_task
+        def send_email(addr): pass
+        """,
+    }
+    individual = reachable_fqnames(build_plugin_graph(files, [CeleryPlugin()]))
+    batched = reachable_fqnames(
+        build_plugin_graph(files, [BatchDispatchAppPlugin(plugins=[CeleryPlugin()])])
+    )
+    assert "app.tasks.send_email" in individual
+    assert "app.tasks.send_email" in batched
+    assert individual == batched
+
+
+def test_spec_property_packages_class_attrs():
+    """The ``spec`` property is a derived view of the plugin's class
+    attributes — same values, packaged in a frozen DispatchAppSpec.
+    Subclasses that override the attributes get a spec that reflects
+    those overrides; no extra wiring needed.
+    """
+    from dataclasses import dataclass
+
+    from dead_cst.plugins import DispatchAppPlugin, DispatchAppSpec
+
+    @dataclass
+    class _Custom(DispatchAppPlugin):
+        marker_prefix: str = "my"
+        app_classes: tuple[str, ...] = ("pkg.App",)
+        registration_decorators: frozenset[str] = frozenset({"handler"})
+        seed_as_entrypoint: bool = False
+
+    plugin = _Custom()
+    spec = plugin.spec
+    assert isinstance(spec, DispatchAppSpec)
+    assert spec.marker_prefix == "my"
+    assert spec.app_classes == ("pkg.App",)
+    assert spec.registration_decorators == frozenset({"handler"})
+    assert spec.seed_as_entrypoint is False
+    # Spec is frozen → hashable; equal-by-value.
+    assert spec == DispatchAppSpec(
+        marker_prefix="my",
+        app_classes=("pkg.App",),
+        registration_decorators=frozenset({"handler"}),
+        seed_as_entrypoint=False,
+    )

--- a/tests/test_plugins/test_batch_dispatch_app.py
+++ b/tests/test_plugins/test_batch_dispatch_app.py
@@ -1,0 +1,191 @@
+"""Tests for :class:`BatchDispatchAppPlugin`.
+
+The plugin's contract is parity with running each wrapped
+``DispatchAppPlugin`` individually — same reachable set, same dead
+set — but with fused queries under the hood. The tests below pin
+that observable equivalence across the framework patterns that
+exercise the trickier branches: ``seed_as_entrypoint=True`` factories,
+``seed_as_entrypoint=False`` dispatch, multiple plugins targeting the
+same module, and plugins targeting disjoint modules.
+"""
+
+from __future__ import annotations
+
+from dead_cst.contrib import (
+    CeleryPlugin,
+    cyclopts_plugin,
+    fastapi_plugin,
+    flask_plugin,
+    typer_plugin,
+)
+from dead_cst.plugins import BatchDispatchAppPlugin, DispatchAppPlugin
+
+
+def _plugins_flask_fastapi() -> list[DispatchAppPlugin]:
+    return [flask_plugin(), fastapi_plugin()]
+
+
+def _plugins_seed_and_dispatch() -> list[DispatchAppPlugin]:
+    # Mixes seed_as_entrypoint=True (Flask, Celery) with
+    # seed_as_entrypoint=False (Cyclopts, Typer) — exercises both
+    # branches of the per-plugin emission.
+    return [flask_plugin(), CeleryPlugin(), cyclopts_plugin(), typer_plugin()]
+
+
+def test_batch_matches_individual_for_flask_fastapi(build_plugin_graph, reachable_fqnames):
+    files = {
+        "app/__init__.py": "",
+        "app/flask_app.py": """
+        from flask import Flask
+
+        app = Flask(__name__)
+
+        @app.route("/hello")
+        def hello(): pass
+
+        @app.get("/items/<id>")
+        def get_item(id): pass
+
+        def helper(): pass
+        """,
+        "app/fastapi_app.py": """
+        from fastapi import FastAPI
+
+        api = FastAPI()
+
+        @api.get("/health")
+        def health(): pass
+
+        @api.post("/items")
+        def create_item(): pass
+
+        def helper(): pass
+        """,
+    }
+
+    individual = reachable_fqnames(build_plugin_graph(files, _plugins_flask_fastapi()))
+    batched = reachable_fqnames(
+        build_plugin_graph(files, [BatchDispatchAppPlugin(plugins=_plugins_flask_fastapi())])
+    )
+    assert individual == batched
+
+
+def test_batch_matches_individual_for_seed_and_dispatch_mix(
+    build_plugin_graph, reachable_fqnames
+):
+    files = {
+        "app/__init__.py": "",
+        "app/flask_app.py": """
+        from flask import Flask
+
+        app = Flask(__name__)
+
+        @app.route("/hello")
+        def hello(): pass
+        """,
+        "app/celery_app.py": """
+        from celery import Celery
+
+        celery_app = Celery("tasks")
+
+        @celery_app.task
+        def add(x, y): return x + y
+        """,
+        "app/cyclopts_app.py": """
+        from cyclopts import App
+
+        cli = App()
+
+        @cli.command
+        def hello(): pass
+
+        def helper_used_by_hello():
+            hello()
+        """,
+        "app/typer_app.py": """
+        import typer
+
+        app = typer.Typer()
+
+        @app.command()
+        def serve(): pass
+        """,
+    }
+
+    plugins = _plugins_seed_and_dispatch()
+    individual = reachable_fqnames(build_plugin_graph(files, plugins))
+    batched = reachable_fqnames(
+        build_plugin_graph(files, [BatchDispatchAppPlugin(plugins=_plugins_seed_and_dispatch())])
+    )
+    assert individual == batched
+
+
+def test_batch_with_factory_chains(build_plugin_graph, reachable_fqnames):
+    """Factory-app promotion (``app = create_app()``) must survive the
+    batched path — exercises the step-6 ``direct_predecessors_idx`` walk
+    via per-plugin emission."""
+    files = {
+        "app/__init__.py": "",
+        "app/factory.py": """
+        from flask import Flask
+
+        def create_app() -> Flask:
+            return Flask(__name__)
+
+        app = create_app()
+
+        @app.route("/")
+        def index(): pass
+        """,
+    }
+    individual = reachable_fqnames(build_plugin_graph(files, [flask_plugin()]))
+    batched = reachable_fqnames(
+        build_plugin_graph(files, [BatchDispatchAppPlugin(plugins=[flask_plugin()])])
+    )
+    assert individual == batched
+    assert "app.factory.index" in batched
+    assert "app.factory.create_app" in batched
+    assert "app.factory.app" in batched
+
+
+def test_batch_skips_when_no_framework_imported(build_plugin_graph, reachable_fqnames):
+    """The import-presence guard short-circuits every wrapped plugin
+    cleanly. Parity check against the unbatched run is the contract:
+    same dead set with or without the framework imports."""
+    files = {
+        "app/__init__.py": "",
+        "app/plain.py": """
+        def unused(): pass
+
+        def used():
+            unused()
+
+        used()
+        """,
+    }
+    individual = reachable_fqnames(build_plugin_graph(files, _plugins_flask_fastapi()))
+    batched = reachable_fqnames(
+        build_plugin_graph(files, [BatchDispatchAppPlugin(plugins=_plugins_flask_fastapi())])
+    )
+    assert individual == batched
+
+
+def test_batch_with_one_plugin_matches_individual(build_plugin_graph, reachable_fqnames):
+    """Degenerate batch (single wrapped plugin) must match the
+    individual run exactly — the simplest equivalence check."""
+    files = {
+        "app/__init__.py": "",
+        "app/main.py": """
+        from flask import Flask
+
+        app = Flask(__name__)
+
+        @app.route("/x")
+        def x(): pass
+        """,
+    }
+    individual = reachable_fqnames(build_plugin_graph(files, [flask_plugin()]))
+    batched = reachable_fqnames(
+        build_plugin_graph(files, [BatchDispatchAppPlugin(plugins=[flask_plugin()])])
+    )
+    assert individual == batched

--- a/tests/test_plugins/test_dispatch_app_auto_batch.py
+++ b/tests/test_plugins/test_dispatch_app_auto_batch.py
@@ -1,12 +1,15 @@
-"""Tests for :class:`BatchDispatchAppPlugin`.
+"""Tests for the harness's automatic batching of
+:class:`DispatchAppPlugin` instances.
 
-The plugin's contract is parity with running each wrapped
-``DispatchAppPlugin`` individually — same reachable set, same dead
-set — but with fused queries under the hood. The tests below pin
-that observable equivalence across the framework patterns that
-exercise the trickier branches: ``seed_as_entrypoint=True`` factories,
-``seed_as_entrypoint=False`` dispatch, multiple plugins targeting the
-same module, and plugins targeting disjoint modules.
+Registering multiple ``DispatchAppPlugin``\\ s with :class:`Analysis`
+no longer requires any wrapper — ``Analysis.materialize_all`` detects
+every dispatch plugin, runs one fused ``_gather_batched`` on the main
+thread, and fans the per-plugin :meth:`policy` calls out through the
+same ``ThreadPoolExecutor`` it uses for non-dispatch plugins.
+
+The tests below pin the observable contract: routes wired correctly
+across frameworks, subclass ``policy()`` overrides honored, and inactive
+plugins (framework not imported) no-op cleanly.
 """
 
 from __future__ import annotations
@@ -18,7 +21,7 @@ from dead_cst.contrib import (
     flask_plugin,
     typer_plugin,
 )
-from dead_cst.plugins import BatchDispatchAppPlugin, DispatchAppPlugin
+from dead_cst.plugins import DispatchAppPlugin
 
 
 def _plugins_flask_fastapi() -> list[DispatchAppPlugin]:
@@ -32,7 +35,9 @@ def _plugins_seed_and_dispatch() -> list[DispatchAppPlugin]:
     return [flask_plugin(), CeleryPlugin(), cyclopts_plugin(), typer_plugin()]
 
 
-def test_batch_matches_individual_for_flask_fastapi(build_plugin_graph, reachable_fqnames):
+def test_multiple_dispatch_plugins_wire_routes(build_plugin_graph, reachable_fqnames):
+    """Two ``DispatchAppPlugin`` instances registered together produce
+    a combined reachable set covering both frameworks' routes."""
     files = {
         "app/__init__.py": "",
         "app/flask_app.py": """
@@ -63,14 +68,24 @@ def test_batch_matches_individual_for_flask_fastapi(build_plugin_graph, reachabl
         """,
     }
 
-    individual = reachable_fqnames(build_plugin_graph(files, _plugins_flask_fastapi()))
-    batched = reachable_fqnames(
-        build_plugin_graph(files, [BatchDispatchAppPlugin(plugins=_plugins_flask_fastapi())])
-    )
-    assert individual == batched
+    alive = reachable_fqnames(build_plugin_graph(files, _plugins_flask_fastapi()))
+    # Every Flask + FastAPI handler should be kept alive.
+    for fq in (
+        "app.flask_app.hello",
+        "app.flask_app.get_item",
+        "app.fastapi_app.health",
+        "app.fastapi_app.create_item",
+    ):
+        assert fq in alive, fq
+    # Unused helpers stay dead.
+    assert "app.flask_app.helper" not in alive
+    assert "app.fastapi_app.helper" not in alive
 
 
-def test_batch_matches_individual_for_seed_and_dispatch_mix(build_plugin_graph, reachable_fqnames):
+def test_mixed_seed_and_dispatch_modes(build_plugin_graph, reachable_fqnames):
+    """``seed_as_entrypoint=True`` (Flask, Celery) and
+    ``seed_as_entrypoint=False`` (Cyclopts, Typer) plugins coexisting
+    in one registration list."""
     files = {
         "app/__init__.py": "",
         "app/flask_app.py": """
@@ -110,18 +125,22 @@ def test_batch_matches_individual_for_seed_and_dispatch_mix(build_plugin_graph, 
         """,
     }
 
-    plugins = _plugins_seed_and_dispatch()
-    individual = reachable_fqnames(build_plugin_graph(files, plugins))
-    batched = reachable_fqnames(
-        build_plugin_graph(files, [BatchDispatchAppPlugin(plugins=_plugins_seed_and_dispatch())])
-    )
-    assert individual == batched
+    alive = reachable_fqnames(build_plugin_graph(files, _plugins_seed_and_dispatch()))
+    # seed_as_entrypoint=True frameworks promote their app instances.
+    assert "app.flask_app.app" in alive
+    assert "app.celery_app.celery_app" in alive
+    assert "app.flask_app.hello" in alive
+    assert "app.celery_app.add" in alive
+    # seed_as_entrypoint=False frameworks don't promote the app — the
+    # handler is only alive because no entrypoint reaches it here.
+    # (Cyclopts / Typer apps stay dead without ``[project.scripts]`` /
+    # ``__main__:`` wiring, and that's the documented contract.)
 
 
-def test_batch_with_factory_chains(build_plugin_graph, reachable_fqnames):
-    """Factory-app promotion (``app = create_app()``) must survive the
-    batched path — exercises the step-6 ``direct_predecessors_idx`` walk
-    via per-plugin emission."""
+def test_factory_chains(build_plugin_graph, reachable_fqnames):
+    """Factory-app promotion (``app = create_app()``) survives the
+    harness's auto-batched gather — exercises the step-6
+    ``direct_predecessors_idx`` walk inside :meth:`policy`."""
     files = {
         "app/__init__.py": "",
         "app/factory.py": """
@@ -136,20 +155,17 @@ def test_batch_with_factory_chains(build_plugin_graph, reachable_fqnames):
         def index(): pass
         """,
     }
-    individual = reachable_fqnames(build_plugin_graph(files, [flask_plugin()]))
-    batched = reachable_fqnames(
-        build_plugin_graph(files, [BatchDispatchAppPlugin(plugins=[flask_plugin()])])
-    )
-    assert individual == batched
-    assert "app.factory.index" in batched
-    assert "app.factory.create_app" in batched
-    assert "app.factory.app" in batched
+    alive = reachable_fqnames(build_plugin_graph(files, [flask_plugin()]))
+    assert "app.factory.index" in alive
+    assert "app.factory.create_app" in alive
+    assert "app.factory.app" in alive
 
 
-def test_batch_skips_when_no_framework_imported(build_plugin_graph, reachable_fqnames):
-    """The import-presence guard short-circuits every wrapped plugin
-    cleanly. Parity check against the unbatched run is the contract:
-    same dead set with or without the framework imports."""
+def test_inactive_dispatch_plugins_skip_cleanly(build_plugin_graph, reachable_fqnames):
+    """When no project file imports the framework, every dispatch
+    plugin's ``_is_active(ctx)`` returns ``False`` and the harness's
+    shim becomes a no-op — same reachable set as registering no
+    plugins at all."""
     files = {
         "app/__init__.py": "",
         "app/plain.py": """
@@ -161,16 +177,15 @@ def test_batch_skips_when_no_framework_imported(build_plugin_graph, reachable_fq
         used()
         """,
     }
-    individual = reachable_fqnames(build_plugin_graph(files, _plugins_flask_fastapi()))
-    batched = reachable_fqnames(
-        build_plugin_graph(files, [BatchDispatchAppPlugin(plugins=_plugins_flask_fastapi())])
-    )
-    assert individual == batched
+    with_dispatch = reachable_fqnames(build_plugin_graph(files, _plugins_flask_fastapi()))
+    without_dispatch = reachable_fqnames(build_plugin_graph(files, []))
+    assert with_dispatch == without_dispatch
 
 
-def test_batch_with_one_plugin_matches_individual(build_plugin_graph, reachable_fqnames):
-    """Degenerate batch (single wrapped plugin) must match the
-    individual run exactly — the simplest equivalence check."""
+def test_single_dispatch_plugin_path(build_plugin_graph, reachable_fqnames):
+    """Degenerate batch (one ``DispatchAppPlugin``) — the auto-batching
+    path with a single plugin must wire the same routes a standalone
+    run would."""
     files = {
         "app/__init__.py": "",
         "app/main.py": """
@@ -182,29 +197,24 @@ def test_batch_with_one_plugin_matches_individual(build_plugin_graph, reachable_
         def x(): pass
         """,
     }
-    individual = reachable_fqnames(build_plugin_graph(files, [flask_plugin()]))
-    batched = reachable_fqnames(
-        build_plugin_graph(files, [BatchDispatchAppPlugin(plugins=[flask_plugin()])])
-    )
-    assert individual == batched
+    alive = reachable_fqnames(build_plugin_graph(files, [flask_plugin()]))
+    assert "app.main.app" in alive
+    assert "app.main.x" in alive
 
 
 # ---------------------------------------------------------------------------
 # spec / policy split — subclass overrides of policy() must be honored
-# uniformly by both the standalone DispatchAppPlugin.run path and the
-# batched BatchDispatchAppPlugin.run path. This is the bit the previous
-# "compose existing plugins" design got wrong: it called
-# ``plugin._emit_ops`` rather than letting subclasses override behavior.
+# uniformly by the harness's auto-batched gather. The previous design
+# (composing plugins inside an explicit BatchDispatchAppPlugin wrapper)
+# got this wrong; the spec/policy split fixes it and the harness now
+# inherits the same guarantee for free.
 # ---------------------------------------------------------------------------
 
 
-def test_subclass_policy_override_honored_by_batch(build_plugin_graph, reachable_fqnames):
-    """A subclass that extends ``policy`` to emit additional ops should
-    have those extra ops fire whether it's invoked standalone OR
-    wrapped in ``BatchDispatchAppPlugin``. This is the regression the
-    spec/policy split fixes — the previous batch design only invoked
-    the standard policy and skipped subclass extensions.
-    """
+def test_subclass_policy_override_fires_under_auto_batch(build_plugin_graph, reachable_fqnames):
+    """A subclass that extends ``policy`` to emit extra ops must have
+    those ops fire whether it runs alongside other dispatch plugins
+    (auto-batched) or as the only plugin."""
     from collections.abc import Iterable
     from dataclasses import dataclass
 
@@ -246,25 +256,28 @@ def test_subclass_policy_override_honored_by_batch(build_plugin_graph, reachable
     def _extra_fqnames(ctx) -> set[str]:
         return {n.fqname for n in ctx.nodes() if n.fqname.startswith("<flask-plus-extra>:")}
 
-    standalone_ctx = build_plugin_graph(files, [FlaskPlusMarker()])
-    batched_ctx = build_plugin_graph(files, [BatchDispatchAppPlugin(plugins=[FlaskPlusMarker()])])
+    # Run the subclass on its own AND alongside another DispatchAppPlugin —
+    # both paths hit the harness's auto-batching code, but the second
+    # path exercises the spec/policy fan-out across N > 1 dispatch plugins.
+    solo_ctx = build_plugin_graph(files, [FlaskPlusMarker()])
+    batched_ctx = build_plugin_graph(files, [FlaskPlusMarker(), fastapi_plugin()])
 
-    standalone_extras = _extra_fqnames(standalone_ctx)
+    solo_extras = _extra_fqnames(solo_ctx)
     batched_extras = _extra_fqnames(batched_ctx)
 
-    # Both paths must emit the same set of extension markers.
-    assert standalone_extras
-    assert standalone_extras == batched_extras
-    # And the underlying dispatch reachability must still match.
-    assert reachable_fqnames(standalone_ctx) == reachable_fqnames(batched_ctx)
+    # Both paths emit the same set of extension markers — the
+    # additional fastapi_plugin slot adds no Flask markers and doesn't
+    # suppress FlaskPlusMarker's extras.
+    assert solo_extras
+    assert solo_extras == batched_extras
+    # And the underlying dispatch reachability matches too.
+    assert reachable_fqnames(solo_ctx) == reachable_fqnames(batched_ctx)
 
 
 def test_celery_shared_task_fires_in_batch(build_plugin_graph, reachable_fqnames):
     """CeleryPlugin's ``@shared_task`` fan-out lives in its policy()
-    override. Wrapping it in BatchDispatchAppPlugin must still trigger
-    that fan-out — the original 'compose existing plugins' design
-    skipped subclass run() overrides; the spec/policy split fixes it.
-    """
+    override. The harness's auto-batching must still trigger that
+    fan-out when CeleryPlugin sits in a list of dispatch plugins."""
     files = {
         "app/__init__.py": "",
         "app/tasks.py": """
@@ -274,13 +287,12 @@ def test_celery_shared_task_fires_in_batch(build_plugin_graph, reachable_fqnames
         def send_email(addr): pass
         """,
     }
-    individual = reachable_fqnames(build_plugin_graph(files, [CeleryPlugin()]))
-    batched = reachable_fqnames(
-        build_plugin_graph(files, [BatchDispatchAppPlugin(plugins=[CeleryPlugin()])])
-    )
-    assert "app.tasks.send_email" in individual
+    alone = reachable_fqnames(build_plugin_graph(files, [CeleryPlugin()]))
+    # Pair Celery with another dispatch plugin to hit the multi-plugin
+    # auto-batch path explicitly.
+    batched = reachable_fqnames(build_plugin_graph(files, [CeleryPlugin(), flask_plugin()]))
+    assert "app.tasks.send_email" in alone
     assert "app.tasks.send_email" in batched
-    assert individual == batched
 
 
 def test_spec_property_packages_class_attrs():

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -36,7 +36,9 @@ EXPECTED_PUBLIC_API: dict[str, list[str]] = {
     "dead_cst.plugins": [
         "BatchDispatchAppPlugin",
         "DecoratedDeclPlugin",
+        "DispatchAppGather",
         "DispatchAppPlugin",
+        "DispatchAppSpec",
         "DynamicImportFallbackPlugin",
         "EXTERNAL_DIST_PREFIX",
         "EXTERNAL_FILE_PREFIX",

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -34,7 +34,6 @@ EXPECTED_PUBLIC_API: dict[str, list[str]] = {
         "write_graph",
     ],
     "dead_cst.plugins": [
-        "BatchDispatchAppPlugin",
         "DecoratedDeclPlugin",
         "DispatchAppGather",
         "DispatchAppPlugin",

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -34,6 +34,7 @@ EXPECTED_PUBLIC_API: dict[str, list[str]] = {
         "write_graph",
     ],
     "dead_cst.plugins": [
+        "BatchDispatchAppPlugin",
         "DecoratedDeclPlugin",
         "DispatchAppPlugin",
         "DynamicImportFallbackPlugin",

--- a/tests/test_query_dsl.py
+++ b/tests/test_query_dsl.py
@@ -40,7 +40,7 @@ def test_decorator_where_module_accepts_single_string(build_decl_graph):
         }
     )
     refs = list(native.query(ctx).decorators().where_module("flask").where_name("route"))
-    fqnames = {r.decorated.fqname for r in refs}
+    fqnames = {ctx.nodes()[r.decorated_idx].fqname for r in refs}
     assert "pkg.mod.handler" in fqnames
 
 
@@ -57,7 +57,7 @@ def test_decorator_where_module_accepts_single_element_list(build_decl_graph):
         }
     )
     refs = list(native.query(ctx).decorators().where_module(["flask"]).where_name("route"))
-    fqnames = {r.decorated.fqname for r in refs}
+    fqnames = {ctx.nodes()[r.decorated_idx].fqname for r in refs}
     assert "pkg.mod.handler" in fqnames
 
 
@@ -83,7 +83,7 @@ def test_decorator_where_module_accepts_multi_element_list(build_decl_graph):
         }
     )
     refs = list(native.query(ctx).decorators().where_module(["flask", "quart"]).where_name("route"))
-    fqnames = {r.decorated.fqname for r in refs}
+    fqnames = {ctx.nodes()[r.decorated_idx].fqname for r in refs}
     assert "pkg.flask_app.f_handler" in fqnames
     assert "pkg.quart_app.q_handler" in fqnames
     assert "pkg.other.o_handler" not in fqnames
@@ -124,7 +124,7 @@ def test_construction_where_module_accepts_list(build_decl_graph):
         .where_module(["flask", "quart"])
         .where_name(["Flask", "Quart"])
     )
-    fqnames = {r.var.fqname for r in refs}
+    fqnames = {ctx.nodes()[r.var_idx].fqname for r in refs}
     assert "pkg.flask_app.app" in fqnames
     assert "pkg.quart_app.app" in fqnames
 
@@ -176,7 +176,7 @@ def test_factory_of_module_accepts_list(build_decl_graph):
     refs = list(
         native.query(ctx).factories().of_module(["flask", "quart"]).where_name(["Flask", "Quart"])
     )
-    by_fq = {r.decl.fqname: r.kinds for r in refs}
+    by_fq = {ctx.nodes()[r.decl_idx].fqname: r.kinds for r in refs}
     assert "pkg.factories.make_flask" in by_fq
     assert "pkg.factories.make_quart" in by_fq
     assert "Flask" in by_fq["pkg.factories.make_flask"]
@@ -206,7 +206,7 @@ def test_decorator_matches_relative_import(build_decl_graph):
         }
     )
     refs = list(native.query(ctx).decorators().where_module("pkg.foo").where_name("route"))
-    fqnames = {r.decorated.fqname for r in refs}
+    fqnames = {ctx.nodes()[r.decorated_idx].fqname for r in refs}
     assert "pkg.handlers.handler" in fqnames
 
 
@@ -224,7 +224,7 @@ def test_construction_matches_relative_import(build_decl_graph):
         }
     )
     refs = list(native.query(ctx).constructions().where_module("pkg.foo").where_name("Worker"))
-    fqnames = {r.var.fqname for r in refs}
+    fqnames = {ctx.nodes()[r.var_idx].fqname for r in refs}
     assert "pkg.handlers.w" in fqnames
 
 
@@ -248,7 +248,7 @@ def test_construction_matches_subscripted_generic(build_decl_graph):
         }
     )
     refs = list(native.query(ctx).constructions().where_module("pkg.lib").where_name("Worker"))
-    fqnames = {r.var.fqname for r in refs}
+    fqnames = {ctx.nodes()[r.var_idx].fqname for r in refs}
     assert "pkg.uses.w" in fqnames
 
 
@@ -266,7 +266,7 @@ def test_construction_matches_subscripted_generic_via_module_attr(build_decl_gra
         }
     )
     refs = list(native.query(ctx).constructions().where_module("pkg.lib").where_name("Worker"))
-    fqnames = {r.var.fqname for r in refs}
+    fqnames = {ctx.nodes()[r.var_idx].fqname for r in refs}
     assert "pkg.uses.w" in fqnames
 
 

--- a/tests/test_query_indices.py
+++ b/tests/test_query_indices.py
@@ -692,3 +692,286 @@ def test_factory_query_row_indices_matches_collect(build_decl_graph):
     for ref, row in zip(refs, rows, strict=True):
         assert all_nodes[row.decl_idx].fqname == ref.decl.fqname
         assert row.kinds == ref.kinds
+
+
+# ---------------------------------------------------------------------------
+# AddEntrypointByIdx — graph op
+# ---------------------------------------------------------------------------
+
+
+def test_add_entrypoint_by_idx_promotes_seed(tmp_path):
+    """``AddEntrypointByIdx(idx, marker=...)`` mints the same
+    ``<marker>:<decl.fqname>`` synthetic the node-form ``AddEntrypoint``
+    does, and the decl + everything it reaches stay alive."""
+    from dead_cst.analyze import Analysis
+    from dead_cst.plugins._base import Plugin
+
+    (tmp_path / "mod.py").write_text(
+        "def used_by_seed(): pass\ndef seed(): used_by_seed()\ndef dead(): pass\n"
+    )
+
+    class SeedByIdx(Plugin):
+        name = "seed_by_idx"
+        version = 1
+
+        def run(self, ctx: native.ProjectContext):
+            (seed_idx,) = ctx.indices_where(fqname_prefix="mod.seed")
+            yield native.AddEntrypointByIdx(seed_idx, marker="<seed>")
+
+    analysis = Analysis(tmp_path, plugins=[SeedByIdx()])
+    ctx = analysis.materialize_all()
+    fqnames = [n.fqname for n in ctx.nodes()]
+    # Marker is composed as ``<marker>:<decl.fqname>`` — same shape
+    # ``AddEntrypoint`` uses.
+    assert "<seed>:mod.seed" in fqnames
+    dead_fqnames = {n.fqname for n in analysis.dead()}
+    assert "mod.seed" not in dead_fqnames
+    assert "mod.used_by_seed" not in dead_fqnames
+    assert "mod.dead" in dead_fqnames
+
+
+def test_add_entrypoint_by_idx_out_of_range_raises(tmp_path):
+    from dead_cst.analyze import Analysis
+    from dead_cst.plugins._base import Plugin
+
+    (tmp_path / "mod.py").write_text("def f(): pass\n")
+
+    class BadIdx(Plugin):
+        name = "bad_idx"
+        version = 1
+
+        def run(self, ctx: native.ProjectContext):
+            yield native.AddEntrypointByIdx(10**9, marker="<seed>")
+
+    analysis = Analysis(tmp_path, plugins=[BadIdx()])
+    with pytest.raises(IndexError, match="decl_idx"):
+        analysis.materialize_all()
+
+
+# ---------------------------------------------------------------------------
+# ctx.find_module_idx
+# ---------------------------------------------------------------------------
+
+
+def test_find_module_idx_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {"pkg/__init__.py": "", "pkg/sub/__init__.py": "", "pkg/sub/inner.py": "x = 1\n"}
+    )
+    for fqn in ("pkg", "pkg.sub", "pkg.sub.inner"):
+        node = ctx.find_module(fqn)
+        idx = ctx.find_module_idx(fqn)
+        assert node is not None
+        assert idx is not None
+        assert ctx.nodes()[idx].fqname == node.fqname
+
+
+def test_find_module_idx_unknown_returns_none(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    assert ctx.find_module_idx("nothing.here") is None
+
+
+# ---------------------------------------------------------------------------
+# ctx.find_module_dunders_indices
+# ---------------------------------------------------------------------------
+
+
+def test_find_module_dunders_indices_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "__all__ = []\n__version__ = '1.0'\n",
+            "pkg/a.py": "def __getattr__(name): pass\nx = 1\n",
+        }
+    )
+    nodes = ctx.find_module_dunders()
+    indices = ctx.find_module_dunders_indices()
+    assert len(nodes) == len(indices)
+    revived = ctx.nodes_at(indices)
+    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
+    # ``x = 1`` is a plain top-level variable — must not be surfaced.
+    assert all("x" not in n.fqname.rsplit(".", 1)[-1] for n in revived)
+
+
+# ---------------------------------------------------------------------------
+# ctx.find_nodes_matching_specs_indices
+# ---------------------------------------------------------------------------
+
+
+def test_find_nodes_matching_specs_indices_matches_node_form(build_decl_graph, tmp_path):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def handler(): pass\n",
+            "pkg/util.py": "def helper(): pass\n",
+        }
+    )
+    # Use the same three spec buckets the ExplicitEntrypointPlugin
+    # exercises: regex, str (relative path or fqname), abs path.
+    nodes = ctx.find_nodes_matching_specs(
+        str(tmp_path),
+        regexes=[r"pkg/svc\.py"],
+        str_specs=["pkg.util.helper"],
+        abs_paths=[],
+    )
+    indices = ctx.find_nodes_matching_specs_indices(
+        str(tmp_path),
+        regexes=[r"pkg/svc\.py"],
+        str_specs=["pkg.util.helper"],
+        abs_paths=[],
+    )
+    assert len(nodes) == len(indices)
+    revived = ctx.nodes_at(indices)
+    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
+    assert {"pkg.svc.handler", "pkg.util.helper"} <= {n.fqname for n in revived}
+
+
+# ---------------------------------------------------------------------------
+# ctx.subclasses_of_fqn_indices + SubclassQuery.of_idx +
+# ctx.find_subclasses_of_idx
+# ---------------------------------------------------------------------------
+
+
+def test_subclasses_of_fqn_indices_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/bases.py": "class Base: pass\n",
+            "pkg/sub.py": (
+                "from pkg.bases import Base\nclass Mid(Base): pass\nclass Leaf(Mid): pass\n"
+            ),
+        }
+    )
+    nodes = ctx.subclasses_of_fqn("pkg.bases.Base", transitive=True)
+    indices = ctx.subclasses_of_fqn_indices("pkg.bases.Base", transitive=True)
+    assert len(nodes) == len(indices)
+    revived = ctx.nodes_at(indices)
+    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
+
+
+def test_subclasses_of_fqn_indices_transitive_flag(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/bases.py": "class Base: pass\n",
+            "pkg/sub.py": (
+                "from pkg.bases import Base\nclass Mid(Base): pass\nclass Leaf(Mid): pass\n"
+            ),
+        }
+    )
+    direct = ctx.subclasses_of_fqn_indices("pkg.bases.Base", transitive=False)
+    direct_revived = {n.fqname for n in ctx.nodes_at(direct)}
+    assert direct_revived == {"pkg.sub.Mid"}  # Leaf is not a *direct* subclass of Base
+
+
+def test_find_subclasses_of_idx_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "class Base: pass\nclass Sub(Base): pass\n",
+        }
+    )
+    (base_idx,) = ctx.indices_where(fqname_prefix="pkg.a.Base", kind="class")
+    base_node = ctx.nodes_at([base_idx])[0]
+    nodes = ctx.find_subclasses_of(base_node)
+    idx_results = ctx.find_subclasses_of_idx(base_idx)
+    assert len(nodes) == len(idx_results)
+    revived = ctx.nodes_at(idx_results)
+    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
+
+
+def test_find_subclasses_of_idx_non_class_returns_empty(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): pass\n"})
+    (f_idx,) = ctx.indices_where(fqname_prefix="pkg.a.f", kind="function")
+    # Same contract as the node-form: non-class seed returns empty.
+    assert ctx.find_subclasses_of_idx(f_idx) == []
+
+
+def test_find_subclasses_of_idx_out_of_range_raises(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "class X: pass\n"})
+    n = len(ctx.nodes())
+    with pytest.raises(IndexError, match="out of range"):
+        ctx.find_subclasses_of_idx(n)
+
+
+def test_subclass_query_of_idx_matches_of_node(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "class Base: pass\nclass Sub(Base): pass\n",
+        }
+    )
+    (base_idx,) = ctx.indices_where(fqname_prefix="pkg.a.Base", kind="class")
+    base_node = ctx.nodes_at([base_idx])[0]
+    by_node = native.query(ctx).subclasses().of_node(base_node).indices()
+    by_idx = native.query(ctx).subclasses().of_idx(base_idx).indices()
+    assert sorted(by_node) == sorted(by_idx)
+
+
+# ---------------------------------------------------------------------------
+# ctx.direct_predecessors_idx
+# ---------------------------------------------------------------------------
+
+
+def test_direct_predecessors_idx_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "def callee(): pass\ndef caller(): callee()\ncaller()\n",
+        }
+    )
+    (callee_idx,) = ctx.indices_where(fqname_prefix="pkg.a.callee", kind="function")
+    callee_node = ctx.nodes_at([callee_idx])[0]
+    nodes = ctx.direct_predecessors(callee_node)
+    indices = ctx.direct_predecessors_idx(callee_idx)
+    assert len(nodes) == len(indices)
+    revived = ctx.nodes_at(indices)
+    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
+    # ``caller`` definitely calls ``callee`` — sanity check.
+    assert "pkg.a.caller" in {n.fqname for n in revived}
+
+
+def test_direct_predecessors_idx_out_of_range_raises(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): pass\n"})
+    n = len(ctx.nodes())
+    with pytest.raises(IndexError, match="out of range"):
+        ctx.direct_predecessors_idx(n)
+
+
+# ---------------------------------------------------------------------------
+# DecoratorQuery.in_decl_idx
+# ---------------------------------------------------------------------------
+
+
+def test_decorator_query_in_decl_idx_matches_in_decl(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/app.py": (
+                "from cyclopts import App\n"
+                "cli = App()\n"
+                "@cli.command\n"
+                "def hello(): pass\n"
+                "@cli.command\n"
+                "def bye(): pass\n"
+            ),
+        }
+    )
+    (cli_idx,) = ctx.indices_where(fqname_prefix="pkg.app.cli", kind="variable")
+    cli_node = ctx.nodes_at([cli_idx])[0]
+    by_node = native.query(ctx).decorators().in_decl(cli_node).where_name("command").row_indices()
+    by_idx = native.query(ctx).decorators().in_decl_idx(cli_idx).where_name("command").row_indices()
+    assert len(by_node) == len(by_idx)
+    assert sorted(r.decorated_idx for r in by_node) == sorted(r.decorated_idx for r in by_idx)
+
+
+def test_decorator_query_in_decl_idx_requires_where_name(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    (x_idx,) = ctx.indices_where(fqname_prefix="pkg.a.x", kind="variable")
+    with pytest.raises(ValueError, match="where_name"):
+        native.query(ctx).decorators().in_decl_idx(x_idx).row_indices()
+
+
+def test_decorator_query_in_decl_idx_out_of_range_raises(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    n = len(ctx.nodes())
+    with pytest.raises(IndexError, match="out of range"):
+        native.query(ctx).decorators().in_decl_idx(n).where_name("command").row_indices()

--- a/tests/test_query_indices.py
+++ b/tests/test_query_indices.py
@@ -647,47 +647,43 @@ def test_node_paths_bounds_check(build_decl_graph):
 
 
 # ---------------------------------------------------------------------------
-# *Query.row_indices — index-form row terminals
+# Ref-query .collect() terminals — idx-shape contract
 # ---------------------------------------------------------------------------
 
 
-def test_decorator_query_row_indices_matches_collect(build_decl_graph):
+def test_decorator_query_collect_returns_idx_rows(build_decl_graph):
     ctx = build_decl_graph(
         {
             "pkg/__init__.py": "",
             "pkg/svc.py": ("import functools\n@functools.lru_cache\ndef cached(): pass\n"),
         }
     )
-    q = native.query(ctx).decorators().where_module("functools").where_name("lru_cache")
-    refs = q.collect()
-    rows = q.row_indices()
-    assert len(refs) == len(rows) == 1
-    all_nodes = ctx.nodes()
-    for ref, row in zip(refs, rows, strict=True):
-        assert all_nodes[row.decorated_idx].fqname == ref.decorated.fqname
-        assert row.decorator_name == ref.decorator_name
-        assert row.decorator_owner == ref.decorator_owner
-        assert row.decorator_via == ref.decorator_via
+    rows = (
+        native.query(ctx).decorators().where_module("functools").where_name("lru_cache").collect()
+    )
+    assert len(rows) == 1
+    [row] = rows
+    assert isinstance(row, native.DecoratorIdxRef)
+    assert ctx.nodes()[row.decorated_idx].fqname == "pkg.svc.cached"
+    assert row.path.endswith("svc.py")
 
 
-def test_construction_query_row_indices_matches_collect(build_decl_graph):
+def test_construction_query_collect_returns_idx_rows(build_decl_graph):
     ctx = build_decl_graph(
         {
             "pkg/__init__.py": "",
             "pkg/app.py": "import flask\napp = flask.Flask(__name__)\n",
         }
     )
-    q = native.query(ctx).constructions().where_module("flask").where_name("Flask")
-    refs = q.collect()
-    rows = q.row_indices()
-    assert len(refs) == len(rows) == 1
-    all_nodes = ctx.nodes()
-    for ref, row in zip(refs, rows, strict=True):
-        assert all_nodes[row.var_idx].fqname == ref.var.fqname
-        assert row.class_name == ref.class_name
+    rows = native.query(ctx).constructions().where_module("flask").where_name("Flask").collect()
+    assert len(rows) == 1
+    [row] = rows
+    assert isinstance(row, native.ConstructionIdxRef)
+    assert ctx.nodes()[row.var_idx].fqname == "pkg.app.app"
+    assert row.class_name == "Flask"
 
 
-def test_call_query_row_indices_matches_collect(build_decl_graph):
+def test_call_query_collect_returns_idx_rows(build_decl_graph):
     ctx = build_decl_graph(
         {
             "pkg/__init__.py": "",
@@ -696,38 +692,34 @@ def test_call_query_row_indices_matches_collect(build_decl_graph):
             ),
         }
     )
-    q = (
+    rows = (
         native.query(ctx)
         .calls()
         .where_owner("app.config")
         .where_attr("from_object")
         .string_arg_at(0)
+        .collect()
     )
-    refs = q.collect()
-    rows = q.row_indices()
-    assert len(refs) == len(rows)
-    if refs:
-        all_nodes = ctx.nodes()
-        for ref, row in zip(refs, rows, strict=True):
-            assert all_nodes[row.owner_idx].fqname == ref.owner.fqname
-            assert row.string_arg == ref.string_arg
+    if rows:
+        [row] = rows
+        assert isinstance(row, native.CallIdxRef)
+        assert ctx.nodes()[row.owner_idx].fqname == "pkg.app"
+        assert row.string_arg == "settings"
 
 
-def test_factory_query_row_indices_matches_collect(build_decl_graph):
+def test_factory_query_collect_returns_idx_rows(build_decl_graph):
     ctx = build_decl_graph(
         {
             "pkg/__init__.py": "",
             "pkg/factory.py": ("import flask\ndef make_app():\n    return flask.Flask(__name__)\n"),
         }
     )
-    q = native.query(ctx).factories().of_module("flask").where_name("Flask")
-    refs = q.collect()
-    rows = q.row_indices()
-    assert len(refs) == len(rows)
-    all_nodes = ctx.nodes()
-    for ref, row in zip(refs, rows, strict=True):
-        assert all_nodes[row.decl_idx].fqname == ref.decl.fqname
-        assert row.kinds == ref.kinds
+    rows = native.query(ctx).factories().of_module("flask").where_name("Flask").collect()
+    assert len(rows) == 1
+    [row] = rows
+    assert isinstance(row, native.FactoryIdxRef)
+    assert ctx.nodes()[row.decl_idx].fqname == "pkg.factory.make_app"
+    assert "Flask" in row.kinds
 
 
 # ---------------------------------------------------------------------------
@@ -993,8 +985,8 @@ def test_decorator_query_in_decl_idx_matches_in_decl(build_decl_graph):
     )
     (cli_idx,) = ctx.indices_where(fqname_prefix="pkg.app.cli", kind="variable")
     cli_node = ctx.nodes_at([cli_idx])[0]
-    by_node = native.query(ctx).decorators().in_decl(cli_node).where_name("command").row_indices()
-    by_idx = native.query(ctx).decorators().in_decl_idx(cli_idx).where_name("command").row_indices()
+    by_node = native.query(ctx).decorators().in_decl(cli_node).where_name("command").collect()
+    by_idx = native.query(ctx).decorators().in_decl_idx(cli_idx).where_name("command").collect()
     assert len(by_node) == len(by_idx)
     assert sorted(r.decorated_idx for r in by_node) == sorted(r.decorated_idx for r in by_idx)
 
@@ -1003,14 +995,14 @@ def test_decorator_query_in_decl_idx_requires_where_name(build_decl_graph):
     ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
     (x_idx,) = ctx.indices_where(fqname_prefix="pkg.a.x", kind="variable")
     with pytest.raises(ValueError, match="where_name"):
-        native.query(ctx).decorators().in_decl_idx(x_idx).row_indices()
+        native.query(ctx).decorators().in_decl_idx(x_idx).collect()
 
 
 def test_decorator_query_in_decl_idx_out_of_range_raises(build_decl_graph):
     ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
     n = len(ctx.nodes())
     with pytest.raises(IndexError, match="out of range"):
-        native.query(ctx).decorators().in_decl_idx(n).where_name("command").row_indices()
+        native.query(ctx).decorators().in_decl_idx(n).where_name("command").collect()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_query_indices.py
+++ b/tests/test_query_indices.py
@@ -151,28 +151,6 @@ def test_edge_query_index_triples_matches_collect(build_decl_graph):
 
 
 # ---------------------------------------------------------------------------
-# ctx.reachable_indices parity with ctx.reachable
-# ---------------------------------------------------------------------------
-
-
-def test_reachable_indices_matches_reachable(build_decl_graph):
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/main.py": """
-            def used(): pass
-            def unused(): pass
-            used()
-            """,
-        }
-    )
-    # Same seed_flags / skip_flags: idx and node forms must agree.
-    nodes = ctx.reachable()
-    indices = ctx.reachable_indices()
-    assert {ctx.nodes()[i].fqname for i in indices} == {n.fqname for n in nodes}
-
-
-# ---------------------------------------------------------------------------
 # ctx.indices_where predicate combos
 # ---------------------------------------------------------------------------
 
@@ -414,67 +392,8 @@ def test_add_node_by_idx_default_no_edges(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# ctx.find_declarations_indices
+# ctx.modules_for_paths — bulk path → module idx lookup
 # ---------------------------------------------------------------------------
-
-
-def test_find_declarations_indices_matches_node_form(build_decl_graph):
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/svc.py": "def handler(): pass\nclass Service: pass\n",
-        }
-    )
-    nodes = ctx.find_declarations("pkg.svc.handler")
-    indices = ctx.find_declarations_indices("pkg.svc.handler")
-    assert len(nodes) == len(indices) == 1
-    all_nodes = ctx.nodes()
-    assert all_nodes[indices[0]].fqname == nodes[0].fqname
-
-
-def test_find_declarations_indices_walks_back(build_decl_graph):
-    """``pkg.svc.Cls.method`` resolves to ``pkg.svc.Cls`` — methods don't
-    get their own graph node."""
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/svc.py": "class Cls:\n    def method(self): pass\n",
-        }
-    )
-    indices = ctx.find_declarations_indices("pkg.svc.Cls.method")
-    revived = ctx.nodes_at(indices)
-    assert {n.fqname for n in revived} == {"pkg.svc.Cls"}
-
-
-def test_find_declarations_indices_unknown_returns_empty(build_decl_graph):
-    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
-    assert ctx.find_declarations_indices("nothing.here") == []
-
-
-# ---------------------------------------------------------------------------
-# ctx.module_for_indices + modules_for_paths
-# ---------------------------------------------------------------------------
-
-
-def test_module_for_indices_matches_node_form(build_decl_graph):
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/svc.py": "def f(): pass\n",
-        }
-    )
-    # ``module_for`` keys on the absolute path stored on the SymbolNode.
-    svc_path = next(n.path for n in ctx.nodes() if n.fqname == "pkg.svc")
-    node = ctx.module_for(svc_path)
-    assert node is not None
-    idx = ctx.module_for_indices(svc_path)
-    assert idx is not None
-    assert ctx.nodes()[idx].fqname == node.fqname
-
-
-def test_module_for_indices_missing_path(build_decl_graph):
-    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
-    assert ctx.module_for_indices("/not/a/real/path.py") is None
 
 
 def test_modules_for_paths_bulk(build_decl_graph):
@@ -498,28 +417,8 @@ def test_modules_for_paths_bulk(build_decl_graph):
 
 
 # ---------------------------------------------------------------------------
-# ctx.module_surface_indices + module_surfaces_indices
+# ctx.module_surfaces_indices — bulk module-surface lookup
 # ---------------------------------------------------------------------------
-
-
-def test_module_surface_indices_matches_node_form(build_decl_graph):
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/svc.py": "def handler(): pass\nclass Service: pass\n",
-            "pkg/sub/__init__.py": "",
-            "pkg/sub/inner.py": "def deep(): pass\n",
-        }
-    )
-    nodes = ctx.module_surface("pkg")
-    indices = ctx.module_surface_indices("pkg")
-    assert len(nodes) == len(indices)
-    assert {ctx.nodes()[i].fqname for i in indices} == {n.fqname for n in nodes}
-
-
-def test_module_surface_indices_unknown_returns_empty(build_decl_graph):
-    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
-    assert ctx.module_surface_indices("nothing.here") == []
 
 
 def test_module_surfaces_indices_bulk(build_decl_graph):
@@ -532,41 +431,16 @@ def test_module_surfaces_indices_bulk(build_decl_graph):
             "other/m.py": "def m(): pass\n",
         }
     )
-    node_buckets = ctx.module_surfaces(["pkg", "other", "missing"])
     idx_buckets = ctx.module_surfaces_indices(["pkg", "other", "missing"])
-    assert set(node_buckets.keys()) == set(idx_buckets.keys())
-    for key in node_buckets:
-        node_fqs = {n.fqname for n in node_buckets[key]}
-        idx_fqs = {ctx.nodes()[i].fqname for i in idx_buckets[key]}
-        assert node_fqs == idx_fqs
-
-
-# ---------------------------------------------------------------------------
-# ctx.find_main_blocks_indices
-# ---------------------------------------------------------------------------
-
-
-def test_find_main_blocks_indices_matches_node_form(build_decl_graph):
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/m.py": (
-                'def helper(): pass\nif __name__ == "__main__":\n    helper()\n    x = 1\n'
-            ),
-        }
-    )
-    node_pairs = ctx.find_main_blocks()
-    idx_pairs = ctx.find_main_blocks_indices()
-    assert len(node_pairs) == len(idx_pairs) == 1
-    (mod_node, decls) = node_pairs[0]
-    (mod_idx, decl_idxs) = idx_pairs[0]
-    assert ctx.nodes()[mod_idx].fqname == mod_node.fqname
-    assert {ctx.nodes()[i].fqname for i in decl_idxs} == {d.fqname for d in decls}
-
-
-def test_find_main_blocks_indices_no_main_block(build_decl_graph):
-    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
-    assert ctx.find_main_blocks_indices() == []
+    assert "missing" in idx_buckets and idx_buckets["missing"] == []
+    fqs_pkg = {ctx.nodes()[i].fqname for i in idx_buckets["pkg"]}
+    fqs_other = {ctx.nodes()[i].fqname for i in idx_buckets["other"]}
+    # ``pkg`` surface is the module + every transitive decl under it.
+    assert "pkg.svc.handler" in fqs_pkg
+    assert "pkg.util.helper" in fqs_pkg
+    assert "other.m.m" in fqs_other
+    # Buckets must not bleed across keys.
+    assert not (fqs_pkg & fqs_other)
 
 
 # ---------------------------------------------------------------------------
@@ -845,84 +719,7 @@ def test_add_entrypoint_by_idx_out_of_range_raises(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# ctx.find_module_idx
-# ---------------------------------------------------------------------------
-
-
-def test_find_module_idx_matches_node_form(build_decl_graph):
-    ctx = build_decl_graph(
-        {"pkg/__init__.py": "", "pkg/sub/__init__.py": "", "pkg/sub/inner.py": "x = 1\n"}
-    )
-    for fqn in ("pkg", "pkg.sub", "pkg.sub.inner"):
-        node = ctx.find_module(fqn)
-        idx = ctx.find_module_idx(fqn)
-        assert node is not None
-        assert idx is not None
-        assert ctx.nodes()[idx].fqname == node.fqname
-
-
-def test_find_module_idx_unknown_returns_none(build_decl_graph):
-    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
-    assert ctx.find_module_idx("nothing.here") is None
-
-
-# ---------------------------------------------------------------------------
-# ctx.find_module_dunders_indices
-# ---------------------------------------------------------------------------
-
-
-def test_find_module_dunders_indices_matches_node_form(build_decl_graph):
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "__all__ = []\n__version__ = '1.0'\n",
-            "pkg/a.py": "def __getattr__(name): pass\nx = 1\n",
-        }
-    )
-    nodes = ctx.find_module_dunders()
-    indices = ctx.find_module_dunders_indices()
-    assert len(nodes) == len(indices)
-    revived = ctx.nodes_at(indices)
-    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
-    # ``x = 1`` is a plain top-level variable — must not be surfaced.
-    assert all("x" not in n.fqname.rsplit(".", 1)[-1] for n in revived)
-
-
-# ---------------------------------------------------------------------------
-# ctx.find_nodes_matching_specs_indices
-# ---------------------------------------------------------------------------
-
-
-def test_find_nodes_matching_specs_indices_matches_node_form(build_decl_graph, tmp_path):
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/svc.py": "def handler(): pass\n",
-            "pkg/util.py": "def helper(): pass\n",
-        }
-    )
-    # Use the same three spec buckets the ExplicitEntrypointPlugin
-    # exercises: regex, str (relative path or fqname), abs path.
-    nodes = ctx.find_nodes_matching_specs(
-        str(tmp_path),
-        regexes=[r"pkg/svc\.py"],
-        str_specs=["pkg.util.helper"],
-        abs_paths=[],
-    )
-    indices = ctx.find_nodes_matching_specs_indices(
-        str(tmp_path),
-        regexes=[r"pkg/svc\.py"],
-        str_specs=["pkg.util.helper"],
-        abs_paths=[],
-    )
-    assert len(nodes) == len(indices)
-    revived = ctx.nodes_at(indices)
-    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
-    assert {"pkg.svc.handler", "pkg.util.helper"} <= {n.fqname for n in revived}
-
-
-# ---------------------------------------------------------------------------
-# ctx.subclasses_of_fqn_indices + SubclassQuery.of_idx +
-# ctx.find_subclasses_of_idx
+# SubclassQuery.of_fqn / of_idx / of_node
 # ---------------------------------------------------------------------------
 
 
@@ -998,36 +795,6 @@ def test_subclass_query_of_idx_matches_of_node(build_decl_graph):
 
 
 # ---------------------------------------------------------------------------
-# ctx.direct_predecessors_idx
-# ---------------------------------------------------------------------------
-
-
-def test_direct_predecessors_idx_matches_node_form(build_decl_graph):
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/a.py": "def callee(): pass\ndef caller(): callee()\ncaller()\n",
-        }
-    )
-    (callee_idx,) = ctx.indices_where(fqname_prefix="pkg.a.callee", kind="function")
-    callee_node = ctx.nodes_at([callee_idx])[0]
-    nodes = ctx.direct_predecessors(callee_node)
-    indices = ctx.direct_predecessors_idx(callee_idx)
-    assert len(nodes) == len(indices)
-    revived = ctx.nodes_at(indices)
-    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
-    # ``caller`` definitely calls ``callee`` — sanity check.
-    assert "pkg.a.caller" in {n.fqname for n in revived}
-
-
-def test_direct_predecessors_idx_out_of_range_raises(build_decl_graph):
-    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): pass\n"})
-    n = len(ctx.nodes())
-    with pytest.raises(IndexError, match="out of range"):
-        ctx.direct_predecessors_idx(n)
-
-
-# ---------------------------------------------------------------------------
 # DecoratorQuery.in_decl_idx
 # ---------------------------------------------------------------------------
 
@@ -1069,164 +836,29 @@ def test_decorator_query_in_decl_idx_out_of_range_raises(build_decl_graph):
 
 
 # ---------------------------------------------------------------------------
-# ctx.resolve_idx
+# TraverseQuery bounds — out-of-range seeds raise IndexError
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_idx_matches_node_form(build_decl_graph):
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/svc.py": "def handler(): pass\nclass Service: pass\n",
-        }
-    )
-    # Exact decl, exact module, walk-back from method-level fqname.
-    for fqn in ("pkg.svc.handler", "pkg.svc", "pkg.svc.Service.method"):
-        node = ctx.resolve(fqn)
-        idx = ctx.resolve_idx(fqn)
-        assert node is not None
-        assert idx is not None
-        assert ctx.nodes()[idx].fqname == node.fqname
-
-
-def test_resolve_idx_unknown_returns_none(build_decl_graph):
-    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
-    assert ctx.resolve_idx("nothing.here") is None
-
-
-# ---------------------------------------------------------------------------
-# ctx.decls_under_indices / decls_matching_indices / decls_matching_name_indices
-# ---------------------------------------------------------------------------
-
-
-def test_decls_under_indices_matches_node_form(build_decl_graph, tmp_path):
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/svc.py": "def handler(): pass\n",
-            "pkg/util.py": "def helper(): pass\n",
-            "other/__init__.py": "",
-            "other/m.py": "def m(): pass\n",
-        }
-    )
-    prefix = str(tmp_path / "pkg")
-    nodes = ctx.decls_under(prefix)
-    indices = ctx.decls_under_indices(prefix)
-    assert len(nodes) == len(indices)
-    revived = ctx.nodes_at(indices)
-    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
-    # Sanity: nothing under "other" leaked into the bucket.
-    assert all(not n.fqname.startswith("other.") for n in revived)
-
-
-def test_decls_matching_indices_matches_node_form(build_decl_graph):
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/test_a.py": "def test_one(): pass\n",
-            "pkg/main.py": "def main(): pass\n",
-        }
-    )
-    nodes = ctx.decls_matching("test_a")
-    indices = ctx.decls_matching_indices("test_a")
-    assert len(nodes) == len(indices)
-    revived = ctx.nodes_at(indices)
-    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
-
-
-def test_decls_matching_name_indices_matches_node_form(build_decl_graph):
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/a.py": "def test_one(): pass\ndef helper(): pass\nclass TestX: pass\n",
-        }
-    )
-    nodes = ctx.decls_matching_name(r"^(test_|Test)")
-    indices = ctx.decls_matching_name_indices(r"^(test_|Test)")
-    assert len(nodes) == len(indices)
-    revived = ctx.nodes_at(indices)
-    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
-    assert {"pkg.a.test_one", "pkg.a.TestX"} <= {n.fqname for n in revived}
-    # The kind filter excludes module nodes — verify a module's name
-    # isn't accidentally surfaced even though "a" matches no pattern here.
-    assert all(n.kind != "module" for n in revived)
-
-
-# ---------------------------------------------------------------------------
-# ctx.descendants_indices / ancestors_indices
-# ---------------------------------------------------------------------------
-
-
-def test_descendants_indices_matches_node_form(build_decl_graph):
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/a.py": ("def leaf(): pass\ndef middle(): leaf()\ndef root(): middle()\nroot()\n"),
-        }
-    )
-    (root_idx,) = ctx.indices_where(fqname_prefix="pkg.a.root", kind="function")
-    root_node = ctx.nodes_at([root_idx])[0]
-    nodes = ctx.descendants(root_node)
-    indices = ctx.descendants_indices(root_idx)
-    assert len(nodes) == len(indices)
-    revived = ctx.nodes_at(indices)
-    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
-    # Sanity: the forward closure includes the transitive targets.
-    assert {"pkg.a.middle", "pkg.a.leaf"} <= {n.fqname for n in revived}
-
-
-def test_descendants_indices_skip_flags(build_decl_graph):
-    """``skip_flags`` parity: DEAD_BRANCH edges are filtered the same
-    way by both forms."""
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/a.py": (
-                "def alive_only_in_dead_branch(): pass\n"
-                "def caller():\n"
-                "    if False:\n"
-                "        alive_only_in_dead_branch()\n"
-                "caller()\n"
-            ),
-        }
-    )
-    (caller_idx,) = ctx.indices_where(fqname_prefix="pkg.a.caller", kind="function")
-    caller_node = ctx.nodes_at([caller_idx])[0]
-    skip = int(native.EdgeFlags.DEAD_BRANCH)
-    nodes = ctx.descendants(caller_node, skip_flags=skip)
-    indices = ctx.descendants_indices(caller_idx, skip_flags=skip)
-    assert {n.fqname for n in nodes} == {ctx.nodes()[i].fqname for i in indices}
-
-
-def test_descendants_indices_out_of_range_raises(build_decl_graph):
+def test_traverse_descendants_out_of_range_raises(build_decl_graph):
     ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): pass\n"})
     n = len(ctx.nodes())
     with pytest.raises(IndexError, match="out of range"):
-        ctx.descendants_indices(n)
+        native.query(ctx).from_idx(n).descendants()
 
 
-def test_ancestors_indices_matches_node_form(build_decl_graph):
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/a.py": ("def leaf(): pass\ndef middle(): leaf()\ndef root(): middle()\nroot()\n"),
-        }
-    )
-    (leaf_idx,) = ctx.indices_where(fqname_prefix="pkg.a.leaf", kind="function")
-    leaf_node = ctx.nodes_at([leaf_idx])[0]
-    nodes = ctx.ancestors(leaf_node)
-    indices = ctx.ancestors_indices(leaf_idx)
-    assert len(nodes) == len(indices)
-    revived = ctx.nodes_at(indices)
-    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
-    assert {"pkg.a.middle", "pkg.a.root"} <= {n.fqname for n in revived}
-
-
-def test_ancestors_indices_out_of_range_raises(build_decl_graph):
+def test_traverse_ancestors_out_of_range_raises(build_decl_graph):
     ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): pass\n"})
     n = len(ctx.nodes())
     with pytest.raises(IndexError, match="out of range"):
-        ctx.ancestors_indices(n)
+        native.query(ctx).from_idx(n).ancestors()
+
+
+def test_traverse_direct_predecessors_out_of_range_raises(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): pass\n"})
+    n = len(ctx.nodes())
+    with pytest.raises(IndexError, match="out of range"):
+        native.query(ctx).from_idx(n).direct_predecessors()
 
 
 # ---------------------------------------------------------------------------
@@ -1423,6 +1055,30 @@ def test_query_reachable_matches_ctx_reachable_indices(build_decl_graph):
     via_query = native.query(ctx).reachable()
     via_ctx = ctx.reachable_indices()
     assert sorted(via_query) == sorted(via_ctx)
+
+
+def test_query_matching_specs_or_form(build_decl_graph, tmp_path):
+    """``QueryBuilder.matching_specs`` ORs across the three buckets:
+    a node matches if it satisfies any of the regex / str / abs_path
+    sets. Mirrors ``ExplicitEntrypointPlugin`` shape."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def handler(): pass\n",
+            "pkg/util.py": "def helper(): pass\n",
+        }
+    )
+    util_path = next(n.path for n in ctx.nodes() if n.fqname == "pkg.util")
+    indices = native.query(ctx).matching_specs(
+        str(tmp_path),
+        regexes=[r"pkg/svc\.py"],
+        str_specs=["pkg.util.helper"],
+        abs_paths=[util_path],
+    )
+    fqnames = {n.fqname for n in ctx.nodes_at(indices)}
+    # Regex bucket pulls pkg.svc + its decl; str-spec bucket pulls
+    # pkg.util.helper; abs-path bucket pulls the pkg.util module.
+    assert {"pkg.svc.handler", "pkg.util.helper", "pkg.util"} <= fqnames
 
 
 def test_query_reachable_seed_flags_kwarg(build_decl_graph):

--- a/tests/test_query_indices.py
+++ b/tests/test_query_indices.py
@@ -975,3 +975,164 @@ def test_decorator_query_in_decl_idx_out_of_range_raises(build_decl_graph):
     n = len(ctx.nodes())
     with pytest.raises(IndexError, match="out of range"):
         native.query(ctx).decorators().in_decl_idx(n).where_name("command").row_indices()
+
+
+# ---------------------------------------------------------------------------
+# ctx.resolve_idx
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_idx_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def handler(): pass\nclass Service: pass\n",
+        }
+    )
+    # Exact decl, exact module, walk-back from method-level fqname.
+    for fqn in ("pkg.svc.handler", "pkg.svc", "pkg.svc.Service.method"):
+        node = ctx.resolve(fqn)
+        idx = ctx.resolve_idx(fqn)
+        assert node is not None
+        assert idx is not None
+        assert ctx.nodes()[idx].fqname == node.fqname
+
+
+def test_resolve_idx_unknown_returns_none(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    assert ctx.resolve_idx("nothing.here") is None
+
+
+# ---------------------------------------------------------------------------
+# ctx.decls_under_indices / decls_matching_indices / decls_matching_name_indices
+# ---------------------------------------------------------------------------
+
+
+def test_decls_under_indices_matches_node_form(build_decl_graph, tmp_path):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def handler(): pass\n",
+            "pkg/util.py": "def helper(): pass\n",
+            "other/__init__.py": "",
+            "other/m.py": "def m(): pass\n",
+        }
+    )
+    prefix = str(tmp_path / "pkg")
+    nodes = ctx.decls_under(prefix)
+    indices = ctx.decls_under_indices(prefix)
+    assert len(nodes) == len(indices)
+    revived = ctx.nodes_at(indices)
+    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
+    # Sanity: nothing under "other" leaked into the bucket.
+    assert all(not n.fqname.startswith("other.") for n in revived)
+
+
+def test_decls_matching_indices_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/test_a.py": "def test_one(): pass\n",
+            "pkg/main.py": "def main(): pass\n",
+        }
+    )
+    nodes = ctx.decls_matching("test_a")
+    indices = ctx.decls_matching_indices("test_a")
+    assert len(nodes) == len(indices)
+    revived = ctx.nodes_at(indices)
+    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
+
+
+def test_decls_matching_name_indices_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "def test_one(): pass\ndef helper(): pass\nclass TestX: pass\n",
+        }
+    )
+    nodes = ctx.decls_matching_name(r"^(test_|Test)")
+    indices = ctx.decls_matching_name_indices(r"^(test_|Test)")
+    assert len(nodes) == len(indices)
+    revived = ctx.nodes_at(indices)
+    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
+    assert {"pkg.a.test_one", "pkg.a.TestX"} <= {n.fqname for n in revived}
+    # The kind filter excludes module nodes — verify a module's name
+    # isn't accidentally surfaced even though "a" matches no pattern here.
+    assert all(n.kind != "module" for n in revived)
+
+
+# ---------------------------------------------------------------------------
+# ctx.descendants_indices / ancestors_indices
+# ---------------------------------------------------------------------------
+
+
+def test_descendants_indices_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": ("def leaf(): pass\ndef middle(): leaf()\ndef root(): middle()\nroot()\n"),
+        }
+    )
+    (root_idx,) = ctx.indices_where(fqname_prefix="pkg.a.root", kind="function")
+    root_node = ctx.nodes_at([root_idx])[0]
+    nodes = ctx.descendants(root_node)
+    indices = ctx.descendants_indices(root_idx)
+    assert len(nodes) == len(indices)
+    revived = ctx.nodes_at(indices)
+    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
+    # Sanity: the forward closure includes the transitive targets.
+    assert {"pkg.a.middle", "pkg.a.leaf"} <= {n.fqname for n in revived}
+
+
+def test_descendants_indices_skip_flags(build_decl_graph):
+    """``skip_flags`` parity: DEAD_BRANCH edges are filtered the same
+    way by both forms."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": (
+                "def alive_only_in_dead_branch(): pass\n"
+                "def caller():\n"
+                "    if False:\n"
+                "        alive_only_in_dead_branch()\n"
+                "caller()\n"
+            ),
+        }
+    )
+    (caller_idx,) = ctx.indices_where(fqname_prefix="pkg.a.caller", kind="function")
+    caller_node = ctx.nodes_at([caller_idx])[0]
+    skip = int(native.EdgeFlags.DEAD_BRANCH)
+    nodes = ctx.descendants(caller_node, skip_flags=skip)
+    indices = ctx.descendants_indices(caller_idx, skip_flags=skip)
+    assert {n.fqname for n in nodes} == {ctx.nodes()[i].fqname for i in indices}
+
+
+def test_descendants_indices_out_of_range_raises(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): pass\n"})
+    n = len(ctx.nodes())
+    with pytest.raises(IndexError, match="out of range"):
+        ctx.descendants_indices(n)
+
+
+def test_ancestors_indices_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": ("def leaf(): pass\ndef middle(): leaf()\ndef root(): middle()\nroot()\n"),
+        }
+    )
+    (leaf_idx,) = ctx.indices_where(fqname_prefix="pkg.a.leaf", kind="function")
+    leaf_node = ctx.nodes_at([leaf_idx])[0]
+    nodes = ctx.ancestors(leaf_node)
+    indices = ctx.ancestors_indices(leaf_idx)
+    assert len(nodes) == len(indices)
+    revived = ctx.nodes_at(indices)
+    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
+    assert {"pkg.a.middle", "pkg.a.root"} <= {n.fqname for n in revived}
+
+
+def test_ancestors_indices_out_of_range_raises(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): pass\n"})
+    n = len(ctx.nodes())
+    with pytest.raises(IndexError, match="out of range"):
+        ctx.ancestors_indices(n)

--- a/tests/test_query_indices.py
+++ b/tests/test_query_indices.py
@@ -611,6 +611,42 @@ def test_node_attrs_bounds_check(build_decl_graph):
 
 
 # ---------------------------------------------------------------------------
+# ctx.node_paths — slim variant of node_attrs
+# ---------------------------------------------------------------------------
+
+
+def test_node_paths_matches_node_attrs_path_field(build_decl_graph):
+    """``node_paths(idxs)`` must return the same ``path`` value
+    ``node_attrs(idxs)`` returns at row position 1 — parity is the
+    whole contract; the only difference is allocation count."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "def f(): pass\nclass C: pass\n",
+            "pkg/b.py": "x = 1\n",
+        }
+    )
+    all_idxs = list(range(len(ctx.nodes())))
+    paths = ctx.node_paths(all_idxs)
+    attrs = ctx.node_attrs(all_idxs)
+    assert len(paths) == len(attrs) == len(all_idxs)
+    for path, (_kind, attr_path, _fq, _flags) in zip(paths, attrs, strict=True):
+        assert path == attr_path
+
+
+def test_node_paths_empty(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    assert ctx.node_paths([]) == []
+
+
+def test_node_paths_bounds_check(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    n = len(ctx.nodes())
+    with pytest.raises(IndexError, match="out of range"):
+        ctx.node_paths([n])
+
+
+# ---------------------------------------------------------------------------
 # *Query.row_indices — index-form row terminals
 # ---------------------------------------------------------------------------
 

--- a/tests/test_query_indices.py
+++ b/tests/test_query_indices.py
@@ -581,12 +581,12 @@ def test_call_query_collect_returns_idx_rows(build_decl_graph):
         assert row.string_arg == "settings"
 
 
-def test_with_args_false_yields_empty_args_kwargs(build_decl_graph):
-    """``with_args(False)`` short-circuits the rust-side
-    ``extract_call_args_kwargs`` walk. Row ``args`` / ``kwargs``
-    getters surface empty containers; node-identity + metadata
-    strings (``decorator_owner``, ``string_arg``, etc.) still populate
-    as normal."""
+def test_with_args_opt_in_populates_args_kwargs(build_decl_graph):
+    """``with_args(True)`` opts into the rust-side
+    ``extract_call_args_kwargs`` walk. Default (``with_args(False)``)
+    skips it; row ``args`` / ``kwargs`` getters surface empty
+    containers, but node-identity + metadata strings populate
+    normally."""
     ctx = build_decl_graph(
         {
             "pkg/__init__.py": "",
@@ -595,34 +595,34 @@ def test_with_args_false_yields_empty_args_kwargs(build_decl_graph):
             ),
         }
     )
-    with_args_rows = (
+    default_rows = (
         native.query(ctx).decorators().where_module("functools").where_name("lru_cache").collect()
     )
-    assert len(with_args_rows) == 1
-    # Sanity: default extracts args/kwargs.
-    assert dict(with_args_rows[0].kwargs)
+    assert len(default_rows) == 1
+    # Default skips extraction.
+    assert list(default_rows[0].args) == []
+    assert dict(default_rows[0].kwargs) == {}
 
-    no_args_rows = (
+    with_args_rows = (
         native.query(ctx)
         .decorators()
         .where_module("functools")
         .where_name("lru_cache")
-        .with_args(False)
+        .with_args(True)
         .collect()
     )
-    assert len(no_args_rows) == 1
-    # Empty containers when extraction is skipped.
-    assert list(no_args_rows[0].args) == []
-    assert dict(no_args_rows[0].kwargs) == {}
-    # Identity + metadata fields still populate normally.
-    assert no_args_rows[0].decorated_idx == with_args_rows[0].decorated_idx
-    assert no_args_rows[0].decorator_owner == with_args_rows[0].decorator_owner
+    assert len(with_args_rows) == 1
+    # ``with_args(True)`` populates args/kwargs.
+    assert dict(with_args_rows[0].kwargs)
+    # Identity + metadata fields stable across both calls.
+    assert with_args_rows[0].decorated_idx == default_rows[0].decorated_idx
+    assert with_args_rows[0].decorator_owner == default_rows[0].decorator_owner
 
 
-def test_with_args_false_does_not_disable_kwarg_filter(build_decl_graph):
-    """Even with ``with_args(False)``, ``.where_kwarg(...)`` must still
-    filter — the rust side forces extraction back on when any kwarg
-    matcher is set."""
+def test_where_kwarg_forces_extraction(build_decl_graph):
+    """``.where_kwarg(...)`` filters even at the default
+    ``with_args=False`` — the rust side forces extraction back on
+    when any kwarg matcher is set."""
     ctx = build_decl_graph(
         {
             "pkg/__init__.py": "",
@@ -640,7 +640,6 @@ def test_with_args_false_does_not_disable_kwarg_filter(build_decl_graph):
         .decorators()
         .where_module("functools")
         .where_name("lru_cache")
-        .with_args(False)
         .where_kwarg("maxsize", 128)
         .collect()
     )
@@ -1283,3 +1282,128 @@ def test_decl_query_simple_name_regex_invalid_raises(build_decl_graph):
     ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
     with pytest.raises(ValueError, match="invalid simple-name regex"):
         native.query(ctx).decls().with_simple_name_regex(r"(unclosed").indices()
+
+
+# ---------------------------------------------------------------------------
+# NodeAttrs — tuple-like row with named fields
+# ---------------------------------------------------------------------------
+
+
+def test_node_attrs_attribute_access(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): pass\n"})
+    (idx,) = ctx.indices_where(fqname_prefix="pkg.a.f", kind="function")
+    (attr,) = ctx.node_attrs([idx])
+    assert attr.kind == "function"
+    assert attr.fqname == "pkg.a.f"
+    assert attr.path.endswith("pkg/a.py")
+    assert isinstance(attr.flags, int)
+
+
+def test_node_attrs_tuple_unpacking(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): pass\n"})
+    (idx,) = ctx.indices_where(fqname_prefix="pkg.a.f", kind="function")
+    (attr,) = ctx.node_attrs([idx])
+    kind, path, fqname, flags = attr
+    assert kind == attr.kind
+    assert path == attr.path
+    assert fqname == attr.fqname
+    assert flags == attr.flags
+
+
+def test_node_attrs_subscript_and_len(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): pass\n"})
+    (idx,) = ctx.indices_where(fqname_prefix="pkg.a.f", kind="function")
+    (attr,) = ctx.node_attrs([idx])
+    assert len(attr) == 4
+    assert attr[0] == attr.kind
+    assert attr[2] == attr.fqname
+    assert attr[-1] == attr.flags
+    with pytest.raises(IndexError):
+        attr[4]
+
+
+# ---------------------------------------------------------------------------
+# .attrs() / .first_idx() / .indices_by_path() — uniform terminals
+# ---------------------------------------------------------------------------
+
+
+def test_decl_query_attrs_matches_node_attrs(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def handler(): pass\nclass Service: pass\n",
+        }
+    )
+    q = native.query(ctx).decls().with_kind("function")
+    via_terminal = q.attrs()
+    via_ctx = ctx.node_attrs(q.indices())
+    assert [a.fqname for a in via_terminal] == [a.fqname for a in via_ctx]
+
+
+def test_decl_query_first_idx(build_decl_graph):
+    ctx = build_decl_graph(
+        {"pkg/__init__.py": "", "pkg/a.py": "def alpha(): pass\ndef beta(): pass\n"}
+    )
+    idx = native.query(ctx).decls().with_fqname_prefix("pkg.a.alpha").first_idx()
+    assert idx is not None
+    assert ctx.nodes()[idx].fqname == "pkg.a.alpha"
+
+
+def test_decl_query_first_idx_none_when_no_match(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": ""})
+    assert native.query(ctx).decls().with_fqname_prefix("nope").first_idx() is None
+
+
+def test_decl_query_indices_by_path(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def handler(): pass\nclass Service: pass\n",
+            "pkg/util.py": "def helper(): pass\n",
+        }
+    )
+    buckets = native.query(ctx).decls().with_kind("function").indices_by_path()
+    fqnames_by_path = {
+        path: sorted(ctx.nodes()[i].fqname for i in idxs) for path, idxs in buckets.items()
+    }
+    assert any(fqs == ["pkg.svc.handler"] for fqs in fqnames_by_path.values()), fqnames_by_path
+    assert any(fqs == ["pkg.util.helper"] for fqs in fqnames_by_path.values()), fqnames_by_path
+
+
+def test_import_query_attrs_first_idx_and_indices_by_path(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "from os.path import join\n",
+            "pkg/b.py": "from os.path import join as j2\n",
+        }
+    )
+    q = native.query(ctx).imports().of("os.path")
+    attrs = q.attrs()
+    assert all(a.kind == "import" for a in attrs)
+    assert q.first_idx() is not None
+    buckets = q.indices_by_path()
+    # Two distinct files both import os.path.
+    assert len(buckets) == 2
+
+
+def test_decorator_query_indices_by_path(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": (
+                "import functools\n@functools.lru_cache(maxsize=128)\ndef cached(): pass\n"
+            ),
+        }
+    )
+    buckets = (
+        native.query(ctx)
+        .decorators()
+        .where_module("functools")
+        .where_name("lru_cache")
+        .indices_by_path()
+    )
+    assert len(buckets) == 1
+    (path, idxs) = next(iter(buckets.items()))
+    assert path.endswith("pkg/svc.py")
+    assert ctx.nodes()[idxs[0]].fqname == "pkg.svc.cached"

--- a/tests/test_query_indices.py
+++ b/tests/test_query_indices.py
@@ -1227,3 +1227,403 @@ def test_ancestors_indices_out_of_range_raises(build_decl_graph):
     n = len(ctx.nodes())
     with pytest.raises(IndexError, match="out of range"):
         ctx.ancestors_indices(n)
+
+
+# ---------------------------------------------------------------------------
+# ModuleQuery — DSL stream for module-shaped lookups
+# ---------------------------------------------------------------------------
+
+
+def test_module_query_with_fqn_returns_module_idx(build_decl_graph):
+    ctx = build_decl_graph(
+        {"pkg/__init__.py": "", "pkg/sub/__init__.py": "", "pkg/sub/inner.py": "x = 1\n"}
+    )
+    idx = native.query(ctx).modules().with_fqn("pkg.sub.inner").first_idx()
+    assert idx is not None
+    assert ctx.nodes()[idx].fqname == "pkg.sub.inner"
+
+
+def test_module_query_with_fqn_missing_returns_none(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    assert native.query(ctx).modules().with_fqn("nothing.here").first_idx() is None
+    assert native.query(ctx).modules().with_fqn("nothing.here").indices() == []
+
+
+def test_module_query_with_path(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/svc.py": "def f(): pass\n"})
+    svc_path = next(n.path for n in ctx.nodes() if n.fqname == "pkg.svc")
+    idx = native.query(ctx).modules().with_path(svc_path).first_idx()
+    assert idx is not None
+    assert ctx.nodes()[idx].fqname == "pkg.svc"
+
+
+def test_module_query_surface_includes_submodules(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def handler(): pass\nclass Service: pass\n",
+            "pkg/sub/__init__.py": "",
+            "pkg/sub/inner.py": "def deep(): pass\n",
+        }
+    )
+    indices = native.query(ctx).modules().with_fqn("pkg").surface().indices()
+    fqnames = {ctx.nodes()[i].fqname for i in indices}
+    assert "pkg" in fqnames
+    assert "pkg.svc" in fqnames
+    assert "pkg.svc.handler" in fqnames
+    assert "pkg.sub.inner" in fqnames
+    assert "pkg.sub.inner.deep" in fqnames
+
+
+def test_module_query_top_level_excludes_submodules(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def handler(): pass\n",
+            "pkg/sub/__init__.py": "",
+            "pkg/sub/inner.py": "def deep(): pass\n",
+        }
+    )
+    indices = native.query(ctx).modules().with_fqn("pkg").top_level().indices()
+    fqnames = {ctx.nodes()[i].fqname for i in indices}
+    # ``pkg/__init__.py`` has no top-level decls of its own; the
+    # submodule node itself is excluded by the contract.
+    assert "pkg.svc" not in fqnames
+    assert "pkg.sub" not in fqnames
+
+
+def test_module_query_dunder_all_returns_listed_exports(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/m.py": '__all__ = ["f"]\ndef f(): pass\ndef g(): pass\n',
+        }
+    )
+    idxs = native.query(ctx).modules().with_fqn("pkg.m").dunder_all()
+    assert idxs is not None
+    fqnames = {ctx.nodes()[i].fqname for i in idxs}
+    assert fqnames == {"pkg.m.f"}
+
+
+def test_module_query_dunder_all_none_when_unset(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/m.py": "def f(): pass\n"})
+    assert native.query(ctx).modules().with_fqn("pkg.m").dunder_all() is None
+
+
+def test_module_query_with_dunders_project_wide(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "__all__ = []\n__version__ = '1.0'\n",
+            "pkg/a.py": "def __getattr__(name): pass\nx = 1\n",
+        }
+    )
+    idxs = native.query(ctx).modules().with_dunders().indices()
+    fqnames = {ctx.nodes()[i].fqname for i in idxs}
+    assert "pkg.__all__" in fqnames
+    assert "pkg.__version__" in fqnames
+    assert "pkg.a.__getattr__" in fqnames
+    assert "pkg.a.x" not in fqnames
+
+
+def test_module_query_no_filter_raises(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    with pytest.raises(ValueError, match="with_fqn"):
+        native.query(ctx).modules().indices()
+
+
+# ---------------------------------------------------------------------------
+# TraverseQuery — parity with ctx.{descendants,ancestors,direct_predecessors}_*
+# ---------------------------------------------------------------------------
+
+
+def test_traverse_descendants_matches_ctx_descendants_indices(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/main.py": """
+            def used(): pass
+            def caller(): used()
+            caller()
+            """,
+        }
+    )
+    main_idx = native.query(ctx).modules().with_fqn("pkg.main").first_idx()
+    assert main_idx is not None
+    via_traverse = native.query(ctx).from_idx(main_idx).descendants()
+    via_ctx = ctx.descendants_indices(main_idx)
+    assert sorted(via_traverse) == sorted(via_ctx)
+
+
+def test_traverse_ancestors_matches_ctx_ancestors_indices(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/main.py": """
+            def used(): pass
+            def caller(): used()
+            caller()
+            """,
+        }
+    )
+    used_idx = native.query(ctx).declarations().with_fqname("pkg.main.used").resolve_idx()
+    assert used_idx is not None
+    via_traverse = native.query(ctx).from_idx(used_idx).ancestors()
+    via_ctx = ctx.ancestors_indices(used_idx)
+    assert sorted(via_traverse) == sorted(via_ctx)
+
+
+def test_traverse_direct_predecessors_matches_ctx(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/main.py": "def f(): pass\ndef g(): f()\ndef h(): f()\n",
+        }
+    )
+    f_idx = native.query(ctx).declarations().with_fqname("pkg.main.f").resolve_idx()
+    assert f_idx is not None
+    via_traverse = native.query(ctx).from_idx(f_idx).direct_predecessors()
+    via_ctx = ctx.direct_predecessors_idx(f_idx)
+    assert sorted(via_traverse) == sorted(via_ctx)
+
+
+def test_traverse_descendants_skip_flags(build_decl_graph):
+    """``skip_flags`` plumbs through to the underlying BFS."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/m.py": """
+            def live(): pass
+            if False:
+                def dead(): pass
+                live()
+            """,
+        }
+    )
+    mod_idx = native.query(ctx).modules().with_fqn("pkg.m").first_idx()
+    assert mod_idx is not None
+    full = native.query(ctx).from_idx(mod_idx).descendants()
+    strict = (
+        native.query(ctx).from_idx(mod_idx).descendants(skip_flags=native.EdgeFlags.DEAD_BRANCH)
+    )
+    # Strict closure is a subset of the dead-branch-traversing closure.
+    assert set(strict).issubset(set(full))
+
+
+def test_query_reachable_matches_ctx_reachable_indices(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/main.py": """
+            def alive(): pass
+            def dead(): pass
+            alive()
+            """,
+        }
+    )
+    via_query = native.query(ctx).reachable()
+    via_ctx = ctx.reachable_indices()
+    assert sorted(via_query) == sorted(via_ctx)
+
+
+def test_query_reachable_seed_flags_kwarg(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/main.py": "def f(): pass\nf()\n",
+        }
+    )
+    via_query = native.query(ctx).reachable(
+        skip_flags=native.EdgeFlags.DEAD_BRANCH,
+        seed_flags=native.NodeFlags.ENTRYPOINT,
+    )
+    via_ctx = ctx.reachable_indices(
+        skip_flags=native.EdgeFlags.DEAD_BRANCH,
+        seed_flags=native.NodeFlags.ENTRYPOINT,
+    )
+    assert sorted(via_query) == sorted(via_ctx)
+
+
+# ---------------------------------------------------------------------------
+# DeclarationsQuery — parity with ctx.find_declarations_indices / resolve_idx
+# ---------------------------------------------------------------------------
+
+
+def test_declarations_query_indices_matches_ctx(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/lib.py": "class Cls:\n    def method(self): pass\n",
+        }
+    )
+    # Walk-back: pkg.lib.Cls.method → pkg.lib.Cls.
+    via_query = native.query(ctx).declarations().with_fqname("pkg.lib.Cls.method").indices()
+    via_ctx = ctx.find_declarations_indices("pkg.lib.Cls.method")
+    assert sorted(via_query) == sorted(via_ctx)
+    assert len(via_query) == 1
+    assert ctx.nodes()[via_query[0]].fqname == "pkg.lib.Cls"
+
+
+def test_declarations_query_resolve_idx_falls_back_to_module(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/lib.py": "def f(): pass\n"})
+    # find_declarations excludes modules — resolve_idx includes them.
+    decls = native.query(ctx).declarations().with_fqname("pkg.lib").indices()
+    assert decls == []
+    resolved = native.query(ctx).declarations().with_fqname("pkg.lib").resolve_idx()
+    assert resolved is not None
+    assert ctx.nodes()[resolved].kind == "module"
+
+
+def test_declarations_query_resolve_idx_unknown_returns_none(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": ""})
+    assert native.query(ctx).declarations().with_fqname("nowhere.such.name").resolve_idx() is None
+
+
+def test_declarations_query_no_fqname_raises(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": ""})
+    with pytest.raises(ValueError, match="with_fqname"):
+        native.query(ctx).declarations().indices()
+
+
+# ---------------------------------------------------------------------------
+# MainBlockQuery — parity with ctx.find_main_blocks_indices
+# ---------------------------------------------------------------------------
+
+
+def test_main_block_query_matches_ctx(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/script.py": """
+            def helper(): pass
+
+            if __name__ == "__main__":
+                def inner_decl(): pass
+                helper()
+            """,
+            "pkg/lib.py": "def lib_fn(): pass\n",
+        }
+    )
+    via_query = native.query(ctx).main_blocks().index_pairs()
+    via_ctx = ctx.find_main_blocks_indices()
+    # Same pairs, same shapes.
+    assert len(via_query) == len(via_ctx) == 1
+    q_mod, q_decls = via_query[0]
+    c_mod, c_decls = via_ctx[0]
+    assert q_mod == c_mod
+    assert sorted(q_decls) == sorted(c_decls)
+
+
+def test_main_block_query_no_main_block(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/lib.py": "def f(): pass\n"})
+    assert native.query(ctx).main_blocks().index_pairs() == []
+
+
+# ---------------------------------------------------------------------------
+# LiteralListQuery — parity with ctx.find_literal_list_entries
+# ---------------------------------------------------------------------------
+
+
+def test_literal_list_query_matches_ctx(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/m.py": """
+            __all__ = ["a", "b"]
+            def a(): pass
+            def b(): pass
+            """,
+        }
+    )
+    via_query = native.query(ctx).literal_lists().for_fqn("pkg.m.__all__").entries()
+    via_ctx = ctx.find_literal_list_entries("pkg.m.__all__")
+    assert via_query == via_ctx == ["a", "b"]
+
+
+def test_literal_list_query_unknown_returns_none(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": ""})
+    assert native.query(ctx).literal_lists().for_fqn("pkg.nope").entries() is None
+
+
+def test_literal_list_query_no_fqn_raises(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": ""})
+    with pytest.raises(ValueError, match="for_fqn"):
+        native.query(ctx).literal_lists().entries()
+
+
+# ---------------------------------------------------------------------------
+# DeclQuery.with_path_prefix / with_path_contains / with_simple_name_regex
+# ---------------------------------------------------------------------------
+
+
+def test_decl_query_with_path_prefix_matches_decls_under(build_decl_graph, tmp_path):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/sub/__init__.py": "",
+            "pkg/sub/inner.py": "def deep(): pass\n",
+            "pkg/top.py": "def shallow(): pass\n",
+        }
+    )
+    prefix = str(tmp_path / "pkg" / "sub")
+    via_query = native.query(ctx).decls().with_path_prefix(prefix).indices()
+    via_ctx = ctx.decls_under_indices(prefix)
+    assert sorted(via_query) == sorted(via_ctx)
+
+
+def test_decl_query_with_path_contains_matches_decls_matching(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/test_a.py": "def t_a(): pass\n",
+            "pkg/lib.py": "def f(): pass\n",
+        }
+    )
+    via_query = native.query(ctx).decls().with_path_contains("test_a").indices()
+    via_ctx = ctx.decls_matching_indices("test_a")
+    assert sorted(via_query) == sorted(via_ctx)
+
+
+def test_decl_query_with_simple_name_regex_matches_decls_matching_name(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "def test_one(): pass\nclass TestThing: pass\ndef helper(): pass\n",
+        }
+    )
+    # decls_matching_name implicitly filters to function|class|variable|import|type_alias;
+    # DeclQuery composes — apply the same kind filter explicitly.
+    via_query = (
+        native.query(ctx)
+        .decls()
+        .with_simple_name_regex(r"^(test_|Test)")
+        .with_kinds(["function", "class", "variable", "import", "type_alias"])
+        .indices()
+    )
+    via_ctx = ctx.decls_matching_name_indices(r"^(test_|Test)")
+    assert sorted(via_query) == sorted(via_ctx)
+
+
+def test_decl_query_path_and_simple_name_compose(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/test_a.py": "def test_one(): pass\ndef helper(): pass\n",
+            "pkg/lib.py": "def test_one(): pass\n",
+        }
+    )
+    indices = (
+        native.query(ctx)
+        .decls()
+        .with_path_contains("test_a")
+        .with_simple_name_regex(r"^test_")
+        .with_kind("function")
+        .indices()
+    )
+    fqnames = {n.fqname for n in ctx.nodes_at(indices)}
+    assert fqnames == {"pkg.test_a.test_one"}
+
+
+def test_decl_query_simple_name_regex_invalid_raises(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    with pytest.raises(ValueError, match="invalid simple-name regex"):
+        native.query(ctx).decls().with_simple_name_regex(r"(unclosed").indices()

--- a/tests/test_query_indices.py
+++ b/tests/test_query_indices.py
@@ -936,11 +936,9 @@ def test_subclasses_of_fqn_indices_matches_node_form(build_decl_graph):
             ),
         }
     )
-    nodes = ctx.subclasses_of_fqn("pkg.bases.Base", transitive=True)
-    indices = ctx.subclasses_of_fqn_indices("pkg.bases.Base", transitive=True)
-    assert len(nodes) == len(indices)
+    indices = native.query(ctx).subclasses().of_fqn("pkg.bases.Base").indices()
     revived = ctx.nodes_at(indices)
-    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
+    assert {n.fqname for n in revived} == {"pkg.sub.Mid", "pkg.sub.Leaf"}
 
 
 def test_subclasses_of_fqn_indices_transitive_flag(build_decl_graph):
@@ -953,7 +951,7 @@ def test_subclasses_of_fqn_indices_transitive_flag(build_decl_graph):
             ),
         }
     )
-    direct = ctx.subclasses_of_fqn_indices("pkg.bases.Base", transitive=False)
+    direct = native.query(ctx).subclasses().of_fqn("pkg.bases.Base").transitive(False).indices()
     direct_revived = {n.fqname for n in ctx.nodes_at(direct)}
     assert direct_revived == {"pkg.sub.Mid"}  # Leaf is not a *direct* subclass of Base
 
@@ -966,26 +964,23 @@ def test_find_subclasses_of_idx_matches_node_form(build_decl_graph):
         }
     )
     (base_idx,) = ctx.indices_where(fqname_prefix="pkg.a.Base", kind="class")
-    base_node = ctx.nodes_at([base_idx])[0]
-    nodes = ctx.find_subclasses_of(base_node)
-    idx_results = ctx.find_subclasses_of_idx(base_idx)
-    assert len(nodes) == len(idx_results)
+    idx_results = native.query(ctx).subclasses().of_idx(base_idx).indices()
     revived = ctx.nodes_at(idx_results)
-    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
+    assert {n.fqname for n in revived} == {"pkg.a.Sub"}
 
 
 def test_find_subclasses_of_idx_non_class_returns_empty(build_decl_graph):
     ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def f(): pass\n"})
     (f_idx,) = ctx.indices_where(fqname_prefix="pkg.a.f", kind="function")
-    # Same contract as the node-form: non-class seed returns empty.
-    assert ctx.find_subclasses_of_idx(f_idx) == []
+    # Non-class seed → empty result.
+    assert native.query(ctx).subclasses().of_idx(f_idx).indices() == []
 
 
 def test_find_subclasses_of_idx_out_of_range_raises(build_decl_graph):
     ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "class X: pass\n"})
     n = len(ctx.nodes())
     with pytest.raises(IndexError, match="out of range"):
-        ctx.find_subclasses_of_idx(n)
+        native.query(ctx).subclasses().of_idx(n).indices()
 
 
 def test_subclass_query_of_idx_matches_of_node(build_decl_graph):

--- a/tests/test_query_indices.py
+++ b/tests/test_query_indices.py
@@ -292,3 +292,403 @@ def test_add_edge_by_idx_carries_flags(tmp_path):
         if s == f_idx and d == g_idx and f == native.EdgeFlags.DEAD_BRANCH
     ]
     assert matching
+
+
+# ---------------------------------------------------------------------------
+# AddNodeByIdx — graph op
+# ---------------------------------------------------------------------------
+
+
+def test_add_node_by_idx_round_trip(tmp_path):
+    """``AddNodeByIdx`` mints a synthetic node and wires its edges from
+    positional indices, the same way ``AddNode`` does with
+    ``SymbolNode`` endpoints."""
+    from dead_cst.analyze import Analysis
+    from dead_cst.plugins._base import Plugin
+
+    (tmp_path / "mod.py").write_text("def f(): pass\ndef g(): pass\n")
+
+    class MintByIdx(Plugin):
+        name = "mint_by_idx"
+        version = 1
+
+        def run(self, ctx: native.ProjectContext):
+            f_idx = ctx.indices_where(fqname_prefix="mod.f")[0]
+            g_idx = ctx.indices_where(fqname_prefix="mod.g")[0]
+            yield native.AddNodeByIdx(
+                "<marker>:mint",
+                path="mod.py",
+                edges_from_idx=[f_idx],
+                edges_to_idx=[g_idx],
+            )
+
+    analysis = Analysis(tmp_path, plugins=[MintByIdx()])
+    ctx = analysis.materialize_all()
+    fqnames = [n.fqname for n in ctx.nodes()]
+    assert "<marker>:mint" in fqnames
+
+    marker_idx = fqnames.index("<marker>:mint")
+    f_idx = fqnames.index("mod.f")
+    g_idx = fqnames.index("mod.g")
+    edges = [(s, d) for (s, d, _f) in ctx.edges()]
+    assert (f_idx, marker_idx) in edges
+    assert (marker_idx, g_idx) in edges
+
+
+def test_add_node_by_idx_entrypoint_flag(tmp_path):
+    """``AddNodeByIdx`` honors ``NodeFlags.ENTRYPOINT`` so a multi-target
+    marker (the idiomatic non-sugar reason to prefer it over
+    ``AddEntrypoint``) makes its targets reachable."""
+    from dead_cst.analyze import Analysis
+    from dead_cst.plugins._base import Plugin
+
+    (tmp_path / "mod.py").write_text(
+        "def alive(): pass\ndef also_alive(): pass\ndef dead(): pass\n"
+    )
+
+    class SeedBoth(Plugin):
+        name = "seed_both"
+        version = 1
+
+        def run(self, ctx: native.ProjectContext):
+            a = ctx.indices_where(fqname_prefix="mod.alive")[0]
+            b = ctx.indices_where(fqname_prefix="mod.also_alive")[0]
+            yield native.AddNodeByIdx(
+                "<seed>:multi",
+                path="mod.py",
+                flags=native.NodeFlags.ENTRYPOINT,
+                edges_to_idx=[a, b],
+            )
+
+    analysis = Analysis(tmp_path, plugins=[SeedBoth()])
+    analysis.materialize_all()
+    dead_fqnames = {n.fqname for n in analysis.dead()}
+    assert "mod.alive" not in dead_fqnames
+    assert "mod.also_alive" not in dead_fqnames
+    assert "mod.dead" in dead_fqnames
+
+
+def test_add_node_by_idx_out_of_range_raises(tmp_path):
+    """An out-of-range ``edges_*_idx`` raises ``IndexError`` at apply
+    time and does *not* leave an orphan synthetic node behind."""
+    from dead_cst.analyze import Analysis
+    from dead_cst.plugins._base import Plugin
+
+    (tmp_path / "mod.py").write_text("def f(): pass\n")
+
+    class BadIdx(Plugin):
+        name = "bad_idx"
+        version = 1
+
+        def run(self, ctx: native.ProjectContext):
+            yield native.AddNodeByIdx(
+                "<should-not-land>",
+                path="mod.py",
+                edges_to_idx=[10**9],
+            )
+
+    analysis = Analysis(tmp_path, plugins=[BadIdx()])
+    with pytest.raises(IndexError, match="edges_to_idx"):
+        analysis.materialize_all()
+
+
+def test_add_node_by_idx_default_no_edges(tmp_path):
+    """A bare ``AddNodeByIdx(fqname, path=...)`` with no edges mints a
+    standalone synthetic node — same defaults as ``AddNode``."""
+    from dead_cst.analyze import Analysis
+    from dead_cst.plugins._base import Plugin
+
+    (tmp_path / "mod.py").write_text("x = 1\n")
+
+    class JustMint(Plugin):
+        name = "just_mint"
+        version = 1
+
+        def run(self, ctx: native.ProjectContext):
+            yield native.AddNodeByIdx("<bare>:marker", path="mod.py")
+
+    analysis = Analysis(tmp_path, plugins=[JustMint()])
+    ctx = analysis.materialize_all()
+    fqnames = [n.fqname for n in ctx.nodes()]
+    assert "<bare>:marker" in fqnames
+
+
+# ---------------------------------------------------------------------------
+# ctx.find_declarations_indices
+# ---------------------------------------------------------------------------
+
+
+def test_find_declarations_indices_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def handler(): pass\nclass Service: pass\n",
+        }
+    )
+    nodes = ctx.find_declarations("pkg.svc.handler")
+    indices = ctx.find_declarations_indices("pkg.svc.handler")
+    assert len(nodes) == len(indices) == 1
+    all_nodes = ctx.nodes()
+    assert all_nodes[indices[0]].fqname == nodes[0].fqname
+
+
+def test_find_declarations_indices_walks_back(build_decl_graph):
+    """``pkg.svc.Cls.method`` resolves to ``pkg.svc.Cls`` — methods don't
+    get their own graph node."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "class Cls:\n    def method(self): pass\n",
+        }
+    )
+    indices = ctx.find_declarations_indices("pkg.svc.Cls.method")
+    revived = ctx.nodes_at(indices)
+    assert {n.fqname for n in revived} == {"pkg.svc.Cls"}
+
+
+def test_find_declarations_indices_unknown_returns_empty(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    assert ctx.find_declarations_indices("nothing.here") == []
+
+
+# ---------------------------------------------------------------------------
+# ctx.module_for_indices + modules_for_paths
+# ---------------------------------------------------------------------------
+
+
+def test_module_for_indices_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def f(): pass\n",
+        }
+    )
+    # ``module_for`` keys on the absolute path stored on the SymbolNode.
+    svc_path = next(n.path for n in ctx.nodes() if n.fqname == "pkg.svc")
+    node = ctx.module_for(svc_path)
+    assert node is not None
+    idx = ctx.module_for_indices(svc_path)
+    assert idx is not None
+    assert ctx.nodes()[idx].fqname == node.fqname
+
+
+def test_module_for_indices_missing_path(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    assert ctx.module_for_indices("/not/a/real/path.py") is None
+
+
+def test_modules_for_paths_bulk(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def f(): pass\n",
+            "pkg/util.py": "def g(): pass\n",
+        }
+    )
+    svc_path = next(n.path for n in ctx.nodes() if n.fqname == "pkg.svc")
+    util_path = next(n.path for n in ctx.nodes() if n.fqname == "pkg.util")
+    results = ctx.modules_for_paths([svc_path, util_path, "/missing.py"])
+    assert len(results) == 3
+    assert results[0] is not None
+    assert results[1] is not None
+    assert results[2] is None
+    all_nodes = ctx.nodes()
+    assert all_nodes[results[0]].fqname == "pkg.svc"
+    assert all_nodes[results[1]].fqname == "pkg.util"
+
+
+# ---------------------------------------------------------------------------
+# ctx.module_surface_indices + module_surfaces_indices
+# ---------------------------------------------------------------------------
+
+
+def test_module_surface_indices_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def handler(): pass\nclass Service: pass\n",
+            "pkg/sub/__init__.py": "",
+            "pkg/sub/inner.py": "def deep(): pass\n",
+        }
+    )
+    nodes = ctx.module_surface("pkg")
+    indices = ctx.module_surface_indices("pkg")
+    assert len(nodes) == len(indices)
+    assert {ctx.nodes()[i].fqname for i in indices} == {n.fqname for n in nodes}
+
+
+def test_module_surface_indices_unknown_returns_empty(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    assert ctx.module_surface_indices("nothing.here") == []
+
+
+def test_module_surfaces_indices_bulk(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": "def handler(): pass\n",
+            "pkg/util.py": "def helper(): pass\n",
+            "other/__init__.py": "",
+            "other/m.py": "def m(): pass\n",
+        }
+    )
+    node_buckets = ctx.module_surfaces(["pkg", "other", "missing"])
+    idx_buckets = ctx.module_surfaces_indices(["pkg", "other", "missing"])
+    assert set(node_buckets.keys()) == set(idx_buckets.keys())
+    for key in node_buckets:
+        node_fqs = {n.fqname for n in node_buckets[key]}
+        idx_fqs = {ctx.nodes()[i].fqname for i in idx_buckets[key]}
+        assert node_fqs == idx_fqs
+
+
+# ---------------------------------------------------------------------------
+# ctx.find_main_blocks_indices
+# ---------------------------------------------------------------------------
+
+
+def test_find_main_blocks_indices_matches_node_form(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/m.py": (
+                'def helper(): pass\nif __name__ == "__main__":\n    helper()\n    x = 1\n'
+            ),
+        }
+    )
+    node_pairs = ctx.find_main_blocks()
+    idx_pairs = ctx.find_main_blocks_indices()
+    assert len(node_pairs) == len(idx_pairs) == 1
+    (mod_node, decls) = node_pairs[0]
+    (mod_idx, decl_idxs) = idx_pairs[0]
+    assert ctx.nodes()[mod_idx].fqname == mod_node.fqname
+    assert {ctx.nodes()[i].fqname for i in decl_idxs} == {d.fqname for d in decls}
+
+
+def test_find_main_blocks_indices_no_main_block(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    assert ctx.find_main_blocks_indices() == []
+
+
+# ---------------------------------------------------------------------------
+# ctx.node_attrs — batched node-field snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_node_attrs_round_trip(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "def alpha(): pass\nclass Beta: pass\n",
+        }
+    )
+    all_nodes = ctx.nodes()
+    indices = list(range(len(all_nodes)))
+    rows = ctx.node_attrs(indices)
+    assert len(rows) == len(indices)
+    for idx, (kind, path, fqname, flags) in zip(indices, rows, strict=True):
+        n = all_nodes[idx]
+        assert kind == n.kind
+        assert path == n.path
+        assert fqname == n.fqname
+        assert flags == n.flags
+
+
+def test_node_attrs_subset(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def alpha(): pass\n"})
+    indices = ctx.indices_where(kind="function", fqname_prefix="pkg.a")
+    assert len(indices) == 1
+    [(kind, path, fqname, _flags)] = ctx.node_attrs(indices)
+    assert kind == "function"
+    assert fqname == "pkg.a.alpha"
+    assert path.endswith("a.py")
+
+
+def test_node_attrs_bounds_check(build_decl_graph):
+    ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "x = 1\n"})
+    n = len(ctx.nodes())
+    with pytest.raises(IndexError, match="out of range"):
+        ctx.node_attrs([n])
+
+
+# ---------------------------------------------------------------------------
+# *Query.row_indices — index-form row terminals
+# ---------------------------------------------------------------------------
+
+
+def test_decorator_query_row_indices_matches_collect(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": ("import functools\n@functools.lru_cache\ndef cached(): pass\n"),
+        }
+    )
+    q = native.query(ctx).decorators().where_module("functools").where_name("lru_cache")
+    refs = q.collect()
+    rows = q.row_indices()
+    assert len(refs) == len(rows) == 1
+    all_nodes = ctx.nodes()
+    for ref, row in zip(refs, rows, strict=True):
+        assert all_nodes[row.decorated_idx].fqname == ref.decorated.fqname
+        assert row.decorator_name == ref.decorator_name
+        assert row.decorator_owner == ref.decorator_owner
+        assert row.decorator_via == ref.decorator_via
+
+
+def test_construction_query_row_indices_matches_collect(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/app.py": "import flask\napp = flask.Flask(__name__)\n",
+        }
+    )
+    q = native.query(ctx).constructions().where_module("flask").where_name("Flask")
+    refs = q.collect()
+    rows = q.row_indices()
+    assert len(refs) == len(rows) == 1
+    all_nodes = ctx.nodes()
+    for ref, row in zip(refs, rows, strict=True):
+        assert all_nodes[row.var_idx].fqname == ref.var.fqname
+        assert row.class_name == ref.class_name
+
+
+def test_call_query_row_indices_matches_collect(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/app.py": (
+                'import flask\napp = flask.Flask(__name__)\napp.config.from_object("settings")\n'
+            ),
+        }
+    )
+    q = (
+        native.query(ctx)
+        .calls()
+        .where_owner("app.config")
+        .where_attr("from_object")
+        .string_arg_at(0)
+    )
+    refs = q.collect()
+    rows = q.row_indices()
+    assert len(refs) == len(rows)
+    if refs:
+        all_nodes = ctx.nodes()
+        for ref, row in zip(refs, rows, strict=True):
+            assert all_nodes[row.owner_idx].fqname == ref.owner.fqname
+            assert row.string_arg == ref.string_arg
+
+
+def test_factory_query_row_indices_matches_collect(build_decl_graph):
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/factory.py": ("import flask\ndef make_app():\n    return flask.Flask(__name__)\n"),
+        }
+    )
+    q = native.query(ctx).factories().of_module("flask").where_name("Flask")
+    refs = q.collect()
+    rows = q.row_indices()
+    assert len(refs) == len(rows)
+    all_nodes = ctx.nodes()
+    for ref, row in zip(refs, rows, strict=True):
+        assert all_nodes[row.decl_idx].fqname == ref.decl.fqname
+        assert row.kinds == ref.kinds

--- a/tests/test_query_indices.py
+++ b/tests/test_query_indices.py
@@ -707,6 +707,74 @@ def test_call_query_collect_returns_idx_rows(build_decl_graph):
         assert row.string_arg == "settings"
 
 
+def test_with_args_false_yields_empty_args_kwargs(build_decl_graph):
+    """``with_args(False)`` short-circuits the rust-side
+    ``extract_call_args_kwargs`` walk. Row ``args`` / ``kwargs``
+    getters surface empty containers; node-identity + metadata
+    strings (``decorator_owner``, ``string_arg``, etc.) still populate
+    as normal."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": (
+                "import functools\n@functools.lru_cache(maxsize=128)\ndef cached(): pass\n"
+            ),
+        }
+    )
+    with_args_rows = (
+        native.query(ctx).decorators().where_module("functools").where_name("lru_cache").collect()
+    )
+    assert len(with_args_rows) == 1
+    # Sanity: default extracts args/kwargs.
+    assert dict(with_args_rows[0].kwargs)
+
+    no_args_rows = (
+        native.query(ctx)
+        .decorators()
+        .where_module("functools")
+        .where_name("lru_cache")
+        .with_args(False)
+        .collect()
+    )
+    assert len(no_args_rows) == 1
+    # Empty containers when extraction is skipped.
+    assert list(no_args_rows[0].args) == []
+    assert dict(no_args_rows[0].kwargs) == {}
+    # Identity + metadata fields still populate normally.
+    assert no_args_rows[0].decorated_idx == with_args_rows[0].decorated_idx
+    assert no_args_rows[0].decorator_owner == with_args_rows[0].decorator_owner
+
+
+def test_with_args_false_does_not_disable_kwarg_filter(build_decl_graph):
+    """Even with ``with_args(False)``, ``.where_kwarg(...)`` must still
+    filter — the rust side forces extraction back on when any kwarg
+    matcher is set."""
+    ctx = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/svc.py": (
+                "import functools\n"
+                "@functools.lru_cache(maxsize=128)\n"
+                "def big(): pass\n"
+                "@functools.lru_cache(maxsize=1)\n"
+                "def small(): pass\n"
+            ),
+        }
+    )
+    rows = (
+        native.query(ctx)
+        .decorators()
+        .where_module("functools")
+        .where_name("lru_cache")
+        .with_args(False)
+        .where_kwarg("maxsize", 128)
+        .collect()
+    )
+    assert len(rows) == 1
+    fqnames = {ctx.nodes()[r.decorated_idx].fqname for r in rows}
+    assert fqnames == {"pkg.svc.big"}
+
+
 def test_factory_query_collect_returns_idx_rows(build_decl_graph):
     ctx = build_decl_graph(
         {


### PR DESCRIPTION
Four commits, taken together: a full SymbolNode → idx conversion of the in-tree plugin surface plus a batched fused-query plugin shape.

## Commit 1 — idx-form APIs + `AddNodeByIdx`

Base idx surface plugins need to stay out of `Py<SymbolNode>` space — the precondition for parallel plugin execution to actually parallelise without GIL contention.

### New `ProjectContext` APIs

- `find_declarations_indices` / `module_for_indices` / `modules_for_paths`
- `module_surface_indices` / `module_surfaces_indices`
- `find_main_blocks_indices`
- `node_attrs(indices)` — batched `(kind, path, fqname, flags)` snapshot. One FFI hop instead of N per-attribute `borrow` round-trips.

### New ref-query terminals

`DecoratorQuery.row_indices()` / `ConstructionQuery.row_indices()` / `CallQuery.row_indices()` / `FactoryQuery.row_indices()` — each returns a new `*IdxRef` pyclass carrying a positional index (`decorated_idx` / `var_idx` / `owner_idx` / `decl_idx`) instead of a `SymbolNode`, plus the row's `path` as a cheap bucket key. Skips `args` / `kwargs` payload work.

### New graph op

`AddNodeByIdx` — index-keyed sibling of `AddNode`. Bounds-checked at apply time *before* interning the synthetic, so a bad endpoint never strands an unconnected node.

### Internal refactor (no public Python API change)

The eight `ctx.find_*` helpers backing the ref queries (plus the three thin wrappers) now return `Vec<(usize, ..., CallArgs)>` instead of allocating `Py<SymbolNode>` themselves. The materialisation moved into each query's `.collect()` terminal; `.row_indices()` skips it entirely.

`AddNode`'s apply pass pre-resolves every endpoint key before minting the synthetic, matching the discipline `AddNodeByIdx` introduces. A missing key now surfaces as a clean `ValueError` instead of stranding an unconnected synthetic.

## Commit 2 — every bundled plugin ported to idx-only

Drops every `Py<SymbolNode>` reference from `plugins/*` and `contrib/*`. Plugins now fan out through `row_indices()` / `.indices()` terminals, batch-fetch attrs via `ctx.node_attrs(indices)`, and yield `AddEdgeByIdx` / `AddNodeByIdx` / `AddEntrypointByIdx` exclusively. The node-returning APIs stay for out-of-tree plugins.

### New rust surface needed to land this

- `AddEntrypointByIdx` graph op — idx-keyed sibling of `AddEntrypoint`. Reads decl `fqname` / `path` on the rust side at apply time.
- `SubclassQuery.of_idx(idx)` + `ctx.find_subclasses_of_idx(idx)`.
- `DecoratorQuery.in_decl_idx(idx)`.
- `ctx.find_module_idx`, `find_module_dunders_indices`, `find_nodes_matching_specs_indices`, `subclasses_of_fqn_indices`, `direct_predecessors_idx` — the missing siblings each plugin needed.

### Plugin-side simplifications

- Construction / factory dedup collapses to `set[var_idx]` / `set[(decl_idx, kind)]` — every position has a globally unique index, so the old `(path, start_line)` keys were redundant.
- Edge / handler dedup likewise — Click's `(owner.path, owner.fqname, handler.path, handler.fqname)` quad becomes `(owner_idx, handler_idx)`.

## Commit 3 — `BatchDispatchAppPlugin`

Composes a list of `DispatchAppPlugin` instances and runs them with fused queries — same observable output as registering each plugin individually, but the construction / factory / variable scans run once across the union of every plugin's config instead of once per plugin.

- Extracted `DispatchAppPlugin._emit_ops` from `run()`. Emission (entrypoint promotion, factory markers, handler wiring, factory walk) takes pre-fetched rows so the same code runs in both the single-plugin and batched paths.
- Module-level `_fetch_direct` / `_fetch_factory_decls` / `_fetch_handlers` / `_build_vars_by_file` helpers.
- `DispatchAppPlugin.run` becomes thin: presence guard → fetch → `_emit_ops`. Public API + behavior unchanged.
- Batch fuses: per-distinct-module construction & factory queries (rows routed by `class_name`); shared subclass-walk cache; one project-wide variable scan.
- Handler queries stay per-plugin (the ref API doesn't carry the matched attr; routing a fused result requires a separate rust change).

## Commit 4 — direct parity tests for the new idx APIs

Each new API the conversion introduced now has focused parity tests against its node-form sibling — previously covered only transitively through the converted plugins. 17 tests added in `tests/test_query_indices.py` covering `AddEntrypointByIdx`, `find_module_idx`, `find_module_dunders_indices`, `find_nodes_matching_specs_indices`, `subclasses_of_fqn_indices`, `find_subclasses_of_idx`, `SubclassQuery.of_idx`, `direct_predecessors_idx`, `DecoratorQuery.in_decl_idx`. Each includes the relevant `IndexError` / `ValueError` edge cases.

## Test plan

- [x] `uv run pytest` — 723 passed.
- [x] `uv run prek run --all-files` — ruff, ruff-format, ty all green.
- [x] `cargo check` / `cargo fmt --all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)