### PR TITLE
pytest: model test → fixture dependencies as graph edges

### DIFF
--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -827,6 +827,50 @@ class ProjectContext:
         """
         ...
 
+    def function_parameters(self, indices: Sequence[int]) -> list[list[str]]:
+        """Batched parameter-name snapshot for each function-kind
+        index. Walks the parsed AST once per distinct path; matches
+        each top-level ``FunctionDef`` against the rust-side
+        ``decl_by_name_range`` by its name's byte range.
+
+        Returns the union of positional-only, positional-or-keyword,
+        and keyword-only parameter names in declaration order;
+        ``*args`` and ``**kwargs`` are skipped. Indices that don't
+        resolve to a top-level ``FunctionDef`` (non-function kinds,
+        nested functions, decorator-only stubs) surface an empty list
+        at the same position.
+
+        Used by :class:`dead_cst.contrib.PytestPlugin` to discover
+        ``test_foo(my_fixture)`` → ``test_foo → my_fixture`` edges.
+
+        Validates bounds and raises :class:`IndexError` when any
+        index is out of range.
+        """
+        ...
+
+    def class_method_parameters(self, indices: Sequence[int]) -> list[list[str]]:
+        """Batched class-method parameter-name snapshot for each
+        class-kind index. For each input class, walks its body's
+        top-level ``FunctionDef`` statements and returns the union
+        of their parameter names (positional-only + positional-or-
+        keyword + keyword-only), deduped in first-seen order, with
+        ``self`` and ``cls`` excluded. ``*args`` and ``**kwargs``
+        are skipped.
+
+        Indices that don't resolve to a top-level ``ClassDef`` in the
+        AST surface an empty list at the same position.
+
+        Used by :class:`dead_cst.contrib.PytestPlugin` to wire
+        ``class → fixture`` edges for ``Test*`` classes — class
+        methods aren't represented as their own graph nodes, so the
+        class itself is the rendezvous point for any fixture any
+        method uses.
+
+        Validates bounds and raises :class:`IndexError` when any
+        index is out of range.
+        """
+        ...
+
     # ----- Pure scans over the in-progress graph ------------------------
     #
     # Plugins use the DSL: ``query(ctx).modules().with_dunders().indices()``

--- a/python/dead_cst/contrib/pytest.py
+++ b/python/dead_cst/contrib/pytest.py
@@ -1,4 +1,6 @@
-"""Plugin: keep pytest-discovered tests, conftest decls, and ``@pytest.fixture`` functions alive."""
+"""Plugin: keep pytest-discovered tests, conftest decls, and
+``@pytest.fixture`` functions alive; model test → fixture dependencies
+as graph edges so callers can introspect them."""
 
 from __future__ import annotations
 
@@ -16,12 +18,37 @@ PYTEST_FIXTURES_PREFIX = "<pytest:fixtures>:"
 
 @dataclass
 class PytestPlugin(Plugin):
-    """Mark pytest-discovered symbols as entrypoints.
+    """Mark pytest-discovered symbols as entrypoints and wire
+    test → fixture edges by parameter-name matching.
 
-    * ``conftest.py``: every top-level function / class / variable.
-    * ``test_*.py`` / ``*_test.py``: every top-level ``test_*`` function
-      and ``Test*`` class.
-    * Top-level functions decorated with ``@pytest.fixture``.
+    * ``conftest.py``: every top-level function / class / variable is
+      seeded alive (covers ``conftest`` fixtures + helpers).
+    * ``test_*.py`` / ``*_test.py``: every top-level ``test_*``
+      function and ``Test*`` class is seeded alive.
+    * Every ``@pytest.fixture``-decorated function is seeded alive
+      via a synthetic ``<pytest:fixtures>:<module>`` entrypoint —
+      same conservative rule we've shipped before. Catches
+      ``autouse=True`` fixtures, ``usefixtures(...)`` markers,
+      ``parametrize(..., indirect=...)``, dynamic
+      ``request.getfixturevalue(...)`` lookups, and anything else
+      we can't statically pin to a parameter name.
+    * On top of the seed, ``test → fixture`` and ``class → fixture``
+      edges are emitted by parameter-name matching, so the
+      dependency structure is queryable (``ancestors(fixture)`` /
+      ``descendants(test)``) even though the seed alone would
+      already keep the fixture alive. The binding name is the
+      ``name=`` kwarg on ``@pytest.fixture(name="alias")`` when set,
+      otherwise the function's simple name.
+    * For ``Test*`` classes, the union of every method's parameter
+      names (minus ``self`` / ``cls``) is name-matched. Class methods
+      aren't graph nodes of their own — the class is the rendezvous
+      point.
+
+    Names from a test/class signature that don't match any project
+    fixture (pytest builtins like ``tmp_path`` / ``capsys``,
+    third-party plugin fixtures like ``mocker``, free-form
+    ``parametrize`` names) are silently ignored, so they never
+    produce spurious edges.
     """
 
     def run(self, ctx: native.ProjectContext) -> Iterable[native.GraphOp]:
