### PR TITLE
Incremental rebuilds via Analysis.re_materialize

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,21 +111,21 @@ you ask a question (`materialize_all`, `reachable`, `dead`,
 `materialize_all()` call, so subsequent BFS queries run on the already-
 built graph — one FFI hop per query, no rebuild.
 
-`Analysis.re_materialize(events=None)` rebuilds the graph against the
-same `ProjectContext` without tearing down the salsa db. With no
-argument it calls `ctx.detect_changes()` (returns a single
-`ChangeEvent.rescan()`); explicit callers pass a
-`list[native.ChangeEvent]` built via the
-`.changed(path)` / `.created(path)` / `.deleted(path)` /
-`.rescan()` classmethods. `ctx.apply_changes(events)` forwards into
-ty's `ProjectDatabase::apply_changes`, which bumps file revisions only
-when mtime / size differ, registers `Created` paths so new files are
-visible on the next walk, drops `Deleted` paths, and triggers a full
-rescan + project reload for the `Rescan` sentinel. Cross-file
-importers invalidate transitively through salsa's auto-tracked
-`file_to_nodes` reads. Plugin `prepare(project_root)` is one-shot
-(owned by `materialize_all`); `re_materialize` only re-drives the
-build + plugin pass.
+`Analysis.re_materialize(events)` rebuilds the graph against the
+same `ProjectContext` without tearing down the salsa db. The caller
+supplies the change set: typically `ctx.detect_changes()` (which
+today returns a single `ChangeEvent.rescan()`), or an explicit
+`list[native.ChangeEvent]` built via the `.changed(path)` /
+`.created(path)` / `.deleted(path)` / `.rescan()` classmethods for
+LSP / file-watcher integrations. `ctx.apply_changes(events)` forwards
+into ty's `ProjectDatabase::apply_changes`, which bumps file
+revisions only when mtime / size differ, registers `Created` paths so
+new files are visible on the next walk, drops `Deleted` paths, and
+triggers a full rescan + project reload for the `Rescan` sentinel.
+Cross-file importers invalidate transitively through salsa's
+auto-tracked `file_to_nodes` reads. Plugin `prepare(project_root)` is
+one-shot (owned by `materialize_all`); `re_materialize` only
+re-drives the build + plugin pass.
 
 ### 3. Graph materialization — `native.ProjectContext.materialize()`
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,6 +111,22 @@ you ask a question (`materialize_all`, `reachable`, `dead`,
 `materialize_all()` call, so subsequent BFS queries run on the already-
 built graph — one FFI hop per query, no rebuild.
 
+`Analysis.re_materialize(events=None)` rebuilds the graph against the
+same `ProjectContext` without tearing down the salsa db. With no
+argument it calls `ctx.detect_changes()` (returns a single
+`ChangeEvent.rescan()`); explicit callers pass a
+`list[native.ChangeEvent]` built via the
+`.changed(path)` / `.created(path)` / `.deleted(path)` /
+`.rescan()` classmethods. `ctx.apply_changes(events)` forwards into
+ty's `ProjectDatabase::apply_changes`, which bumps file revisions only
+when mtime / size differ, registers `Created` paths so new files are
+visible on the next walk, drops `Deleted` paths, and triggers a full
+rescan + project reload for the `Rescan` sentinel. Cross-file
+importers invalidate transitively through salsa's auto-tracked
+`file_to_nodes` reads. Plugin `prepare(project_root)` is one-shot
+(owned by `materialize_all`); `re_materialize` only re-drives the
+build + plugin pass.
+
 ### 3. Graph materialization — `native.ProjectContext.materialize()`
 
 Driven from Python by `Analysis.materialize_all()`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,32 @@ two versions.
 
 ### Added
 
-- `Analysis.re_materialize(dirty_files)` — incrementally rebuild the
-  project graph against the existing `native.ProjectContext`. Notifies
-  salsa that the listed files have changed (via the new
-  `native.ProjectContext.sync_paths`), resets progress state (new
-  `reset_progress`), clears plugins (new `clear_plugins`), then
-  re-drives the build + plugin pipeline. The per-file salsa cache for
-  unchanged files survives across calls, so only dirty +
-  transitively-dirty files re-fire — cross-file importers invalidate
-  automatically through salsa's read-tracking on `file_to_nodes`.
-  Plugin `prepare` is a one-shot, not re-run. The assemble pass and
-  plugin pass still execute on every call; they're cheap O(N) walks
-  over a warm cache.
+- `Analysis.re_materialize(events=None)` — incrementally rebuild the
+  project graph against the existing `native.ProjectContext`. With no
+  argument, calls `native.ProjectContext.detect_changes()` to
+  auto-discover what changed on disk (currently emits a single
+  `ChangeEvent.rescan()`); explicit callers (LSP integrations, file
+  watchers) can pass a list of `native.ChangeEvent` instances.
+  `native.ProjectContext.apply_changes(events)` forwards to
+  `ty_project::ProjectDatabase::apply_changes`, which handles each
+  variant correctly — `Changed` bumps the file's salsa revision only
+  if its mtime / size actually differ; `Created` registers brand-new
+  paths with the project file set so they're discovered on the next
+  rebuild; `Deleted` removes them; `Rescan` triggers a full
+  `Files::sync_all` + project re-walk + metadata rediscovery.
+  Configuration files (`pyproject.toml`, ignore files, custom-stdlib
+  `VERSIONS`) trigger a project reload automatically. Salsa's
+  per-file cache for content-unchanged files survives across calls,
+  so the assemble pass and plugin pass run on a warm cache. Plugin
+  `prepare` is a one-shot owned by `materialize_all`, not re-run on
+  re_materialize.
+- `native.ChangeEvent` Python class with `changed(path)`,
+  `created(path)`, `deleted(path)`, and `rescan()` classmethods plus
+  `.kind` / `.path` accessors, exposed for LSP-style integrations
+  that want precise control over what to invalidate.
+- `native.ProjectContext.clear_plugins()` and `reset_progress()` —
+  internal helpers `re_materialize` uses to keep plugin registrations
+  and progress counters from leaking across calls.
 
 ## [0.13.0] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ two versions.
 
 ## [Unreleased]
 
+### Added
+
+- `Analysis.re_materialize(dirty_files)` — incrementally rebuild the
+  project graph against the existing `native.ProjectContext`. Notifies
+  salsa that the listed files have changed (via the new
+  `native.ProjectContext.sync_paths`), resets progress state (new
+  `reset_progress`), clears plugins (new `clear_plugins`), then
+  re-drives the build + plugin pipeline. The per-file salsa cache for
+  unchanged files survives across calls, so only dirty +
+  transitively-dirty files re-fire — cross-file importers invalidate
+  automatically through salsa's read-tracking on `file_to_nodes`.
+  Plugin `prepare` is a one-shot, not re-run. The assemble pass and
+  plugin pass still execute on every call; they're cheap O(N) walks
+  over a warm cache.
+
 ## [0.13.0] - 2026-05-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ two versions.
 
 ### Added
 
-- `Analysis.re_materialize(events=None)` — incrementally rebuild the
-  project graph against the existing `native.ProjectContext`. With no
-  argument, calls `native.ProjectContext.detect_changes()` to
-  auto-discover what changed on disk (currently emits a single
-  `ChangeEvent.rescan()`); explicit callers (LSP integrations, file
-  watchers) can pass a list of `native.ChangeEvent` instances.
+- `Analysis.re_materialize(events)` — incrementally rebuild the
+  project graph against the existing `native.ProjectContext`. The
+  caller supplies the change events: typically
+  `ctx.detect_changes()` (which today returns a single
+  `ChangeEvent.rescan()`), or an explicit list of
+  `native.ChangeEvent`s for LSP integrations and file-watchers.
   `native.ProjectContext.apply_changes(events)` forwards to
   `ty_project::ProjectDatabase::apply_changes`, which handles each
   variant correctly — `Changed` bumps the file's salsa revision only

--- a/README.md
+++ b/README.md
@@ -192,33 +192,36 @@ the graph into Python.
 ### Incremental rebuilds
 
 For long-lived `Analysis` instances (LSP harnesses, watch loops),
-`Analysis.re_materialize(events=None)` rebuilds the graph against the
-same `ProjectContext` without tearing down ty's salsa db. With no
-argument it auto-detects changes via
-`native.ProjectContext.detect_changes()` (which delegates to ty's
-`apply_changes` rescan handler: mtime-checked `Files::sync_all`,
-project file re-walk, metadata rediscovery). Pass an explicit
-`list[native.ChangeEvent]` when you know what changed (e.g. an LSP
-consuming `didChangeWatchedFiles`):
+`Analysis.re_materialize(events)` rebuilds the graph against the
+same `ProjectContext` without tearing down ty's salsa db. The caller
+supplies the change events — either an explicit list (from an LSP
+consuming `didChangeWatchedFiles`, a file-watcher, or a CI script
+that knows which files it touched), or `ctx.detect_changes()` to let
+ty figure it out:
 
 ```python
 from dead_cst import _native as native
 
-analysis.materialize_all()
+ctx = analysis.materialize_all()
 # ... source files change on disk ...
-analysis.re_materialize()                                   # autodetect
-analysis.re_materialize([                                   # or explicit
+
+analysis.re_materialize(ctx.detect_changes())              # autodetect via ty
+analysis.re_materialize([                                  # or explicit
     native.ChangeEvent.changed("/abs/foo.py"),
     native.ChangeEvent.created("/abs/new.py"),
     native.ChangeEvent.deleted("/abs/gone.py"),
 ])
 ```
 
-Salsa's per-file cache survives across calls, so unchanged files skip
-parsing / `file_to_nodes` / `file_to_edges` / `file_to_ref_edges`
-recomputation; cross-file importers invalidate transitively through
-salsa's read-tracking. The assemble pass and plugin pass run on every
-call, but they're cheap O(N) walks over the warm cache.
+`ctx.detect_changes()` currently returns a single
+`ChangeEvent.rescan()`, which ty's apply handler turns into an
+mtime-checked `Files::sync_all` + project file re-walk + metadata
+rediscovery. Salsa's per-file cache survives across calls, so
+unchanged files skip parsing / `file_to_nodes` / `file_to_edges` /
+`file_to_ref_edges` recomputation; cross-file importers invalidate
+transitively through salsa's read-tracking. The assemble pass and
+plugin pass run on every call, but they're cheap O(N) walks over the
+warm cache.
 
 Entrypoint detection is fully plugin-driven. Builtins:
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,37 @@ print(meta.node_count, meta.edge_count, dict(meta.user_meta))
 `kept_alive_by_flags_only`) delegate to the rust BFS without copying
 the graph into Python.
 
+### Incremental rebuilds
+
+For long-lived `Analysis` instances (LSP harnesses, watch loops),
+`Analysis.re_materialize(events=None)` rebuilds the graph against the
+same `ProjectContext` without tearing down ty's salsa db. With no
+argument it auto-detects changes via
+`native.ProjectContext.detect_changes()` (which delegates to ty's
+`apply_changes` rescan handler: mtime-checked `Files::sync_all`,
+project file re-walk, metadata rediscovery). Pass an explicit
+`list[native.ChangeEvent]` when you know what changed (e.g. an LSP
+consuming `didChangeWatchedFiles`):
+
+```python
+from dead_cst import _native as native
+
+analysis.materialize_all()
+# ... source files change on disk ...
+analysis.re_materialize()                                   # autodetect
+analysis.re_materialize([                                   # or explicit
+    native.ChangeEvent.changed("/abs/foo.py"),
+    native.ChangeEvent.created("/abs/new.py"),
+    native.ChangeEvent.deleted("/abs/gone.py"),
+])
+```
+
+Salsa's per-file cache survives across calls, so unchanged files skip
+parsing / `file_to_nodes` / `file_to_edges` / `file_to_ref_edges`
+recomputation; cross-file importers invalidate transitively through
+salsa's read-tracking. The assemble pass and plugin pass run on every
+call, but they're cheap O(N) walks over the warm cache.
+
 Entrypoint detection is fully plugin-driven. Builtins:
 
 | Plugin | Purpose |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -147,19 +147,18 @@ demand.
 Folded down from earlier tiers as they landed:
 
 - **Unreleased**: Incremental rebuilds.
-  `Analysis.re_materialize(events=None)` rebuilds the graph against
-  the existing `native.ProjectContext` without tearing down ty's
-  salsa db. With no argument it auto-detects via
+  `Analysis.re_materialize(events)` rebuilds the graph against the
+  existing `native.ProjectContext` without tearing down ty's salsa
+  db. The caller supplies the change set — typically
   `ctx.detect_changes()` (today: a single `ChangeEvent.rescan()` that
   hits ty's mtime-checked `Files::sync_all` + project re-walk +
-  metadata rediscovery). Explicit callers (LSP integrations
-  consuming `didChangeWatchedFiles`) pass a list of
-  `native.ChangeEvent`s built via
-  `.changed(path)` / `.created(path)` / `.deleted(path)` /
-  `.rescan()`. Salsa's per-file cache survives across calls; only
-  dirty + transitively-dirty files re-fire `file_to_nodes` /
-  `file_to_edges` / `file_to_ref_edges`. The assemble + plugin
-  passes still run every call but on a warm cache.
+  metadata rediscovery), or an explicit list of `native.ChangeEvent`s
+  built via `.changed(path)` / `.created(path)` / `.deleted(path)` /
+  `.rescan()` for LSP integrations consuming `didChangeWatchedFiles`.
+  Salsa's per-file cache survives across calls; only dirty +
+  transitively-dirty files re-fire `file_to_nodes` / `file_to_edges`
+  / `file_to_ref_edges`. The assemble + plugin passes still run every
+  call but on a warm cache.
 - **v0.11.0**: Rust-native graph builder. libcst visitor, SQLite cache,
   and networkx are replaced by a pyo3 extension on ty's ``SemanticIndex``;
   libcst now only powers the codemod.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -146,6 +146,20 @@ demand.
 
 Folded down from earlier tiers as they landed:
 
