### PR TITLE
Port server_config (per-file) + unittest native plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,15 +103,19 @@ two versions.
 ### Changed
 
 - **Built-in plugins are migrating to native (Rust) implementations.**
-  The `main_block`, `module_dunders`, and `init_subclass` built-ins now
-  resolve to native `NativePlugin` instances through a Rust registry
+  The `main_block`, `module_dunders`, `init_subclass`, `server_config`,
+  and `unittest` built-ins now resolve to native `NativePlugin`
+  instances through a Rust registry
   (`native._builtin_native_plugin(name)`) that the CLI's `_load_plugin`
   consults before the Python builtin map. Behaviour is identical;
-  `module_dunders` is now a *per-file* (salsa-cached) plugin, so an
-  unchanged file's dunder/`__future__` entrypoints are reused across
-  `re_materialize` with zero re-run. The Python `ModuleDundersPlugin` /
-  `InitSubclassPlugin` / `MainBlockPlugin` classes remain available for
-  now; they will be removed once every built-in is ported.
+  `module_dunders` and `server_config` are *per-file* (salsa-cached)
+  plugins, so an unchanged file's entrypoints are reused across
+  `re_materialize` with zero re-run. The native `server_config` bakes
+  the default server-config filename set; the Python `ServerConfigPlugin`
+  remains for custom filenames. The Python `ModuleDundersPlugin` /
+  `InitSubclassPlugin` / `MainBlockPlugin` / `ServerConfigPlugin` /
+  `UnittestPlugin` classes remain available for now; they will be removed
+  once every built-in is ported.
 
 ### Removed
 

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -388,6 +388,26 @@ class NativePlugin:
         """
         ...
 
+    @staticmethod
+    def server_config() -> NativePlugin:
+        """Native equivalent of
+        :class:`dead_cst.contrib.server_config.ServerConfigPlugin`.
+        Marks conventional WSGI/ASGI server-config modules
+        (``gunicorn.conf.py``, ``hypercorn.conf.py``, …) as entrypoints.
+        Per-file (salsa-cached); bakes the default filename set.
+        """
+        ...
+
+    @staticmethod
+    def unittest() -> NativePlugin:
+        """Native equivalent of
+        :class:`dead_cst.contrib.unittest.UnittestPlugin`. Keeps stdlib
+        ``unittest`` test classes (transitive subclasses of
+        ``TestCase`` / ``IsolatedAsyncioTestCase``) and module lifecycle
+        hooks alive.
+        """
+        ...
+
 def _builtin_native_plugin(name: str) -> NativePlugin | None:
     """Resolve a built-in plugin name (e.g. ``"main_block"``) to its
     native implementation, or ``None`` if no native plugin owns that

--- a/python/dead_cst/cli.py
+++ b/python/dead_cst/cli.py
@@ -43,10 +43,8 @@ from .contrib.fastmcp import fastmcp_plugin
 from .contrib.flask import flask_plugin
 from .contrib.mock_patch import MockPatchPlugin
 from .contrib.pytest import PytestPlugin
-from .contrib.server_config import ServerConfigPlugin
 from .contrib.slack_bolt import slack_bolt_plugin
 from .contrib.typer import typer_plugin