@@ -56,8 +83,13 @@ class PytestPlugin(Plugin):
         # Single batched ``node_attrs`` for every test candidate
         # across every test file — one FFI hop regardless of how many
         # test files the project has. Re-bucket by path after the
-        # filter.
+        # filter; track function- vs class-kind tests separately so
+        # the fixture-edge pass below can wire each kind from its
+        # own parameter source (function bodies vs class method
+        # bodies).
         test_filtered_by_path: dict[str, list[int]] = {}
+        test_function_idxs: list[int] = []
+        test_class_idxs: list[int] = []
         if test_candidate_idxs:
             attrs = ctx.node_attrs(test_candidate_idxs)
             for idx, path, attr in zip(
@@ -65,6 +97,10 @@ class PytestPlugin(Plugin):
             ):
                 if _is_test_decl(attr.kind, attr.fqname):
                     test_filtered_by_path.setdefault(path, []).append(idx)
+                    if attr.kind == "function":
+                        test_function_idxs.append(idx)
+                    elif attr.kind == "class":
+                        test_class_idxs.append(idx)
 
         # Module-fqname fetch — only for paths we'll actually seed
         # (conftest + filtered tests). Skips the cost for irrelevant
@@ -82,24 +118,78 @@ class PytestPlugin(Plugin):
                 continue
             yield from _mark_seed(f"{PYTEST_TESTS_PREFIX}{module_fqname}", path, test_idxs)
 
-        # ``@pytest.fixture`` decorators. Bucketed per-file the same way
-        # — only fetch module fqnames for paths that have at least one
-        # fixture.
+        # Fixture pass. Single decorator query feeds both the
+        # unconditional ``<pytest:fixtures>:<module>`` seed (every
+        # ``@pytest.fixture`` is alive, the conservative rule that
+        # catches autouse / usefixtures / indirect / dynamic lookups)
+        # AND the parameter-name edge emission (queryable
+        # ``test → fixture`` / ``class → fixture`` structure on top
+        # of the seed).
+        #
+        # ``.with_args(True)`` is on so we can read the ``name=``
+        # kwarg off ``@pytest.fixture(name="alias")`` — pytest binds
+        # the fixture under the alias instead of the function name.
+        fixture_refs = (
+            native.query(ctx)
+            .decorators()
+            .where_module("pytest")
+            .where_name("fixture")
+            .with_args(True)
+            .collect()
+        )
+        if not fixture_refs:
+            return
+        # Per-file seed-alive marker, mirroring the conftest/test
+        # seed shape — every fixture in the project stays alive
+        # regardless of whether a static parameter match exists.
         fixtures_by_path: dict[str, list[int]] = {}
-        for ref in (
-            native.query(ctx).decorators().where_module("pytest").where_name("fixture").collect()
-        ):
+        for ref in fixture_refs:
             fixtures_by_path.setdefault(ref.path, []).append(ref.decorated_idx)
