### PR TITLE
Fix macOS dynamic-wheel repack (duplicate rpath + install-name relocation)

### DIFF
--- a/scripts/repack_dynamic_wheel.py
+++ b/scripts/repack_dynamic_wheel.py
@@ -62,29 +62,79 @@ def _host_std_lib() -> Path:
     return sysroot / "lib" / "rustlib" / host / "lib"
 
 
-def _set_rpath_origin(lib: Path) -> None:
-    """Point ``lib`` at its own directory for sibling resolution, dropping the
-    builder's absolute rpaths so the wheel relocates. No-op (with a warning) if
-    the platform tool is missing — the prefer-dynamic build already bakes the
-    loader-relative entry, so siblings still resolve; this is hygiene."""
-    if _is_macos():
-        tool = "install_name_tool"
-        if shutil.which(tool) is None:
-            print(f"warning: {tool} not found; leaving rpaths as built", file=sys.stderr)
-            return
-        # Best-effort: ensure @loader_path is present (the build already adds it).
-        _run(tool, "-add_rpath", "@loader_path", str(lib))
-    else:
-        if shutil.which("patchelf") is None:
-            print("warning: patchelf not found; leaving rpaths as built", file=sys.stderr)
-            return
-        _run("patchelf", "--set-rpath", "$ORIGIN", str(lib))
+def _otool_load_paths(lib: Path) -> list[str]:
+    out = subprocess.run(
+        ["otool", "-L", str(lib)], capture_output=True, text=True, check=True
+    ).stdout
+    return [line.strip().split(" ", 1)[0] for line in out.splitlines()[1:] if line.strip()]
+
+
+def _otool_rpaths(lib: Path) -> set[str]:
+    out = subprocess.run(
+        ["otool", "-l", str(lib)], capture_output=True, text=True, check=True
+    ).stdout
+    lines = out.splitlines()
+    found: set[str] = set()
+    for i, line in enumerate(lines):
+        if "LC_RPATH" in line:
+            for follow in lines[i : i + 4]:
+                s = follow.strip()
+                if s.startswith("path "):
+                    found.add(s[len("path ") :].split(" (offset")[0].strip())
+    return found
+
+
+def _relocate_linux(lib: Path) -> None:
+    """Set ``lib``'s run path to ``$ORIGIN`` (sibling resolution), dropping the
+    builder's absolute rpaths. ``patchelf --set-rpath`` overwrites wholesale.
+    No-op (warning) without patchelf — the build bakes ``$ORIGIN`` too."""
+    if shutil.which("patchelf") is None:
+        print("warning: patchelf not found; leaving rpaths as built", file=sys.stderr)
+        return
+    _run("patchelf", "--set-rpath", "$ORIGIN", str(lib))
+
+
+def _relocate_macos(module: Path, runtime: Path, std_lib: Path) -> None:
+    """Rewrite install names so the shim + runtime load each other (and libstd)
+    relocatably via ``@rpath`` / ``@loader_path``. The prefer-dynamic build
+    already bakes ``@loader_path`` (so only add it when missing) and the absolute
+    sysroot rpath (drop it)."""
+    if shutil.which("install_name_tool") is None:
+        print(
+            "warning: install_name_tool not found; leaving install names as built", file=sys.stderr
+        )
+        return
+    runtime_id = f"@rpath/{runtime.name}"
+
+    def ensure_loader_path(lib: Path) -> None:
+        if "@loader_path" not in _otool_rpaths(lib):
+            _run("install_name_tool", "-add_rpath", "@loader_path", str(lib))
+
+    def drop_abs_std(lib: Path) -> None:
+        if str(std_lib) in _otool_rpaths(lib):
+            _run("install_name_tool", "-delete_rpath", str(std_lib), str(lib))
+
+    # runtime: relocatable id + @loader_path (to find its sibling libstd).
+    _run("install_name_tool", "-id", runtime_id, str(runtime))
+    ensure_loader_path(runtime)
+    drop_abs_std(runtime)
+
+    # shim: point its load command for the runtime at @rpath; @loader_path rpath.
+    for path in _otool_load_paths(module):
+        if "libdead_cst_runtime" in path and path != runtime_id:
+            _run("install_name_tool", "-change", path, runtime_id, str(module))
+            break
+    ensure_loader_path(module)
+    drop_abs_std(module)
 
 
 def _strip(lib: Path) -> None:
+    # Strip debug info only: keeps the dynamic symbol table AND the embedded
+    # rust metadata section, so `build-plugin`'s `rustc --extern` against the
+    # shipped runtime dylib still reads its crate metadata.
     if shutil.which("strip") is None:
         return
-    _run("strip", *(["-x"] if _is_macos() else ["--strip-unneeded"]), str(lib))
+    _run("strip", *(["-S"] if _is_macos() else ["--strip-debug"]), str(lib))
 
 
 def _resign(lib: Path) -> None:
@@ -126,11 +176,15 @@ def repack(static_wheel: Path, deps_dir: Path, std_lib: Path, out_dir: Path) -> 
         shutil.copyfile(runtime_src, runtime_dst)
         shutil.copyfile(libstd_src, libstd_dst)
 
-        for lib in (module, runtime_dst):
-            _set_rpath_origin(lib)
+        if _is_macos():
+            _relocate_macos(module, runtime_dst, std_lib)
+        else:
+            for lib in (module, runtime_dst):
+                _relocate_linux(lib)
         for lib in (module, runtime_dst, libstd_dst):
             _strip(lib)
-            _resign(lib)
+        for lib in (module, runtime_dst, libstd_dst):
+            _resign(lib)  # no-op off macOS
 
         _run(sys.executable, "-m", "wheel", "pack", str(unpacked), "-d", str(out_dir))
 


### PR DESCRIPTION
## Problem

The publish workflow's macOS `dynamic` job crashed in the repack:

```
install_name_tool: ... option "-add_rpath @loader_path" would duplicate path,
file already has LC_RPATH for: @loader_path
```

The prefer-dynamic build already bakes an `@loader_path` rpath, so the unconditional `-add_rpath` is a duplicate. Worse, adding the rpath alone was never sufficient on macOS — the shipped dylibs also need their **install names** rewritten or `dyld` can't locate the runtime at load.

## Fix

Port the relocation that the old `_relocate_bundle_macos` did into `scripts/repack_dynamic_wheel.py`'s macOS path:

- set the runtime's install **id** to `@rpath/libdead_cst_runtime.dylib`,
- rewrite the `_native` shim's load command to reference it (`install_name_tool -change`),
- add `@loader_path` **only when missing** (the actual crash fix — guarded via `otool -l`),
- drop the builder's absolute sysroot rpath.

Linux is unchanged (soname + `patchelf --set-rpath $ORIGIN`, which overwrites wholesale — no duplicate).

Also switched the strip from `--strip-unneeded` to **debug-only** (`-S` / `--strip-debug`) so the runtime dylib keeps its `.rustc` metadata section, which `build-plugin`'s `rustc --extern` reads.

## Validation

- Linux re-validated locally: the strip-debug'd wheel installs into a fresh venv and runs `materialize_all()` with the runtime resolved via `$ORIGIN`, and a plugin still compiles against the in-wheel runtime (`.rustc` survives `--strip-debug`).
- The macOS path mirrors the previously-working bundle relocation; it can't be run from the Linux sandbox, so the macOS `dynamic` job on this PR is the real test.

https://claude.ai/code/session_01SKCtADZNXrZQ61zg5kGVNE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKCtADZNXrZQ61zg5kGVNE)_