-from .contrib.unittest import UnittestPlugin
 from .graph import (
     KEEPALIVE_DEFAULT,
     GraphMetadata,
@@ -71,16 +69,15 @@ app = typer.Typer(help="Dead code analysis for Python.")
 
 
 # Python-side built-ins. Plugins ported to Rust (``main_block``,
-# ``module_dunders``, ``init_subclass``) are *not* here — ``_load_plugin``
-# resolves those through the native registry (``_builtin_native_plugin``)
-# first, so they move out of this map as they're ported.
+# ``module_dunders``, ``init_subclass``, ``server_config``, ``unittest``)
+# are *not* here — ``_load_plugin`` resolves those through the native
+# registry (``_builtin_native_plugin``) first, so they move out of this map
+# as they're ported.
 _BUILTIN_PLUGINS: dict[str, Plugin] = {
     "project_scripts": ProjectScriptsPlugin(),
     "explicit": ExplicitEntrypointPlugin(),
     "pytest": PytestPlugin(),
-    "unittest": UnittestPlugin(),
     "mock_patch": MockPatchPlugin(),
-    "server_config": ServerConfigPlugin(),
     "fastapi": fastapi_plugin(),
     "fastmcp": fastmcp_plugin(),
     "flask": flask_plugin(),

--- a/runtime/src/native_plugins.rs
+++ b/runtime/src/native_plugins.rs
@@ -197,6 +197,7 @@ pub(crate) trait PerFileNativePluginImpl: Send + Sync {
 pub(crate) enum PerFilePluginKind {
     MainBlock,
     ModuleDunders,
+    ServerConfig,
 }
 
 impl PerFilePluginKind {
@@ -205,6 +206,7 @@ impl PerFilePluginKind {
         match self {
             PerFilePluginKind::MainBlock => "MainBlockPlugin",
             PerFilePluginKind::ModuleDunders => "ModuleDundersPlugin",
+            PerFilePluginKind::ServerConfig => "ServerConfigPlugin",
         }
     }
 
@@ -213,6 +215,7 @@ impl PerFilePluginKind {
         match self {
             PerFilePluginKind::MainBlock => MainBlockPluginImpl.run_on_file(file_ctx, sink),
             PerFilePluginKind::ModuleDunders => ModuleDundersPluginImpl.run_on_file(file_ctx, sink),
+            PerFilePluginKind::ServerConfig => ServerConfigPluginImpl.run_on_file(file_ctx, sink),
         }
     }
 }
@@ -384,6 +387,28 @@ impl NativePlugin {
             kind: NativePluginKind::ProjectWide(Box::new(InitSubclassPluginImpl)),
         }
     }
+
+    /// Native `ServerConfigPlugin` — mark conventional WSGI/ASGI server
+    /// config modules (`gunicorn.conf.py`, `hypercorn.conf.py`, …) as
+    /// entrypoints. Per-file (salsa-cached): a file matches purely on its
+    /// own basename and keeps its own top-level surface alive. Bakes the
+    /// default filename set; the configurable Python plugin remains for
+    /// custom filenames.
+    #[staticmethod]
+    fn server_config() -> Self {
+        Self {
+            kind: NativePluginKind::PerFile(PerFilePluginKind::ServerConfig),
+        }
+    }
+
+    /// Native `UnittestPlugin` — keep stdlib `unittest` test classes and
+    /// lifecycle hooks alive. Project-wide (the subclass walk spans files).
+    #[staticmethod]
+    fn unittest() -> Self {
+        Self {
+            kind: NativePluginKind::ProjectWide(Box::new(UnittestPluginImpl)),
+        }
+    }
 }
 
 /// Resolve a built-in plugin name to its native implementation, or `None`
@@ -396,6 +421,8 @@ pub(crate) fn _builtin_native_plugin(name: &str) -> Option<NativePlugin> {
         "main_block" => NativePlugin::main_block(),
         "module_dunders" => NativePlugin::module_dunders(),
         "init_subclass" => NativePlugin::init_subclass(),
+        "server_config" => NativePlugin::server_config(),
+        "unittest" => NativePlugin::unittest(),
         _ => return None,
     })
 }
