### PR TITLE
Native rust-side plugins + Analysis returns indices

### DIFF
--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -325,14 +325,24 @@ class CollectedOps:
     """
 
 class NativePlugin:
-    """Rust-side plugin. Constructed via a static factory (one per
-    available impl, e.g. :meth:`main_block`); the default constructor
-    is intentionally not exposed.
+    """Rust-side plugin — in-tree only.
 
-    Drop-in interchangeable with a Python :class:`Plugin` subclass in
-    :class:`Analysis` plugin lists — the harness detects the wrapper
-    and dispatches to the rust impl directly, skipping the Python
-    ``.run(ctx)`` call and the per-op ``GraphOp`` allocation.
+    Constructed via a static factory (one per available bundled impl,
+    e.g. :meth:`main_block`); the default constructor is intentionally
+    not exposed. Drop-in interchangeable with a Python
+    :class:`Plugin` subclass in :class:`Analysis` plugin lists — the
+    harness detects the wrapper and dispatches to the rust impl
+    directly, skipping the Python ``.run(ctx)`` call and the per-op
+    ``GraphOp`` allocation.
+
+    **Not an extension mechanism.** Native plugins are a hot-path
+    optimization for bundled plugins whose logic is fixed; the
+    underlying rust trait and types are crate-private with no
+    stability commitment. Out-of-tree plugin authors use the Python
+    :class:`Plugin` protocol — they can still write hot code in rust
+    (as a pyo3 extension their ``run(ctx)`` calls into), but they
+    emit ops through the public ``AddNodeByIdx`` / ``AddEdgeByIdx`` /
+    ``AddEntrypointByIdx`` graph ops.
     """
 
     @property

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -324,6 +324,41 @@ class CollectedOps:
     the collect and apply phases of plugin execution.
     """
 
+class NativePlugin:
+    """Rust-side plugin. Constructed via a static factory (one per
+    available impl, e.g. :meth:`main_block`); the default constructor
+    is intentionally not exposed.
+
+    Drop-in interchangeable with a Python :class:`Plugin` subclass in
+    :class:`Analysis` plugin lists — the harness detects the wrapper
+    and dispatches to the rust impl directly, skipping the Python
+    ``.run(ctx)`` call and the per-op ``GraphOp`` allocation.
+    """
+
+    @property
+    def name(self) -> str:
+        """Plugin name. Matches the conventional name of the
+        equivalent Python plugin (e.g. ``"MainBlockPlugin"``).
+        """
+        ...
+
+    def prepare(self, project_root: Any) -> None:
+        """``Plugin`` protocol's pre-graph hook. No-op for native
+        plugins today — every impl reads from the frozen ctx in
+        ``run``.
+        """
+        ...
+
+    @staticmethod
+    def main_block() -> NativePlugin:
+        """Native equivalent of
+        :class:`dead_cst.plugins.MainBlockPlugin`. Marks every file
+        with a top-level ``if __name__ == "__main__":`` block as an
+        entrypoint and wires edges to the containing module + every
+        top-level decl inside the block.
+        """
+        ...
+
 class NativeGraph:
     """The project-wide graph snapshot returned by ``Project.build()``
     and ``ProjectContext.materialize()``.

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Sequence, TypedDict
 
-from .graph import KEEPALIVE_DEFAULT, EdgeFlags, SymbolNode
+from .graph import KEEPALIVE_DEFAULT, EdgeFlags
 
 if TYPE_CHECKING:
     from dead_cst import _native as native
@@ -77,17 +77,22 @@ class ProgressSnapshot(TypedDict):
 
 
 _NON_DECL_TYPES: frozenset[str] = frozenset({"module", "synthetic"})
+_DECL_KINDS: tuple[str, ...] = ("function", "class", "variable", "import", "type_alias")
 
 
-def _iter_dead(
+def _iter_dead_indices(
     ctx: native.ProjectContext,
-    reachable: set[SymbolNode],
-) -> Iterator[SymbolNode]:
-    for n in ctx.nodes():
-        if n.kind in _NON_DECL_TYPES:
-            continue
-        if n not in reachable:
-            yield n
+    reachable: set[int],
+) -> Iterator[int]:
+    """Yield positional indices of every decl-kind node not in
+    ``reachable``. ``module`` / ``synthetic`` nodes are filtered out
+    via the kind whitelist (synthetic markers, anchor modules — they
+    aren't "dead" in any meaningful sense).
+    """
+    for kind in _DECL_KINDS:
+        for idx in ctx.indices_where(kind=kind):
+            if idx not in reachable:
+                yield idx
 
 
 def _serial_mode() -> bool:
@@ -877,44 +882,57 @@ class Analysis:
             if poller is not None:
                 poller.stop()
 
-    def reachable(self, *, seed_flags: int = KEEPALIVE_DEFAULT) -> set[SymbolNode]:
-        """Set of every decl reachable from any seed in ``seed_flags``."""
+    def reachable(self, *, seed_flags: int = KEEPALIVE_DEFAULT) -> set[int]:
+        """Positional indices of every decl reachable from any seed in
+        ``seed_flags``. Pair with :meth:`native.ProjectContext.nodes_at`
+        / :meth:`native.ProjectContext.node_attrs` to materialise the
+        underlying ``SymbolNode``\\ s or batched attribute snapshots
+        on demand.
+        """
         ctx = self.materialize_all()
-        return set(ctx.reachable(seed_flags=seed_flags))
+        return set(ctx.reachable_indices(seed_flags=seed_flags))
 
-    def dead(self, *, seed_flags: int = KEEPALIVE_DEFAULT) -> Iterator[SymbolNode]:
-        """Yield every decl that no seed in ``seed_flags`` reaches."""
+    def dead(self, *, seed_flags: int = KEEPALIVE_DEFAULT) -> Iterator[int]:
+        """Yield positional indices of every decl that no seed in
+        ``seed_flags`` reaches. Skips ``module`` and ``synthetic``
+        nodes (markers/anchors, not "dead" in the actionable sense).
+        """
         ctx = self.materialize_all()
-        return _iter_dead(ctx, self.reachable(seed_flags=seed_flags))
+        return _iter_dead_indices(ctx, self.reachable(seed_flags=seed_flags))
 
-    def descendants(self, root: SymbolNode, *, skip_flags: int = 0) -> list[SymbolNode]:
-        """Forward closure from ``root`` (rust BFS, single FFI hop)."""
+    def descendants(self, root_idx: int, *, skip_flags: int = 0) -> list[int]:
+        """Forward closure from ``root_idx`` (rust BFS, single FFI
+        hop). Returns positional indices into
+        :meth:`native.ProjectContext.nodes`.
+        """
         ctx = self.materialize_all()
