### PR TITLE
Query DSL: drop SymbolNode terminals; idx-form is the only contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ two versions.
 
 ## [Unreleased]
 
+### Removed
+
+#### Query DSL — SymbolNode terminals and SymbolNode-taking sugar
+- `SubclassQuery.collect()`, `ImportQuery.collect()`, `ClassQuery.collect()`,
+  `DeclQuery.collect()` (each previously returned `list[SymbolNode]`).
+  Use the existing `.indices()` terminal (positional indices into
+  `ctx.nodes()`), `.attrs()` (`list[NodeAttrs]`), or `.first_idx()`
+  instead — pair with `ctx.nodes_at(indices)` if you need
+  `SymbolNode` rows.
+- `EdgeQuery.collect()` and the `EdgeRef` class (previously returned
+  `list[EdgeRef]` with `SymbolNode` endpoints). Use the existing
+  `.index_triples()` terminal (`list[tuple[src_idx, dst_idx, flags]]`).
+  `EdgeQuery.first()` is gone for the same reason.
+- `SubclassQuery.of_node(node)` and `DecoratorQuery.in_decl(node)`
+  (both took a `SymbolNode`). Use `.of_idx(idx)` / `.in_decl_idx(idx)`
+  with a positional index into `ctx.nodes()`.
+- `__iter__` on `SubclassQuery` / `ImportQuery` / `ClassQuery` /
+  `DeclQuery` / `EdgeQuery` (which iterated `SymbolNode` / `EdgeRef`).
+  Iterate the appropriate idx-form terminal instead.
+
+The chainable query DSL is now fully idx-form: every terminal returns
+positional indices into `ctx.nodes()` (or an `IdxRef` row that carries
+one). This drops a layer of `Py<SymbolNode>` allocations on the hot
+path and removes the parallel-API confusion of having both
+SymbolNode- and idx-form terminals on the same query.
+
 ## [0.13.0] - 2026-05-26
 
 ### Added

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -555,13 +555,10 @@ class ProjectContext:
     # type-stub contract; use ``query(ctx)`` instead.
 
     # The subclass-walk surface lives entirely on
-    # :class:`SubclassQuery`. The point-lookup ``ctx.find_subclasses(fqn)``
-    # / ``find_subclasses_of(node)`` / ``find_subclasses_of_idx(idx)``
-    # methods that used to mirror these queries are now rust-only
-    # (called by :class:`SubclassQuery` internally). Plugin authors:
-    # use the DSL — ``native.query(ctx).subclasses().of_fqn(fqn)`` /
-    # ``.of_idx(idx)`` / ``.of_node(node)`` (legacy node-form input)
-    # with ``.collect()`` or ``.indices()`` terminals.
+    # :class:`SubclassQuery`. The point-lookup helpers that backed it
+    # are rust-internal — plugin authors use the DSL:
+    # ``native.query(ctx).subclasses().of_fqn(fqn).indices()`` or
+    # ``.of_idx(idx).indices()``.
 
     # ----- FQN resolution ------------------------------------------------
     #
@@ -1175,16 +1172,20 @@ def query(ctx: ProjectContext) -> QueryBuilder:
 class QueryBuilder:
     """Entry point for the chainable query API.
 
-    Filtered streams (terminated by ``.collect()``):
+    Every terminal returns positional indices into
+    :meth:`ProjectContext.nodes` (or one of the ``IdxRef`` row types
+    that carry an idx + per-row metadata for decorator / construction
+    / call / factory rows). Pair index returns with
+    :meth:`ProjectContext.nodes_at` / :meth:`node_attrs` to revive
+    :class:`SymbolNode` / :class:`NodeAttrs` fields on demand.
+
+    Filtered streams:
     :meth:`decorators` / :meth:`constructions` / :meth:`calls` /
     :meth:`subclasses` / :meth:`imports` / :meth:`classes` /
     :meth:`factories` / :meth:`edges`.
 
-    Point lookups (e.g. :meth:`ProjectContext.find_module`,
-    :meth:`ProjectContext.find_declarations`,
-    :meth:`ProjectContext.find_main_blocks`,
+    Point lookups (e.g. :meth:`ProjectContext.find_main_blocks`,
     :meth:`ProjectContext.find_comment_patterns`,
-    :meth:`ProjectContext.find_module_dunders`,
     :meth:`ProjectContext.find_literal_list_entries`) live directly on
     :class:`ProjectContext`.
     """
@@ -1258,11 +1259,13 @@ class DecoratorQuery:
     def where_owner_attr_via(
         self, via: str, attrs: str | list[str] | tuple[str, ...]
     ) -> DecoratorQuery: ...
-    def in_decl(self, node: SymbolNode) -> DecoratorQuery: ...
     def in_decl_idx(self, idx: int) -> DecoratorQuery:
-        """Idx-form sibling of :meth:`in_decl`. Pass a positional index
-        into :meth:`ProjectContext.nodes` directly so plugins working
-        in idx-space don't round-trip through a ``SymbolNode``.
+        """Anchor the decorator search on the decl at positional index
+        ``idx`` into :meth:`ProjectContext.nodes`. Pairs with
+        :meth:`where_name` to match ``@<owner>.<name>`` same-file
+        instance-method decorators where ``<owner>`` is the decl at
+        ``idx``. Raises :class:`IndexError` at terminal time when
+        ``idx`` is out of range.
         """
         ...
     def where_path(self, regex: str) -> DecoratorQuery: ...
@@ -1382,30 +1385,27 @@ class CallQuery:
 class SubclassQuery:
     """Walk the subclass closure of a class.
 
-    Pick exactly one of :meth:`of_fqn` / :meth:`of_node`. The
-    default :meth:`transitive` is ``True``; flip to ``False`` for
-    direct subclasses only. Mirrors the union of
-    ``ProjectContext.find_subclasses`` and ``find_subclasses_of``.
+    Pick exactly one of :meth:`of_fqn` / :meth:`of_idx`. The default
+    :meth:`transitive` is ``True``; flip to ``False`` for direct
+    subclasses only.
     """
 
     def of_fqn(self, fqn: str) -> SubclassQuery: ...
-    def of_node(self, node: SymbolNode) -> SubclassQuery: ...
     def of_idx(self, idx: int) -> SubclassQuery:
-        """Idx-form sibling of :meth:`of_node`. Pass a positional
-        index into :meth:`ProjectContext.nodes` directly so plugins
-        working in idx-space don't round-trip through a ``SymbolNode``.
+        """Anchor the walk on the class at positional index ``idx``
+        into :meth:`ProjectContext.nodes`. Raises :class:`IndexError`
+        at terminal time when ``idx`` is out of range; returns an
+        empty list when the seed isn't a class node.
         """
         ...
 
     def transitive(self, value: bool) -> SubclassQuery: ...
-    def collect(self) -> list[SymbolNode]: ...
     def count(self) -> int: ...
-    def __iter__(self) -> Iterator[SymbolNode]: ...
     def indices(self) -> list[int]:
-        """Index-returning terminal. Same lookup as :meth:`collect`,
-        but emits each subclass's positional index into
-        :meth:`ProjectContext.nodes` instead of allocating
-        ``SymbolNode`` clones.
+        """Index-returning terminal. Emits each subclass's positional
+        index into :meth:`ProjectContext.nodes`; pair with
+        :meth:`ProjectContext.node_attrs` / :meth:`nodes_at` to revive
+        ``kind`` / ``path`` / ``fqname`` / ``flags`` on demand.
         """
         ...
 
@@ -1431,12 +1431,9 @@ class SubclassQuery:
 class ImportQuery:
     """Enumerate the ``kind="import"`` nodes that bind a name from a
     given module. Requires :meth:`of` (the upstream module name).