@@ -1007,6 +1034,26 @@ pub(crate) fn load_native_plugins(path: String) -> PyResult<Vec<NativePlugin>> {
 
 const MODULE_DUNDERS_PREFIX: &str = "<dunder>:";
 const INIT_SUBCLASS_PREFIX: &str = "<__init_subclass__>:";
+const SERVER_CONFIG_PREFIX: &str = "<server-config>:";
+const UNITTEST_PREFIX: &str = "<unittest>:";
+
+/// Conventional filenames Gunicorn / Hypercorn load at startup. Baked
+/// default for the native [`ServerConfigPluginImpl`]; the configurable
+/// Python `ServerConfigPlugin` covers custom filenames.
+const SERVER_CONFIG_FILENAMES: [&str; 4] = [
+    "gunicorn.conf.py",
+    "gunicorn_conf.py",
+    "hypercorn.conf.py",
+    "hypercorn_conf.py",
+];
+
+/// stdlib `unittest` lifecycle hooks kept alive in any file importing
+/// `unittest` (mirrors `dead_cst.contrib.unittest._MODULE_HOOKS`).
+const UNITTEST_MODULE_HOOKS: [&str; 3] = ["setUpModule", "tearDownModule", "load_tests"];
+
+/// Base classes whose transitive subclasses are kept alive (mirrors
+/// `dead_cst.contrib.unittest._UNITTEST_BASE_FQNAMES`).
+const UNITTEST_BASE_FQNAMES: [&str; 2] = ["unittest.TestCase", "unittest.IsolatedAsyncioTestCase"];
 
 /// Per-file port of `dead_cst.plugins.module_dunders.ModuleDundersPlugin`:
 /// pin a file's module-level dunders (variables + PEP 562 functions) and its
@@ -1069,5 +1116,141 @@ impl NativePluginImpl for InitSubclassPluginImpl {
             }
             Ok(())
         })
+    }
+}
+
+/// Per-file port of `dead_cst.contrib.server_config.ServerConfigPlugin`
+/// (default-filename form): when a file's basename is one of the
+/// conventional server-config names, mint a `<server-config>:` entrypoint
+/// keeping that file's whole top-level surface alive. File-local — the
+/// match and the targets are both functions of the single file.
+pub(crate) struct ServerConfigPluginImpl;
+
+impl PerFileNativePluginImpl for ServerConfigPluginImpl {
+    fn run_on_file(&self, file_ctx: &FileContext<'_>, sink: &mut Vec<FileLocalOpData>) {
+        let nodes = file_ctx.nodes();
+        let path = nodes[0].path.as_str();
+        let basename = path
+            .rsplit_once(std::path::MAIN_SEPARATOR)
+            .map(|(_, name)| name)
+            .unwrap_or(path);
+        if !SERVER_CONFIG_FILENAMES.contains(&basename) {
+            return;
+        }
+        // `_TARGET_KINDS` from the Python plugin: every top-level surface
+        // node (the module node included), excluding `type_alias`.
+        let targets: Vec<u32> = nodes
+            .iter()
+            .enumerate()
+            .filter(|(_, node)| {
+                matches!(
+                    node.kind.as_static_str(),
+                    "module" | "function" | "class" | "variable" | "import"
+                )
+            })
+            .map(|(local_idx, _)| local_idx as u32)
+            .collect();
+        if targets.is_empty() {
+            return;
+        }
+        let synthetic = intern_kind("synthetic").expect("'synthetic' is a valid kind");
+        sink.push(FileLocalOpData {
+            fqname: format!("{SERVER_CONFIG_PREFIX}{}", file_ctx.module_fqname()),
+            kind: synthetic,
+            flags: NodeFlags::ENTRYPOINT,
+            edges_to_local_idx: targets,
+        });
+    }
+}
+
+/// Project-wide port of `dead_cst.contrib.unittest.UnittestPlugin`: keep
+/// every transitive subclass of `unittest.TestCase` /
+/// `IsolatedAsyncioTestCase` alive, plus module-level lifecycle hooks
+/// (`setUpModule` / `tearDownModule` / `load_tests`) in any file that
+/// imports `unittest`. Cross-file (the subclass walk spans files), so it
+/// can't be per-file.
+pub(crate) struct UnittestPluginImpl;
+
+impl NativePluginImpl for UnittestPluginImpl {
+    fn name(&self) -> &'static str {
+        "UnittestPlugin"
+    }
+
+    fn run(&self, ctx: &ProjectContext, sink: &mut Vec<PreparedOp>) -> PyResult<()> {
+        // O(1) presence probe — short-circuit before the subclass walk.
+        if !ctx.has_imports_of("unittest")? {
+            return Ok(());
+        }
+        let import_idxs = ctx.find_imports_of_indices("unittest")?;
+        let importer_paths: std::collections::HashSet<String> =
+            ctx.node_paths(import_idxs)?.into_iter().collect();
+
+        // path -> [decl_idx, ...] seeds to keep alive.
+        let mut decls_by_path: std::collections::HashMap<String, Vec<usize>> =
+            std::collections::HashMap::new();
+
+        Python::with_gil(|py| -> PyResult<()> {
+            for base in UNITTEST_BASE_FQNAMES {
+                let sub_idxs = ctx.find_subclasses_indices(py, base, true)?;
+                if sub_idxs.is_empty() {
+                    continue;
+                }
+                let paths = ctx.node_paths(sub_idxs.clone())?;
+                for (idx, path) in sub_idxs.into_iter().zip(paths) {
+                    decls_by_path.entry(path).or_default().push(idx);
+                }
+            }
+            Ok(())
+        })?;
+
+        // Lifecycle hooks: function nodes in an importer file whose
+        // trailing fqname segment is one of the module hooks.
+        {
+            let outputs = ctx.materialized("UnittestPlugin")?;
+            for (idx, node_py) in outputs.builder.nodes.iter().enumerate() {
+                let node = node_py.get();
+                if node.kind != "function" || !importer_paths.contains(node.path.as_str()) {
+                    continue;
+                }
+                let simple = node
+                    .fqname
+                    .rsplit_once('.')
+                    .map(|(_, n)| n)
+                    .unwrap_or(node.fqname.as_str());
+                if UNITTEST_MODULE_HOOKS.contains(&simple) {
+                    decls_by_path
+                        .entry(node.path.clone())
+                        .or_default()
+                        .push(idx);
+                }
+            }
+        }
+
+        if decls_by_path.is_empty() {
+            return Ok(());
+        }
+        let paths: Vec<String> = decls_by_path.keys().cloned().collect();
+        let module_idxs = ctx.modules_for_paths(paths.clone())?;
+        let present: Vec<(String, usize)> = paths
+            .into_iter()
+            .zip(module_idxs)
+            .filter_map(|(p, idx)| idx.map(|i| (p, i)))
+            .collect();
+        if present.is_empty() {
+            return Ok(());
+        }
+        let module_attrs = ctx.node_attrs(present.iter().map(|(_, i)| *i).collect())?;
+        let synthetic = intern_kind("synthetic").expect("'synthetic' is a valid kind");
+        for ((path, _idx), attr) in present.iter().zip(module_attrs.iter()) {
+            sink.push(PreparedOp::NodeByIdx {
+                fqname: format!("{UNITTEST_PREFIX}{}", attr.fqname),
+                kind: synthetic,
+                path: path.clone(),
+                flags: NodeFlags::TESTCASE,
+                edges_from_idx: Vec::new(),
+                edges_to_idx: decls_by_path[path].clone(),
+            });
+        }
+        Ok(())
     }
 }