+        fixture_module_fqnames = _module_fqnames(ctx, list(fixtures_by_path.keys()))
+        for path, fixture_idxs in fixtures_by_path.items():
+            module_fqname = fixture_module_fqnames.get(path)
+            if module_fqname is None:
+                continue
+            yield from _mark_seed(f"{PYTEST_FIXTURES_PREFIX}{module_fqname}", path, fixture_idxs)
 
-        if fixtures_by_path:
-            fixture_module_fqnames = _module_fqnames(ctx, list(fixtures_by_path.keys()))
-            for path, fixture_idxs in fixtures_by_path.items():
-                module_fqname = fixture_module_fqnames.get(path)
-                if module_fqname is None:
-                    continue
-                yield from _mark_seed(
-                    f"{PYTEST_FIXTURES_PREFIX}{module_fqname}", path, fixture_idxs
-                )
+        # Parameter-name edges. Skip the rust calls entirely when
+        # there's no test signature to inspect.
+        if not test_function_idxs and not test_class_idxs:
+            return
+        # Build ``binding_name -> [fixture_idx, ...]``. The binding
+        # name is the ``name=`` kwarg literal when present
+        # (``@pytest.fixture(name="alias")``), else the function's
+        # simple name. Collisions are kept (a fixture in
+        # ``conftest.py`` plus a same-named fixture in a test file:
+        # both targets receive edges from any test whose param matches
+        # the name — pessimistic, but harmless).
+        fixture_idxs_all = [r.decorated_idx for r in fixture_refs]
+        fixture_attrs = ctx.node_attrs(fixture_idxs_all)
+        fixtures_by_name: dict[str, list[int]] = {}
+        for ref, attr in zip(fixture_refs, fixture_attrs, strict=True):
+            binding = _fixture_binding_name(ref, attr.fqname)
+            fixtures_by_name.setdefault(binding, []).append(ref.decorated_idx)
+        # Pull every test function's parameter list in one batched
+        # rust call; emit edges per param-name match. Parameters that
+        # don't resolve to a project fixture (pytest builtins like
+        # ``tmp_path`` / ``capsys``, third-party plugin fixtures like
+        # ``mocker``, free-form names from ``parametrize``) are
+        # silently skipped.
+        if test_function_idxs:
+            test_params = ctx.function_parameters(test_function_idxs)
+            for test_idx, params in zip(test_function_idxs, test_params, strict=True):
+                for param in params:
+                    for fixture_idx in fixtures_by_name.get(param, ()):
+                        yield native.AddEdgeByIdx(test_idx, fixture_idx)
+        # ``Test*`` classes: union of every method's parameter names
+        # (minus ``self`` / ``cls``) → ``class → fixture`` edges per
+        # match.
+        if test_class_idxs:
+            class_params = ctx.class_method_parameters(test_class_idxs)
+            for cls_idx, params in zip(test_class_idxs, class_params, strict=True):
+                for param in params:
+                    for fixture_idx in fixtures_by_name.get(param, ()):
+                        yield native.AddEdgeByIdx(cls_idx, fixture_idx)
 
 
 def _module_fqnames(ctx: native.ProjectContext, paths: list[str]) -> dict[str, str]:
@@ -142,3 +232,22 @@ def _is_test_decl(kind: str, fqname: str) -> bool:
 
 def _is_test_filename(name: str) -> bool:
     return (name.startswith("test_") and name.endswith(".py")) or name.endswith("_test.py")
+
+
+def _fixture_binding_name(ref: native.DecoratorIdxRef, fixture_fqname: str) -> str:
+    """Pytest binding name for a ``@pytest.fixture``-decorated function.
+
+    Defaults to the function's simple name (last fqname segment) and
+    is overridden by the ``name=`` kwarg literal on the decorator —
+    ``@pytest.fixture(name="alias")\\ndef some_fn(): ...`` is resolved
+    by pytest as fixture ``alias`` regardless of ``some_fn``.
+
+    Anything other than a string-literal kwarg (e.g. a non-literal
+    expression that the rust extractor surfaces as ``ArgOpaque``)
+    falls back to the function name — we can't statically determine
+    the runtime binding for non-literal values.
+    """
+    alias = ref.kwargs.get("name")
+    if isinstance(alias, native.ArgLiteral) and isinstance(alias.value, str):
+        return alias.value
+    return fixture_fqname.rsplit(".", 1)[-1]