-
-    Mirrors :meth:`ProjectContext.find_imports_of`.
     """
 
     def of(self, module: str) -> ImportQuery: ...
-    def collect(self) -> list[SymbolNode]: ...
     def indices(self) -> list[int]:
         """Index-returning terminal. Reads positional indices straight
         out of the pre-built ``imports_by_module`` index — no Python
@@ -1448,8 +1445,8 @@ class ImportQuery:
     def exists(self) -> bool:
         """O(1) presence probe — does any project file import the
         configured module? Short-circuits without materialising a
-        Python list. Preferred over ``.count() > 0`` / ``.collect()``
-        for plugin guards that just need a boolean.
+        Python list. Preferred over ``.count() > 0`` for plugin
+        guards that just need a boolean.
         """
         ...
 
@@ -1471,8 +1468,6 @@ class ImportQuery:
         path.
         """
         ...
-
-    def __iter__(self) -> Iterator[SymbolNode]: ...
 
 class ModuleQuery:
     """Enumerate / inspect project module nodes.
@@ -1686,19 +1681,16 @@ class ClassQuery:
     """Enumerate classes by structural property. Today the only filter
     is :meth:`defining_method` (matches classes whose body has a
     ``FunctionDef`` with that name).
-
-    Mirrors :meth:`ProjectContext.find_classes_defining_method`.
     """
 
     def defining_method(self, name: str) -> ClassQuery: ...
-    def collect(self) -> list[SymbolNode]: ...
     def count(self) -> int: ...
-    def __iter__(self) -> Iterator[SymbolNode]: ...
     def indices(self) -> list[int]:
-        """Index-returning terminal. Same per-file parallel walk as
-        :meth:`collect`, but emits positional indices into
-        :meth:`ProjectContext.nodes` instead of allocating
-        ``SymbolNode`` clones.
+        """Index-returning terminal. Per-file parallel walk emitting
+        each matched class's positional index into
+        :meth:`ProjectContext.nodes`; pair with
+        :meth:`ProjectContext.node_attrs` / :meth:`nodes_at` to revive
+        ``kind`` / ``path`` / ``fqname`` / ``flags`` on demand.
         """
         ...
 
@@ -1745,23 +1737,12 @@ class FactoryQuery:
         """
         ...
 
-class EdgeRef:
-    """One graph edge with both endpoint nodes resolved.
-
-    Avoids the ``nodes[src_idx]`` / ``nodes[dst_idx]`` ping-pong that a
-    Python-side ``for src_idx, dst_idx, flags in ctx.edges()`` loop pays.
-    """
-
-    src: SymbolNode
-    dst: SymbolNode
-    flags: int
-
 class EdgeQuery:
     """Filtered enumeration over the in-progress graph's edges.
 
     Predicates AND together; any unset predicate doesn't filter. The
-    entire filter runs rust-side and only the surviving rows are
-    materialized into ``Py<SymbolNode>``.
+    entire filter runs rust-side; the only terminal is
+    :meth:`index_triples`.
     """
 
     def with_flags(self, mask: int) -> EdgeQuery:
@@ -1782,20 +1763,13 @@ class EdgeQuery:
         """Keep edges whose ``dst`` node has the given ``kind``."""
         ...
 
-    def collect(self) -> list[EdgeRef]: ...
-    def first(self) -> EdgeRef | None: ...
     def count(self) -> int: ...
-    def __iter__(self) -> Iterator[EdgeRef]: ...
     def index_triples(self) -> list[tuple[int, int, int]]:
-        """Index-returning terminal for edges. Same per-edge predicate
-        pipeline as :meth:`collect`, but emits ``(src_idx, dst_idx,
-        flags)`` triples instead of materialising one :class:`EdgeRef`
-        (and two ``SymbolNode`` clones) per row.
-
-        Faster than :meth:`collect` when you only need set-membership
-        / counting over edge endpoints; pair with
-        :meth:`ProjectContext.nodes_at` to revive the surviving
-        endpoints on demand.
+        """Index-returning terminal for edges. Emits
+        ``(src_idx, dst_idx, flags)`` triples into
+        :meth:`ProjectContext.nodes` after applying every configured
+        predicate. Pair with :meth:`ProjectContext.nodes_at` to revive
+        the surviving endpoints on demand.
         """
         ...
 
@@ -1878,25 +1852,21 @@ class DeclQuery:
         the node's ``fqname`` matches any element. ``re.Pattern``
         instances are recompiled rust-side using rust's ``regex``
         crate, so any PCRE-only syntax raises ``ValueError`` at the
-        call site (not later at ``collect``).
+        call site (not later at the terminal).
         """
         ...
 
-    def collect(self) -> list[SymbolNode]: ...
     def count(self) -> int: ...
-    def __iter__(self) -> Iterator[SymbolNode]: ...
     def indices(self) -> list[int]:
-        """Index-returning terminal. Same predicate semantics as
-        :meth:`collect`, but emits each surviving node's positional
-        index into :meth:`ProjectContext.nodes` (a plain
-        ``list[int]``) instead of allocating one ``SymbolNode`` per
-        row.
+        """Index-returning terminal. Emits each surviving node's
+        positional index into :meth:`ProjectContext.nodes` (a plain
+        ``list[int]``) after applying every configured predicate.
 
         Use when you only need set membership / counting on the
         surviving nodes (or want to feed an index-keyed
         :class:`AddEdgeByIdx`); call