--- a/tests/test_plugins/test_server_config.py
+++ b/tests/test_plugins/test_server_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dead_cst import _native as native
 from dead_cst.graph import NodeFlags
 from dead_cst.contrib import ServerConfigPlugin
 
@@ -150,7 +151,32 @@ def test_server_config_plugin_loads_via_cli_loader():
     from dead_cst.cli import _load_plugin
 
     plugin = _load_plugin("server_config")
-    assert isinstance(plugin, ServerConfigPlugin)
+    assert isinstance(plugin, native.NativePlugin)
+    assert plugin.name == "ServerConfigPlugin"
+
+
+def test_native_server_config_matches_python_plugin(build_plugin_graph, reachable_fqnames):
+    """``NativePlugin.server_config()`` produces the same reachable set
+    as the default-filename ``ServerConfigPlugin()``."""
+    files = {
+        "pkg/__init__.py": "",
+        "gunicorn.conf.py": """
+        import os
+
+        bind = "0.0.0.0:8000"
+        workers = 4
+
+        class CustomLogger: pass
+
+        def on_starting(server):
+            pass
+        """,
+        "hypercorn_conf.py": "loglevel = 'info'",
+        "regular.py": "def untouched(): pass",
+    }
+    py_ctx = build_plugin_graph(files, [ServerConfigPlugin()])
+    rs_ctx = build_plugin_graph(files, [native.NativePlugin.server_config()])
+    assert reachable_fqnames(py_ctx) == reachable_fqnames(rs_ctx)
 
 
 def test_seeds_are_not_tagged_testcase(build_plugin_graph):

