### PR TITLE
Per-file native plugins with salsa-cached output

### DIFF
--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -2085,3 +2085,15 @@ def read_graph(path: str) -> tuple[NativeGraph, GraphMetadata]:
     a graph is cheap.
     """
     ...
+
+def _main_block_run_count() -> int:
+    """Test helper. Total executions of the per-file ``MainBlockPlugin``
+    impl since the last reset — a salsa cache *miss* counter. Lets the
+    test suite assert an unchanged main-block file isn't re-run on
+    ``re_materialize``. Not part of the supported surface.
+    """
+    ...
+
+def _reset_main_block_run_count() -> None:
+    """Test helper. Zero the :func:`_main_block_run_count` counter."""
+    ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ use crate::builder::{
 use crate::graph::{EdgeFlags, Import, NativeGraph, NodeFlags, SymbolNode};
 use crate::helpers::{ArgLiteral, ArgNodeRef, ArgOpaque, NodeAttrs};
 use crate::io::{read_graph, write_graph, GraphMetadata};
-use crate::native_plugins::NativePlugin;
+use crate::native_plugins::{_main_block_run_count, _reset_main_block_run_count, NativePlugin};
 use crate::progress::ProgressHandle;
 use crate::project::{ChangeEvent, Project, ProjectContext};
 use crate::query::{
@@ -118,6 +118,8 @@ fn dead_cst_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(query_fn, m)?)?;
     m.add_function(wrap_pyfunction!(write_graph, m)?)?;
     m.add_function(wrap_pyfunction!(read_graph, m)?)?;
+    m.add_function(wrap_pyfunction!(_main_block_run_count, m)?)?;
+    m.add_function(wrap_pyfunction!(_reset_main_block_run_count, m)?)?;
     Ok(())
 }
 

--- a/src/native_plugins.rs
+++ b/src/native_plugins.rs
@@ -42,10 +42,18 @@
 //! ``Analysis(plugins=[...])`` and inside the harness's
 //! :class:`ThreadPoolExecutor` fan-out.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use pyo3::prelude::*;
+use ruff_db::files::File;
+use ruff_db::parsed::parsed_module;
+use ruff_db::source::line_index;
+use ty_project::Db as ProjectDb;
 
 use crate::builder::PreparedOp;
+use crate::file_payload::{file_to_nodes, NodeData};
 use crate::graph::{intern_kind, NodeFlags};
+use crate::helpers::find_main_block_range;
 use crate::project::ProjectContext;
 
 /// Rust-side plugin contract. Each impl describes how to derive ops
@@ -65,31 +73,186 @@ pub(crate) trait NativePluginImpl: Send + Sync {
     /// for progress reporting (``plugin_start`` / ``plugin_end``
     /// events). Should match the conventional name of the equivalent
     /// Python plugin so existing harness logs read the same.
+    //
+    // Retained alongside the [`NativePluginKind::ProjectWide`] path for
+    // future native plugins whose logic spans files (subclass walks,
+    // dispatch handlers). The bundled `MainBlockPlugin` moved to the
+    // per-file path, so no impl uses this today.
+    #[allow(dead_code)]
     fn name(&self) -> &'static str;
 
     /// Walk the frozen ``ctx`` and append the plugin's ops to
     /// ``sink``. Same frozen-graph contract as the Python path: the
     /// impl observes the base graph only; its emissions are folded in
     /// by the apply pass after every plugin returns.
+    #[allow(dead_code)]
     fn run(&self, ctx: &ProjectContext, sink: &mut Vec<PreparedOp>) -> PyResult<()>;
 }
 
-/// Python-visible wrapper for a [`NativePluginImpl`]. Constructed via
-/// static factories (one per concrete impl, e.g.
+// ---------------------------------------------------------------------------
+// Per-file native plugins
+//
+// A *per-file* native plugin is invoked once per project file with a
+// restricted [`FileContext`] — it sees only that file's nodes / parsed
+// AST, nothing project-wide. The invocation is wrapped in the
+// [`per_file_plugin_ops`] salsa-tracked query, so when a file's
+// ``file_to_nodes`` / ``parsed_module`` is unchanged across a
+// ``re_materialize``, the plugin's cached output is reused with zero
+// re-run. Cache soundness comes from the restriction: a per-file
+// plugin can only reference nodes in its own file, so its output is a
+// pure function of that file's tracked inputs.
+//
+// Ops are emitted in a *file-local* index space ([`FileLocalOpData`]),
+// positions into ``FileNodes(file).refs``. The harness translates
+// those to global indices at apply time via the ``ref_to_global`` map.
+// ---------------------------------------------------------------------------
+
+/// File-local op produced by a [`PerFileNativePluginImpl`]. Mirrors
+/// ``AddNodeByIdx`` but with ``edges_to_local_idx`` as positions into
+/// the *file's own* ``FileNodes.refs`` array rather than global graph
+/// indices. Salsa-cached as the per-file plugin's output, so it must
+/// be pure rust + ``salsa::Update`` (no ``File`` handle, no global
+/// idx — both would couple the cache to project-wide assemble order).
+#[derive(Debug, Clone, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) struct FileLocalOpData {
+    pub(crate) fqname: String,
+    pub(crate) kind: &'static str,
+    pub(crate) flags: u32,
+    /// Indices into the owning file's ``FileNodes.refs`` array.
+    pub(crate) edges_to_local_idx: Vec<u32>,
+}
+
+/// Read-only, single-file view handed to a [`PerFileNativePluginImpl`].
+/// Deliberately tiny: it exposes only this file's salsa-tracked
+/// per-file payload + parsed AST. No project-wide queries, no
+/// ``node_attrs(indices)`` over arbitrary nodes — that restriction is
+/// what makes the plugin's output a pure function of the file and
+/// therefore salsa-cacheable.
+pub(crate) struct FileContext<'db> {
+    db: &'db dyn ProjectDb,
+    file: File,
+}
+
+impl<'db> FileContext<'db> {
+    fn new(db: &'db dyn ProjectDb, file: File) -> Self {
+        Self { db, file }
+    }
+
+    /// This file's nodes — index 0 is the synthetic module node, the
+    /// rest are top-level decls. Indices line up with [`Self::refs`].
+    pub(crate) fn nodes(&self) -> &'db [NodeData] {
+        &file_to_nodes(self.db, self.file).nodes
+    }
+
+    /// The file's module fqname (``nodes()[0].fqname``).
+    pub(crate) fn module_fqname(&self) -> &'db str {
+        &file_to_nodes(self.db, self.file).nodes[0].fqname
+    }
+
+    /// Local index of the synthetic module node (always 0 — kept as a
+    /// named accessor so impls don't hard-code the convention).
+    pub(crate) fn module_local_idx(&self) -> u32 {
+        0
+    }
+
+    /// 1-based ``(start_line, end_line)`` of the byte ``range`` in this
+    /// file, via the salsa-cached line index. Used to map a TextRange
+    /// (e.g. the ``if __name__`` block) onto the line numbers carried
+    /// by [`NodeData`].
+    pub(crate) fn line_span(&self, range: ruff_text_size::TextRange) -> (usize, usize) {
+        let source = ruff_db::source::source_text(self.db, self.file);
+        let idx = line_index(self.db, self.file);
+        let start = idx.line_column(range.start(), &source).line.get() as usize;
+        let end = idx.line_column(range.end(), &source).line.get() as usize;
+        (start, end)
+    }
+
+    /// The parsed module for this file (salsa-cached).
+    pub(crate) fn parsed(&self) -> ruff_db::parsed::ParsedModuleRef {
+        parsed_module(self.db, self.file).load(self.db)
+    }
+}
+
+/// Rust-side per-file plugin contract. Called once per project file
+/// with a restricted [`FileContext`]; pushes [`FileLocalOpData`] into
+/// the sink. Pure function of the file's tracked inputs — no
+/// project-wide reads, no side effects — so the harness can cache the
+/// result in salsa keyed on ``(file, name())``.
+pub(crate) trait PerFileNativePluginImpl: Send + Sync {
+    /// Walk ``file_ctx`` and append this file's ops to ``sink``.
+    /// Naming + salsa keying live on [`PerFilePluginKind`], so the
+    /// trait itself only carries the work method.
+    fn run_on_file(&self, file_ctx: &FileContext<'_>, sink: &mut Vec<FileLocalOpData>);
+}
+
+/// Salsa cache-key discriminant for a per-file plugin. A cheap
+/// ``Copy`` enum rather than a ``&'static str`` because salsa tracked
+/// function arguments must be owned + ``'static`` (a borrowed key
+/// would force ``'db: 'static``). One variant per configless per-file
+/// impl; configured per-file plugins would carry a config-hash here
+/// (out of scope).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum PerFilePluginKind {
+    MainBlock,
+}
+
+impl PerFilePluginKind {
+    /// Human-readable name, matching the equivalent Python plugin.
+    fn name(self) -> &'static str {
+        match self {
+            PerFilePluginKind::MainBlock => "MainBlockPlugin",
+        }
+    }
+
+    /// Run the concrete impl for this kind against ``file_ctx``.
+    fn run_on_file(self, file_ctx: &FileContext<'_>, sink: &mut Vec<FileLocalOpData>) {
+        match self {
+            PerFilePluginKind::MainBlock => MainBlockPluginImpl.run_on_file(file_ctx, sink),
+        }
+    }
+}
+
+/// Salsa-tracked per-file plugin invocation. Keyed on ``(file,
+/// kind)``; re-runs only when the file's tracked inputs
+/// (``file_to_nodes`` / ``parsed_module`` / ``line_index``) change.
+/// Returns the file-local ops the harness translates to global
+/// indices at apply time.
+#[salsa::tracked(returns(ref), heap_size = ruff_memory_usage::heap_size)]
+pub(crate) fn per_file_plugin_ops(
+    db: &dyn ProjectDb,
+    file: File,
+    kind: PerFilePluginKind,
+) -> Vec<FileLocalOpData> {
+    let file_ctx = FileContext::new(db, file);
+    let mut sink = Vec::new();
+    kind.run_on_file(&file_ctx, &mut sink);
+    sink
+}
+
+/// Internal classification of what a [`NativePlugin`] wraps. The
+/// harness branches on this: project-wide plugins run once against the
+/// whole ``ProjectContext``; per-file plugins run once per file
+/// through the salsa-cached [`per_file_plugin_ops`] query.
+pub(crate) enum NativePluginKind {
+    /// Project-wide native plugin — one ``run`` against the whole
+    /// graph. Retained for future non-file-local native plugins; the
+    /// bundled `MainBlockPlugin` is per-file, so nothing constructs
+    /// this variant today.
+    #[allow(dead_code)]
+    ProjectWide(Box<dyn NativePluginImpl>),
+    PerFile(PerFilePluginKind),
+}
+
+/// Python-visible wrapper for a native plugin (project-wide or
+/// per-file). Constructed via static factories (e.g.
 /// :meth:`NativePlugin.main_block`); ``__init__`` is intentionally
-/// unsupported so plugin authors discover the existing factories
-/// (and we keep the configuration surface inside the wrapper rust-
-/// side).
+/// unsupported.
 ///
-/// Sendable because the inner trait bound (``Send + Sync``) carries
-/// across: the harness drives plugins from a
-/// :class:`ThreadPoolExecutor`, so the ``Py<NativePlugin>`` handle
-/// shuttles between threads alongside Python plugins. The impl's
-/// :meth:`run` is invoked under the GIL on whichever worker picks
-/// up the task.
+/// Sendable so the harness can shuttle the handle between
+/// :class:`ThreadPoolExecutor` workers alongside Python plugins.
 #[pyclass(name = "NativePlugin")]
 pub(crate) struct NativePlugin {
-    pub(crate) inner: Box<dyn NativePluginImpl>,
+    pub(crate) kind: NativePluginKind,
 }
 
 #[pymethods]
@@ -100,28 +263,31 @@ impl NativePlugin {
     /// native or Python instance is registered.
     #[getter]
     fn name(&self) -> &'static str {
-        self.inner.name()
+        match &self.kind {
+            NativePluginKind::ProjectWide(inner) => inner.name(),
+            NativePluginKind::PerFile(kind) => kind.name(),
+        }
     }
 
     /// ``Plugin`` protocol's ``prepare(project_root)`` no-op hook.
-    /// Native plugins don't have a pre-graph prepare phase today —
-    /// every impl reads from the frozen ctx in :meth:`run`.
+    /// Native plugins don't have a pre-graph prepare phase today.
     fn prepare(&self, _project_root: PyObject) {}
 
-    /// Construct the native [``MainBlockPlugin``](
-    /// crate::native_plugins::MainBlockPluginImpl) — same observable
-    /// behaviour as ``dead_cst.plugins.MainBlockPlugin``, no Python
-    /// loop or ``AddNodeByIdx`` allocation in the hot path.
+    /// Construct the native ``MainBlockPlugin`` — same observable
+    /// behaviour as ``dead_cst.plugins.MainBlockPlugin``, but
+    /// implemented as a *per-file* plugin: invoked once per file
+    /// through a salsa-cached query, so an unchanged file's marker is
+    /// reused across ``re_materialize`` with zero re-run.
     #[staticmethod]
     fn main_block() -> Self {
         Self {
-            inner: Box::new(MainBlockPluginImpl),
+            kind: NativePluginKind::PerFile(PerFilePluginKind::MainBlock),
         }
     }
 }
 
 // ---------------------------------------------------------------------------
-// MainBlockPlugin — first native impl. Equivalent to
+// MainBlockPlugin — first per-file impl. Equivalent to
 // ``dead_cst.plugins.main_block.MainBlockPlugin``: emit one synthetic
 // ``<__main__>:<module_fqname>`` entrypoint per file with a top-level
 // ``if __name__ == "__main__":`` block, with edges to the containing
@@ -130,40 +296,54 @@ impl NativePlugin {
 
 const MAIN_BLOCK_PREFIX: &str = "<__main__>:";
 
+/// Test-only counter: number of times [`MainBlockPluginImpl::run_on_file`]
+/// actually executed (i.e. salsa cache *misses* for the per-file
+/// query). A salsa hit reuses the cached ops without touching the
+/// impl, so this counter stays flat for unchanged files across a
+/// ``re_materialize``. Surfaced to tests via
+/// :func:`main_block_run_count` / :func:`reset_main_block_run_count`.
+static MAIN_BLOCK_RUN_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// Test helper — total `MainBlockPluginImpl::run_on_file` executions
+/// since the last reset. Lets the cache-behaviour test assert that an
+/// unchanged main-block file isn't re-run on ``re_materialize``.
+#[pyfunction]
+pub(crate) fn _main_block_run_count() -> usize {
+    MAIN_BLOCK_RUN_COUNT.load(Ordering::Relaxed)
+}
+
+/// Test helper — zero the [`MAIN_BLOCK_RUN_COUNT`] counter.
+#[pyfunction]
+pub(crate) fn _reset_main_block_run_count() {
+    MAIN_BLOCK_RUN_COUNT.store(0, Ordering::Relaxed);
+}
+
 pub(crate) struct MainBlockPluginImpl;
 
-impl NativePluginImpl for MainBlockPluginImpl {
-    fn name(&self) -> &'static str {
-        "MainBlockPlugin"
-    }
-
-    fn run(&self, ctx: &ProjectContext, sink: &mut Vec<PreparedOp>) -> PyResult<()> {
-        let pairs = ctx.find_main_blocks_indices()?;
-        if pairs.is_empty() {
-            return Ok(());
+impl PerFileNativePluginImpl for MainBlockPluginImpl {
+    fn run_on_file(&self, file_ctx: &FileContext<'_>, sink: &mut Vec<FileLocalOpData>) {
+        MAIN_BLOCK_RUN_COUNT.fetch_add(1, Ordering::Relaxed);
+        let parsed = file_ctx.parsed();
+        let Some(block_range) = find_main_block_range(&parsed) else {
+            return;
+        };
+        let (block_start_line, block_end_line) = file_ctx.line_span(block_range);
+        let nodes = file_ctx.nodes();
+        // Local indices of every top-level decl whose source span falls
+        // inside the ``if __name__`` block. Skip index 0 (the module
+        // node) — it's added explicitly below as the first edge.
+        let mut edges_to_local_idx: Vec<u32> = vec![file_ctx.module_local_idx()];
+        for (local_idx, node) in nodes.iter().enumerate().skip(1) {
+            if node.start_line >= block_start_line && node.end_line <= block_end_line {
+                edges_to_local_idx.push(local_idx as u32);
+            }
         }
-        // One batched ``node_attrs`` for every matched module — same
-        // shape the Python ``MainBlockPlugin`` uses, but without the
-        // ``Py<NodeAttrs>`` round-trip: we read straight off the
-        // ``Vec<NodeAttrs>`` the rust helper returns. Note: no ``py``
-        // argument — ``node_attrs`` reads via ``Py::get`` (frozen-Sync
-        // pyclass fast path).
-        let module_idxs: Vec<usize> = pairs.iter().map(|(m, _)| *m).collect();
-        let attrs = ctx.node_attrs(module_idxs)?;
-        let synthetic_kind = intern_kind("synthetic")?;
-        for ((module_idx, decl_idxs), attr) in pairs.iter().zip(attrs.iter()) {
-            let mut edges_to_idx: Vec<usize> = Vec::with_capacity(decl_idxs.len() + 1);
-            edges_to_idx.push(*module_idx);
-            edges_to_idx.extend(decl_idxs);
-            sink.push(PreparedOp::NodeByIdx {
-                fqname: format!("{MAIN_BLOCK_PREFIX}{}", attr.fqname),
-                kind: synthetic_kind,
-                path: attr.path.clone(),
-                flags: NodeFlags::ENTRYPOINT,
-                edges_from_idx: Vec::new(),
-                edges_to_idx,
-            });
-        }
-        Ok(())
+        let synthetic_kind = intern_kind("synthetic").expect("'synthetic' is a valid kind");
+        sink.push(FileLocalOpData {
+            fqname: format!("{MAIN_BLOCK_PREFIX}{}", file_ctx.module_fqname()),
+            kind: synthetic_kind,
+            flags: NodeFlags::ENTRYPOINT,
+            edges_to_local_idx,
+        });
     }
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -170,6 +170,12 @@ pub(crate) struct BuildOutputs {
     /// O(1) fast path; not yet wired into the current path.
     #[allow(dead_code)]
     pub(crate) children_by_fqn: FxHashMap<String, Vec<usize>>,
+    /// `(file, local_idx) -> global node idx`, where ``local_idx`` is a
+    /// position in that file's ``FileNodes.refs`` array. Lets per-file
+    /// native plugins emit ops in file-local index space; the harness
+    /// translates them to global indices at apply time. See
+    /// [`crate::native_plugins`].
+    pub(crate) local_to_global: FxHashMap<(File, u32), usize>,
 }
 
 /// Run the three build phases (ingest → hierarchy+imports → references)
@@ -398,6 +404,7 @@ pub(crate) fn build_project_graph(
     let module_nodes_by_file = assembled.module_nodes_by_file;
     let class_by_selection = assembled.class_by_selection;
     let decl_by_name_range = assembled.decl_by_name_range;
+    let local_to_global = assembled.local_to_global;
     let ref_to_global = assembled.ref_to_global;
 
     counters.start_phase(PHASE_FQNAME, Some(builder.nodes.len()));
@@ -462,6 +469,7 @@ pub(crate) fn build_project_graph(
         children_by_node,
         children_by_fqn,
         children_by_parent,
+        local_to_global,
     })
 }
 
@@ -492,6 +500,12 @@ struct AssembledGraph<'db> {
     module_nodes_by_file: FxHashMap<File, usize>,
     class_by_selection: FxHashMap<(File, (u32, u32)), usize>,
     decl_by_name_range: FxHashMap<(File, (u32, u32)), usize>,
+    /// `(file, local_idx) -> global node idx`. ``local_idx`` is the
+    /// position in that file's ``FileNodes.refs`` array. Lets per-file
+    /// native plugins (which emit ops in file-local index space) get
+    /// translated to global indices at apply time without a live
+    /// ``ref_to_global`` (whose ``'db`` lifetime can't outlive assemble).
+    local_to_global: FxHashMap<(File, u32), usize>,
     /// PROTOTYPE: kept around so the class-hierarchy builder can map
     /// `NodeRef -> global idx`.
     ref_to_global: FxHashMap<NodeRef<'db>, usize>,
@@ -562,6 +576,8 @@ fn assemble_graph<'db>(
         FxHashMap::with_capacity_and_hasher(total_decls, Default::default());
     let mut ref_to_global: FxHashMap<NodeRef<'db>, usize> =
         FxHashMap::with_capacity_and_hasher(total_nodes, Default::default());
+    let mut local_to_global: FxHashMap<(File, u32), usize> =
+        FxHashMap::with_capacity_and_hasher(total_nodes, Default::default());
     let mut all_warnings: Vec<String> = Vec::new();
 
     // Pass 1: node mint.
@@ -628,6 +644,7 @@ fn assemble_graph<'db>(
             };
             let global_idx = builder.intern_node(py, symbol)?;
             ref_to_global.insert(node_ref, global_idx);
+            local_to_global.insert((file, local_idx as u32), global_idx);
 
             match node_ref {
                 NodeRef::Module(_) => {
@@ -844,6 +861,7 @@ fn assemble_graph<'db>(
         module_nodes_by_file,
         class_by_selection,
         decl_by_name_range,
+        local_to_global,
         ref_to_global,
     })
 }
@@ -1722,17 +1740,26 @@ fn collect_prepared_plugin_ops(
     plugin: &PyObject,
     sink: &mut Vec<PreparedOp>,
 ) -> PyResult<()> {
-    // Native fast path: ``NativePlugin`` instances expose a rust
-    // [`NativePluginImpl::run`] that fills ``sink`` directly with
-    // [`PreparedOp`] variants — no Python ``.run(ctx)`` call, no
-    // ``GraphOp`` allocation per yield, no ``prepare_graph_op``
-    // extraction loop. The frozen-graph contract is identical to
-    // the Python path: the impl borrows ``ctx`` immutably; the
-    // apply pass folds ``sink`` in afterwards.
+    // Native fast path: ``NativePlugin`` instances run rust directly,
+    // filling ``sink`` with [`PreparedOp`] variants — no Python
+    // ``.run(ctx)`` call, no ``GraphOp`` allocation per yield, no
+    // ``prepare_graph_op`` extraction loop. The frozen-graph contract
+    // is identical to the Python path.
     let plugin_bound = plugin.bind(py);
     if let Ok(native) = plugin_bound.downcast::<crate::native_plugins::NativePlugin>() {
         let ctx_ref = ctx.borrow(py);
-        return native.borrow().inner.run(&ctx_ref, sink);
+        match &native.borrow().kind {
+            // Project-wide impl: one ``run`` against the whole graph.
+            crate::native_plugins::NativePluginKind::ProjectWide(inner) => {
+                return inner.run(&ctx_ref, sink);
+            }
+            // Per-file impl: invoke the salsa-cached per-file query for
+            // every project file, translating each file-local op to a
+            // global ``PreparedOp::NodeByIdx`` via ``local_to_global``.
+            crate::native_plugins::NativePluginKind::PerFile(kind) => {
+                return ctx_ref.collect_per_file_plugin_ops(*kind, sink);
+            }
+        }
     }
     let result = plugin_bound.call_method1("run", (ctx.clone_ref(py),))?;
     if result.is_none() {
@@ -1818,6 +1845,47 @@ impl ProjectContext {
             return Err(not_materialized(op));
         }
         Ok(RwLockReadGuard::map(guard, |o| o.as_ref().unwrap()))
+    }
+
+    /// Drive a per-file native plugin across every project file and
+    /// translate its file-local ops to global [`PreparedOp`]s.
+    ///
+    /// For each file, the salsa-cached [`per_file_plugin_ops`] query
+    /// returns the plugin's [`FileLocalOpData`] (cheap on cache hit —
+    /// unchanged files skip the plugin re-run entirely). Each op's
+    /// ``edges_to_local_idx`` are positions in that file's
+    /// ``FileNodes.refs``; we map them to global indices via the
+    /// build's ``local_to_global`` table. A local idx with no global
+    /// entry (shouldn't happen for a well-formed plugin) is skipped.
+    pub(crate) fn collect_per_file_plugin_ops(
+        &self,
+        kind: crate::native_plugins::PerFilePluginKind,
+        sink: &mut Vec<PreparedOp>,
+    ) -> PyResult<()> {
+        let outputs = self.materialized("collect_per_file_plugin_ops")?;
+        for &file in &outputs.project_files {
+            let file_ops = crate::native_plugins::per_file_plugin_ops(&self.db, file, kind);
+            if file_ops.is_empty() {
+                continue;
+            }
+            let path = file_path_string(&self.db, file);
+            for op in file_ops {
+                let edges_to_idx: Vec<usize> = op
+                    .edges_to_local_idx
+                    .iter()
+                    .filter_map(|&local| outputs.local_to_global.get(&(file, local)).copied())
+                    .collect();
+                sink.push(PreparedOp::NodeByIdx {
+                    fqname: op.fqname.clone(),
+                    kind: op.kind,
+                    path: path.clone(),
+                    flags: op.flags,
+                    edges_from_idx: Vec::new(),
+                    edges_to_idx,
+                });
+            }
+        }
+        Ok(())
     }
 }
 

--- a/tests/test_plugins/test_native_plugin.py
+++ b/tests/test_plugins/test_native_plugin.py
@@ -108,3 +108,92 @@ def test_native_plugin_cannot_be_directly_instantiated():
 
     with pytest.raises(TypeError):
         native.NativePlugin()
+
+
+# ---------------------------------------------------------------------------
+# Per-file salsa caching: the per-file MainBlockPlugin is invoked through a
+# salsa-tracked query keyed on (file, kind). Unchanged files reuse the
+# cached ops across re_materialize without re-running the impl. These tests
+# use the rust-side run-counter (``_main_block_run_count`` / reset) to assert
+# the cache actually fires.
+# ---------------------------------------------------------------------------
+
+
+def _write(path, src: str) -> None:
+    import textwrap
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(src).strip() + "\n")
+
+
+def test_per_file_main_block_caches_unchanged_files(tmp_path):
+    """Editing one file should re-run the per-file MainBlock plugin for
+    *only* that file on ``re_materialize`` — every other file's marker is
+    served from the salsa cache."""
+    from dead_cst import Analysis
+
+    _write(tmp_path / "pkg/__init__.py", "")
+    _write(
+        tmp_path / "pkg/a.py",
+        """
+        def main(): pass
+        if __name__ == "__main__":
+            main()
+        """,
+    )
+    _write(
+        tmp_path / "pkg/b.py",
+        """
+        def serve(): pass
+        if __name__ == "__main__":
+            serve()
+        """,
+    )
+    _write(tmp_path / "pkg/c.py", "def helper(): pass\n")
+
+    analysis = Analysis(tmp_path, plugins=[native.NativePlugin.main_block()])
+    native._reset_main_block_run_count()
+    analysis.materialize_all()
+    first_pass = native._main_block_run_count()
+    # Cold build: the impl runs once per project file (a, b, c, __init__).
+    assert first_pass >= 3
+
+    # Edit only c.py (no main block either before or after). On
+    # re_materialize, a.py and b.py must hit the salsa cache; only c.py
+    # re-runs the impl.
+    native._reset_main_block_run_count()
+    _write(tmp_path / "pkg/c.py", "def helper(): pass\ndef extra(): pass\n")
+    analysis.re_materialize(analysis.materialize_all().detect_changes())
+    second_pass = native._main_block_run_count()
+    assert second_pass == 1, (
+        f"expected exactly 1 per-file re-run (the edited c.py), got {second_pass} "
+        "— salsa cache for unchanged a.py/b.py/__init__.py should have served their ops"
+    )
+
+
+def test_per_file_main_block_cache_invalidates_on_edit(tmp_path):
+    """Editing the main-block file itself re-runs its per-file plugin and
+    reflects the new block contents."""
+    from dead_cst import Analysis
+
+    _write(tmp_path / "pkg/__init__.py", "")
+    _write(
+        tmp_path / "pkg/a.py",
+        """
+        def main(): pass
+        if __name__ == "__main__":
+            main()
+        """,
+    )
+
+    analysis = Analysis(tmp_path, plugins=[native.NativePlugin.main_block()])
+    ctx = analysis.materialize_all()
+    assert any(n.fqname == "<__main__>:pkg.a" for n in ctx.nodes())
+
+    # Remove the main block entirely; the marker should disappear after
+    # re_materialize (cache miss on the edited file).
+    native._reset_main_block_run_count()
+    _write(tmp_path / "pkg/a.py", "def main(): pass\n")
+    ctx2 = analysis.re_materialize(analysis.materialize_all().detect_changes())
+    assert native._main_block_run_count() >= 1  # a.py re-ran
+    assert not any(n.fqname == "<__main__>:pkg.a" for n in ctx2.nodes())


### PR DESCRIPTION
## Summary

Adds a **per-file** native plugin path on top of the project-wide one from #245. A per-file plugin is invoked once per file with a restricted view, and its output is cached in salsa keyed on `(file, kind)`. On `re_materialize`, unchanged files reuse the cached ops with zero re-run — inheriting the same incremental win the per-file `file_to_nodes` / `file_to_edges` salsa queries already give the graph build.

### How it works

- **`FileContext` — restricted query API.** Exposes only this file's salsa-tracked payload + parsed AST: `nodes()` (the file's `NodeData` slice), `module_fqname()`, `module_local_idx()`, `line_span(range)`, `parsed()`. No project-wide `query(ctx)`, no arbitrary `node_attrs(indices)`. That restriction is the cache-soundness constraint: a plugin's output is a pure function of the file's tracked inputs.
- **File-local op space.** Per-file plugins emit `FileLocalOpData` whose `edges_to_local_idx` are positions in the file's own `FileNodes.refs`. The harness translates them to global indices at apply time via a new `local_to_global: (File, u32) -> usize` index built during assemble. (`ref_to_global` can't be persisted — its `'db` lifetime can't outlive the assemble pass.) No new `PreparedOp` variant: file-local ops fold into the existing `NodeByIdx` once resolved.
- **Salsa wiring.** `per_file_plugin_ops(db, file, kind)` is a `#[salsa::tracked]` function returning `Vec<FileLocalOpData>`. `kind` is a `Copy` `PerFilePluginKind` enum (salsa keys must be owned + `'static`; a `&'static str` would force `'db: 'static`). `FileContext` reads only tracked per-file inputs, so editing one file invalidates only that file's cached ops.

### MainBlockPlugin converted

`MainBlockPluginImpl` moves from the project-wide `NativePluginImpl` (#245) to the per-file `PerFileNativePluginImpl`. `NativePlugin.main_block()` is unchanged from the Python user's perspective. The project-wide `NativePluginImpl` trait + `ProjectWide` variant are retained (`#[allow(dead_code)]`) for future non-file-local native plugins.

### Tests (8 in `test_native_plugin.py`)

The 6 parity/registration tests from #245 still pass against the per-file impl. Two new salsa-cache tests use a rust-side run-counter (`_main_block_run_count` / `_reset_main_block_run_count`):

- `test_per_file_main_block_caches_unchanged_files` — edit one unrelated file, `re_materialize`, assert the per-file plugin re-ran for **exactly that one file** (every unchanged file served from the salsa cache).
- `test_per_file_main_block_cache_invalidates_on_edit` — edit the main-block file itself, assert the cache misses and the marker reflects the new contents.

## Design choices (from the planning conversation)

- **File-local indices only** — per-file plugins reference only nodes in their own file; harness resolves to global at apply time.
- **Rust-only** — Python plugins can't be salsa-cached (opaque side effects, no stable hash). The per-file path is a `NativePluginImpl` sibling.
- **MainBlockPlugin first** — smallest file-local impl to validate the pipeline.

## Out of scope (deferred)

- Configured per-file plugins (dataclass fields) — would need `PerFilePluginKind` to carry a config-hash.
- `FileLocalEdge` / `FileLocalEntrypoint` op variants — only `FileLocalNode`-shape (via `NodeByIdx`) needed for MainBlock.
- Rayon parallelism over the per-file invocations — single-threaded for the prototype.
- Converting other per-file-shaped plugins (`ModuleDundersPlugin`, `PytestPlugin`).

## Test plan

- [x] `uv run pytest tests/test_plugins/test_native_plugin.py` — 8 passed
- [x] `uv run pytest tests/test_incremental.py` — re_materialize path
- [x] `uv run pytest` — 782 passed
- [x] `uv run prek run --all-files` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)