-        :meth:`ProjectContext.nodes_at` to materialize back to
-        ``SymbolNode`` later.
+        :meth:`ProjectContext.nodes_at` / :meth:`node_attrs` to
+        revive ``SymbolNode`` / :class:`NodeAttrs` rows on demand.
         """
         ...
 

--- a/python/dead_cst/plugins/dynamic_import.py
+++ b/python/dead_cst/plugins/dynamic_import.py
@@ -48,10 +48,8 @@ class DynamicImportFallbackPlugin(Plugin):
         # flags don't intersect ``DYNAMIC_IMPORT``) + ``with_dst_kind``
         # (drop edges whose ``dst.kind`` isn't ``"module"``).
         # ``index_triples()`` returns ``(src_idx, dst_idx, flags)`` —
-        # cheaper than materialising ``EdgeRef`` rows with
-        # ``Py<SymbolNode>`` endpoints up-front. We batch-materialise
-        # only the (src, dst) pair we actually need for the
-        # path / fqname filter via ``ctx.nodes_at``.
+        # we batch-materialise only the (src, dst) pair we actually
+        # need for the path / fqname filter via ``ctx.nodes_at``.
         triples = (
             native.query(ctx)
             .edges()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,9 +52,9 @@ use crate::progress::ProgressHandle;
 use crate::project::{Project, ProjectContext};
 use crate::query::{
     CallIdxRef, CallQuery, ClassQuery, ConstructionIdxRef, ConstructionQuery, DeclQuery,
-    DeclarationsQuery, DecoratorIdxRef, DecoratorQuery, EdgeQuery, EdgeRef, FactoryIdxRef,
-    FactoryQuery, ImportQuery, LiteralListQuery, MainBlockQuery, ModuleQuery, QueryBuilder,
-    SubclassQuery, TraverseQuery,
+    DeclarationsQuery, DecoratorIdxRef, DecoratorQuery, EdgeQuery, FactoryIdxRef, FactoryQuery,
+    ImportQuery, LiteralListQuery, MainBlockQuery, ModuleQuery, QueryBuilder, SubclassQuery,
+    TraverseQuery,
 };
 
 // ---------------------------------------------------------------------------
@@ -104,7 +104,6 @@ fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<FactoryQuery>()?;
     m.add_class::<FactoryIdxRef>()?;
     m.add_class::<EdgeQuery>()?;
-    m.add_class::<EdgeRef>()?;
     m.add_class::<DeclQuery>()?;
     m.add_class::<DeclarationsQuery>()?;
     m.add_class::<MainBlockQuery>()?;

--- a/src/project.rs
+++ b/src/project.rs
@@ -1682,41 +1682,20 @@ impl ProjectContext {
 }
 
 // ``find_imports_of`` / ``_indices`` / ``imports_of_count`` /
-// ``has_imports_of`` back :class:`ImportQuery` and its ``.count()`` /
-// ``.exists()`` shortcuts. NOT exposed to Python — plugin authors use
-// the DSL: ``native.query(ctx).imports().of(module).indices()`` /
-// ``.count()`` / ``.exists()``.
+// ``find_imports_of_indices`` / ``imports_of_count`` / ``has_imports_of``
+// back :class:`ImportQuery` and its ``.count()`` / ``.exists()``
+// shortcuts. NOT exposed to Python — plugin authors use the DSL:
+// ``native.query(ctx).imports().of(module).indices()`` / ``.count()`` /
+// ``.exists()``.
 impl ProjectContext {
-    /// Return every import-kind node whose upstream `module` matches.
+    /// Every import-kind node whose upstream `module` matches, as
+    /// positional indices into ``ctx.nodes()``.
     ///
     /// Covers both `import <module_name>` and
     /// `from <module_name> import ...` styles — both bind import-kind
     /// nodes whose `Import.module` is the absolute dotted name. Star
     /// reexports synthesized from `from <module_name> import *` are
     /// also included.
-    pub(crate) fn find_imports_of(
-        &self,
-        py: Python<'_>,
-        module_name: &str,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.materialized("find_imports_of")?;
-        // O(1) lookup against the pre-built ``imports_by_module``
-        // index — no scan over all interned nodes. Empty when nothing
-        // imports the module.
-        let Some(idxs) = outputs.imports_by_module.get(module_name) else {
-            return Ok(Vec::new());
-        };
-        let mut out = Vec::with_capacity(idxs.len());
-        for &idx in idxs {
-            out.push(outputs.builder.nodes[idx].clone_ref(py));
-        }
-        Ok(out)
-    }
-
-    /// Idx-only variant of :meth:`find_imports_of`. Same lookup, but
-    /// returns the positional indices into ``ctx.nodes()`` rather than
-    /// materializing ``Py<SymbolNode>`` clones — drives the
-    /// :meth:`ImportQuery.indices` terminal.
     pub(crate) fn find_imports_of_indices(&self, module_name: &str) -> PyResult<Vec<usize>> {
         let outputs = self.materialized("find_imports_of_indices")?;
         Ok(outputs
@@ -2903,33 +2882,17 @@ impl ProjectContext {
     }
 }
 
-// ``find_classes_defining_method`` is the rust-side helper backing
-// :class:`ClassQuery`. It's NOT exposed to Python — plugin authors use
-// the DSL: ``native.query(ctx).classes().defining_method(name).collect()``.
+// ``find_classes_defining_method_indices`` is the rust-side helper
+// backing :class:`ClassQuery`. It's NOT exposed to Python — plugin
+// authors use the DSL:
+// ``native.query(ctx).classes().defining_method(name).indices()``.
 impl ProjectContext {
-    /// Every class that defines a method with the given name.
+    /// Every class that defines a method with the given name, as
+    /// positional indices into ``ctx.nodes()``.
     ///
     /// Walks each class's `DefinitionKind::Class` body for an
     /// `Stmt::FunctionDef` whose name matches. ty's `parsed_module` is
     /// Salsa-cached, so this is just a body scan per class.
-    pub(crate) fn find_classes_defining_method(
-        &self,
-        py: Python<'_>,
-        method_name: &str,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let indices = self.find_classes_defining_method_indices(py, method_name)?;
-        let outputs = self.materialized("find_classes_defining_method")?;
-        Ok(indices
-            .into_iter()
-            .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
-            .collect())
-    }
-}
-
-impl ProjectContext {
-    /// Idx-only variant of :meth:`find_classes_defining_method`. Same
-    /// per-file parallel walk, but returns positional indices into
-    /// ``ctx.nodes()`` instead of allocating ``Py<SymbolNode>`` clones.
     pub(crate) fn find_classes_defining_method_indices(
         &self,
         py: Python<'_>,
@@ -2983,45 +2946,15 @@ impl ProjectContext {
     }
 }
 
-// ``find_subclasses_of_indices`` / ``_idx`` back :class:`SubclassQuery`.
+// ``find_subclasses_of_idx`` backs :class:`SubclassQuery.of_idx`.
 // NOT exposed to Python — plugin authors use the DSL:
 // ``native.query(ctx).subclasses().of_idx(idx).indices()`` or
 // ``of_fqn(fqn)``.
 impl ProjectContext {
-    /// Idx-only variant of :meth:`find_subclasses_of`. Same lookup,
-    /// returns positional indices into ``ctx.nodes()`` rather than
-    /// allocating ``Py<SymbolNode>`` clones.
-    pub(crate) fn find_subclasses_of_indices(
-        &self,
-        class_node: &SymbolNode,
-    ) -> PyResult<Vec<usize>> {
-        if class_node.kind != "class" {
-            return Ok(Vec::new());
-        }
-        let outputs = self.materialized("find_subclasses_of_indices")?;
-        if let Some((seed_file, seed_range)) = locate_class_def(
-            &self.db,
-            &outputs.path_to_file,
-            &class_node.path,
-            class_node,
-        ) {
-            let rk = (seed_range.start().to_u32(), seed_range.end().to_u32());
-            if let Some(&seed_idx) = outputs.class_by_selection.get(&(seed_file, rk)) {
-                return Ok(transitive_subclasses_via_index(
-                    seed_idx,
-                    &outputs.children_by_node,
-                ));
-            }
-        }
-        Ok(Vec::new())
-    }
-}
-
-impl ProjectContext {
-    /// Idx-keyed variant of :meth:`find_subclasses_of_indices` —
-    /// resolves the seed class by positional index into ``ctx.nodes()``
-    /// rather than taking a ``Py<SymbolNode>`` reference. Bounds-checks
-    /// the index and raises :class:`IndexError` when out of range.
+    /// Subclasses of the class at positional index ``class_idx`` into
+    /// ``ctx.nodes()``. Bounds-checks the index and raises
+    /// :class:`IndexError` when out of range; returns an empty list
+    /// when the seed isn't a class node.
     pub(crate) fn find_subclasses_of_idx(
         &self,
         py: Python<'_>,
@@ -3273,8 +3206,10 @@ impl ProjectContext {
         };
         let mut ctors: Vec<String> = vec![name.to_string()];
         if include_subclasses {
-            for sub in self.find_subclasses(py, class_fqn, true)? {
-                let simple = sub
+            let sub_idxs = self.find_subclasses_indices(py, class_fqn, true)?;
+            let outputs = self.materialized("find_constructions.subclasses")?;
+            for idx in sub_idxs {
+                let simple = outputs.builder.nodes[idx]
                     .borrow(py)
                     .fqname
                     .rsplit('.')
@@ -3321,37 +3256,19 @@ impl ProjectContext {
     }
 }
 
-// ``find_subclasses`` + ``_indices`` back :class:`SubclassQuery`.
+// ``find_subclasses_indices`` backs :class:`SubclassQuery`.
 // NOT exposed to Python — plugin authors use the DSL:
-// ``native.query(ctx).subclasses().of_fqn(fqn).collect()``.
+// ``native.query(ctx).subclasses().of_fqn(fqn).indices()``.
 impl ProjectContext {
-    /// Subclasses of the class addressed by ``base_fqn``.
+    /// Subclasses of the class addressed by ``base_fqn``, as positional
+    /// indices into ``ctx.nodes()``.
     ///
     /// Works for both project classes (where the fqn resolves to a
     /// graph node) and external classes (``unittest.TestCase``,
     /// ``pydantic.BaseModel``) via ty's module resolver +
-    /// ``type_hierarchy_subtypes``. ``transitive=True`` (default)
-    /// walks the full subclass closure; ``transitive=False`` returns
-    /// only direct subclasses.
-    pub(crate) fn find_subclasses(
-        &self,
-        py: Python<'_>,
-        base_fqn: &str,
-        transitive: bool,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let indices = self.find_subclasses_indices(py, base_fqn, transitive)?;
-        let outputs = self.materialized("find_subclasses")?;
-        Ok(indices
-            .into_iter()
-            .map(|idx| outputs.builder.nodes[idx].clone_ref(py))
-            .collect())
-    }
-}
-
-impl ProjectContext {
-    /// Idx-only variant of :meth:`find_subclasses`. Same lookup,
-    /// returns positional indices into ``ctx.nodes()`` rather than
-    /// allocating ``Py<SymbolNode>`` clones.
+    /// ``type_hierarchy_subtypes``. ``transitive=true`` walks the full
+    /// subclass closure; ``transitive=false`` returns only direct
+    /// subclasses.
     pub(crate) fn find_subclasses_indices(
         &self,
         py: Python<'_>,

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,7 +1,10 @@
 //! The chainable query DSL exposed to Python via `ProjectContext.query()`.
 //! Result types (`DecoratorIdxRef` / `ConstructionIdxRef` / `CallIdxRef`
-//! / `FactoryIdxRef` / `EdgeRef`), the `QueryBuilder` entry point, and
-//! the per-stream `Query` builders.
+//! / `FactoryIdxRef`), the `QueryBuilder` entry point, and the
+//! per-stream `Query` builders. Every terminal returns positional
+//! indices into `ctx.nodes()` (or an `IdxRef` row that carries one);
+//! plugins revive `SymbolNode` / `NodeAttrs` fields via
+//! `ProjectContext::nodes_at` / `node_attrs` on demand.
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -458,18 +461,16 @@ pub(crate) fn _to_iter(py: Python<'_>, items: Vec<Py<impl PyClass>>) -> PyResult
     Ok(iter_obj.unbind())
 }
 
-/// Generate the `first` / `count` / `__iter__` boilerplate that every
-/// chainable query exposes. Each variant is what the query's `.collect()`
-/// supports — see the three call sites below.
+/// Generate the `first` / `count` / `__iter__` boilerplate that the
+/// `IdxRef`-returning chainable queries expose. Each variant is what
+/// the query's `.collect()` supports.
 ///
 /// `with_first $Q, $R`: query whose `collect()` returns `Vec<Py<$R>>`
 /// and that wants a typed `.first() -> Option<Py<$R>>` shortcut.
 ///
-/// `no_first $Q`: query that wants only `.count()` + `.__iter__()`
-/// (typically returns plain `Py<SymbolNode>`).
-///
-/// `iter_only $Q`: query with a custom `.count()` (cheaper than
-/// materializing `.collect()`); just gets `.__iter__()`.
+/// `no_first $Q`: query whose `collect()` returns `Vec<Py<$R>>` for
+/// some `$R` but doesn't want the `.first()` shortcut; gets
+/// `.count()` + `.__iter__()` over `collect()`'s rows.
 macro_rules! impl_query_methods {
     (with_first $q:ty, $r:ty) => {
         #[pymethods]
@@ -496,14 +497,6 @@ macro_rules! impl_query_methods {
             }
         }
     };
-    (iter_only $q:ty) => {
-        #[pymethods]
-        impl $q {
-            fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
-                _to_iter(py, self.collect(py)?)
-            }
-        }
-    };
 }
 
 /// Find decorated top-level functions / classes. Pick exactly one of:
@@ -516,8 +509,9 @@ macro_rules! impl_query_methods {
 ///   ``decorator_owner`` carries the textual prefix.
 /// * ``where_owner_attr_via(via, attrs)`` —
 ///   ``@<owner>.<via>.<attr>(...)`` two-level chain.
-/// * ``in_decl(node).where_name(names)`` — ``@<node>.<name>``
-///   same-file instance-method decorators.
+/// * ``in_decl_idx(idx).where_name(names)`` — ``@<node>.<name>``
+///   same-file instance-method decorators, anchored on a positional
+///   index into ``ctx.nodes()``.
 #[pyclass(unsendable)]
 pub(crate) struct DecoratorQuery {
     pub(crate) ctx: Py<ProjectContext>,
@@ -526,7 +520,6 @@ pub(crate) struct DecoratorQuery {
     pub(crate) names: Option<Vec<String>>,
     pub(crate) owner_attrs: Option<Vec<String>>,
     pub(crate) via_attr: Option<String>,
-    pub(crate) in_decl: Option<Py<SymbolNode>>,
     pub(crate) in_decl_idx: Option<usize>,
     pub(crate) path_regex: Option<String>,
     pub(crate) kwarg_matchers: Vec<(String, KwargMatcher)>,
@@ -548,7 +541,6 @@ impl DecoratorQuery {
             names: None,
             owner_attrs: None,
             via_attr: None,
-            in_decl: None,
             in_decl_idx: None,
             path_regex: None,
             kwarg_matchers: Vec::new(),
@@ -596,10 +588,6 @@ impl DecoratorQuery {
         slf.via_attr = Some(via);
         slf.owner_attrs = Some(_extract_str_or_list(py, attrs)?);
         Ok(slf)
-    }
-    fn in_decl<'py>(mut slf: PyRefMut<'py, Self>, node: Py<SymbolNode>) -> PyRefMut<'py, Self> {
-        slf.in_decl = Some(node);
-        slf
     }
     fn in_decl_idx<'py>(mut slf: PyRefMut<'py, Self>, idx: usize) -> PyRefMut<'py, Self> {
         slf.in_decl_idx = Some(idx);
@@ -736,32 +724,6 @@ impl DecoratorQuery {
                     decorator_name: None,
                     decorator_owner: Some(owner_name),
                     decorator_via: self.via_attr.clone(),
-                    call_args,
-                });
-            }
-        } else if let Some(in_decl_node) = &self.in_decl {
-            let names = self.names.as_ref().ok_or_else(|| {
-                PyValueError::new_err("DecoratorQuery.in_decl(...) requires .where_name(...)")
-            })?;
-            let in_decl_ref = in_decl_node.borrow(py);
-            let decls =
-                ctx.find_decorations_on(py, &in_decl_ref, names.clone(), path_regex, extract_args)?;
-            let owner_simple = in_decl_ref
-                .fqname
-                .rsplit('.')
-                .next()
-                .unwrap_or("")
-                .to_string();
-            drop(in_decl_ref);
-            for (decorated_idx, call_args) in decls {
-                if !call_args_match_kwargs(&call_args, kwarg_matchers) {
-                    continue;
-                }
-                out.push(DecoratorRowIdx {
-                    decorated_idx,
-                    decorator_name: None,
-                    decorator_owner: Some(owner_simple.clone()),
-                    decorator_via: None,
                     call_args,
                 });
             }
@@ -1233,7 +1195,6 @@ impl_query_methods!(with_first CallQuery, CallIdxRef);
 pub(crate) struct SubclassQuery {
     pub(crate) ctx: Py<ProjectContext>,
     pub(crate) base_fqn: Option<String>,
-    pub(crate) base_node: Option<Py<SymbolNode>>,
     pub(crate) base_idx: Option<usize>,
     pub(crate) transitive: bool,
 }
@@ -1243,7 +1204,6 @@ impl SubclassQuery {
         Self {
             ctx,
             base_fqn: None,
-            base_node: None,
             base_idx: None,
             transitive: true,
         }
@@ -1256,10 +1216,6 @@ impl SubclassQuery {
         slf.base_fqn = Some(fqn);
         slf
     }
-    fn of_node<'py>(mut slf: PyRefMut<'py, Self>, node: Py<SymbolNode>) -> PyRefMut<'py, Self> {
-        slf.base_node = Some(node);
-        slf
-    }
     fn of_idx<'py>(mut slf: PyRefMut<'py, Self>, idx: usize) -> PyRefMut<'py, Self> {
         slf.base_idx = Some(idx);
         slf
@@ -1269,30 +1225,19 @@ impl SubclassQuery {
         slf
     }
 
-    fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<SymbolNode>>> {
-        let indices = self.indices(py)?;
-        let ctx = self.ctx.borrow(py);
-        let outputs = ctx.materialized("SubclassQuery.collect")?;
-        Ok(indices
-            .into_iter()
-            .map(|i| outputs.builder.nodes[i].clone_ref(py))
-            .collect())
-    }
-
-    /// Index-returning terminal. Same lookup as :meth:`collect`, but
-    /// emits each subclass's positional index into ``ctx.nodes()``
-    /// instead of allocating one ``Py<SymbolNode>`` per row.
+    /// Index-returning terminal. Emits each subclass's positional
+    /// index into ``ctx.nodes()``; pair with
+    /// :meth:`ProjectContext.node_attrs` / :meth:`nodes_at` to revive
+    /// the fqname / path / kind / flags fields if you need them.
     fn indices(&self, py: Python<'_>) -> PyResult<Vec<usize>> {
         let ctx = self.ctx.borrow(py);
         if let Some(fqn) = &self.base_fqn {
             ctx.find_subclasses_indices(py, fqn, self.transitive)
-        } else if let Some(node) = &self.base_node {
-            ctx.find_subclasses_of_indices(&node.borrow(py))
         } else if let Some(idx) = self.base_idx {
             ctx.find_subclasses_of_idx(py, idx)
         } else {
             Err(PyValueError::new_err(
-                "SubclassQuery requires .of_fqn(...), .of_node(...), or .of_idx(...)",
+                "SubclassQuery requires .of_fqn(...) or .of_idx(...)",
             ))
         }
     }
@@ -1317,9 +1262,11 @@ impl SubclassQuery {
         let ctx = self.ctx.borrow(py);
         _bucket_indices_by_path(&ctx, py, indices)
     }
-}
 
-impl_query_methods!(no_first SubclassQuery);
+    fn count(&self, py: Python<'_>) -> PyResult<usize> {
+        Ok(self.indices(py)?.len())
+    }
+}
 
 /// Enumerate the ``kind="import"`` nodes that bind a name from a
 /// given module. Requires ``of(module)``.
@@ -1347,11 +1294,6 @@ impl ImportQuery {
         slf.module = Some(module);
         slf
     }
-    fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<SymbolNode>>> {
-        self.ctx
-            .borrow(py)
-            .find_imports_of(py, self.module_or_err()?)
-    }
     /// Index-returning terminal. Reads positional indices straight
     /// out of the pre-built ``imports_by_module`` index — no Python
     /// allocation per row.
@@ -1367,8 +1309,8 @@ impl ImportQuery {
     fn exists(&self, py: Python<'_>) -> PyResult<bool> {
         self.ctx.borrow(py).has_imports_of(self.module_or_err()?)
     }
-    /// Count without allocating `Py<SymbolNode>` clones — read the
-    /// length of the pre-built index entry directly.
+    /// Count without iterating — reads the length of the pre-built
+    /// index entry directly.
     fn count(&self, py: Python<'_>) -> PyResult<usize> {
         Ok(self.ctx.borrow(py).imports_of_count(self.module_or_err()?))
     }
@@ -1394,8 +1336,6 @@ impl ImportQuery {
         _bucket_indices_by_path(&ctx, py, indices)
     }
 }
-
-impl_query_methods!(iter_only ImportQuery);
 
 /// Enumerate / inspect project module nodes. Pick exactly one filter
 /// (``with_fqn`` / ``with_path`` / ``with_dunders``), optionally
@@ -1591,19 +1531,12 @@ impl ClassQuery {
         slf.defining_method = Some(name);
         slf
     }
-    fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<SymbolNode>>> {
-        let ctx = self.ctx.borrow(py);
-        let name = self
-            .defining_method
-            .as_deref()
-            .ok_or_else(|| PyValueError::new_err("ClassQuery requires .defining_method(name)"))?;
-        ctx.find_classes_defining_method(py, name)
-    }
 
-    /// Index-returning terminal. Same per-file parallel walk as
-    /// :meth:`collect`, but emits each class node's positional index
-    /// into ``ctx.nodes()`` instead of allocating ``Py<SymbolNode>``
-    /// clones.
+    /// Index-returning terminal. Per-file parallel walk emitting each
+    /// matched class's positional index into ``ctx.nodes()``; pair
+    /// with :meth:`ProjectContext.node_attrs` / :meth:`nodes_at` to
+    /// revive ``kind`` / ``path`` / ``fqname`` / ``flags`` if you
+    /// need them.
     fn indices(&self, py: Python<'_>) -> PyResult<Vec<usize>> {
         let ctx = self.ctx.borrow(py);
         let name = self
@@ -1633,9 +1566,11 @@ impl ClassQuery {
         let ctx = self.ctx.borrow(py);
         _bucket_indices_by_path(&ctx, py, indices)
     }
-}
 
-impl_query_methods!(no_first ClassQuery);
+    fn count(&self, py: Python<'_>) -> PyResult<usize> {
+        Ok(self.indices(py)?.len())
+    }
+}
 
 /// One result row from :class:`FactoryQuery`. ``decl`` is the
 /// Walk function / class bodies for ``<Ctor>(...)`` calls where
@@ -1743,16 +1678,6 @@ impl_query_methods!(no_first FactoryQuery);
 // EdgeQuery — filtered enumeration over the in-progress graph's edges
 // ---------------------------------------------------------------------------
 
-/// One graph edge with both endpoint nodes resolved. Avoids the
-/// `nodes[src_idx]` / `nodes[dst_idx]` ping-pong that a Python-side
-/// ``for src_idx, dst_idx, flags in ctx.edges()`` loop pays.
-#[pyclass(frozen, get_all)]
-pub(crate) struct EdgeRef {
-    pub(crate) src: Py<SymbolNode>,
-    pub(crate) dst: Py<SymbolNode>,
-    pub(crate) flags: u32,
-}
-
 /// Filtered enumeration over the in-progress graph's edges. Predicates
 /// AND together; any unset predicate doesn't filter.
 ///
@@ -1760,11 +1685,10 @@ pub(crate) struct EdgeRef {
 /// * ``with_src_kind(kind)`` / ``with_dst_kind(kind)`` — keep edges
 ///   whose endpoint ``SymbolNode.kind`` matches the given string.
 ///
-/// Avoids the per-edge Python ↔ rust FFI hop that a
-/// ``for src_idx, dst_idx, flags in ctx.edges()`` plus
-/// ``nodes = ctx.nodes(); nodes[src_idx]`` pattern pays — the entire
-/// filter runs rust-side and only the surviving rows are materialized
-/// into ``Py<SymbolNode>``.
+/// The single terminal :meth:`index_triples` returns
+/// ``(src_idx, dst_idx, flags)`` tuples into ``ctx.nodes()``; pair
+/// with :meth:`ProjectContext.nodes_at` if you need to revive the
+/// endpoint nodes.
 #[pyclass(unsendable)]
 pub(crate) struct EdgeQuery {
     pub(crate) ctx: Py<ProjectContext>,
@@ -1806,53 +1730,9 @@ impl EdgeQuery {
         slf
     }
 
-    fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<EdgeRef>>> {
-        let ctx = self.ctx.borrow(py);
-        let outputs = ctx.materialized("EdgeQuery.collect")?;
-        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
-        let edges: &[(usize, usize, u32)] = &outputs.builder.edges;
-        let flag_mask = self.flag_mask;
-        let src_kind = self.src_kind.as_deref();
-        let dst_kind = self.dst_kind.as_deref();
-        let mut refs: Vec<Py<EdgeRef>> = Vec::new();
-        for &(src_idx, dst_idx, flags) in edges {
-            if let Some(mask) = flag_mask {
-                if flags & mask == 0 {
-                    continue;
-                }
-            }
-            // Endpoint-kind predicates: borrow only the side(s) the
-            // caller actually filtered on so the common
-            // ``with_flags(...)`` shape pays nothing for kind checks.
-            if let Some(needle) = src_kind {
-                if nodes[src_idx].borrow(py).kind != needle {
-                    continue;
-                }
-            }
-            if let Some(needle) = dst_kind {
-                if nodes[dst_idx].borrow(py).kind != needle {
-                    continue;
-                }
-            }
-            refs.push(Py::new(
-                py,
-                EdgeRef {
-                    src: nodes[src_idx].clone_ref(py),
-                    dst: nodes[dst_idx].clone_ref(py),
-                    flags,
-                },
-            )?);
-        }
-        Ok(refs)
-    }
-
-    /// Index-returning terminal for edges. Same per-edge predicate
-    /// pipeline as :meth:`collect`, but emits ``(src_idx, dst_idx,
-    /// flags)`` triples instead of materialising one :class:`EdgeRef`
-    /// (and two ``Py<SymbolNode>`` clones) per row.
-    ///
-    /// Faster than :meth:`collect` when you only need set-membership
-    /// or counting over edge endpoints; pair with
+    /// Index-returning terminal for edges. Emits
+    /// ``(src_idx, dst_idx, flags)`` triples into ``ctx.nodes()``
+    /// after applying every configured predicate. Pair with
     /// :meth:`ProjectContext.nodes_at` to revive the surviving
     /// endpoints on demand.
     fn index_triples(&self, py: Python<'_>) -> PyResult<Vec<(usize, usize, u32)>> {
@@ -1884,9 +1764,11 @@ impl EdgeQuery {
         }
         Ok(out)
     }
-}
 
-impl_query_methods!(with_first EdgeQuery, EdgeRef);
+    fn count(&self, py: Python<'_>) -> PyResult<usize> {
+        Ok(self.index_triples(py)?.len())
+    }
+}
 
 // ---------------------------------------------------------------------------
 // DeclQuery — generic node-stream filter
@@ -2125,25 +2007,14 @@ impl DeclQuery {
         Ok(slf)
     }
 
-    fn collect(&self, py: Python<'_>) -> PyResult<Vec<Py<SymbolNode>>> {
-        let indices = self.indices(py)?;
-        let ctx = self.ctx.borrow(py);
-        let outputs = ctx.materialized("DeclQuery.collect")?;
-        Ok(indices
-            .into_iter()
-            .map(|i| outputs.builder.nodes[i].clone_ref(py))
-            .collect())
-    }
-
-    /// Index-returning terminal. Same predicate semantics as
-    /// :meth:`collect`, but emits each surviving node's positional
-    /// index into ``ctx.nodes()`` (a plain ``list[int]``) instead of
-    /// allocating one ``Py<SymbolNode>`` per row.
+    /// Index-returning terminal. Emits each surviving node's
+    /// positional index into ``ctx.nodes()`` (a plain ``list[int]``)
+    /// after applying every configured predicate.
     ///
     /// Use when you only need set membership / counting on the
     /// surviving nodes (or want to feed an index-keyed
     /// :class:`AddEdgeByIdx`); call :meth:`ProjectContext.nodes_at`
-    /// to materialize back to ``SymbolNode`` later.
+    /// / :meth:`node_attrs` to revive node fields if you need them.
     fn indices(&self, py: Python<'_>) -> PyResult<Vec<usize>> {
         let ctx = self.ctx.borrow(py);
         let outputs = ctx.materialized("DeclQuery.indices")?;
@@ -2345,9 +2216,11 @@ impl DeclQuery {
         let ctx = self.ctx.borrow(py);
         _bucket_indices_by_path(&ctx, py, indices)
     }
-}
 
-impl_query_methods!(no_first DeclQuery);
+    fn count(&self, py: Python<'_>) -> PyResult<usize> {
+        Ok(self.indices(py)?.len())
+    }
+}
 
 // ---------------------------------------------------------------------------
 // TraverseQuery — seeded closure walks

--- a/tests/prototype/test_plugin_protocol.py
+++ b/tests/prototype/test_plugin_protocol.py
@@ -155,15 +155,15 @@ def test_find_subclasses_of_returns_empty_for_non_class(make_ctx):
     """Asking for subclasses of a function-kind node yields []."""
     ctx = make_ctx({"mod.py": "def f(): pass\n"})
 
-    captured: list[list] = []
+    captured: list[list[int]] = []
 
     class Inspect:
         name = "inspect"
 
         def run(self, ctx: native.ProjectContext) -> None:
-            for node in ctx.nodes():
+            for idx, node in enumerate(ctx.nodes()):
                 if node.fqname == "mod.f":
-                    captured.append(native.query(ctx).subclasses().of_node(node).collect())
+                    captured.append(native.query(ctx).subclasses().of_idx(idx).indices())
 
     ctx.add_plugin(Inspect())
     ctx.materialize()

--- a/tests/test_module_surface.py
+++ b/tests/test_module_surface.py
@@ -188,7 +188,7 @@ def test_with_fqname_under_segment_bounded(build_decl_graph):
             "pkg/foobar.py": "C = 3\n",
         }
     )
-    fqnames = {r.fqname for r in native.query(ctx).decls().with_fqname_under("pkg.foo")}
+    fqnames = {r.fqname for r in native.query(ctx).decls().with_fqname_under("pkg.foo").attrs()}
     assert "pkg.foo.A" in fqnames
     assert "pkg.foo.inner.B" in fqnames
     assert "pkg.foobar" not in fqnames
@@ -204,10 +204,14 @@ def test_with_fqname_under_includes_root_module(build_decl_graph):
             "pkg/foo/__init__.py": "A = 1\n",
         }
     )
-    nodes = list(
-        native.query(ctx).decls().with_fqname_under("pkg.foo").with_kinds(["module", "variable"])
+    rows = (
+        native.query(ctx)
+        .decls()
+        .with_fqname_under("pkg.foo")
+        .with_kinds(["module", "variable"])
+        .attrs()
     )
-    fqnames = {n.fqname for n in nodes}
+    fqnames = {r.fqname for r in rows}
     assert "pkg.foo" in fqnames
     assert "pkg.foo.A" in fqnames
 
@@ -219,8 +223,8 @@ def test_with_fqname_under_unknown_parent_yields_empty(build_decl_graph):
             "pkg/a.py": "def f(): ...\n",
         }
     )
-    nodes = list(native.query(ctx).decls().with_fqname_under("does.not.exist"))
-    assert nodes == []
+    indices = native.query(ctx).decls().with_fqname_under("does.not.exist").indices()
+    assert indices == []
 
 
 def test_with_fqname_prefix_remains_raw_starts_with(build_decl_graph):
@@ -236,7 +240,7 @@ def test_with_fqname_prefix_remains_raw_starts_with(build_decl_graph):
     )
     fqnames = {
         r.fqname
-        for r in native.query(ctx).decls().with_kind("module").with_fqname_prefix("pkg.foo")
+        for r in native.query(ctx).decls().with_kind("module").with_fqname_prefix("pkg.foo").attrs()
     }
     # Raw starts_with picks up both ``pkg.foo`` AND ``pkg.foobar``.
     assert "pkg.foo" in fqnames
@@ -257,6 +261,7 @@ def test_with_fqname_under_composes_with_other_predicates(build_decl_graph):
         }
     )
     fqnames = {
-        r.fqname for r in native.query(ctx).decls().with_fqname_under("pkg").with_kind("function")
+        r.fqname
+        for r in native.query(ctx).decls().with_fqname_under("pkg").with_kind("function").attrs()
     }
     assert fqnames == {"pkg.a.foo"}

--- a/tests/test_query_dsl.py
+++ b/tests/test_query_dsl.py
@@ -284,7 +284,7 @@ def test_where_fqname_str_literal(build_decl_graph):
             "pkg/b.py": "def foo(): ...\n",
         }
     )
-    refs = list(native.query(ctx).decls().where_fqname("pkg.a.foo"))
+    refs = native.query(ctx).decls().where_fqname("pkg.a.foo").attrs()
     assert {r.fqname for r in refs} == {"pkg.a.foo"}
 
 
@@ -297,7 +297,7 @@ def test_where_fqname_list_of_str(build_decl_graph):
             "pkg/b.py": "def baz(): ...\n",
         }
     )
-    refs = list(native.query(ctx).decls().where_fqname(["pkg.a.foo", "pkg.b.baz"]))
+    refs = native.query(ctx).decls().where_fqname(["pkg.a.foo", "pkg.b.baz"]).attrs()
     assert {r.fqname for r in refs} == {"pkg.a.foo", "pkg.b.baz"}
 
 
@@ -309,7 +309,7 @@ def test_where_fqname_regex(build_decl_graph):
             "pkg/a.py": "def foo(): ...\ndef foobar(): ...\ndef bar(): ...\n",
         }
     )
-    refs = list(native.query(ctx).decls().where_fqname(re.compile(r"^pkg\.a\.foo")))
+    refs = native.query(ctx).decls().where_fqname(re.compile(r"^pkg\.a\.foo")).attrs()
     assert {r.fqname for r in refs} == {"pkg.a.foo", "pkg.a.foobar"}
 
 
@@ -321,8 +321,11 @@ def test_where_fqname_list_of_regex(build_decl_graph):
             "pkg/a.py": "def foo(): ...\ndef bar(): ...\ndef baz(): ...\n",
         }
     )
-    refs = list(
-        native.query(ctx).decls().where_fqname([re.compile(r"\.foo$"), re.compile(r"\.bar$")])
+    refs = (
+        native.query(ctx)
+        .decls()
+        .where_fqname([re.compile(r"\.foo$"), re.compile(r"\.bar$")])
+        .attrs()
     )
     assert {r.fqname for r in refs} == {"pkg.a.foo", "pkg.a.bar"}
 
@@ -335,14 +338,14 @@ def test_where_fqname_mixed_str_and_regex(build_decl_graph):
             "pkg/a.py": "def foo(): ...\ndef bar(): ...\ndef baz(): ...\n",
         }
     )
-    refs = list(native.query(ctx).decls().where_fqname(["pkg.a.foo", re.compile(r"\.baz$")]))
+    refs = native.query(ctx).decls().where_fqname(["pkg.a.foo", re.compile(r"\.baz$")]).attrs()
     assert {r.fqname for r in refs} == {"pkg.a.foo", "pkg.a.baz"}
 
 
 def test_where_fqname_empty_list_matches_nothing(build_decl_graph):
     """``where_fqname([])`` is the matches-nothing sentinel."""
     ctx = build_decl_graph({"pkg/__init__.py": "", "pkg/a.py": "def foo(): ...\n"})
-    refs = list(native.query(ctx).decls().where_fqname([]))
+    refs = native.query(ctx).decls().where_fqname([]).attrs()
     assert refs == []
 
 

--- a/tests/test_query_indices.py
+++ b/tests/test_query_indices.py
@@ -3,9 +3,9 @@ the ``ctx.reachable_indices`` / ``ctx.indices_where`` / ``ctx.nodes_at``
 sibling helpers on :class:`ProjectContext`, and the
 :class:`AddEdgeByIdx` graph op.
 
-These cover the additive surface added to let plugins do index-level set
-operations without paying the per-row ``Py<SymbolNode>`` allocation that
-``.collect()`` does.
+The chainable query DSL has only idx-form terminals — every query
+returns positional indices into :meth:`ProjectContext.nodes` (or one of
+the ``IdxRef`` row types). These tests pin that idx-form contract.
 """
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ from dead_cst import _native as native
 # ---------------------------------------------------------------------------
 
 