-        return list(ctx.descendants(root, skip_flags=skip_flags))
+        return list(ctx.descendants_indices(root_idx, skip_flags=skip_flags))
 
-    def ancestors(self, decl: SymbolNode, *, skip_flags: int = 0) -> list[SymbolNode]:
-        """Reverse closure into ``decl`` (rust BFS, single FFI hop)."""
+    def ancestors(self, decl_idx: int, *, skip_flags: int = 0) -> list[int]:
+        """Reverse closure into ``decl_idx`` (rust BFS, single FFI
+        hop). Returns positional indices into
+        :meth:`native.ProjectContext.nodes`.
+        """
         ctx = self.materialize_all()
-        return list(ctx.ancestors(decl, skip_flags=skip_flags))
+        return list(ctx.ancestors_indices(decl_idx, skip_flags=skip_flags))
 
-    def kept_alive_by_dead_branches(
-        self, *, seed_flags: int = KEEPALIVE_DEFAULT
-    ) -> set[SymbolNode]:
-        """Decls reachable only via ``EdgeFlags.DEAD_BRANCH`` edges."""
+    def kept_alive_by_dead_branches(self, *, seed_flags: int = KEEPALIVE_DEFAULT) -> set[int]:
+        """Indices reachable only via ``EdgeFlags.DEAD_BRANCH`` edges."""
         ctx = self.materialize_all()
-        full = set(ctx.reachable(seed_flags=seed_flags))
-        strict = set(ctx.reachable(seed_flags=seed_flags, skip_flags=EdgeFlags.DEAD_BRANCH))
+        full = set(ctx.reachable_indices(seed_flags=seed_flags))
+        strict = set(ctx.reachable_indices(seed_flags=seed_flags, skip_flags=EdgeFlags.DEAD_BRANCH))
         return full - strict
 
     def kept_alive_by_flags_only(
         self, flags: int, *, seed_flags: int = KEEPALIVE_DEFAULT
-    ) -> set[SymbolNode]:
+    ) -> set[int]:
         """Blast radius of dropping every seed whose flags carry any
-        bit in ``flags`` — the diff between ``reachable(seed_flags)``
-        and ``reachable(seed_flags & ~flags)``."""
+        bit in ``flags`` — the diff between
+        ``reachable_indices(seed_flags)`` and
+        ``reachable_indices(seed_flags & ~flags)``."""
         ctx = self.materialize_all()
-        full = set(ctx.reachable(seed_flags=seed_flags))
-        without = set(ctx.reachable(seed_flags=seed_flags & ~flags))
+        full = set(ctx.reachable_indices(seed_flags=seed_flags))
+        without = set(ctx.reachable_indices(seed_flags=seed_flags & ~flags))
         return full - without
 
 

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -642,12 +642,16 @@ class Analysis:
         # construction happens. Type-validate each plugin here so
         # ``Pluign()`` typos and bare dicts fail with a clean
         # ``TypeError`` instead of being silently dropped by the rust
-        # ``add_plugin`` loop below.
+        # ``add_plugin`` loop below. ``_native.NativePlugin`` instances
+        # (rust-side native plugins, e.g.
+        # ``NativePlugin.main_block()``) aren't ``Plugin`` subclasses —
+        # accept them via the tuple check.
+        plugin_types: tuple[type, ...] = (Plugin, _native.NativePlugin)
         for plugin in self._plugins:
-            if not isinstance(plugin, Plugin):
+            if not isinstance(plugin, plugin_types):
                 raise TypeError(
-                    f"Expected a dead_cst.plugins.Plugin instance, got "
-                    f"{type(plugin).__name__!r}: {plugin!r}"
+                    f"Expected a dead_cst.plugins.Plugin or NativePlugin "
+                    f"instance, got {type(plugin).__name__!r}: {plugin!r}"
                 )
             plugin.prepare(self._project_root)
 

--- a/python/dead_cst/codemod.py
+++ b/python/dead_cst/codemod.py
@@ -161,12 +161,12 @@ def remove_code(dead_nodes: Iterable[SymbolNode], package_path: Path) -> None:
     anything still referenced (defensive -- the graph already classifies
     these as dead, but the scope check is cheap insurance).
 
-    ``dead_nodes`` is typically the set of unreachable nodes from
-    :class:`Analysis`; the codemod does not look at edges. Symbols
-    whose path is not under ``package_path`` are skipped, so call once
-    per package when analysing several packages together. The
-    transformation is destructive -- back the files up first, or run on
-    a clean working tree.
+    ``dead_nodes`` is typically materialised from the dead-index set
+    via ``ctx.nodes_at(list(analysis.dead()))``. The codemod does not
+    look at edges. Symbols whose path is not under ``package_path``
+    are skipped, so call once per package when analysing several
+    packages together. The transformation is destructive -- back the
+    files up first, or run on a clean working tree.
     """
     by_file, deleted_modules = _select_files(dead_nodes, package_path)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ mod graph;
 mod helpers;
 mod ingest;
 mod io;
+mod native_plugins;
 mod progress;
 mod project;
 mod query;