+- **Unreleased**: Incremental rebuilds.
+  `Analysis.re_materialize(events=None)` rebuilds the graph against
+  the existing `native.ProjectContext` without tearing down ty's
+  salsa db. With no argument it auto-detects via
+  `ctx.detect_changes()` (today: a single `ChangeEvent.rescan()` that
+  hits ty's mtime-checked `Files::sync_all` + project re-walk +
+  metadata rediscovery). Explicit callers (LSP integrations
+  consuming `didChangeWatchedFiles`) pass a list of
+  `native.ChangeEvent`s built via
+  `.changed(path)` / `.created(path)` / `.deleted(path)` /
+  `.rescan()`. Salsa's per-file cache survives across calls; only
+  dirty + transitively-dirty files re-fire `file_to_nodes` /
+  `file_to_edges` / `file_to_ref_edges`. The assemble + plugin
+  passes still run every call but on a warm cache.
 - **v0.11.0**: Rust-native graph builder. libcst visitor, SQLite cache,
   and networkx are replaced by a pyo3 extension on ty's ``SemanticIndex``;
   libcst now only powers the codemod.

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -360,6 +360,44 @@ class Project:
 class _ProjectPluginLike(Protocol):
     def run(self, ctx: "ProjectContext") -> Iterable[GraphOp] | None: ...
 
+class ChangeEvent:
+    """A file-system change event consumed by
+    :meth:`ProjectContext.apply_changes`. Construct via the
+    classmethods :meth:`changed` / :meth:`created` / :meth:`deleted` /
+    :meth:`rescan`; or get a list back from
+    :meth:`ProjectContext.detect_changes` to autodetect what changed
+    on disk since the last build."""
+
+    @property
+    def kind(self) -> str:
+        """One of ``"changed"`` / ``"created"`` / ``"deleted"`` /
+        ``"rescan"``."""
+
+    @property
+    def path(self) -> str | None:
+        """The path the event refers to, or ``None`` for
+        :meth:`rescan`."""
+
+    @classmethod
+    def changed(cls, path: str) -> "ChangeEvent":
+        """File at ``path`` was modified (content or metadata)."""
+        ...
+
+    @classmethod
+    def created(cls, path: str) -> "ChangeEvent":
+        """File or directory at ``path`` was created."""
+        ...
+
+    @classmethod
+    def deleted(cls, path: str) -> "ChangeEvent":
+        """File or directory at ``path`` was deleted."""
+        ...
+
+    @classmethod
+    def rescan(cls) -> "ChangeEvent":
+        """Full-project rescan sentinel."""
+        ...
+
 class ProjectContext:
     """Plugin-aware project graph builder.
 
@@ -424,15 +462,37 @@ class ProjectContext:
         double-register plugins on the rust-serial path."""
         ...
 
-    def sync_paths(self, paths: Iterable[str]) -> None:
-        """Notify salsa that ``paths`` have changed on disk.
+    def apply_changes(self, events: Iterable[ChangeEvent]) -> None:
+        """Apply a batch of file-system change events to the salsa db.
 