-def test_decl_query_indices_matches_collect(build_decl_graph):
+def test_decl_query_indices_resolves_to_matching_nodes(build_decl_graph):
     ctx = build_decl_graph(
         {
             "pkg/__init__.py": "",
@@ -28,15 +28,10 @@ def test_decl_query_indices_matches_collect(build_decl_graph):
             "pkg/b.py": "def beta(): pass\n",
         }
     )
-    q = native.query(ctx).decls().with_kind("function")
-    nodes = q.collect()
-    indices = q.indices()
-    assert len(nodes) == len(indices)
-    all_nodes = ctx.nodes()
-    for node, idx in zip(nodes, indices, strict=True):
-        assert all_nodes[idx].fqname == node.fqname
-        assert all_nodes[idx].path == node.path
-        assert all_nodes[idx].start_line == node.start_line
+    indices = native.query(ctx).decls().with_kind("function").indices()
+    revived = ctx.nodes_at(indices)
+    assert {n.fqname for n in revived} == {"pkg.a.alpha", "pkg.b.beta"}
+    assert {n.kind for n in revived} == {"function"}
 
 
 def test_decl_query_indices_predicate_combos(build_decl_graph):
@@ -59,7 +54,7 @@ def test_decl_query_indices_predicate_combos(build_decl_graph):
 # ---------------------------------------------------------------------------
 
 