--- a/tests/test_plugins/test_unittest.py
+++ b/tests/test_plugins/test_unittest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 
+from dead_cst import _native as native
 from dead_cst.graph import NodeFlags
 from dead_cst.contrib import UnittestPlugin
 
@@ -172,7 +173,41 @@ def test_unittest_plugin_loads_via_cli_loader():
     from dead_cst.cli import _load_plugin
 
     plugin = _load_plugin("unittest")
-    assert isinstance(plugin, UnittestPlugin)
+    assert isinstance(plugin, native.NativePlugin)
+    assert plugin.name == "UnittestPlugin"
+
+
+def test_native_unittest_matches_python_plugin(build_plugin_graph, reachable_fqnames):
+    """``NativePlugin.unittest()`` produces the same reachable set as
+    ``UnittestPlugin()`` — same subclass walk, same lifecycle hooks."""
+    files = {
+        "pkg/__init__.py": "",
+        "pkg/things.py": """
+        import unittest
+
+        class MyThings(unittest.TestCase):
+            def test_one(self): pass
+
+        class AsyncThings(unittest.IsolatedAsyncioTestCase):
+            async def test_two(self): pass
+
+        class Helper: pass
+
+        def setUpModule(): pass
+        def tearDownModule(): pass
+        def load_tests(loader, tests, pattern): return tests
+        """,
+        "pkg/derived.py": """
+        from pkg.things import MyThings
+
+        class Derived(MyThings):
+            def test_three(self): pass
+        """,
+        "pkg/regular.py": "def untouched(): pass",
+    }
+    py_ctx = build_plugin_graph(files, [UnittestPlugin()])
+    rs_ctx = build_plugin_graph(files, [native.NativePlugin.unittest()])
+    assert reachable_fqnames(py_ctx) == reachable_fqnames(rs_ctx)
 
 
 def test_unittest_plugin_tags_seeds_as_testcase(build_plugin_graph):


### PR DESCRIPTION
## Summary

Continues the plugin → Rust migration by porting two more built-ins to native `NativePlugin` implementations resolved through the registry (`native._builtin_native_plugin`):

- **`server_config` → per-file (salsa-cached).** A file matches purely on its own basename against the baked default server-config filename set (`gunicorn.conf.py`, `hypercorn.conf.py`, …); on a match it mints a `<server-config>:` entrypoint keeping the file's whole top-level surface alive. Because both the match and the targets are functions of the single file, it rides the salsa-cached per-file path — an unchanged file's marker is reused across `re_materialize` with zero re-run. The native impl bakes the *default* filenames; the configurable Python `ServerConfigPlugin` stays for custom filename sets.
- **`unittest` → project-wide.** Walks the transitive subclasses of `unittest.TestCase` / `IsolatedAsyncioTestCase` and keeps module lifecycle hooks (`setUpModule` / `tearDownModule` / `load_tests`) in any file importing `unittest` alive. The subclass walk spans files, so this can't be per-file.

Both move out of the Python `_BUILTIN_PLUGINS` map (and their now-unused imports are dropped from `cli.py`); the Python classes remain for parity tests and custom config until the final teardown PR.

## Changes

- `runtime/src/native_plugins.rs` — `PerFilePluginKind::ServerConfig` + `ServerConfigPluginImpl`; `UnittestPluginImpl`; `server_config()` / `unittest()` factories; registry entries.
- `python/dead_cst/cli.py` — registry now owns `server_config` / `unittest`; removed from the Python map.
- `python/dead_cst/_native.pyi` — stubs for the two new factories.
- `tests/test_plugins/test_{server_config,unittest}.py` — native↔Python parity tests; loader assertions updated to expect the native instance.
- `CHANGELOG.md` — extended the migration entry.

## Test plan

- [x] `cargo clippy -p dead-cst-runtime` clean
- [x] `uv run prek run --all-files` (ruff, ruff-format, ty, cargo fmt, cargo clippy) green
- [x] `uv run pytest` — 794 passed, 2 skipped
- [x] Parity tests assert identical reachable sets for native vs Python on the same fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)