-        Bumps each file's revision so any salsa-tracked query that
-        read its contents re-fires on next access; cross-file
-        importers invalidate transitively. Call before re-running
-        :meth:`materialize` (or :meth:`build_only`) to incrementally
-        rebuild after a source edit. Paths may be absolute or relative
-        to the project root.
+        Forwards to ty_project's ``ProjectDatabase::apply_changes``,
+        which handles each variant correctly:
+
+        * ``Changed`` — bumps the file's revision iff mtime / size
+          differ; otherwise no-op.
+        * ``Created`` — registers the path with the project file set
+          so brand-new files are visible on next enumeration.
+        * ``Deleted`` — removes the file from the project set.
+        * ``Rescan`` — triggers a full ``sync_all`` + project re-walk
+          + metadata rediscovery.
+
+        Project configuration files (``pyproject.toml``, ignore files,
+        custom-stdlib ``VERSIONS``) are detected automatically and
+        trigger a project reload.
+        """
+        ...
+
+    def detect_changes(self) -> list[ChangeEvent]:
+        """Return :class:`ChangeEvent`\\s that, when fed to
+        :meth:`apply_changes`, bring the salsa db in sync with the
+        current on-disk state.
+
+        Today this returns a single ``ChangeEvent.rescan()``; the
+        underlying ty rescan handler does an mtime-checked
+        ``Files::sync_all`` (so per-file salsa caches survive when
+        the file content hasn't changed), a project file re-walk
+        (so new files are discovered and deleted ones dropped), and
+        a metadata rediscovery (so config changes take effect).
         """
         ...
 

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -418,6 +418,35 @@ class ProjectContext:
         invocation during :meth:`materialize`."""
         ...
 
+    def clear_plugins(self) -> None:
+        """Drop every plugin registered via :meth:`add_plugin`. Used by
+        :class:`dead_cst.Analysis` so a re-materialize doesn't
+        double-register plugins on the rust-serial path."""
+        ...
+
+    def sync_paths(self, paths: Iterable[str]) -> None:
+        """Notify salsa that ``paths`` have changed on disk.
+
+        Bumps each file's revision so any salsa-tracked query that
+        read its contents re-fires on next access; cross-file
+        importers invalidate transitively. Call before re-running
+        :meth:`materialize` (or :meth:`build_only`) to incrementally
+        rebuild after a source edit. Paths may be absolute or relative
+        to the project root.
+        """
+        ...
+
+    def reset_progress(self) -> None:
+        """Reset the progress counter state for a re-run.
+
+        Replaces the rust-side ``ProgressCounters`` with a fresh
+        instance so a subsequent :meth:`materialize` /
+        :meth:`build_only` call starts from zero. Without it, a poller
+        spun up for the second build would observe ``finished=true``
+        from the first build and exit immediately.
+        """
+        ...
+
     def materialize(self) -> NativeGraph:
         """Build the project-wide graph, run each registered plugin's
         ``run(ctx)``, then snapshot the final state.

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -673,36 +673,44 @@ class Analysis:
         self._ctx = ctx
         return ctx
 
-    def re_materialize(self, dirty_files: Sequence[Path | str]) -> native.ProjectContext:
+    def re_materialize(
+        self, events: Sequence[native.ChangeEvent] | None = None
+    ) -> native.ProjectContext:
         """Incrementally re-run materialize against the existing ctx.
 
-        Notifies salsa that ``dirty_files`` have changed (via
-        :meth:`native.ProjectContext.sync_paths`), then re-drives the
-        build + plugin pipeline on the same :class:`native.ProjectContext`.
-        Salsa's per-file cache survives across calls, so unchanged files
-        skip parsing / ``file_to_nodes`` / ``file_to_edges`` /
+        With no argument, autodetects file-system changes via
+        :meth:`native.ProjectContext.detect_changes` (which today
+        returns a single ``ChangeEvent.rescan()`` — ty stats every
+        known file and only invalidates salsa for the ones whose mtime
+        / size actually changed, then re-walks for new / deleted
+        files). Callers with explicit knowledge of what changed (e.g.
+        an LSP integration consuming ``didChangeWatchedFiles``) can
+        pass a list of :class:`native.ChangeEvent` instances directly.
+
+        Salsa's per-file cache survives across calls, so unchanged
+        files skip parsing / ``file_to_nodes`` / ``file_to_edges`` /
         ``file_to_ref_edges`` recomputation; cross-file importers
         invalidate transitively through salsa's auto-tracked reads.
-
-        The assemble pass and plugin pass still run unconditionally —
-        they're cheap O(N) walks over a warm salsa cache. Plugin
-        ``prepare`` is *not* re-run; plugins are assumed unchanged
-        across the lifetime of the :class:`Analysis`.
+        The assemble pass and plugin pass run unconditionally — cheap
+        O(N) walks over the warm cache. Plugin ``prepare`` is *not*
+        re-run; plugins are assumed unchanged across the lifetime of
+        the :class:`Analysis`.
 
         Returns the same (now-rebuilt) :class:`native.ProjectContext`
         instance that :meth:`materialize_all` returned. Callers that
-        cached :class:`SymbolNode` objects from the previous build must
-        re-fetch them — node identities are rebuilt by the assemble
-        pass.
+        cached :class:`SymbolNode` objects from the previous build
+        must re-fetch them — node identities are rebuilt by the
+        assemble pass.
 
         Raises :class:`RuntimeError` if :meth:`materialize_all` hasn't
-        been called yet (there's no ctx to re-build).
+        been called yet.
         """
         if self._ctx is None:
             raise RuntimeError(
                 "re_materialize() requires a prior materialize_all() call to construct the ctx"
             )
-        self._ctx.sync_paths([str(p) for p in dirty_files])
+        change_events = list(events) if events is not None else self._ctx.detect_changes()
+        self._ctx.apply_changes(change_events)
         self._ctx.reset_progress()
         self._drive_build(self._ctx)
         return self._ctx

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -673,21 +673,23 @@ class Analysis:
         self._ctx = ctx
         return ctx
 
-    def re_materialize(
-        self, events: Sequence[native.ChangeEvent] | None = None
-    ) -> native.ProjectContext:
+    def re_materialize(self, events: Sequence[native.ChangeEvent]) -> native.ProjectContext:
         """Incrementally re-run materialize against the existing ctx.
 
-        With no argument, autodetects file-system changes via
-        :meth:`native.ProjectContext.detect_changes` (which today
-        returns a single ``ChangeEvent.rescan()`` — ty stats every
-        known file and only invalidates salsa for the ones whose mtime
-        / size actually changed, then re-walks for new / deleted
-        files). Callers with explicit knowledge of what changed (e.g.
-        an LSP integration consuming ``didChangeWatchedFiles``) can
-        pass a list of :class:`native.ChangeEvent` instances directly.
+        ``events`` is the list of :class:`native.ChangeEvent`\\s to
+        apply before rebuilding. Build it from any source you trust:
+        an LSP integration consuming ``didChangeWatchedFiles``, a
+        file-watcher that emits ``Changed`` / ``Created`` / ``Deleted``,
+        or — when you have no precise list — a single
+        ``ChangeEvent.rescan()`` (or the equivalent
+        ``ctx.detect_changes()`` helper, which is the same call).
 
-        Salsa's per-file cache survives across calls, so unchanged
+        :meth:`native.ProjectContext.apply_changes` forwards the events
+        to ty's ``ProjectDatabase::apply_changes``, which only bumps
+        salsa revisions for files whose mtime / size actually changed,
+        registers ``Created`` paths, drops ``Deleted`` ones, and on
+        ``Rescan`` re-walks the project and reloads metadata. Salsa's
+        per-file cache for unaffected files survives, so unchanged
         files skip parsing / ``file_to_nodes`` / ``file_to_edges`` /
         ``file_to_ref_edges`` recomputation; cross-file importers
         invalidate transitively through salsa's auto-tracked reads.
@@ -709,8 +711,7 @@ class Analysis:
             raise RuntimeError(
                 "re_materialize() requires a prior materialize_all() call to construct the ctx"
             )
-        change_events = list(events) if events is not None else self._ctx.detect_changes()
-        self._ctx.apply_changes(change_events)
+        self._ctx.apply_changes(list(events))
         self._ctx.reset_progress()
         self._drive_build(self._ctx)
         return self._ctx

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -669,6 +669,59 @@ class Analysis:
         if self._stack_size is not None:
             ctx.set_stack_size(self._stack_size)
 
+        self._drive_build(ctx)
+        self._ctx = ctx
+        return ctx
+
+    def re_materialize(self, dirty_files: Sequence[Path | str]) -> native.ProjectContext:
+        """Incrementally re-run materialize against the existing ctx.
+
+        Notifies salsa that ``dirty_files`` have changed (via
+        :meth:`native.ProjectContext.sync_paths`), then re-drives the
+        build + plugin pipeline on the same :class:`native.ProjectContext`.
+        Salsa's per-file cache survives across calls, so unchanged files
+        skip parsing / ``file_to_nodes`` / ``file_to_edges`` /
+        ``file_to_ref_edges`` recomputation; cross-file importers
+        invalidate transitively through salsa's auto-tracked reads.
+
+        The assemble pass and plugin pass still run unconditionally —
+        they're cheap O(N) walks over a warm salsa cache. Plugin
+        ``prepare`` is *not* re-run; plugins are assumed unchanged
+        across the lifetime of the :class:`Analysis`.
+
+        Returns the same (now-rebuilt) :class:`native.ProjectContext`
+        instance that :meth:`materialize_all` returned. Callers that
+        cached :class:`SymbolNode` objects from the previous build must
+        re-fetch them — node identities are rebuilt by the assemble
+        pass.
+
+        Raises :class:`RuntimeError` if :meth:`materialize_all` hasn't
+        been called yet (there's no ctx to re-build).
+        """
+        if self._ctx is None:
+            raise RuntimeError(
+                "re_materialize() requires a prior materialize_all() call to construct the ctx"
+            )
+        self._ctx.sync_paths([str(p) for p in dirty_files])
+        self._ctx.reset_progress()
+        self._drive_build(self._ctx)
+        return self._ctx
+
+    def _drive_build(self, ctx: native.ProjectContext) -> None:
+        """Run the build + plugin pipeline on an already-constructed ctx.
+
+        Factored out of :meth:`materialize_all` so
+        :meth:`re_materialize` can drive a second build on the same
+        ctx without duplicating the dispatch / progress / plugin-pool
+        plumbing. Plugin ``prepare`` is *not* invoked here — that's a
+        one-shot hook owned by :meth:`materialize_all`.
+        """
+        # The rust-serial path below calls ``ctx.add_plugin(p)`` per
+        # plugin, which appends. Clear first so a re_materialize doesn't
+        # stack a second copy of every plugin on top of the first run's
+        # registrations.
+        ctx.clear_plugins()
+
         # Spin up the progress polling thread if the user asked for
         # callbacks. The thread reads rust-side atomic counters at
         # ~100 ms and fires structured events. Joined in a ``finally``
@@ -810,8 +863,6 @@ class Analysis:
         finally:
             if poller is not None:
                 poller.stop()
-        self._ctx = ctx
-        return ctx
 
     def reachable(self, *, seed_flags: int = KEEPALIVE_DEFAULT) -> set[SymbolNode]:
         """Set of every decl reachable from any seed in ``seed_flags``."""

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ use crate::graph::{EdgeFlags, Import, NativeGraph, NodeFlags, SymbolNode};
 use crate::helpers::{ArgLiteral, ArgNodeRef, ArgOpaque, NodeAttrs};
 use crate::io::{read_graph, write_graph, GraphMetadata};
 use crate::progress::ProgressHandle;
-use crate::project::{Project, ProjectContext};
+use crate::project::{ChangeEvent, Project, ProjectContext};
 use crate::query::{
     CallIdxRef, CallQuery, ClassQuery, ConstructionIdxRef, ConstructionQuery, DeclQuery,
     DeclarationsQuery, DecoratorIdxRef, DecoratorQuery, EdgeQuery, EdgeRef, FactoryIdxRef,
@@ -77,6 +77,7 @@ fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<NativeGraph>()?;
     m.add_class::<Project>()?;
     m.add_class::<ProjectContext>()?;
+    m.add_class::<ChangeEvent>()?;
     m.add_class::<AddEdge>()?;
     m.add_class::<AddEdgeByIdx>()?;
     m.add_class::<AddEntrypoint>()?;

--- a/src/project.rs
+++ b/src/project.rs
@@ -1198,6 +1198,52 @@ impl ProjectContext {
         self.plugins.push(plugin);
     }
 
+    /// Drop every plugin registered via :meth:`add_plugin`.
+    ///
+    /// :class:`dead_cst.Analysis` calls this at the top of its build
+    /// driver so a re-materialize doesn't double-register plugins on
+    /// the rust-serial path (where ``add_plugin`` is invoked once per
+    /// :meth:`materialize` call). Idempotent.
+    pub(crate) fn clear_plugins(&mut self) {
+        self.plugins.clear();
+    }
+
+    /// Notify salsa that the listed files have changed on disk.
+    ///
+    /// Bumps each file's revision so any salsa-tracked query that read
+    /// its contents (``file_to_nodes`` / ``file_to_edges`` /
+    /// ``file_to_ref_edges``, ty's ``SemanticIndex`` / ``parsed_module``
+    /// / use-def chains) re-fires on next access. Other files that
+    /// imported the dirty file are invalidated transitively via
+    /// salsa's auto-tracked cross-file reads.
+    ///
+    /// Call before re-running :meth:`materialize` (or
+    /// :meth:`build_only`) to incrementally rebuild the project graph
+    /// after a source edit. The per-file salsa cache for unchanged
+    /// files survives the bump, so only the dirty + transitively-dirty
+    /// files re-fire — the assemble pass still walks every project
+    /// file but reads from a warm cache for the rest.
+    ///
+    /// Paths may be absolute or relative; relative paths are resolved
+    /// against the db's current directory (the project root).
+    pub(crate) fn sync_paths(&mut self, paths: Vec<String>) {
+        use ruff_db::system::SystemPath;
+        for p in paths {
+            let sp = SystemPath::new(&p);
+            File::sync_path(&mut self.db, sp);
+        }
+    }
+
+    /// Reset the progress counter state to a fresh instance so a
+    /// subsequent :meth:`materialize` / :meth:`build_only` call starts
+    /// from zero. Without this, the polling thread on the next run
+    /// would observe ``finished=true`` from the prior run and exit
+    /// immediately. Called by :meth:`dead_cst.Analysis.re_materialize`
+    /// before driving a re-build on the same context.
+    pub(crate) fn reset_progress(&mut self) {
+        self.progress = Arc::new(ProgressCounters::new());
+    }
+
     /// Open a chainable query builder against this context.
     ///
     /// Equivalent to the top-level :func:`query` function; both return

--- a/src/project.rs
+++ b/src/project.rs
@@ -11,6 +11,7 @@ use parking_lot::{MappedRwLockReadGuard, Mutex, RwLock, RwLockReadGuard};
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use pyo3::exceptions::{PyOSError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
+use pyo3::types::PyType;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
@@ -22,6 +23,7 @@ use ruff_text_size::{Ranged, TextRange};
 use ty_project::metadata::options::{EnvironmentOptions, Options};
 use ty_project::metadata::python_version::SupportedPythonVersion;
 use ty_project::metadata::value::RangedValue;
+use ty_project::watch::{ChangeEvent as TyChangeEvent, ChangedKind, CreatedKind, DeletedKind};
 use ty_project::{Db as ProjectDb, ProjectDatabase, ProjectMetadata};
 use ty_python_core::definition::DefinitionState;
 use ty_python_core::program::UseDefaultStrategy;
@@ -1068,6 +1070,145 @@ pub(crate) fn build_fqname_indices(
 /// through `type_hierarchy_subtypes`, method-defines walks each class's
 /// `DefinitionKind::Class`, module dunders scan global-scope variable
 /// nodes, and comment patterns walk the parser's `Tokens` stream.
+/// Variant discriminant for [`ChangeEvent`]. Mirrors the high-level
+/// kinds of [`ty_project::watch::ChangeEvent`] that
+/// [`ProjectContext::apply_changes`] forwards to the salsa db; the
+/// per-variant `kind` enum on the upstream event (FileContent /
+/// FileMetadata / Any) is collapsed to `Any` because that's the right
+/// default for the user-facing constructors and lets ty do its own
+/// stat-based classification.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub(crate) enum ChangeEventKind {
+    Changed,
+    Created,
+    Deleted,
+    Rescan,
+}
+
+/// A file-system change event, passed to
+/// [`ProjectContext::apply_changes`] to incrementally invalidate the
+/// salsa db. Construct via the classmethods
+/// :py:meth:`changed` / :py:meth:`created` / :py:meth:`deleted` /
+/// :py:meth:`rescan`. Returned by
+/// [`ProjectContext::detect_changes`] for auto-detection flows.
+#[pyclass]
+#[derive(Debug, Clone)]
+pub(crate) struct ChangeEvent {
+    pub(crate) kind: ChangeEventKind,
+    /// Absolute or relative path the event refers to. ``None`` for
+    /// :py:meth:`rescan` (which has no path).
+    pub(crate) path: Option<SystemPathBuf>,
+}
+
+impl ChangeEvent {
+    /// Lower this event to the upstream :type:`ty_project::watch::ChangeEvent`
+    /// representation `apply_changes` consumes. Relative paths are
+    /// absolutized against the db's current directory (handled
+    /// downstream by `File::sync_path` and friends).
+    pub(crate) fn to_ty_event(&self) -> TyChangeEvent {
+        match (self.kind, &self.path) {
+            (ChangeEventKind::Changed, Some(path)) => TyChangeEvent::Changed {
+                path: path.clone(),
+                kind: ChangedKind::Any,
+            },
+            (ChangeEventKind::Created, Some(path)) => TyChangeEvent::Created {
+                path: path.clone(),
+                kind: CreatedKind::Any,
+            },
+            (ChangeEventKind::Deleted, Some(path)) => TyChangeEvent::Deleted {
+                path: path.clone(),
+                kind: DeletedKind::Any,
+            },
+            (ChangeEventKind::Rescan, _) => TyChangeEvent::Rescan,
+            // Path is required for non-Rescan variants. The Python
+            // constructors enforce this; if we somehow reach here
+            // without one, fall back to a Rescan which is the safe
+            // sledgehammer.
+            (_, None) => TyChangeEvent::Rescan,
+        }
+    }
+}
+
+#[pymethods]
+impl ChangeEvent {
+    /// File at ``path`` was modified (content or metadata).
+    ///
+    /// Forwarded to ``ty_project`` as a ``Changed{kind: Any}`` event;
+    /// ty's apply pass does the actual mtime / size comparison via
+    /// ``File::sync_path_only`` and only bumps the salsa revision if
+    /// something genuinely differs.
+    #[classmethod]
+    pub(crate) fn changed(_cls: &Bound<'_, PyType>, path: String) -> Self {
+        Self {
+            kind: ChangeEventKind::Changed,
+            path: Some(SystemPathBuf::from(path)),
+        }
+    }
+
+    /// File or directory at ``path`` was created.
+    ///
+    /// Forwarded as ``Created{kind: Any}``; ty stats the path to
+    /// decide whether to register a single file or to walk a
+    /// directory's contents.
+    #[classmethod]
+    pub(crate) fn created(_cls: &Bound<'_, PyType>, path: String) -> Self {
+        Self {
+            kind: ChangeEventKind::Created,
+            path: Some(SystemPathBuf::from(path)),
+        }
+    }
+
+    /// File or directory at ``path`` was deleted.
+    ///
+    /// Forwarded as ``Deleted{kind: Any}``; ty checks whether the
+    /// path was previously a file (drop one entry) or a directory
+    /// (drop recursively).
+    #[classmethod]
+    pub(crate) fn deleted(_cls: &Bound<'_, PyType>, path: String) -> Self {
+        Self {
+            kind: ChangeEventKind::Deleted,
+            path: Some(SystemPathBuf::from(path)),
+        }
+    }
+
+    /// Full-project rescan sentinel. Triggers ``Files::sync_all`` +
+    /// project file re-walk + metadata rediscovery in the apply pass.
+    /// Use when you don't know which paths changed (or want to be
+    /// safe after a long quiet period).
+    #[classmethod]
+    pub(crate) fn rescan(_cls: &Bound<'_, PyType>) -> Self {
+        Self {
+            kind: ChangeEventKind::Rescan,
+            path: None,
+        }
+    }
+
+    /// The path this event refers to, or ``None`` for ``rescan()``.
+    #[getter]
+    pub(crate) fn path(&self) -> Option<String> {
+        self.path.as_ref().map(|p| p.as_str().to_string())
+    }
+
+    /// One of ``"changed"`` / ``"created"`` / ``"deleted"`` /
+    /// ``"rescan"`` — useful for assertions and pretty-printing.
+    #[getter]
+    pub(crate) fn kind(&self) -> &'static str {
+        match self.kind {
+            ChangeEventKind::Changed => "changed",
+            ChangeEventKind::Created => "created",
+            ChangeEventKind::Deleted => "deleted",
+            ChangeEventKind::Rescan => "rescan",
+        }
+    }
+
+    pub(crate) fn __repr__(&self) -> String {
+        match &self.path {
+            Some(p) => format!("ChangeEvent.{}({:?})", self.kind(), p.as_str()),
+            None => format!("ChangeEvent.{}()", self.kind()),
+        }
+    }
+}
+
 #[pyclass]
 pub(crate) struct ProjectContext {
     pub(crate) db: ProjectDatabase,
@@ -1208,30 +1349,64 @@ impl ProjectContext {
         self.plugins.clear();
     }
 
-    /// Notify salsa that the listed files have changed on disk.
+    /// Apply a batch of file-system change events to the salsa db.
     ///
-    /// Bumps each file's revision so any salsa-tracked query that read
-    /// its contents (``file_to_nodes`` / ``file_to_edges`` /
-    /// ``file_to_ref_edges``, ty's ``SemanticIndex`` / ``parsed_module``
-    /// / use-def chains) re-fires on next access. Other files that
-    /// imported the dirty file are invalidated transitively via
-    /// salsa's auto-tracked cross-file reads.
+    /// Forwards to :meth:`ty_project::ProjectDatabase::apply_changes`,
+    /// which handles every event variant correctly: ``Changed`` bumps
+    /// the file's revision iff its mtime / size differ; ``Created``
+    /// adds the path to the project file set (so brand-new files
+    /// become visible on the next ``files()`` enumeration);
+    /// ``Deleted`` removes the file from the set; ``Rescan`` triggers
+    /// a full ``Files::sync_all`` + project re-walk. Project
+    /// configuration files (``pyproject.toml``, ignore files,
+    /// ``VERSIONS``) are detected automatically and trigger a project
+    /// reload.
     ///
     /// Call before re-running :meth:`materialize` (or
-    /// :meth:`build_only`) to incrementally rebuild the project graph
-    /// after a source edit. The per-file salsa cache for unchanged
-    /// files survives the bump, so only the dirty + transitively-dirty
-    /// files re-fire — the assemble pass still walks every project
-    /// file but reads from a warm cache for the rest.
+    /// :meth:`build_only`) to incrementally rebuild after a source
+    /// edit. Salsa's per-file cache for files whose events didn't
+    /// invalidate them stays warm.
     ///
-    /// Paths may be absolute or relative; relative paths are resolved
-    /// against the db's current directory (the project root).
-    pub(crate) fn sync_paths(&mut self, paths: Vec<String>) {
-        use ruff_db::system::SystemPath;
-        for p in paths {
-            let sp = SystemPath::new(&p);
-            File::sync_path(&mut self.db, sp);
-        }
+    /// :class:`dead_cst.Analysis.re_materialize` calls this in
+    /// combination with :meth:`detect_changes` to autodetect the
+    /// dirty set; callers with explicit knowledge of what changed
+    /// (e.g. an LSP integration) can build :class:`ChangeEvent` lists
+    /// directly via the classmethods on :class:`ChangeEvent`.
+    pub(crate) fn apply_changes(&mut self, events: Vec<Py<ChangeEvent>>, py: Python<'_>) {
+        let ty_events: Vec<TyChangeEvent> =
+            events.iter().map(|e| e.borrow(py).to_ty_event()).collect();
+        self.db.apply_changes(&ty_events, None);
+    }
+
+    /// Return a list of :class:`ChangeEvent`\\s that, when passed to
+    /// :meth:`apply_changes`, brings the salsa db in sync with the
+    /// current on-disk state of the project.
+    ///
+    /// Currently emits a single ``Rescan`` event, which under the
+    /// hood runs:
+    ///
+    /// * ``Files::sync_all(db)`` — stats every salsa-known file; bumps
+    ///   each file's revision only if its mtime / size changed. Per-file
+    ///   salsa caches for unchanged files survive the call.
+    /// * ``Project::reload_files`` — re-walks the project tree to
+    ///   discover newly created files and drop deleted ones.
+    /// * Project metadata rediscovery — re-reads ``pyproject.toml`` /
+    ///   ignore files so config changes take effect.
+    ///
+    /// This is the "simple and correct" implementation; a future
+    /// optimization could compare salsa-cached metadata to disk and
+    /// emit precise ``Changed`` / ``Created`` / ``Deleted`` events to
+    /// skip the metadata rediscovery and tree re-walk in the
+    /// "everything unchanged" case.
+    pub(crate) fn detect_changes(&self, py: Python<'_>) -> PyResult<Vec<Py<ChangeEvent>>> {
+        let ev = Py::new(
+            py,
+            ChangeEvent {
+                kind: ChangeEventKind::Rescan,
+                path: None,
+            },
+        )?;
+        Ok(vec![ev])
     }
 
     /// Reset the progress counter state to a fresh instance so a

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1,10 +1,11 @@
 """Incremental :meth:`Analysis.re_materialize` correctness tests.
 
 Each test builds an initial graph, mutates one or more source files on
-disk, calls ``re_materialize(dirty_files)``, and asserts the resulting
-graph matches an independent fresh full build of the same end state.
-The fresh build is the ground truth — incremental is correct iff it
-produces the same edges and the same node set.
+disk, calls ``re_materialize()`` (which autodetects via
+``ctx.detect_changes()`` -> ty's rescan handler), and asserts the
+resulting graph matches an independent fresh full build of the same
+end state. The fresh build is the ground truth — incremental is
+correct iff it produces the same edges and the same node set.
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ from pathlib import Path
 import pytest
 
 from dead_cst import Analysis
+from dead_cst import _native as native
 from dead_cst.plugins import MainBlockPlugin
 
 
@@ -35,36 +37,40 @@ def _edges(ctx) -> set[tuple[str, str]]:
     return {(nodes[src].fqname, nodes[dst].fqname) for src, dst, _flags in ctx.edges()}
 
 
-def _node_keys(ctx) -> set[tuple[str, str, int]]:
-    """``{(fqname, kind, start_line)}`` for every node in ``ctx``.
+def _node_keys(ctx) -> list[tuple[str, str, int]]:
+    """``[(fqname, kind, start_line), ...]`` for every node in ``ctx``.
 
-    Stable across rebuilds (independent of node-index allocation)."""
-    return {(n.fqname, n.kind, n.start_line) for n in ctx.nodes()}
+    Returns a list (not a set) so duplicate-node bugs don't get
+    silently collapsed by set equality."""
+    keys = [(n.fqname, n.kind, n.start_line) for n in ctx.nodes()]
+    keys.sort()
+    return keys
 
 
 def _dead_fqnames(analysis: Analysis) -> set[str]:
     return {n.fqname for n in analysis.dead()}
 
 
-def _build_fresh(tmp_path: Path) -> Analysis:
-    fresh = Analysis(tmp_path)
+def _build_fresh(tmp_path: Path, *, plugins=()) -> Analysis:
+    fresh = Analysis(tmp_path, plugins=plugins)
     fresh.materialize_all()
     return fresh
 
 
-def _assert_matches_fresh(analysis: Analysis, tmp_path: Path) -> None:
+def _assert_matches_fresh(analysis: Analysis, tmp_path: Path, *, plugins=()) -> None:
     """Ground-truth check: the incremental build must produce the same
     edges, node set, and dead set as a fresh full build of the same
-    on-disk source state."""
-    fresh = _build_fresh(tmp_path)
+    on-disk source state. Pass ``plugins=`` to mirror a plugin-aware
+    Analysis."""
+    fresh = _build_fresh(tmp_path, plugins=plugins)
     assert _edges(analysis.materialize_all()) == _edges(fresh.materialize_all())
     assert _node_keys(analysis.materialize_all()) == _node_keys(fresh.materialize_all())
     assert _dead_fqnames(analysis) == _dead_fqnames(fresh)
 
 
 def test_re_materialize_no_op(tmp_path):
-    """A re_materialize with no source edits and no dirty files should
-    produce a graph identical to the original build."""
+    """A re_materialize with no source edits should match a fresh
+    build of the same state."""
     _write(tmp_path / "a.py", "def f(): pass\n")
     _write(tmp_path / "b.py", "from a import f\nf()\n")
 
@@ -72,7 +78,7 @@ def test_re_materialize_no_op(tmp_path):
     ctx1 = analysis.materialize_all()
     edges_before = _edges(ctx1)
 
-    ctx2 = analysis.re_materialize([])
+    ctx2 = analysis.re_materialize()
 
     assert ctx1 is ctx2  # re_materialize rebuilds in place.
     assert _edges(ctx2) == edges_before
@@ -80,7 +86,7 @@ def test_re_materialize_no_op(tmp_path):
 
 
 def test_re_materialize_add_decl(tmp_path):
-    """Add a new top-level function in a dirty file."""
+    """Add a new top-level function to an existing file."""
     _write(tmp_path / "a.py", "def f(): pass\n")
     _write(tmp_path / "b.py", "from a import f\nf()\n")
 
@@ -88,16 +94,15 @@ def test_re_materialize_add_decl(tmp_path):
     analysis.materialize_all()
 
     _write(tmp_path / "a.py", "def f(): pass\ndef g(): pass\n")
-    analysis.re_materialize([tmp_path / "a.py"])
+    analysis.re_materialize()
 
     _assert_matches_fresh(analysis, tmp_path)
-    # Sanity: the new decl appears in the rebuilt graph.
     assert any(n.fqname == "a.g" for n in analysis.materialize_all().nodes())
 
 
 def test_re_materialize_remove_decl(tmp_path):
-    """Remove a decl from a dirty file; the old node and its edges
-    should disappear from the rebuild."""
+    """Remove a decl from an existing file; the node and its edges
+    should disappear."""
     _write(tmp_path / "a.py", "def f(): pass\ndef g(): pass\n")
     _write(tmp_path / "b.py", "from a import f\nf()\n")
 
@@ -106,21 +111,17 @@ def test_re_materialize_remove_decl(tmp_path):
     assert any(n.fqname == "a.g" for n in analysis.materialize_all().nodes())
 
     _write(tmp_path / "a.py", "def f(): pass\n")
-    analysis.re_materialize([tmp_path / "a.py"])
+    analysis.re_materialize()
 
     assert not any(n.fqname == "a.g" for n in analysis.materialize_all().nodes())
     _assert_matches_fresh(analysis, tmp_path)
 
 
-def test_re_materialize_transitive_invalidation(tmp_path):
-    """Rename ``a.f`` -> ``a.g`` with only ``a.py`` in the dirty list.
-
-    ``b.py`` is unchanged on disk but its old ``from a import f`` no
-    longer resolves. Salsa should still invalidate
-    ``file_to_ref_edges(b)`` because that query previously read
-    ``file_to_nodes(a)``, which changed. The fresh build is the
-    ground-truth comparator.
-    """
+def test_re_materialize_rename_decl(tmp_path):
+    """Rename ``a.f`` to ``a.g``; ``b.py`` is unchanged on disk but
+    its import no longer resolves. ty's rescan does an mtime-checked
+    sync_all so ``b.py``'s file_to_ref_edges re-fires via the
+    cross-file salsa dep."""
     _write(tmp_path / "a.py", "def f(): pass\n")
     _write(tmp_path / "b.py", "from a import f\nf()\n")
 
@@ -128,18 +129,51 @@ def test_re_materialize_transitive_invalidation(tmp_path):
     analysis.materialize_all()
 
     _write(tmp_path / "a.py", "def g(): pass\n")
-    analysis.re_materialize([tmp_path / "a.py"])
+    analysis.re_materialize()
 
     _assert_matches_fresh(analysis, tmp_path)
-    # Sanity: a.f is gone, a.g exists.
     fqs = {n.fqname for n in analysis.materialize_all().nodes()}
     assert "a.f" not in fqs
     assert "a.g" in fqs
 
 
-def test_re_materialize_multi_file_dirty(tmp_path):
-    """Mutate two files at once and re_materialize with both in the
-    dirty list."""
+def test_re_materialize_new_file(tmp_path):
+    """Create a brand-new file between builds; autodetect should
+    discover it via ty's project file re-walk."""
+    _write(tmp_path / "a.py", "def f(): pass\nf()\n")
+
+    analysis = Analysis(tmp_path)
+    analysis.materialize_all()
+    initial_files = {Path(n.path).name for n in analysis.materialize_all().nodes()}
+    assert "c.py" not in initial_files
+
+    _write(tmp_path / "c.py", "def h(): pass\nh()\n")
+    analysis.re_materialize()
+
+    rebuilt_files = {Path(n.path).name for n in analysis.materialize_all().nodes()}
+    assert "c.py" in rebuilt_files
+    _assert_matches_fresh(analysis, tmp_path)
+
+
+def test_re_materialize_deleted_file(tmp_path):
+    """Delete a file between builds; the file's nodes must be gone in
+    the rebuild."""
+    _write(tmp_path / "a.py", "def f(): pass\nf()\n")
+    _write(tmp_path / "b.py", "def g(): pass\ng()\n")
+
+    analysis = Analysis(tmp_path)
+    analysis.materialize_all()
+    assert any(Path(n.path).name == "b.py" for n in analysis.materialize_all().nodes())
+
+    (tmp_path / "b.py").unlink()
+    analysis.re_materialize()
+
+    assert not any(Path(n.path).name == "b.py" for n in analysis.materialize_all().nodes())
+    _assert_matches_fresh(analysis, tmp_path)
+
+
+def test_re_materialize_multi_file_mutation(tmp_path):
+    """Mutate two files at once. Autodetect picks up both."""
     _write(tmp_path / "a.py", "def f(): pass\n")
     _write(tmp_path / "b.py", "from a import f\nf()\n")
     _write(tmp_path / "c.py", "def h(): pass\n")
@@ -149,15 +183,52 @@ def test_re_materialize_multi_file_dirty(tmp_path):
 
     _write(tmp_path / "a.py", "def f(): pass\ndef extra(): pass\n")
     _write(tmp_path / "c.py", "def h(): pass\ndef other(): pass\n")
-    analysis.re_materialize([tmp_path / "a.py", tmp_path / "c.py"])
+    analysis.re_materialize()
 
     _assert_matches_fresh(analysis, tmp_path)
 
 
+def test_re_materialize_explicit_events(tmp_path):
+    """Pass explicit events instead of auto-detecting; the result must
+    match the autodetect path."""
+    _write(tmp_path / "a.py", "def f(): pass\nf()\n")
+
+    analysis = Analysis(tmp_path)
+    analysis.materialize_all()
+
+    _write(tmp_path / "a.py", "def f(): pass\ndef g(): pass\nf()\n")
+    analysis.re_materialize([native.ChangeEvent.changed(str(tmp_path / "a.py"))])
+
+    _assert_matches_fresh(analysis, tmp_path)
+
+
+def test_change_event_constructors_and_accessors():
+    """Smoke-test the :class:`ChangeEvent` Python-facing API."""
+    changed = native.ChangeEvent.changed("/abs/foo.py")
+    assert changed.kind == "changed"
+    assert changed.path == "/abs/foo.py"
+
+    created = native.ChangeEvent.created("/abs/bar.py")
+    assert created.kind == "created"
+    assert created.path == "/abs/bar.py"
+
+    deleted = native.ChangeEvent.deleted("/abs/baz.py")
+    assert deleted.kind == "deleted"
+    assert deleted.path == "/abs/baz.py"
+
+    rescan = native.ChangeEvent.rescan()
+    assert rescan.kind == "rescan"
+    assert rescan.path is None
+
+    # __repr__ surfaces both kind and path.
+    assert "changed" in repr(changed)
+    assert "foo.py" in repr(changed)
+    assert "rescan" in repr(rescan)
+
+
 def test_re_materialize_with_entrypoint_plugin(tmp_path):
-    """Re-materialize against a non-empty plugin set. Verifies that
-    plugin ops are produced correctly on the second build (plugins are
-    re-driven, not double-registered)."""
+    """Plugins run cleanly on the second build (no double-registration,
+    plugin ops applied to the rebuilt graph)."""
     _write(
         tmp_path / "a.py",
         """
@@ -175,7 +246,6 @@ def test_re_materialize_with_entrypoint_plugin(tmp_path):
     assert "a.f" not in dead_before  # main block keeps it alive
     assert "a.g" in dead_before
 
-    # Mutation: main block now also calls g, so g becomes alive.
     _write(
         tmp_path / "a.py",
         """
@@ -187,20 +257,17 @@ def test_re_materialize_with_entrypoint_plugin(tmp_path):
             g()
         """,
     )
-    analysis.re_materialize([tmp_path / "a.py"])
+    analysis.re_materialize()
 
     dead_after = _dead_fqnames(analysis)
     assert "a.f" not in dead_after
     assert "a.g" not in dead_after
 
-    fresh = Analysis(tmp_path, plugins=[MainBlockPlugin()])
-    fresh.materialize_all()
-    assert _dead_fqnames(analysis) == _dead_fqnames(fresh)
-    assert _edges(analysis.materialize_all()) == _edges(fresh.materialize_all())
+    _assert_matches_fresh(analysis, tmp_path, plugins=[MainBlockPlugin()])
 
 
 def test_re_materialize_requires_prior_materialize(tmp_path):
     _write(tmp_path / "a.py", "def f(): pass\n")
     analysis = Analysis(tmp_path)
     with pytest.raises(RuntimeError, match="prior materialize_all"):
-        analysis.re_materialize([tmp_path / "a.py"])
+        analysis.re_materialize()

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1,8 +1,8 @@
 """Incremental :meth:`Analysis.re_materialize` correctness tests.
 
 Each test builds an initial graph, mutates one or more source files on
-disk, calls ``re_materialize()`` (which autodetects via
-``ctx.detect_changes()`` -> ty's rescan handler), and asserts the
+disk, calls ``re_materialize(events)`` (with events from
+``ctx.detect_changes()`` or an explicit list), and asserts the
 resulting graph matches an independent fresh full build of the same
 end state. The fresh build is the ground truth — incremental is
 correct iff it produces the same edges and the same node set.
@@ -78,7 +78,7 @@ def test_re_materialize_no_op(tmp_path):
     ctx1 = analysis.materialize_all()
     edges_before = _edges(ctx1)
 
-    ctx2 = analysis.re_materialize()
+    ctx2 = analysis.re_materialize(ctx1.detect_changes())
 
     assert ctx1 is ctx2  # re_materialize rebuilds in place.
     assert _edges(ctx2) == edges_before
@@ -94,7 +94,7 @@ def test_re_materialize_add_decl(tmp_path):
     analysis.materialize_all()
 
     _write(tmp_path / "a.py", "def f(): pass\ndef g(): pass\n")
-    analysis.re_materialize()
+    analysis.re_materialize(analysis.materialize_all().detect_changes())
 
     _assert_matches_fresh(analysis, tmp_path)
     assert any(n.fqname == "a.g" for n in analysis.materialize_all().nodes())
@@ -111,7 +111,7 @@ def test_re_materialize_remove_decl(tmp_path):
     assert any(n.fqname == "a.g" for n in analysis.materialize_all().nodes())
 
     _write(tmp_path / "a.py", "def f(): pass\n")
-    analysis.re_materialize()
+    analysis.re_materialize(analysis.materialize_all().detect_changes())
 
     assert not any(n.fqname == "a.g" for n in analysis.materialize_all().nodes())
     _assert_matches_fresh(analysis, tmp_path)
@@ -129,7 +129,7 @@ def test_re_materialize_rename_decl(tmp_path):
     analysis.materialize_all()
 
     _write(tmp_path / "a.py", "def g(): pass\n")
-    analysis.re_materialize()
+    analysis.re_materialize(analysis.materialize_all().detect_changes())
 
     _assert_matches_fresh(analysis, tmp_path)
     fqs = {n.fqname for n in analysis.materialize_all().nodes()}
@@ -148,7 +148,7 @@ def test_re_materialize_new_file(tmp_path):
     assert "c.py" not in initial_files
 
     _write(tmp_path / "c.py", "def h(): pass\nh()\n")
-    analysis.re_materialize()
+    analysis.re_materialize(analysis.materialize_all().detect_changes())
 
     rebuilt_files = {Path(n.path).name for n in analysis.materialize_all().nodes()}
     assert "c.py" in rebuilt_files
@@ -166,7 +166,7 @@ def test_re_materialize_deleted_file(tmp_path):
     assert any(Path(n.path).name == "b.py" for n in analysis.materialize_all().nodes())
 
     (tmp_path / "b.py").unlink()
-    analysis.re_materialize()
+    analysis.re_materialize(analysis.materialize_all().detect_changes())
 
     assert not any(Path(n.path).name == "b.py" for n in analysis.materialize_all().nodes())
     _assert_matches_fresh(analysis, tmp_path)
@@ -183,7 +183,7 @@ def test_re_materialize_multi_file_mutation(tmp_path):
 
     _write(tmp_path / "a.py", "def f(): pass\ndef extra(): pass\n")
     _write(tmp_path / "c.py", "def h(): pass\ndef other(): pass\n")
-    analysis.re_materialize()
+    analysis.re_materialize(analysis.materialize_all().detect_changes())
 
     _assert_matches_fresh(analysis, tmp_path)
 
@@ -257,7 +257,7 @@ def test_re_materialize_with_entrypoint_plugin(tmp_path):
             g()
         """,
     )
-    analysis.re_materialize()
+    analysis.re_materialize(analysis.materialize_all().detect_changes())
 
     dead_after = _dead_fqnames(analysis)
     assert "a.f" not in dead_after
@@ -270,4 +270,4 @@ def test_re_materialize_requires_prior_materialize(tmp_path):
     _write(tmp_path / "a.py", "def f(): pass\n")
     analysis = Analysis(tmp_path)
     with pytest.raises(RuntimeError, match="prior materialize_all"):
-        analysis.re_materialize()
+        analysis.re_materialize([])

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1,0 +1,206 @@
+"""Incremental :meth:`Analysis.re_materialize` correctness tests.
+
+Each test builds an initial graph, mutates one or more source files on
+disk, calls ``re_materialize(dirty_files)``, and asserts the resulting
+graph matches an independent fresh full build of the same end state.
+The fresh build is the ground truth — incremental is correct iff it
+produces the same edges and the same node set.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from dead_cst import Analysis
+from dead_cst.plugins import MainBlockPlugin
+
+
+def _write(path: Path, src: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(src).strip() + "\n")
+
+
+def _edges(ctx) -> set[tuple[str, str]]:
+    """Return ``{(src_fqname, dst_fqname)}`` for every edge in ``ctx``.
+
+    Reduces edges to plain strings so the comparison is robust to
+    node-identity differences between a re-materialized ctx and a
+    fresh-built one. Edge flags are dropped — structural equivalence
+    is what we care about here.
+    """
+    nodes = list(ctx.nodes())
+    return {(nodes[src].fqname, nodes[dst].fqname) for src, dst, _flags in ctx.edges()}
+
+
+def _node_keys(ctx) -> set[tuple[str, str, int]]:
+    """``{(fqname, kind, start_line)}`` for every node in ``ctx``.
+
+    Stable across rebuilds (independent of node-index allocation)."""
+    return {(n.fqname, n.kind, n.start_line) for n in ctx.nodes()}
+
+
+def _dead_fqnames(analysis: Analysis) -> set[str]:
+    return {n.fqname for n in analysis.dead()}
+
+
+def _build_fresh(tmp_path: Path) -> Analysis:
+    fresh = Analysis(tmp_path)
+    fresh.materialize_all()
+    return fresh
+
+
+def _assert_matches_fresh(analysis: Analysis, tmp_path: Path) -> None:
+    """Ground-truth check: the incremental build must produce the same
+    edges, node set, and dead set as a fresh full build of the same
+    on-disk source state."""
+    fresh = _build_fresh(tmp_path)
+    assert _edges(analysis.materialize_all()) == _edges(fresh.materialize_all())
+    assert _node_keys(analysis.materialize_all()) == _node_keys(fresh.materialize_all())
+    assert _dead_fqnames(analysis) == _dead_fqnames(fresh)
+
+
+def test_re_materialize_no_op(tmp_path):
+    """A re_materialize with no source edits and no dirty files should
+    produce a graph identical to the original build."""
+    _write(tmp_path / "a.py", "def f(): pass\n")
+    _write(tmp_path / "b.py", "from a import f\nf()\n")
+
+    analysis = Analysis(tmp_path)
+    ctx1 = analysis.materialize_all()
+    edges_before = _edges(ctx1)
+
+    ctx2 = analysis.re_materialize([])
+
+    assert ctx1 is ctx2  # re_materialize rebuilds in place.
+    assert _edges(ctx2) == edges_before
+    _assert_matches_fresh(analysis, tmp_path)
+
+
+def test_re_materialize_add_decl(tmp_path):
+    """Add a new top-level function in a dirty file."""
+    _write(tmp_path / "a.py", "def f(): pass\n")
+    _write(tmp_path / "b.py", "from a import f\nf()\n")
+
+    analysis = Analysis(tmp_path)
+    analysis.materialize_all()
+
+    _write(tmp_path / "a.py", "def f(): pass\ndef g(): pass\n")
+    analysis.re_materialize([tmp_path / "a.py"])
+
+    _assert_matches_fresh(analysis, tmp_path)
+    # Sanity: the new decl appears in the rebuilt graph.
+    assert any(n.fqname == "a.g" for n in analysis.materialize_all().nodes())
+
+
+def test_re_materialize_remove_decl(tmp_path):
+    """Remove a decl from a dirty file; the old node and its edges
+    should disappear from the rebuild."""
+    _write(tmp_path / "a.py", "def f(): pass\ndef g(): pass\n")
+    _write(tmp_path / "b.py", "from a import f\nf()\n")
+
+    analysis = Analysis(tmp_path)
+    analysis.materialize_all()
+    assert any(n.fqname == "a.g" for n in analysis.materialize_all().nodes())
+
+    _write(tmp_path / "a.py", "def f(): pass\n")
+    analysis.re_materialize([tmp_path / "a.py"])
+
+    assert not any(n.fqname == "a.g" for n in analysis.materialize_all().nodes())
+    _assert_matches_fresh(analysis, tmp_path)
+
+
+def test_re_materialize_transitive_invalidation(tmp_path):
+    """Rename ``a.f`` -> ``a.g`` with only ``a.py`` in the dirty list.
+
+    ``b.py`` is unchanged on disk but its old ``from a import f`` no
+    longer resolves. Salsa should still invalidate
+    ``file_to_ref_edges(b)`` because that query previously read
+    ``file_to_nodes(a)``, which changed. The fresh build is the
+    ground-truth comparator.
+    """
+    _write(tmp_path / "a.py", "def f(): pass\n")
+    _write(tmp_path / "b.py", "from a import f\nf()\n")
+
+    analysis = Analysis(tmp_path)
+    analysis.materialize_all()
+
+    _write(tmp_path / "a.py", "def g(): pass\n")
+    analysis.re_materialize([tmp_path / "a.py"])
+
+    _assert_matches_fresh(analysis, tmp_path)
+    # Sanity: a.f is gone, a.g exists.
+    fqs = {n.fqname for n in analysis.materialize_all().nodes()}
+    assert "a.f" not in fqs
+    assert "a.g" in fqs
+
+
+def test_re_materialize_multi_file_dirty(tmp_path):
+    """Mutate two files at once and re_materialize with both in the
+    dirty list."""
+    _write(tmp_path / "a.py", "def f(): pass\n")
+    _write(tmp_path / "b.py", "from a import f\nf()\n")
+    _write(tmp_path / "c.py", "def h(): pass\n")
+
+    analysis = Analysis(tmp_path)
+    analysis.materialize_all()
+
+    _write(tmp_path / "a.py", "def f(): pass\ndef extra(): pass\n")
+    _write(tmp_path / "c.py", "def h(): pass\ndef other(): pass\n")
+    analysis.re_materialize([tmp_path / "a.py", tmp_path / "c.py"])
+
+    _assert_matches_fresh(analysis, tmp_path)
+
+
+def test_re_materialize_with_entrypoint_plugin(tmp_path):
+    """Re-materialize against a non-empty plugin set. Verifies that
+    plugin ops are produced correctly on the second build (plugins are
+    re-driven, not double-registered)."""
+    _write(
+        tmp_path / "a.py",
+        """
+        def f(): pass
+        def g(): pass
+
+        if __name__ == "__main__":
+            f()
+        """,
+    )
+
+    analysis = Analysis(tmp_path, plugins=[MainBlockPlugin()])
+    analysis.materialize_all()
+    dead_before = _dead_fqnames(analysis)
+    assert "a.f" not in dead_before  # main block keeps it alive
+    assert "a.g" in dead_before
+
+    # Mutation: main block now also calls g, so g becomes alive.
+    _write(
+        tmp_path / "a.py",
+        """
+        def f(): pass
+        def g(): pass
+
+        if __name__ == "__main__":
+            f()
+            g()
+        """,
+    )
+    analysis.re_materialize([tmp_path / "a.py"])
+
+    dead_after = _dead_fqnames(analysis)
+    assert "a.f" not in dead_after
+    assert "a.g" not in dead_after
+
+    fresh = Analysis(tmp_path, plugins=[MainBlockPlugin()])
+    fresh.materialize_all()
+    assert _dead_fqnames(analysis) == _dead_fqnames(fresh)
+    assert _edges(analysis.materialize_all()) == _edges(fresh.materialize_all())
+
+
+def test_re_materialize_requires_prior_materialize(tmp_path):
+    _write(tmp_path / "a.py", "def f(): pass\n")
+    analysis = Analysis(tmp_path)
+    with pytest.raises(RuntimeError, match="prior materialize_all"):
+        analysis.re_materialize([tmp_path / "a.py"])


### PR DESCRIPTION
## Summary

- Adds `Analysis.re_materialize(events)` — rebuilds the project graph against the existing `native.ProjectContext` without tearing down ty's salsa db. The caller supplies the change events: typically `ctx.detect_changes()` (which today returns a single `ChangeEvent.rescan()`, ty's mtime-checked `Files::sync_all` + project re-walk + metadata rediscovery), or an explicit `list[native.ChangeEvent]` for LSP integrations consuming `didChangeWatchedFiles` and file-watcher harnesses.
- Exposes `native.ChangeEvent` with `changed(path)` / `created(path)` / `deleted(path)` / `rescan()` classmethods plus `.kind` / `.path` accessors, and `native.ProjectContext.apply_changes(events)` / `detect_changes()` / `clear_plugins()` / `reset_progress()` to support the flow.
- Underlying mechanism: `apply_changes` forwards to `ty_project::ProjectDatabase::apply_changes`, which handles each variant correctly — `Changed` bumps the file's salsa revision only when mtime / size actually differ; `Created` registers brand-new paths with the project file set; `Deleted` removes them; `Rescan` triggers the full sync + reload. Project configuration files (`pyproject.toml`, ignore files, custom-stdlib `VERSIONS`) trigger a project reload automatically.
- Salsa's per-file cache (`file_to_nodes` / `file_to_edges` / `file_to_ref_edges`, ty's `SemanticIndex` / `parsed_module` / use-def chains) survives across calls; only dirty + transitively-dirty files re-fire. Cross-file importers invalidate automatically through salsa's read-tracking. The assemble pass and plugin pass still run every call but on a warm cache.
- Plugin `prepare(project_root)` is one-shot (owned by `materialize_all`); `re_materialize` only re-drives the build + plugin pass. Refactors `materialize_all`'s body into a private `_drive_build` helper that `re_materialize` re-uses.
- Docs updated: README has an Incremental rebuilds section, ARCHITECTURE describes the new flow on the `Analysis` stage, ROADMAP folds it into Recently shipped, CHANGELOG carries an Unreleased entry.

## Test plan

- [x] `tests/test_incremental.py` — 11 tests covering no-op, add decl, remove decl, rename (transitive invalidation: rename `a.f → a.g` — ty's rescan catches `b.py`'s edges via cross-file salsa deps), brand-new file, deleted file, multi-file mutation, explicit `ChangeEvent` list, `ChangeEvent` constructor/accessor smoke, plugin-aware (`MainBlockPlugin` re-running cleanly on the rebuilt graph), and the prior-materialize guard. Every correctness test compares the rebuilt graph against a fresh full build as ground truth.
- [x] Full suite (774 tests) green; `prek` (ruff, ty, clippy, cargo fmt) clean.
- [x] origin/main merged in; the upstream query-DSL idx-form-only refactor coexists cleanly.

https://claude.ai/code/session_0159KK86zAdoRm65vSWh4Lqd