-def test_subclass_query_indices_matches_collect(build_decl_graph):
+def test_subclass_query_indices_walks_transitive_closure(build_decl_graph):
     ctx = build_decl_graph(
         {
             "pkg/__init__.py": "",
@@ -71,13 +66,9 @@ def test_subclass_query_indices_matches_collect(build_decl_graph):
             """,
         }
     )
-    q = native.query(ctx).subclasses().of_fqn("pkg.bases.Base")
-    indices = q.indices()
-    nodes = q.collect()
-    assert len(indices) == len(nodes)
-    # Round-trip back through nodes_at — same fqnames.
+    indices = native.query(ctx).subclasses().of_fqn("pkg.bases.Base").indices()
     revived = ctx.nodes_at(indices)
-    assert {n.fqname for n in revived} == {n.fqname for n in nodes}
+    assert {n.fqname for n in revived} == {"pkg.sub.Mid", "pkg.sub.Leaf"}
 
 
 # ---------------------------------------------------------------------------
@@ -85,7 +76,7 @@ def test_subclass_query_indices_matches_collect(build_decl_graph):
 # ---------------------------------------------------------------------------
 
 
-def test_import_query_indices_matches_collect(build_decl_graph):
+def test_import_query_indices_returns_import_nodes(build_decl_graph):
     ctx = build_decl_graph(
         {
             "pkg/__init__.py": "",
@@ -93,10 +84,7 @@ def test_import_query_indices_matches_collect(build_decl_graph):
             "pkg/b.py": "from os.path import join as j2\n",
         }
     )
-    q = native.query(ctx).imports().of("os.path")
-    indices = q.indices()
-    nodes = q.collect()
-    assert len(indices) == len(nodes)
+    indices = native.query(ctx).imports().of("os.path").indices()
     assert len(indices) >= 2  # at least the two import nodes
     revived = ctx.nodes_at(indices)
     assert {n.kind for n in revived} == {"import"}
@@ -107,7 +95,7 @@ def test_import_query_indices_matches_collect(build_decl_graph):
 # ---------------------------------------------------------------------------
 
 
-def test_class_query_indices_matches_collect(build_decl_graph):
+def test_class_query_indices_filters_by_defining_method(build_decl_graph):
     ctx = build_decl_graph(
         {
             "pkg/__init__.py": "",
@@ -119,12 +107,9 @@ def test_class_query_indices_matches_collect(build_decl_graph):
             """,
         }
     )