@@ -48,6 +49,7 @@ use crate::builder::{
 use crate::graph::{EdgeFlags, Import, NativeGraph, NodeFlags, SymbolNode};
 use crate::helpers::{ArgLiteral, ArgNodeRef, ArgOpaque, NodeAttrs};
 use crate::io::{read_graph, write_graph, GraphMetadata};
+use crate::native_plugins::NativePlugin;
 use crate::progress::ProgressHandle;
 use crate::project::{ChangeEvent, Project, ProjectContext};
 use crate::query::{
@@ -85,6 +87,7 @@ fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<AddNode>()?;
     m.add_class::<AddNodeByIdx>()?;
     m.add_class::<CollectedOps>()?;
+    m.add_class::<NativePlugin>()?;
     m.add_class::<NodeFlags>()?;
     m.add_class::<EdgeFlags>()?;
     m.add_class::<DecoratorIdxRef>()?;

--- a/src/native_plugins.rs
+++ b/src/native_plugins.rs
@@ -1,4 +1,4 @@
-//! Native (rust-side) plugins. Prototype.
+//! Native (rust-side) plugins — in-tree only.
 //!
 //! A native plugin is a rust implementation of the plugin contract
 //! that skips the Python `.run(ctx)` call entirely: the harness
@@ -9,7 +9,19 @@
 //! instances are ever constructed, no per-op ``extract`` /
 //! ``prepare_graph_op`` extraction step.
 //!
-//! Trade-off vs the Python-side plugin path:
+//! **Scope.** Native plugins are an in-tree fast-path for bundled
+//! plugins whose logic is fixed and hot. They're not a public
+//! extension mechanism: the trait and its dependent types
+//! ([`PreparedOp`], [`ProjectContext`]) are `pub(crate)` by design,
+//! the `dead-cst-native` crate is not published to crates.io, and
+//! the rust API has no stability commitment. Out-of-tree plugin
+//! authors continue to use the Python :class:`Plugin` protocol —
+//! they can still write hot code in rust, but they ship it as a
+//! pyo3 extension that their `run(ctx)` body calls into, and they
+//! emit ops via the public Python ``AddNodeByIdx`` / ``AddEdgeByIdx``
+//! / ``AddEntrypointByIdx`` graph ops.
+//!
+//! Trade-off vs the Python-side plugin path (for in-tree authors):
 //!
 //! * **Lighter per-op cost** — every Python plugin op pays one
 //!   ``Py::new(AddNodeByIdx { ... })`` allocation on the yield side,
@@ -20,11 +32,11 @@
 //!   still drop the GIL via ``py.allow_threads`` if they want to.
 //! * **Costs flexibility** — a native plugin's logic is compiled
 //!   into the wheel; it can't be authored / overridden / dataclass-
-//!   configured by out-of-tree plugin authors. Python plugins
-//!   remain the right home for anything user-configurable.
+//!   configured externally. Python plugins remain the right home
+//!   for anything user-configurable.
 //!
-//! The contract is the same as the Python ``Plugin`` protocol: see
-//! the base graph (frozen mid-pass), emit ops, ops apply in a
+//! The frozen-graph contract is identical on both paths: the impl
+//! observes the base graph mid-pass, emits ops, ops apply in a
 //! single batch after every plugin completes. Native plugins are
 //! drop-in interchangeable with Python ones in
 //! ``Analysis(plugins=[...])`` and inside the harness's

--- a/src/native_plugins.rs
+++ b/src/native_plugins.rs
@@ -1,0 +1,157 @@
+//! Native (rust-side) plugins. Prototype.
+//!
+//! A native plugin is a rust implementation of the plugin contract
+//! that skips the Python `.run(ctx)` call entirely: the harness
+//! detects a :class:`NativePlugin` pyclass via downcast in
+//! ``collect_prepared_plugin_ops``, invokes the inner
+//! [`NativePluginImpl::run`] directly, and the impl pushes its
+//! ops into the shared [`PreparedOp`] sink — no Python ``GraphOp``
+//! instances are ever constructed, no per-op ``extract`` /
+//! ``prepare_graph_op`` extraction step.
+//!
+//! Trade-off vs the Python-side plugin path:
+//!
+//! * **Lighter per-op cost** — every Python plugin op pays one
+//!   ``Py::new(AddNodeByIdx { ... })`` allocation on the yield side,
+//!   then one ``extract::<PyRef<...>>`` + ``.clone()`` of the inner
+//!   fields on the harness side. Native plugins skip both ends.
+//! * **No GIL release between op yields** — the impl runs entirely
+//!   in rust under one GIL hold; rust queries inside the impl can
+//!   still drop the GIL via ``py.allow_threads`` if they want to.
+//! * **Costs flexibility** — a native plugin's logic is compiled
+//!   into the wheel; it can't be authored / overridden / dataclass-
+//!   configured by out-of-tree plugin authors. Python plugins
+//!   remain the right home for anything user-configurable.
+//!
+//! The contract is the same as the Python ``Plugin`` protocol: see
+//! the base graph (frozen mid-pass), emit ops, ops apply in a
+//! single batch after every plugin completes. Native plugins are
+//! drop-in interchangeable with Python ones in
+//! ``Analysis(plugins=[...])`` and inside the harness's
+//! :class:`ThreadPoolExecutor` fan-out.
+
+use pyo3::prelude::*;
+
+use crate::builder::PreparedOp;
+use crate::graph::{intern_kind, NodeFlags};
+use crate::project::ProjectContext;
+
+/// Rust-side plugin contract. Each impl describes how to derive ops
+/// from a frozen :class:`ProjectContext` and push them into the
+/// shared [`PreparedOp`] sink the harness drains at the end of the
+/// plugin pass.
+///
+/// Implementations don't construct Python ``GraphOp`` instances —
+/// they push pure-rust [`PreparedOp`] variants directly, skipping
+/// the prepare-from-Python round-trip.
+pub(crate) trait NativePluginImpl: Send + Sync {
+    /// Human-readable name surfaced by ``NativePlugin.name`` and used
+    /// for progress reporting (``plugin_start`` / ``plugin_end``
+    /// events). Should match the conventional name of the equivalent
+    /// Python plugin so existing harness logs read the same.
+    fn name(&self) -> &'static str;
+
+    /// Walk the frozen ``ctx`` and append the plugin's ops to
+    /// ``sink``. Same frozen-graph contract as the Python path: the
+    /// impl observes the base graph only; its emissions are folded in
+    /// by the apply pass after every plugin returns.
+    fn run(&self, py: Python<'_>, ctx: &ProjectContext, sink: &mut Vec<PreparedOp>)
+        -> PyResult<()>;
+}
+
+/// Python-visible wrapper for a [`NativePluginImpl`]. Constructed via
+/// static factories (one per concrete impl, e.g.
+/// :meth:`NativePlugin.main_block`); ``__init__`` is intentionally
+/// unsupported so plugin authors discover the existing factories
+/// (and we keep the configuration surface inside the wrapper rust-
+/// side).
+///
+/// Sendable because the inner trait bound (``Send + Sync``) carries
+/// across: the harness drives plugins from a
+/// :class:`ThreadPoolExecutor`, so the ``Py<NativePlugin>`` handle
+/// shuttles between threads alongside Python plugins. The impl's
+/// :meth:`run` is invoked under the GIL on whichever worker picks
+/// up the task.
+#[pyclass(name = "NativePlugin")]
+pub(crate) struct NativePlugin {
+    pub(crate) inner: Box<dyn NativePluginImpl>,
+}
+
+#[pymethods]
+impl NativePlugin {
+    /// Plugin name. Matches the conventional name of the equivalent
+    /// Python plugin (e.g. ``"MainBlockPlugin"``), so harness logs
+    /// and ``progress_callback`` events look the same whether a
+    /// native or Python instance is registered.
+    #[getter]
+    fn name(&self) -> &'static str {
+        self.inner.name()
+    }
+
+    /// ``Plugin`` protocol's ``prepare(project_root)`` no-op hook.
+    /// Native plugins don't have a pre-graph prepare phase today —
+    /// every impl reads from the frozen ctx in :meth:`run`.
+    fn prepare(&self, _project_root: PyObject) {}
+
+    /// Construct the native [``MainBlockPlugin``](
+    /// crate::native_plugins::MainBlockPluginImpl) — same observable
+    /// behaviour as ``dead_cst.plugins.MainBlockPlugin``, no Python
+    /// loop or ``AddNodeByIdx`` allocation in the hot path.
+    #[staticmethod]
+    fn main_block() -> Self {
+        Self {
+            inner: Box::new(MainBlockPluginImpl),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MainBlockPlugin — first native impl. Equivalent to
+// ``dead_cst.plugins.main_block.MainBlockPlugin``: emit one synthetic
+// ``<__main__>:<module_fqname>`` entrypoint per file with a top-level
+// ``if __name__ == "__main__":`` block, with edges to the containing
+// module and to every top-level decl inside the block.
+// ---------------------------------------------------------------------------
+
+const MAIN_BLOCK_PREFIX: &str = "<__main__>:";
+
+pub(crate) struct MainBlockPluginImpl;
+
+impl NativePluginImpl for MainBlockPluginImpl {
+    fn name(&self) -> &'static str {
+        "MainBlockPlugin"
+    }
+
+    fn run(
+        &self,
+        py: Python<'_>,
+        ctx: &ProjectContext,
+        sink: &mut Vec<PreparedOp>,
+    ) -> PyResult<()> {
+        let pairs = ctx.find_main_blocks_indices()?;
+        if pairs.is_empty() {
+            return Ok(());
+        }
+        // One batched ``node_attrs`` for every matched module — same
+        // shape the Python ``MainBlockPlugin`` uses, but without the
+        // ``Py<NodeAttrs>`` round-trip: we read straight off the
+        // ``Vec<NodeAttrs>`` the rust helper returns.
+        let module_idxs: Vec<usize> = pairs.iter().map(|(m, _)| *m).collect();
+        let attrs = ctx.node_attrs(py, module_idxs)?;
+        let synthetic_kind = intern_kind("synthetic")?;
+        for ((module_idx, decl_idxs), attr) in pairs.iter().zip(attrs.iter()) {
+            let mut edges_to_idx: Vec<usize> = Vec::with_capacity(decl_idxs.len() + 1);
+            edges_to_idx.push(*module_idx);
+            edges_to_idx.extend(decl_idxs);
+            sink.push(PreparedOp::NodeByIdx {
+                fqname: format!("{MAIN_BLOCK_PREFIX}{}", attr.fqname),
+                kind: synthetic_kind,
+                path: attr.path.clone(),
+                flags: NodeFlags::ENTRYPOINT,
+                edges_from_idx: Vec::new(),
+                edges_to_idx,
+            });
+        }
+        Ok(())
+    }
+}

--- a/src/native_plugins.rs
+++ b/src/native_plugins.rs
@@ -55,7 +55,11 @@ use crate::project::ProjectContext;
 ///
 /// Implementations don't construct Python ``GraphOp`` instances —
 /// they push pure-rust [`PreparedOp`] variants directly, skipping
-/// the prepare-from-Python round-trip.
+/// the prepare-from-Python round-trip. No ``Python<'_>`` parameter
+/// either: every ctx accessor a native plugin needs (``node_attrs``,
+/// ``find_main_blocks_indices``, the query DSL helpers) is GIL-free,
+/// reading ``Sync`` ``#[pyclass(frozen)]`` data via ``Py::get`` rather
+/// than ``Py::borrow``.
 pub(crate) trait NativePluginImpl: Send + Sync {
     /// Human-readable name surfaced by ``NativePlugin.name`` and used
     /// for progress reporting (``plugin_start`` / ``plugin_end``
@@ -67,8 +71,7 @@ pub(crate) trait NativePluginImpl: Send + Sync {
     /// ``sink``. Same frozen-graph contract as the Python path: the
     /// impl observes the base graph only; its emissions are folded in
     /// by the apply pass after every plugin returns.
-    fn run(&self, py: Python<'_>, ctx: &ProjectContext, sink: &mut Vec<PreparedOp>)
-        -> PyResult<()>;
+    fn run(&self, ctx: &ProjectContext, sink: &mut Vec<PreparedOp>) -> PyResult<()>;
 }
 
 /// Python-visible wrapper for a [`NativePluginImpl`]. Constructed via
@@ -134,12 +137,7 @@ impl NativePluginImpl for MainBlockPluginImpl {
         "MainBlockPlugin"
     }
 
-    fn run(
-        &self,
-        py: Python<'_>,
-        ctx: &ProjectContext,
-        sink: &mut Vec<PreparedOp>,
-    ) -> PyResult<()> {
+    fn run(&self, ctx: &ProjectContext, sink: &mut Vec<PreparedOp>) -> PyResult<()> {
         let pairs = ctx.find_main_blocks_indices()?;
         if pairs.is_empty() {
             return Ok(());
@@ -147,9 +145,11 @@ impl NativePluginImpl for MainBlockPluginImpl {
         // One batched ``node_attrs`` for every matched module — same
         // shape the Python ``MainBlockPlugin`` uses, but without the
         // ``Py<NodeAttrs>`` round-trip: we read straight off the
-        // ``Vec<NodeAttrs>`` the rust helper returns.
+        // ``Vec<NodeAttrs>`` the rust helper returns. Note: no ``py``
+        // argument — ``node_attrs`` reads via ``Py::get`` (frozen-Sync
+        // pyclass fast path).
         let module_idxs: Vec<usize> = pairs.iter().map(|(m, _)| *m).collect();
-        let attrs = ctx.node_attrs(py, module_idxs)?;
+        let attrs = ctx.node_attrs(module_idxs)?;
         let synthetic_kind = intern_kind("synthetic")?;
         for ((module_idx, decl_idxs), attr) in pairs.iter().zip(attrs.iter()) {
             let mut edges_to_idx: Vec<usize> = Vec::with_capacity(decl_idxs.len() + 1);

--- a/src/project.rs
+++ b/src/project.rs
@@ -1732,7 +1732,7 @@ fn collect_prepared_plugin_ops(
     let plugin_bound = plugin.bind(py);
     if let Ok(native) = plugin_bound.downcast::<crate::native_plugins::NativePlugin>() {
         let ctx_ref = ctx.borrow(py);
-        return native.borrow().inner.run(py, &ctx_ref, sink);
+        return native.borrow().inner.run(&ctx_ref, sink);
     }
     let result = plugin_bound.call_method1("run", (ctx.clone_ref(py),))?;
     if result.is_none() {
@@ -3917,7 +3917,6 @@ impl ProjectContext {
     /// :class:`IndexError` when any index is out of range.
     pub(crate) fn node_attrs(
         &self,
-        py: Python<'_>,
         indices: Vec<usize>,
     ) -> PyResult<Vec<crate::helpers::NodeAttrs>> {
         let outputs = self.materialized("node_attrs")?;
@@ -3929,7 +3928,11 @@ impl ProjectContext {
                     "node index {idx} out of range (len={len})"
                 )));
             }
-            let node = outputs.builder.nodes[idx].borrow(py);
+            // ``Py<T>::get`` is GIL-free for frozen pyclasses with
+            // ``Sync`` fields. ``SymbolNode`` is ``#[pyclass(frozen)]``
+            // with all-``Sync`` fields, so we read its data without
+            // threading ``Python<'_>`` through every internal helper.
+            let node = outputs.builder.nodes[idx].get();
             out.push(crate::helpers::NodeAttrs {
                 kind: node.kind.to_string(),
                 path: node.path.clone(),
@@ -3948,7 +3951,7 @@ impl ProjectContext {
     ///
     /// Validates bounds and raises :class:`IndexError` when any index
     /// is out of range. Mirrors the contract of :meth:`node_attrs`.
-    pub(crate) fn node_paths(&self, py: Python<'_>, indices: Vec<usize>) -> PyResult<Vec<String>> {
+    pub(crate) fn node_paths(&self, indices: Vec<usize>) -> PyResult<Vec<String>> {
         let outputs = self.materialized("node_paths")?;
         let len = outputs.builder.nodes.len();
         let mut out: Vec<String> = Vec::with_capacity(indices.len());
@@ -3958,7 +3961,10 @@ impl ProjectContext {
                     "node index {idx} out of range (len={len})"
                 )));
             }
-            out.push(outputs.builder.nodes[idx].borrow(py).path.clone());
+            // ``Py::get`` is GIL-free on ``#[pyclass(frozen)]`` types
+            // with ``Sync`` fields; SymbolNode qualifies. See
+            // :meth:`node_attrs` for the rationale.
+            out.push(outputs.builder.nodes[idx].get().path.clone());
         }
         Ok(out)
     }

--- a/src/project.rs
+++ b/src/project.rs
@@ -1722,7 +1722,19 @@ fn collect_prepared_plugin_ops(
     plugin: &PyObject,
     sink: &mut Vec<PreparedOp>,
 ) -> PyResult<()> {
-    let result = plugin.bind(py).call_method1("run", (ctx.clone_ref(py),))?;
+    // Native fast path: ``NativePlugin`` instances expose a rust
+    // [`NativePluginImpl::run`] that fills ``sink`` directly with
+    // [`PreparedOp`] variants — no Python ``.run(ctx)`` call, no
+    // ``GraphOp`` allocation per yield, no ``prepare_graph_op``
+    // extraction loop. The frozen-graph contract is identical to
+    // the Python path: the impl borrows ``ctx`` immutably; the
+    // apply pass folds ``sink`` in afterwards.
+    let plugin_bound = plugin.bind(py);
+    if let Ok(native) = plugin_bound.downcast::<crate::native_plugins::NativePlugin>() {
+        let ctx_ref = ctx.borrow(py);
+        return native.borrow().inner.run(py, &ctx_ref, sink);
+    }
+    let result = plugin_bound.call_method1("run", (ctx.clone_ref(py),))?;
     if result.is_none() {
         return Ok(());
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -444,10 +444,9 @@ where
 /// per-path bins.
 pub(crate) fn _bucket_indices_by_path(
     ctx: &ProjectContext,
-    py: Python<'_>,
     indices: Vec<usize>,
 ) -> PyResult<FxHashMap<String, Vec<usize>>> {
-    let paths = ctx.node_paths(py, indices.clone())?;
+    let paths = ctx.node_paths(indices.clone())?;
     let mut buckets: FxHashMap<String, Vec<usize>> = FxHashMap::default();
     for (idx, path) in indices.into_iter().zip(paths.into_iter()) {
         buckets.entry(path).or_default().push(idx);
@@ -1247,7 +1246,7 @@ impl SubclassQuery {
     fn attrs(&self, py: Python<'_>) -> PyResult<Vec<crate::helpers::NodeAttrs>> {
         let indices = self.indices(py)?;
         let ctx = self.ctx.borrow(py);
-        ctx.node_attrs(py, indices)
+        ctx.node_attrs(indices)
     }
 
     /// Terminal — first matched subclass's positional index, or
@@ -1260,7 +1259,7 @@ impl SubclassQuery {
     fn indices_by_path(&self, py: Python<'_>) -> PyResult<FxHashMap<String, Vec<usize>>> {
         let indices = self.indices(py)?;
         let ctx = self.ctx.borrow(py);
-        _bucket_indices_by_path(&ctx, py, indices)
+        _bucket_indices_by_path(&ctx, indices)
     }
 
     fn count(&self, py: Python<'_>) -> PyResult<usize> {
@@ -1320,7 +1319,7 @@ impl ImportQuery {
     fn attrs(&self, py: Python<'_>) -> PyResult<Vec<crate::helpers::NodeAttrs>> {
         let indices = self.indices(py)?;
         let ctx = self.ctx.borrow(py);
-        ctx.node_attrs(py, indices)
+        ctx.node_attrs(indices)
     }
 
     /// Terminal — first matched import node's positional index, or
@@ -1333,7 +1332,7 @@ impl ImportQuery {
     fn indices_by_path(&self, py: Python<'_>) -> PyResult<FxHashMap<String, Vec<usize>>> {
         let indices = self.indices(py)?;
         let ctx = self.ctx.borrow(py);
-        _bucket_indices_by_path(&ctx, py, indices)
+        _bucket_indices_by_path(&ctx, indices)
     }
 }
 
@@ -1422,7 +1421,7 @@ impl ModuleQuery {
         if self.all_dunders {
             return ctx.find_module_dunders_indices(py);
         }
-        let fqn = self.resolve_fqn(py, &ctx)?;
+        let fqn = self.resolve_fqn(&ctx)?;
         let Some(fqn) = fqn else {
             return Ok(Vec::new());
         };
@@ -1474,7 +1473,7 @@ impl ModuleQuery {
     fn attrs(&self, py: Python<'_>) -> PyResult<Vec<crate::helpers::NodeAttrs>> {
         let indices = self.indices(py)?;
         let ctx = self.ctx.borrow(py);
-        ctx.node_attrs(py, indices)
+        ctx.node_attrs(indices)
     }
 
     /// Terminal — group matched indices by their owning file path.
@@ -1483,13 +1482,13 @@ impl ModuleQuery {
     fn indices_by_path(&self, py: Python<'_>) -> PyResult<FxHashMap<String, Vec<usize>>> {
         let indices = self.indices(py)?;
         let ctx = self.ctx.borrow(py);
-        _bucket_indices_by_path(&ctx, py, indices)
+        _bucket_indices_by_path(&ctx, indices)
     }
 }
 
 impl ModuleQuery {
     /// Resolve the query's filter to a dotted fqname.
-    fn resolve_fqn(&self, py: Python<'_>, ctx: &ProjectContext) -> PyResult<Option<String>> {
+    fn resolve_fqn(&self, ctx: &ProjectContext) -> PyResult<Option<String>> {
         if let Some(ref fqn) = self.fqn {
             return Ok(Some(fqn.clone()));
         }
@@ -1498,7 +1497,7 @@ impl ModuleQuery {
             let Some(idx) = ctx.module_for_indices(path)? else {
                 return Ok(None);
             };
-            let attrs = ctx.node_attrs(py, vec![idx])?;
+            let attrs = ctx.node_attrs(vec![idx])?;
             return Ok(attrs.into_iter().next().map(|a| a.fqname));
         }
         Err(PyValueError::new_err(
@@ -1551,7 +1550,7 @@ impl ClassQuery {
     fn attrs(&self, py: Python<'_>) -> PyResult<Vec<crate::helpers::NodeAttrs>> {
         let indices = self.indices(py)?;
         let ctx = self.ctx.borrow(py);
-        ctx.node_attrs(py, indices)
+        ctx.node_attrs(indices)
     }
 
     /// Terminal — first matched class's positional index, or ``None``
@@ -1564,7 +1563,7 @@ impl ClassQuery {
     fn indices_by_path(&self, py: Python<'_>) -> PyResult<FxHashMap<String, Vec<usize>>> {
         let indices = self.indices(py)?;
         let ctx = self.ctx.borrow(py);
-        _bucket_indices_by_path(&ctx, py, indices)
+        _bucket_indices_by_path(&ctx, indices)
     }
 
     fn count(&self, py: Python<'_>) -> PyResult<usize> {
@@ -2196,7 +2195,7 @@ impl DeclQuery {
     fn attrs(&self, py: Python<'_>) -> PyResult<Vec<crate::helpers::NodeAttrs>> {
         let indices = self.indices(py)?;
         let ctx = self.ctx.borrow(py);
-        ctx.node_attrs(py, indices)
+        ctx.node_attrs(indices)
     }
 
     /// Terminal — first matching node's positional index, or ``None``
@@ -2214,7 +2213,7 @@ impl DeclQuery {
     fn indices_by_path(&self, py: Python<'_>) -> PyResult<FxHashMap<String, Vec<usize>>> {
         let indices = self.indices(py)?;
         let ctx = self.ctx.borrow(py);
-        _bucket_indices_by_path(&ctx, py, indices)
+        _bucket_indices_by_path(&ctx, indices)
     }
 
     fn count(&self, py: Python<'_>) -> PyResult<usize> {
@@ -2356,7 +2355,7 @@ impl DeclarationsQuery {
     fn attrs(&self, py: Python<'_>) -> PyResult<Vec<crate::helpers::NodeAttrs>> {
         let indices = self.indices(py)?;
         let ctx = self.ctx.borrow(py);
-        ctx.node_attrs(py, indices)
+        ctx.node_attrs(indices)
     }
 
     /// Terminal — first matched decl's positional index, or ``None``
@@ -2370,7 +2369,7 @@ impl DeclarationsQuery {
     fn indices_by_path(&self, py: Python<'_>) -> PyResult<FxHashMap<String, Vec<usize>>> {
         let indices = self.indices(py)?;
         let ctx = self.ctx.borrow(py);
-        _bucket_indices_by_path(&ctx, py, indices)
+        _bucket_indices_by_path(&ctx, indices)
     }
 }
 

--- a/tests/e2e/test_flux0.py
+++ b/tests/e2e/test_flux0.py
@@ -95,9 +95,9 @@ def _ancestor_fqnames(base: Path, target_fqname: str) -> list[str]:
     """
     analysis = Analysis(base, plugins=[MainBlockPlugin()])
     ctx = analysis.materialize_all()
-    target = next((n for n in ctx.nodes() if n.fqname == target_fqname), None)
-    assert target is not None, f"{target_fqname} not in graph"
-    return [n.fqname for n in analysis.ancestors(target)]
+    target_idx = next((i for i, n in enumerate(ctx.nodes()) if n.fqname == target_fqname), None)
+    assert target_idx is not None, f"{target_fqname} not in graph"
+    return [a.fqname for a in ctx.node_attrs(analysis.ancestors(target_idx))]
 
 
 def test_why_alive_flux0_server_main(flux0_server_src):

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -48,7 +48,8 @@ def _node_keys(ctx) -> list[tuple[str, str, int]]:
 
 
 def _dead_fqnames(analysis: Analysis) -> set[str]:
-    return {n.fqname for n in analysis.dead()}
+    ctx = analysis.materialize_all()
+    return {a.fqname for a in ctx.node_attrs(list(analysis.dead()))}
 
 
 def _build_fresh(tmp_path: Path, *, plugins=()) -> Analysis:

--- a/tests/test_kept_alive_by_noqa.py
+++ b/tests/test_kept_alive_by_noqa.py
@@ -126,5 +126,6 @@ def test_analysis_kept_alive_by_flags_only_noqa(make_analysis, write_files):
     )
     analysis = make_analysis()
     diff = analysis.kept_alive_by_flags_only(NodeFlags.NOQA)
-    fqnames = {n.fqname for n in diff}
+    ctx = analysis.materialize_all()
+    fqnames = {a.fqname for a in ctx.node_attrs(list(diff))}
     assert "pkg.side_effect" in fqnames

--- a/tests/test_kept_alive_by_tests.py
+++ b/tests/test_kept_alive_by_tests.py
@@ -111,5 +111,6 @@ def test_analysis_method_returns_strict_diff(make_analysis, write_files):
     )
     analysis = make_analysis(plugins=[PytestPlugin()])
     blast = analysis.kept_alive_by_flags_only(NodeFlags.TESTCASE)
-    fqnames = {n.fqname for n in blast}
+    ctx = analysis.materialize_all()
+    fqnames = {a.fqname for a in ctx.node_attrs(list(blast))}
     assert "pkg.lib.helper" in fqnames

--- a/tests/test_noqa_pinning.py
+++ b/tests/test_noqa_pinning.py
@@ -135,7 +135,8 @@ def test_unpinned_import_in_dead_module_stays_dead(make_analysis, write_files):
     """Without the directive, an unused import in an otherwise-dead module is dead."""
     write_files({"m.py": "import os\n"})
     analysis = make_analysis()
-    dead_fqs = {n.fqname for n in analysis.dead()}
+    ctx = analysis.materialize_all()
+    dead_fqs = {a.fqname for a in ctx.node_attrs(list(analysis.dead()))}
     assert "m.os" in dead_fqs
 
 

--- a/tests/test_plugins/test_native_plugin.py
+++ b/tests/test_plugins/test_native_plugin.py
@@ -1,0 +1,112 @@
+"""Tests for the prototype rust-side ``NativePlugin``.
+
+A native plugin is a pyo3 wrapper around a rust :trait:`NativePluginImpl`
+that the harness drives through the same ``ThreadPoolExecutor`` /
+``CollectedOps`` / ``apply_ops_batched`` flow as a Python plugin —
+the only difference is that the per-op extraction step is replaced
+by a direct ``Vec<PreparedOp>`` push from rust.
+
+These tests pin: parity with the Python equivalent, registration
+acceptance by the ``Analysis`` harness, mix-and-match with Python
+plugins in the same registration list.
+"""
+
+from __future__ import annotations
+
+from dead_cst import _native as native
+from dead_cst.plugins import MainBlockPlugin
+
+
+def test_native_main_block_matches_python_plugin(build_plugin_graph, reachable_fqnames):
+    """``NativePlugin.main_block()`` produces the same reachable set as
+    ``MainBlockPlugin()`` — same synthetic entrypoint per main block,
+    same edges, same alive set."""
+    files = {
+        "pkg/__init__.py": "",
+        "pkg/script.py": """
+        def main(): pass
+        def unused(): pass
+        if __name__ == "__main__":
+            main()
+        """,
+        "pkg/other.py": "def g(): pass",
+    }
+    py_ctx = build_plugin_graph(files, [MainBlockPlugin()])
+    rs_ctx = build_plugin_graph(files, [native.NativePlugin.main_block()])
+    assert reachable_fqnames(py_ctx) == reachable_fqnames(rs_ctx)
+
+
+def test_native_main_block_emits_entrypoint_marker(build_plugin_graph):
+    """The synthetic ``<__main__>:<module>`` marker still lands in the
+    graph — verify the node is interned and carries ``ENTRYPOINT``."""
+    ctx = build_plugin_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/script.py": """
+            def main(): pass
+            if __name__ == "__main__":
+                main()
+            """,
+        },
+        [native.NativePlugin.main_block()],
+    )
+    markers = [n for n in ctx.nodes() if n.fqname == "<__main__>:pkg.script"]
+    assert len(markers) == 1
+    assert markers[0].flags & native.NodeFlags.ENTRYPOINT
+
+
+def test_native_plugin_name_attribute():
+    """``NativePlugin.name`` mirrors the conventional Python plugin
+    name, so harness progress logs and ``progress_callback`` events
+    are indistinguishable between the two impls."""
+    plugin = native.NativePlugin.main_block()
+    assert plugin.name == "MainBlockPlugin"
+
+
+def test_native_plugin_mixed_with_python_plugins(build_plugin_graph, reachable_fqnames):
+    """A native plugin and a Python plugin in the same registration
+    list both run; the harness routes each to the appropriate path
+    transparently."""
+    from dead_cst.plugins import ModuleDundersPlugin
+
+    files = {
+        "pkg/__init__.py": "__all__ = ['x']\nx = 1\n",
+        "pkg/script.py": """
+        def main(): pass
+        if __name__ == "__main__":
+            main()
+        """,
+    }
+    # Mix: rust native main-block + python module-dunders.
+    ctx = build_plugin_graph(
+        files, [native.NativePlugin.main_block(), ModuleDundersPlugin()]
+    )
+    reached = reachable_fqnames(ctx)
+    # Main-block contribution.
+    assert "pkg.script.main" in reached
+    # Module-dunders contribution.
+    assert "pkg.__all__" in reached
+    assert "pkg.x" in reached
+
+
+def test_native_plugin_no_main_block_no_ops(build_plugin_graph):
+    """A project without any ``if __name__ == "__main__":`` block
+    produces no synthetic markers — same shape as the Python
+    equivalent's empty path."""
+    ctx = build_plugin_graph(
+        {"pkg/__init__.py": "", "pkg/m.py": "def f(): pass\n"},
+        [native.NativePlugin.main_block()],
+    )
+    main_markers = [n for n in ctx.nodes() if n.fqname.startswith("<__main__>:")]
+    assert main_markers == []
+
+
+def test_native_plugin_cannot_be_directly_instantiated():
+    """``NativePlugin()`` (no-arg) should raise — the wrapper requires
+    a factory like :meth:`NativePlugin.main_block` to bind to a
+    concrete impl. Pinned so the constructor doesn't silently
+    succeed with no inner impl."""
+    import pytest
+
+    with pytest.raises(TypeError):
+        native.NativePlugin()

--- a/tests/test_plugins/test_native_plugin.py
+++ b/tests/test_plugins/test_native_plugin.py
@@ -78,9 +78,7 @@ def test_native_plugin_mixed_with_python_plugins(build_plugin_graph, reachable_f
         """,
     }
     # Mix: rust native main-block + python module-dunders.
-    ctx = build_plugin_graph(
-        files, [native.NativePlugin.main_block(), ModuleDundersPlugin()]
-    )
+    ctx = build_plugin_graph(files, [native.NativePlugin.main_block(), ModuleDundersPlugin()])
     reached = reachable_fqnames(ctx)
     # Main-block contribution.
     assert "pkg.script.main" in reached

--- a/tests/test_query_indices.py
+++ b/tests/test_query_indices.py
@@ -320,8 +320,8 @@ def test_add_node_by_idx_entrypoint_flag(tmp_path):
             )
 
     analysis = Analysis(tmp_path, plugins=[SeedBoth()])
-    analysis.materialize_all()
-    dead_fqnames = {n.fqname for n in analysis.dead()}
+    ctx = analysis.materialize_all()
+    dead_fqnames = {a.fqname for a in ctx.node_attrs(list(analysis.dead()))}
     assert "mod.alive" not in dead_fqnames
     assert "mod.also_alive" not in dead_fqnames
     assert "mod.dead" in dead_fqnames
@@ -674,7 +674,7 @@ def test_add_entrypoint_by_idx_promotes_seed(tmp_path):
     # Marker is composed as ``<marker>:<decl.fqname>`` — same shape
     # ``AddEntrypoint`` uses.
     assert "<seed>:mod.seed" in fqnames
-    dead_fqnames = {n.fqname for n in analysis.dead()}
+    dead_fqnames = {a.fqname for a in ctx.node_attrs(list(analysis.dead()))}
     assert "mod.seed" not in dead_fqnames
     assert "mod.used_by_seed" not in dead_fqnames
     assert "mod.dead" in dead_fqnames


### PR DESCRIPTION
## Summary

Two coupled changes, both flowing from the same observation: native plugins shouldn't need to touch Python at all.

### 1. ``NativePlugin`` — rust-side plugin contract

A new pyclass ``NativePlugin`` wraps a rust ``NativePluginImpl`` trait object. The harness's ``collect_prepared_plugin_ops`` downcasts on hit and invokes the impl directly — no Python ``.run(ctx)`` call, no per-op ``GraphOp`` allocation, no ``prepare_graph_op`` extraction loop. The trait is GIL-free:

```rust
pub(crate) trait NativePluginImpl: Send + Sync {
    fn name(&self) -> &'static str;
    fn run(&self, ctx: &ProjectContext, sink: &mut Vec<PreparedOp>) -> PyResult<()>;
}
```

No ``Python<'_>`` parameter — internal ctx accessors (``node_attrs``, ``node_paths``, ``_bucket_indices_by_path``, ``ModuleQuery.resolve_fqn``) were converted from ``.borrow(py)`` to ``Py<T>::get()`` (pyo3 0.22's GIL-free accessor on ``#[pyclass(frozen)]`` types with ``Sync`` fields). No graph-storage refactor needed — storage still holds ``Vec<Py<SymbolNode>>``; we just stopped paying GIL-borrow on field reads.

**Scope: in-tree only.** ``NativePluginImpl`` and the rust types it depends on are ``pub(crate)``; ``dead-cst-native`` is not published. Native plugins are a hot-path optimization for bundled plugins, not an extension mechanism. Out-of-tree plugin authors continue with the Python ``Plugin`` protocol (and can still write hot code in rust via pyo3 inside their ``run(ctx)`` body, emitting ops through the public ``Add*ByIdx`` graph ops).

**First concrete impl: ``MainBlockPluginImpl``.** Drop-in equivalent of ``dead_cst.plugins.MainBlockPlugin``. Pushes ``PreparedOp::NodeByIdx`` per file directly.

### 2. ``Analysis.*`` returns indices instead of ``SymbolNode``

Breaking change to the user-facing reachability API:

| before | after |
|---|---|
| ``Analysis.reachable() -> set[SymbolNode]`` | ``Analysis.reachable() -> set[int]`` |
| ``Analysis.dead() -> Iterator[SymbolNode]`` | ``Analysis.dead() -> Iterator[int]`` |
| ``Analysis.descendants(root: SymbolNode) -> list[SymbolNode]`` | ``Analysis.descendants(root_idx: int) -> list[int]`` |
| ``Analysis.ancestors(decl: SymbolNode) -> list[SymbolNode]`` | ``Analysis.ancestors(decl_idx: int) -> list[int]`` |
| ``Analysis.kept_alive_by_*() -> set[SymbolNode]`` | ``Analysis.kept_alive_by_*() -> set[int]`` |

Callers materialise nodes / fields on demand:

```python
analysis = Analysis(project_root, plugins=[...])
ctx = analysis.materialize_all()

# field data via batched node_attrs (the faster idiom):
dead_attrs = ctx.node_attrs(list(analysis.dead()))
for attr in dead_attrs:
    print(attr.fqname, attr.kind, attr.path)

# full SymbolNodes when you need them (e.g. for the codemod):
from dead_cst.codemod import remove_code
remove_code(ctx.nodes_at(list(analysis.dead())), project_root)
```

This brings Analysis in line with the plugin-side idiom that's been idiomatic since 0.13 — idx + ``node_attrs`` instead of full ``SymbolNode``. ``codemod.remove_code`` / ``generate_patch`` still take ``Iterable[SymbolNode]`` (they need ``imports`` / ``start_line`` beyond what ``NodeAttrs`` carries); CLI is untouched (its internal ``_select_dead`` uses ``view.reachable()`` directly).

## Public API

- ``dead_cst._native.NativePlugin`` — wrapper pyclass.
- ``NativePlugin.main_block()`` — first factory; constructs the ``MainBlockPlugin`` native impl.
- ``NativePlugin.name`` getter, ``NativePlugin.prepare(project_root)`` no-op (matches the Python ``Plugin`` protocol).
- ``Analysis(plugins=...)`` accepts ``(Plugin, _native.NativePlugin)`` so a native instance doesn't need to subclass the Python ``Plugin`` base.

## Usage

```python
from dead_cst import Analysis
from dead_cst import _native as native

# Drop-in replacement for the Python MainBlockPlugin().
analysis = Analysis(project_root, plugins=[native.NativePlugin.main_block()])
ctx = analysis.materialize_all()

# New indices-based Analysis API.
dead_attrs = ctx.node_attrs(list(analysis.dead()))
for attr in dead_attrs:
    print(attr.fqname)
```

## Tests

- ``tests/test_plugins/test_native_plugin.py`` — 6 new tests covering parity vs ``MainBlockPlugin``, marker emission + ``ENTRYPOINT`` flag, ``.name`` mirror, mixed native+Python registration, no-op path, direct-construction rejection.
- ``tests/test_kept_alive_by_noqa.py``, ``tests/test_kept_alive_by_tests.py``, ``tests/test_noqa_pinning.py``, ``tests/test_query_indices.py``, ``tests/test_incremental.py``, ``tests/e2e/test_flux0.py`` — updated to use the new indices-based ``Analysis`` API.

## Trade-offs

- **Zero per-op Python allocation + zero ``extract`` round-trip** for native plugins — the impl runs entirely rust-side, pushes ``PreparedOp`` directly.
- **Costs flexibility** — the impl is compiled into the wheel. Out-of-tree plugin authors can't override or dataclass-configure a native impl. Python plugins remain the right home for anything user-configurable.
- **``Analysis`` is a breaking change** for callers that did ``{n.fqname for n in analysis.dead()}``. Migration is one line: ``ctx = analysis.materialize_all(); {a.fqname for a in ctx.node_attrs(list(analysis.dead()))}``.

## Test plan

- [x] ``uv run pytest tests/test_plugins/test_native_plugin.py`` — 6 passed
- [x] ``uv run pytest`` — 780 passed
- [x] ``uv run prek run --all-files`` clean
- [x] CI green (lint, e2e, rust-test, build, test 3.11–3.14)

## Open questions for follow-up

- **Factory shape.** Each concrete impl is a ``@staticmethod`` on ``NativePlugin`` (``NativePlugin.main_block()``). Alternative: one ``NativePlugin`` subclass per impl. Sticking with factories until a clear winner emerges with more impls.
- **Configuration.** ``MainBlockPlugin`` has no configurable knobs, so this prototype dodges the question. A native ``ExplicitEntrypointPlugin`` would need to take user-provided specs through the factory — needs design.
- **Scope of next conversions.** Easy wins: pure-query+emit plugins with no user config (``ModuleDundersPlugin``, ``InitSubclassPlugin``).

🤖 Generated with [Claude Code](https://claude.com/claude-code)