--- a/src/project.rs
+++ b/src/project.rs
@@ -3812,6 +3812,195 @@ impl ProjectContext {
         }
         Ok(out)
     }
+
+    /// Batched ``parameter_names`` snapshot for each function-kind
+    /// index in ``indices``. Non-function nodes (and indices that
+    /// don't resolve to a top-level ``FunctionDef`` in the AST)
+    /// surface an empty list at the same position.
+    ///
+    /// Walks the parsed AST once per distinct path; matches each
+    /// top-level ``FunctionDef`` against ``decl_by_name_range`` via
+    /// its name's byte range. Used by ``PytestPlugin`` to discover
+    /// fixture-dependency edges (``test_foo(my_fixture)`` →
+    /// ``test_foo → my_fixture``) — same shape as
+    /// :meth:`node_attrs` / :meth:`node_paths`: one FFI hop per
+    /// batch, validated bounds.
+    ///
+    /// Parameter shape: returns the union of positional-only,
+    /// positional-or-keyword, and keyword-only parameter names in
+    /// declaration order. ``*args`` and ``**kwargs`` are skipped
+    /// (pytest never resolves them as fixture references).
+    pub(crate) fn function_parameters(
+        &self,
+        _py: Python<'_>,
+        indices: Vec<usize>,
+    ) -> PyResult<Vec<Vec<String>>> {
+        let outputs = self.materialized("function_parameters")?;
+        let nodes = &outputs.builder.nodes;
+        let len = nodes.len();
+        for &idx in &indices {
+            if idx >= len {
+                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                    "node index {idx} out of range (len={len})"
+                )));
+            }
+        }
+        if indices.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Build the wanted set + an idx → (file, name_range) inverse
+        // by scanning ``decl_by_name_range`` once. The decl-by-name
+        // index already has the byte range of every function decl
+        // (the name range, e.g. ``test_foo`` in ``def test_foo``);
+        // we use that as the rendezvous key against the AST below.
+        let wanted: FxHashSet<usize> = indices.iter().copied().collect();
+        let mut idx_to_loc: FxHashMap<usize, (File, (u32, u32))> =
+            FxHashMap::with_capacity_and_hasher(wanted.len(), Default::default());
+        for (&(file, rk), &idx) in &outputs.decl_by_name_range {
+            if wanted.contains(&idx) {
+                idx_to_loc.insert(idx, (file, rk));
+            }
+        }
+
+        // Group wanted ranges by file for a single AST walk per
+        // distinct path.
+        let mut by_file: FxHashMap<File, FxHashMap<(u32, u32), usize>> = FxHashMap::default();
+        for (&idx, &(file, rk)) in &idx_to_loc {
+            by_file.entry(file).or_default().insert(rk, idx);
+        }
+
+        let mut params_for_idx: FxHashMap<usize, Vec<String>> =
+            FxHashMap::with_capacity_and_hasher(wanted.len(), Default::default());
+        for (&file, rk_to_idx) in &by_file {
+            let parsed = parsed_module(&self.db, file).load(&self.db);
+            for stmt in &parsed.syntax().body {
+                let Stmt::FunctionDef(func) = stmt else {
+                    continue;
+                };
+                let rk = crate::helpers::range_key(func.name.range());
+                let Some(&idx) = rk_to_idx.get(&rk) else {
+                    continue;
+                };
+                let params = &func.parameters;
+                let mut names: Vec<String> = Vec::with_capacity(
+                    params.posonlyargs.len() + params.args.len() + params.kwonlyargs.len(),
+                );
+                for p in &params.posonlyargs {
+                    names.push(p.parameter.name.id.to_string());
+                }
+                for p in &params.args {
+                    names.push(p.parameter.name.id.to_string());
+                }
+                for p in &params.kwonlyargs {
+                    names.push(p.parameter.name.id.to_string());
+                }
+                params_for_idx.insert(idx, names);
+            }
+        }
+
+        Ok(indices
+            .into_iter()
+            .map(|idx| params_for_idx.remove(&idx).unwrap_or_default())
+            .collect())
+    }
+
+    /// Batched class-method parameter-name snapshot for each
+    /// class-kind index. For each input class, walks its body's
+    /// top-level ``FunctionDef`` statements and returns the union of
+    /// their parameter names (positional-only + positional-or-keyword
+    /// + keyword-only), deduped in first-seen order, with ``self`` and
+    /// ``cls`` excluded.
+    ///
+    /// Indices that don't resolve to a top-level ``ClassDef`` in the
+    /// AST surface an empty list at the same position. ``*args`` and
+    /// ``**kwargs`` are skipped (pytest never resolves them as
+    /// fixture references).
+    ///
+    /// Used by ``PytestPlugin`` to wire ``class → fixture`` edges for
+    /// ``Test*`` classes whose method signatures mention fixtures.
+    /// We don't represent class methods as their own graph nodes, so
+    /// the class itself is the rendezvous point for any fixture any
+    /// method uses.
+    pub(crate) fn class_method_parameters(
+        &self,
+        _py: Python<'_>,
+        indices: Vec<usize>,
+    ) -> PyResult<Vec<Vec<String>>> {
+        let outputs = self.materialized("class_method_parameters")?;
+        let nodes = &outputs.builder.nodes;
+        let len = nodes.len();
+        for &idx in &indices {
+            if idx >= len {
+                return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                    "node index {idx} out of range (len={len})"
+                )));
+            }
+        }
+        if indices.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Same rendezvous strategy as ``function_parameters``, but
+        // keyed off ``class_by_selection`` (class name-range → idx)
+        // instead of ``decl_by_name_range``.
+        let wanted: FxHashSet<usize> = indices.iter().copied().collect();
+        let mut idx_to_loc: FxHashMap<usize, (File, (u32, u32))> =
+            FxHashMap::with_capacity_and_hasher(wanted.len(), Default::default());
+        for (&(file, rk), &idx) in &outputs.class_by_selection {
+            if wanted.contains(&idx) {
+                idx_to_loc.insert(idx, (file, rk));
+            }
+        }
+
+        let mut by_file: FxHashMap<File, FxHashMap<(u32, u32), usize>> = FxHashMap::default();
+        for (&idx, &(file, rk)) in &idx_to_loc {
+            by_file.entry(file).or_default().insert(rk, idx);
+        }
+
+        let mut params_for_idx: FxHashMap<usize, Vec<String>> =
+            FxHashMap::with_capacity_and_hasher(wanted.len(), Default::default());
+        for (&file, rk_to_idx) in &by_file {
+            let parsed = parsed_module(&self.db, file).load(&self.db);
+            for stmt in &parsed.syntax().body {
+                let Stmt::ClassDef(cls) = stmt else {
+                    continue;
+                };
+                let rk = crate::helpers::range_key(cls.name.range());
+                let Some(&idx) = rk_to_idx.get(&rk) else {
+                    continue;
+                };
+                let mut seen: FxHashSet<String> = FxHashSet::default();
+                let mut names: Vec<String> = Vec::new();
+                for body_stmt in &cls.body {
+                    let Stmt::FunctionDef(method) = body_stmt else {
+                        continue;
+                    };
+                    let params = &method.parameters;
+                    for p in params
+                        .posonlyargs
+                        .iter()
+                        .chain(params.args.iter())
+                        .chain(params.kwonlyargs.iter())
+                    {
+                        let n = p.parameter.name.id.as_str();
+                        if n == "self" || n == "cls" {
+                            continue;
+                        }
+                        if seen.insert(n.to_string()) {
+                            names.push(n.to_string());
+                        }
+                    }
+                }
+                params_for_idx.insert(idx, names);
+            }
+        }
+
+        Ok(indices
+            .into_iter()
+            .map(|idx| params_for_idx.remove(&idx).unwrap_or_default())
+            .collect())
+    }
 }
 
 impl ProjectContext {

--- a/tests/test_plugins/test_pytest.py
+++ b/tests/test_plugins/test_pytest.py
@@ -82,6 +82,11 @@ def test_pytest_plugin_marks_conftest_decls(build_plugin_graph, reachable_fqname
 def test_pytest_plugin_marks_decorated_fixtures_outside_conftest(
     build_plugin_graph, reachable_fqnames
 ):
+    """Every ``@pytest.fixture``-decorated function is unconditionally
+    alive via the synthetic ``<pytest:fixtures>:<module>`` seed,
+    regardless of whether any test parameter mentions it. The
+    parameter-name edges are *additive* — they make the dependency
+    queryable without changing the alive set."""
     graph = build_plugin_graph(
         {
             "tests/__init__.py": "",
@@ -112,6 +117,210 @@ def test_pytest_plugin_marks_decorated_fixtures_outside_conftest(
     assert "tests.fixtures.parametrized_fixture" in reached
     assert "tests.fixtures.imported_fixture" in reached
     assert "tests.fixtures.not_a_fixture" not in reached
+
+
+def test_pytest_plugin_emits_test_to_fixture_edge(build_plugin_graph):
+    """The ``test → fixture`` edge is the load-bearing artifact for
+    the new fixture model. Verify it's actually in the graph (not just
+    that reachability happens to land right)."""
+    graph = build_plugin_graph(
+        {
+            "tests/__init__.py": "",
+            "tests/fixtures.py": """
+            import pytest
+
+            @pytest.fixture
+            def my_fixture():
+                return 1
+            """,
+            "tests/test_x.py": """
+            from tests.fixtures import my_fixture  # noqa: F401
+
+            def test_uses(my_fixture):
+                assert my_fixture == 1
+            """,
+        },
+        [PytestPlugin()],
+    )
+    nodes = graph.nodes()
+    by_fqname = {n.fqname: i for i, n in enumerate(nodes)}
+    test_idx = by_fqname["tests.test_x.test_uses"]
+    fixture_idx = by_fqname["tests.fixtures.my_fixture"]
+    assert (test_idx, fixture_idx, 0) in [(s, d, f) for (s, d, f) in graph.edges()]
+
+
+def test_pytest_plugin_unrelated_param_no_edge(build_plugin_graph):
+    """Parameter names that don't match any project fixture (pytest
+    builtins like ``tmp_path``, third-party plugin fixtures like
+    ``mocker``, free-form ``parametrize`` names) are silently ignored —
+    no spurious edges to unrelated decls that happen to share the
+    name."""
+    graph = build_plugin_graph(
+        {
+            "tests/__init__.py": "",
+            "tests/test_x.py": """
+            def test_uses_builtin(tmp_path, capsys):
+                pass
+            """,
+        },
+        [PytestPlugin()],
+    )
+    # No fixture ⇒ no edge out of test_uses_builtin.
+    nodes = graph.nodes()
+    by_fqname = {n.fqname: i for i, n in enumerate(nodes)}
+    test_idx = by_fqname["tests.test_x.test_uses_builtin"]
+    out_edges = [(s, d, f) for (s, d, f) in graph.edges() if s == test_idx]
+    # Only the module-anchor edge (test → its module).
+    assert all(nodes[d].kind == "module" for (_, d, _) in out_edges)
+
+
+def test_pytest_plugin_class_method_pulls_fixture_alive(build_plugin_graph, reachable_fqnames):
+    """A fixture used only by a ``Test*`` class method must stay alive.
+    We don't have method-level graph nodes, so the class is the
+    rendezvous point — ``class → fixture`` edges by name match."""
+    graph = build_plugin_graph(
+        {
+            "tests/__init__.py": "",
+            "tests/fixtures.py": """
+            import pytest
+
+            @pytest.fixture
+            def class_only_fixture():
+                return 1
+            """,
+            "tests/test_cls.py": """
+            from tests.fixtures import class_only_fixture  # noqa: F401
+
+            class TestThing:
+                def test_method(self, class_only_fixture):
+                    assert class_only_fixture == 1
+            """,
+        },
+        [PytestPlugin()],
+    )
+    reached = reachable_fqnames(graph)
+    assert "tests.fixtures.class_only_fixture" in reached
+
+
+def test_pytest_plugin_emits_class_to_fixture_edge(build_plugin_graph):
+    """The ``class → fixture`` edge is the load-bearing artifact for
+    Test* class fixture deps. Verify it's actually in the graph."""
+    graph = build_plugin_graph(
+        {
+            "tests/__init__.py": "",
+            "tests/fixtures.py": """
+            import pytest
+
+            @pytest.fixture
+            def my_fixture():
+                return 1
+            """,
+            "tests/test_cls.py": """
+            from tests.fixtures import my_fixture  # noqa: F401
+
+            class TestThing:
+                def test_a(self, my_fixture): pass
+                def test_b(self): pass
+            """,
+        },
+        [PytestPlugin()],
+    )
+    nodes = graph.nodes()
+    by_fqname = {n.fqname: i for i, n in enumerate(nodes)}
+    cls_idx = by_fqname["tests.test_cls.TestThing"]
+    fixture_idx = by_fqname["tests.fixtures.my_fixture"]
+    assert (cls_idx, fixture_idx, 0) in [(s, d, f) for (s, d, f) in graph.edges()]
+
+
+def test_pytest_plugin_class_self_cls_excluded(build_plugin_graph):
+    """``self`` and ``cls`` parameter names must NOT produce edges
+    even if a fixture happens to share the name."""
+    graph = build_plugin_graph(
+        {
+            "tests/__init__.py": "",
+            "tests/fixtures.py": """
+            import pytest
+
+            @pytest.fixture
+            def self():
+                return 1
+
+            @pytest.fixture
+            def cls():
+                return 2
+            """,
+            "tests/test_cls.py": """
+            from tests.fixtures import self, cls  # noqa: F401
+
+            class TestThing:
+                def test_a(self): pass
+                @classmethod
+                def test_b(cls): pass
+            """,
+        },
+        [PytestPlugin()],
+    )
+    nodes = graph.nodes()
+    by_fqname = {n.fqname: i for i, n in enumerate(nodes)}
+    cls_idx = by_fqname["tests.test_cls.TestThing"]
+    bad_targets = {by_fqname["tests.fixtures.self"], by_fqname["tests.fixtures.cls"]}
+    edges = [(s, d, f) for (s, d, f) in graph.edges() if s == cls_idx]
+    assert not any(d in bad_targets for (_, d, _) in edges)
+
+
+def test_pytest_plugin_fixture_name_kwarg_alias(build_plugin_graph):
+    """``@pytest.fixture(name="alias")`` binds the fixture under the
+    alias, not its function name. The ``test → fixture`` edge must
+    resolve through the alias — verify the edge is present in the
+    graph. (Reachability of the fixture itself is guaranteed by the
+    unconditional fixture seed, so we check the edge directly.)"""
+    graph = build_plugin_graph(
+        {
+            "tests/__init__.py": "",
+            "tests/fixtures.py": """
+            import pytest
+
+            @pytest.fixture(name="alias")
+            def some_fn():
+                return 1
+            """,
+            "tests/test_uses_alias.py": """
+            from tests.fixtures import some_fn  # noqa: F401
+
+            def test_takes_alias(alias):
+                assert alias == 1
+            """,
+        },
+        [PytestPlugin()],
+    )
+    nodes = graph.nodes()
+    by_fqname = {n.fqname: i for i, n in enumerate(nodes)}
+    test_idx = by_fqname["tests.test_uses_alias.test_takes_alias"]
+    fixture_idx = by_fqname["tests.fixtures.some_fn"]
+    assert (test_idx, fixture_idx, 0) in [(s, d, f) for (s, d, f) in graph.edges()]
+
+
+def test_pytest_plugin_conftest_fixture_unused_stays_alive(build_plugin_graph, reachable_fqnames):
+    """Fixtures defined in a ``conftest.py`` are still seeded alive via
+    the conftest-seeds-everything rule (they're often referenced by
+    tests we don't model precisely). The test → fixture edge is
+    *additive* — it pulls non-conftest fixtures alive when used."""
+    graph = build_plugin_graph(
+        {
+            "tests/__init__.py": "",
+            "tests/conftest.py": """
+            import pytest
+
+            @pytest.fixture
+            def conftest_fixture():
+                return 1
+            """,
+        },
+        [PytestPlugin()],
+    )
+    reached = reachable_fqnames(graph)
+    # No test even uses it — conftest seed still keeps it alive.
+    assert "tests.conftest.conftest_fixture" in reached
 
 
 def test_pytest_plugin_ignores_non_test_modules(build_plugin_graph, reachable_fqnames):


### PR DESCRIPTION
## Summary

Adds queryable ``test → fixture`` and ``class → fixture`` edges to ``PytestPlugin`` on top of the existing unconditional ``<pytest:fixtures>:<module>`` seed. Same alive set as before (the seed handles every flavor — ``autouse``, ``usefixtures``, ``parametrize(indirect=)``, ``request.getfixturevalue``, and anything else we can't statically pin); the new edges make the dependency structure introspectable via ``ancestors(fixture)`` / ``descendants(test)``.

### Edge emission

- **Function-kind tests** — parameter list walked; each name that matches a project ``@pytest.fixture`` binding name emits a ``test → fixture`` edge.
- **``Test*`` classes** — union of every method's parameter names (deduped, ``self`` / ``cls`` excluded) matched against the fixture index; matches emit ``class → fixture`` edges. Class methods aren't graph nodes, so the class is the rendezvous point.
- **``name=`` kwarg** — ``@pytest.fixture(name=""alias"")`` is honored. The fixture's binding name is the kwarg literal when present, otherwise the function's simple name.
- Parameter names with no project fixture match (``tmp_path``, ``capsys``, ``mocker``, free-form ``parametrize`` names) are silently ignored — no spurious edges.

### New rust helpers

- ``ProjectContext.function_parameters(indices) -> list[list[str]]`` — batched AST walk for each top-level ``FunctionDef``; returns positional-only + positional-or-keyword + keyword-only param names (``*args`` / ``**kwargs`` skipped).
- ``ProjectContext.class_method_parameters(indices) -> list[list[str]]`` — same for top-level ``ClassDef``, unioning across every method body.

Both rendezvous-key off the existing ``decl_by_name_range`` / ``class_by_selection`` indices via the AST name range — no line/col conversion, one parse + one walk per distinct path.

### Tests (15 total in ``test_plugins/test_pytest.py``)

Existing tests preserved (test/class discovery, conftest seed, fixture seed). New pins:

- ``test_pytest_plugin_emits_test_to_fixture_edge``
- ``test_pytest_plugin_class_method_pulls_fixture_alive``
- ``test_pytest_plugin_emits_class_to_fixture_edge``
- ``test_pytest_plugin_class_self_cls_excluded``
- ``test_pytest_plugin_fixture_name_kwarg_alias``
- ``test_pytest_plugin_conftest_fixture_unused_stays_alive``
- ``test_pytest_plugin_unrelated_param_no_edge``

### Out of scope (no regression vs main)

These flavors still rely on the unconditional fixture seed for aliveness, not on the new edges:
- ``autouse=True`` fixtures
- ``@pytest.mark.usefixtures(""name"")`` markers
- ``@pytest.mark.parametrize(..., indirect=[...])``
- ``request.getfixturevalue(""name"")`` dynamic lookups
- ``pytest_plugins = [...]`` external module fixtures

## Test plan

- [x] ``uv run pytest tests/test_plugins/test_pytest.py`` — 15 passed
- [x] ``uv run pytest`` — 764 passed
- [x] ``uv run prek run --all-files`` clean (ruff / ruff-format / uv-lock / ty / cargo fmt / cargo clippy)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)