-    q = native.query(ctx).classes().defining_method("greet")
-    indices = q.indices()
-    nodes = q.collect()
-    assert len(indices) == len(nodes) == 1
+    indices = native.query(ctx).classes().defining_method("greet").indices()
     revived = ctx.nodes_at(indices)
-    assert revived[0].fqname == "pkg.a.Greeter"
+    assert [n.fqname for n in revived] == ["pkg.a.Greeter"]
 
 
 # ---------------------------------------------------------------------------
@@ -132,22 +117,18 @@ def test_class_query_indices_matches_collect(build_decl_graph):
 # ---------------------------------------------------------------------------
 
 
-def test_edge_query_index_triples_matches_collect(build_decl_graph):
+def test_edge_query_index_triples_filters_by_src_kind(build_decl_graph):
     ctx = build_decl_graph(
         {
             "pkg/__init__.py": "",
             "pkg/a.py": "def f(): pass\ndef g(): f()\n",
         }
     )
-    q = native.query(ctx).edges().with_src_kind("function")
-    triples = q.index_triples()
-    refs = q.collect()
-    assert len(triples) == len(refs)
+    triples = native.query(ctx).edges().with_src_kind("function").index_triples()
     all_nodes = ctx.nodes()
-    for (src_idx, dst_idx, flags), ref in zip(triples, refs, strict=True):
-        assert all_nodes[src_idx].fqname == ref.src.fqname
-        assert all_nodes[dst_idx].fqname == ref.dst.fqname
-        assert flags == ref.flags
+    assert triples  # at least one function-sourced edge
+    for src_idx, _dst_idx, _flags in triples:
+        assert all_nodes[src_idx].kind == "function"
 
 
 # ---------------------------------------------------------------------------
@@ -779,26 +760,12 @@ def test_find_subclasses_of_idx_out_of_range_raises(build_decl_graph):
         native.query(ctx).subclasses().of_idx(n).indices()
 
 
-def test_subclass_query_of_idx_matches_of_node(build_decl_graph):
-    ctx = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/a.py": "class Base: pass\nclass Sub(Base): pass\n",
-        }
-    )
-    (base_idx,) = ctx.indices_where(fqname_prefix="pkg.a.Base", kind="class")
-    base_node = ctx.nodes_at([base_idx])[0]
-    by_node = native.query(ctx).subclasses().of_node(base_node).indices()
-    by_idx = native.query(ctx).subclasses().of_idx(base_idx).indices()
-    assert sorted(by_node) == sorted(by_idx)
-
-
 # ---------------------------------------------------------------------------
 # DecoratorQuery.in_decl_idx
 # ---------------------------------------------------------------------------
 
 
-def test_decorator_query_in_decl_idx_matches_in_decl(build_decl_graph):
+def test_decorator_query_in_decl_idx_finds_instance_method_decorators(build_decl_graph):
     ctx = build_decl_graph(
         {
             "pkg/__init__.py": "",
@@ -813,11 +780,9 @@ def test_decorator_query_in_decl_idx_matches_in_decl(build_decl_graph):
         }
     )
     (cli_idx,) = ctx.indices_where(fqname_prefix="pkg.app.cli", kind="variable")
-    cli_node = ctx.nodes_at([cli_idx])[0]
-    by_node = native.query(ctx).decorators().in_decl(cli_node).where_name("command").collect()
-    by_idx = native.query(ctx).decorators().in_decl_idx(cli_idx).where_name("command").collect()
-    assert len(by_node) == len(by_idx)
-    assert sorted(r.decorated_idx for r in by_node) == sorted(r.decorated_idx for r in by_idx)
+    rows = native.query(ctx).decorators().in_decl_idx(cli_idx).where_name("command").collect()
+    decorated = ctx.nodes_at([r.decorated_idx for r in rows])
+    assert {n.fqname for n in decorated} == {"pkg.app.hello", "pkg.app.bye"}
 
 
 def test_decorator_query_in_decl_idx_requires_where_name(build_decl_graph):


### PR DESCRIPTION
## Summary

Simplifies the chainable `query(ctx)…` DSL by collapsing its parallel SymbolNode / idx surface down to one. Every terminal now returns positional indices into `ctx.nodes()` (or an `IdxRef` row that carries one); callers revive `SymbolNode` / `NodeAttrs` fields via `ctx.nodes_at` / `node_attrs` on demand.

### Removed from the query DSL
- `SubclassQuery.collect()`, `ImportQuery.collect()`, `ClassQuery.collect()`, `DeclQuery.collect()` — each previously returned `list[SymbolNode]`. Use `.indices()` / `.attrs()` / `.first_idx()`.
- `EdgeQuery.collect()` + `EdgeQuery.first()` + the `EdgeRef` class — use `.index_triples()`.
- `SubclassQuery.of_node(SymbolNode)` → `.of_idx(int)`.
- `DecoratorQuery.in_decl(SymbolNode)` → `.in_decl_idx(int)`.
- `__iter__` on `SubclassQuery` / `ImportQuery` / `ClassQuery` / `DeclQuery` / `EdgeQuery` (which iterated `SymbolNode` / `EdgeRef`).

### Rust internals removed
Helpers that only existed to back the removed terminals:
- `find_subclasses` (SymbolNode form) — inlined into `find_constructions` via the existing `_indices` variant.
- `find_subclasses_of_indices(&SymbolNode)` — merged into `find_subclasses_of_idx`.
- `find_imports_of` (SymbolNode form).
- `find_classes_defining_method` (SymbolNode form).
- The `iter_only` variant of `impl_query_methods!` (no longer used).

### Callers migrated
- `tests/test_query_indices.py` — rewritten as straight idx-form contracts (no more `.collect()` parity checks).
- `tests/test_module_surface.py`, `tests/test_query_dsl.py` — `list(query…)` → `.attrs()` / `.indices()`.
- `tests/prototype/test_plugin_protocol.py` — `of_node` → `of_idx`.

Net diff: −244 lines.

`Analysis` / `ProjectContext` `descendants` / `ancestors` / `reachable` (not part of the chainable DSL) are unchanged.

## Test plan
- [x] `uv run pytest` — 763 passed, 10 deselected
- [x] `uv run prek run --all-files` — ruff, ty, cargo fmt, cargo clippy all pass
- [x] `CHANGELOG.md` updated under `[Unreleased]`


---
_Generated by [Claude Code](https://claude.ai/code/session_01NF4uCL9DoFFnzAcZihsKMp)_