### PR TITLE
Add attr-method call query; dedup plugin-host closure; expose regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,20 +139,25 @@ two versions.
   closed: `PluginCtx` gains `find_subclasses_of_fqn(base_fqn, transitive)`
   (subclass search by string FQN, not just an in-graph index),
   `handler_decorators(&[attr])` (functions decorated `@<owner>.<attr>(...)`,
-  paired with their owner), and `calls_with_string_arg(modules, name,
+  paired with their owner), `calls_with_string_arg(modules, name,
   arg_index)` (calls to an imported callable paired with a string-literal
-  positional argument); `PluginOps::add_synthetic_node` now takes a source
+  positional argument), and `calls_on_attr(attr, arg_index)` (its attr-method
+  twin — `<recv>.<attr>(...)` calls of any receiver shape paired with a
+  string-literal positional argument, mirroring
+  `query(ctx).calls().where_attr(...).string_arg_at(...)`);
+  `PluginOps::add_synthetic_node` now takes a source
   `path` (empty for a placeless marker) so a project-wide synthetic node can
   be attributed to a file. On the Python side, `NativePlugin.dispatch_app(name,
   marker_prefix, app_classes, registration_decorators, seed_as_entrypoint)`
   exposes the generic engine behind `flask()` … `celery()`, so a custom
   framework can be wired without a bespoke plugin (the celery `@shared_task`
   fan-out stays internal to `celery()`).
-- **`serde_json` is available to external plugin authors.** It is pinned as a
-  direct runtime dependency so its `.rlib` is always in the plugin-compile
-  closure, and `dead-cst build-plugin` wires `--extern serde_json` so a plugin
-  can `use serde_json::Value;` out of the box. The rest of the runtime's
-  private dependency tree is intentionally not exposed.
+- **`serde_json` and `regex` are available to external plugin authors.** Both
+  are pinned as direct runtime dependencies so their `.rlib`s are always in the
+  plugin-compile closure, and `dead-cst build-plugin` wires `--extern serde_json`
+  / `--extern regex` from a curated allowlist so a plugin can `use
+  serde_json::Value;` / `use regex::Regex;` out of the box. The rest of the
+  runtime's private dependency tree is intentionally not exposed.
 
 ### Changed
 
@@ -231,6 +236,12 @@ SymbolNode- and idx-form terminals on the same query.
 
 ### Fixed
 
+- `dead-cst bundle-plugin-host` no longer ships duplicate dependency archives.
+  Cargo's `deps/` directory accumulates multiple SVH-suffixed artifacts per
+  crate across incremental rebuilds, and the closure copy previously shipped all
+  of them (e.g. two `regex` rlibs), bloating the `dead-cst-plugin-host` payload.
+  The closure is now deduplicated to exactly one artifact per `(crate, kind)` —
+  the newest, which is the set this build's runtime dylib binds against.
 - Uses inside an assignment whose target is a subscript or slice
   (`os.environ["k"] = v`, `f[:] = [SomeClass()]`) are no longer
   dropped. Such a target binds no name, so ty mints no Definition and

--- a/NATIVE_PLUGINS.md
+++ b/NATIVE_PLUGINS.md
@@ -125,20 +125,25 @@ flags }`.
 | `module_for(path)` | `Option<usize>` | module node by source path |
 | `resolve(fqname)` | `Option<usize>` | decl-or-module, walking back dotted segments |
 | `decls_under(path_prefix)` | `Vec<usize>` | every node under a path prefix |
-| `find_subclasses_of(class_idx)` | `Vec<usize>` | transitive subclasses |
+| `find_subclasses_of(class_idx)` | `Vec<usize>` | transitive subclasses of the class at `class_idx` |
+| `find_subclasses_of_fqn(fqn)` | `Vec<usize>` | transitive subclasses of the class named by dotted `fqn` (fqn twin of `find_subclasses_of`) |
 | `descendants(root_idx)` | `Vec<usize>` | forward reachability closure |
 | `ancestors(decl_idx)` | `Vec<usize>` | reverse reachability closure |
 | `direct_predecessors(idx)` | `Vec<usize>` | one-hop reverse step |
 | `main_blocks()` | `Vec<(usize, Vec<usize>)>` | each `if __name__` block as `(module, [decls])` |
 | `decorated_decls(modules, names)` | `Vec<usize>` | decls decorated by one of `names` imported from one of `modules` (mirrors `query(ctx).decorators()...`) |
 | `constructions(modules, names)` | `Vec<usize>` | `X = Ctor(...)` decls whose `Ctor` is one of `names` imported from one of `modules` |
+| `handler_decorators(attrs)` | `Vec<(String, usize)>` | top-level fns decorated `@<owner>.<attr>(...)` for `attr` in `attrs`; returns `(owner_name, decl_idx)` — the raw textual owner, unresolved (mirrors `query(ctx).decorators().where_owner_attr(...)`) |
+| `calls_with_string_arg(modules, name, arg_index)` | `Vec<(usize, String)>` | calls to `name` (imported from one of `modules`) whose arg at `arg_index` is a string literal; returns `(owning_decl_idx, literal)` (mirrors `query(ctx).calls()...string_arg_at(...)`) |
+| `calls_on_attr(attr, arg_index)` | `Vec<(usize, String)>` | `<recv>.<attr>(...)` calls (any receiver shape) whose arg at `arg_index` is a string literal; returns `(owning_decl_idx, literal)` (mirrors `query(ctx).calls().where_attr(attr).string_arg_at(...)`) |
 | `module_surface(module_fqn)` | `Vec<usize>` | the names `from module_fqn import *` would bind |
 | `dunder_all_exports(module_fqn)` | `Option<Vec<usize>>` | the decls named by `module_fqn`'s `__all__`, or `None` |
 | `literal_list_entries(var_fqn)` | `Option<Vec<String>>` | the string entries of a `X = ["a", "b"]` literal-list assignment |
 | `decls_matching_name(pattern)` | `Vec<usize>` | top-level decls whose simple name matches the regex `pattern` |
 
-The last six delegate to the same query core as the `query(ctx)` DSL, so they
-agree with it; they're the project-wide analogue of the per-file
+The decorator / construction / call / subclass-by-fqn / name-pattern matchers
+delegate to the same query core as the `query(ctx)` DSL, so they agree with it;
+they're the project-wide analogue of the per-file
 [`PluginFileCtx`](#per-file-plugins-optional-salsa-cached) helpers.
 
 `PluginOps` — emit ops (mirrors the three Python graph ops):
@@ -270,13 +275,14 @@ options. (In a dev/static checkout there's no in-package runtime dylib, so
 
 ### Dependencies available to a plugin
 
-`build-plugin` wires `--extern serde_json` for you, so a plugin can pull in
-`serde_json` directly (e.g. `use serde_json::Value;`) to parse config or
-metadata — it's pinned into the compile closure for exactly this. The rest of
-the runtime's transitive dependency tree is *not* exposed as a stable surface:
-it ships in the closure (so the runtime itself links), but its crates and
-versions are an implementation detail and may change between releases. Build on
-`dead_cst_runtime` and `serde_json` only.
+`build-plugin` wires `--extern` for a small, curated allowlist of runtime
+dependencies, so a plugin can pull them in directly: `serde_json` (e.g. `use
+serde_json::Value;`) to parse config or metadata, and `regex` (`use
+regex::Regex;`) for pattern matching. Both are pinned into the compile closure
+for exactly this. The rest of the runtime's transitive dependency tree is *not*
+exposed as a stable surface: it ships in the closure (so the runtime itself
+links), but its crates and versions are an implementation detail and may change
+between releases. Build on `dead_cst_runtime`, `serde_json`, and `regex` only.
 
 ---
 

--- a/python/dead_cst/cli.py
+++ b/python/dead_cst/cli.py
@@ -582,6 +582,26 @@ def _dylib_name(stem: str) -> str:
     return f"lib{stem}{_dylib_suffix()}"
 
 
+# Curated allowlist of runtime deps exposed to plugin authors via `rustc
+# --extern` in `build-plugin`. Each must be a *direct* dependency of the runtime
+# crate (so its `.rlib` is guaranteed in the compile closure). The rest of the
+# runtime's transitive dep tree is intentionally NOT a stable surface — exposing
+# it would leak ruff/ty's private deps as a de-facto public API.
+_PLUGIN_EXTERN_CRATES = ("serde_json", "regex")
+
+
+def _crate_key(filename: str) -> str:
+    """Crate name from a cargo ``deps/`` artifact filename, dropping the SVH
+    suffix: ``libserde_json-1a2b3c4d.rlib`` (or ``.dylib`` / ``.so`` for a
+    proc-macro) -> ``serde_json``. Cargo names every dep artifact
+    ``lib<crate>-<hash>.<ext>``, so strip the ``lib`` prefix, the extension, and
+    the trailing ``-<hash>``."""
+    stem = filename.rsplit(".", 1)[0]
+    if stem.startswith("lib"):
+        stem = stem[3:]
+    return stem.rsplit("-", 1)[0]
+
+
 def _prefer_dynamic_link_args(std_lib: Path) -> list[str]:
     """The ``-Wl,...`` linker args (without the ``-C link-arg=`` prefix) that
     make a ``prefer-dynamic`` artifact defer host symbols and find libstd + its
@@ -698,9 +718,10 @@ def build_plugin(
     Prints the plugin path on stdout; load it with
     ``native.load_native_plugins(<path>)``.
 
-    ``serde_json`` is wired in via ``--extern`` for plugin authors (``use
-    serde_json::Value;`` works out of the box); the rest of the runtime's
-    private dependency tree is intentionally not exposed.
+    A curated allowlist of runtime deps (``serde_json``, ``regex``) is wired in
+    via ``--extern`` for plugin authors (``use serde_json::Value;`` / ``use
+    regex::Regex;`` work out of the box); the rest of the runtime's private
+    dependency tree is intentionally not exposed.
 
     Needs the pinned rust toolchain (the ABI fingerprint rejects a mismatch at
     load) and the dynamic-runtime wheel (``pip install dead-cst[build-plugin]``).
@@ -756,17 +777,19 @@ def build_plugin(
     crate_name = name.replace("-", "_")
     out = output.resolve() if output is not None else Path.cwd() / _dylib_name(crate_name)
 
-    # Curated allowlist: expose serde_json to plugin authors (it's pinned as a
-    # direct runtime dep, so its rlib is always in the closure). Newest wins if a
-    # deps dir holds stale copies; absent (unexpected) → skip rather than fail.
-    serde_json_externs: list[str] = []
-    serde_json_rlibs = sorted(dep_dir.glob("libserde_json-*.rlib"), key=lambda p: p.stat().st_mtime)
-    if serde_json_rlibs:
-        serde_json_externs = ["--extern", f"serde_json={serde_json_rlibs[-1]}"]
-    elif verbose:
-        typer.echo(
-            "note: serde_json rlib not found in dep dir; --extern serde_json skipped.", err=True
-        )
+    # Curated allowlist (`_PLUGIN_EXTERN_CRATES`): expose these direct runtime
+    # deps to plugin authors via `--extern` (their rlibs are always in the
+    # closure). Newest wins if a deps dir holds stale SVH-suffixed copies; an
+    # absent crate (unexpected) is skipped rather than fatal.
+    exposed_externs: list[str] = []
+    for crate in _PLUGIN_EXTERN_CRATES:
+        rlibs = sorted(dep_dir.glob(f"lib{crate}-*.rlib"), key=lambda p: p.stat().st_mtime)
+        if rlibs:
+            exposed_externs += ["--extern", f"{crate}={rlibs[-1]}"]
+        elif verbose:
+            typer.echo(
+                f"note: {crate} rlib not found in dep dir; --extern {crate} skipped.", err=True
+            )
 
     # --extern reads the runtime dylib's embedded metadata; -L finds the dep
     # rlibs/proc-macro dylibs; undefined Python + runtime symbols resolve from
@@ -783,7 +806,7 @@ def build_plugin(
         "prefer-dynamic",
         "--extern",
         f"dead_cst_runtime={runtime_dylib}",
-        *serde_json_externs,
+        *exposed_externs,
         "-L",
         f"dependency={dep_dir}",
         *(
@@ -876,8 +899,17 @@ def bundle_plugin_host(
     # the dynamic `_native`, and libstd are EXCLUDED — they ship in the base
     # `dead_cst` wheel. (.rmeta are skipped: redundant with the .rlib, which
     # embed metadata, and would nearly double the payload.)
+    #
+    # Dedup by (crate, kind): cargo's deps/ accumulates multiple SVH-suffixed
+    # artifacts per crate across incremental rebuilds (this target dir is reused,
+    # not cleaned, to keep rebuilds fast). Ship exactly one per (crate, kind) —
+    # the newest, which is the set this build's runtime dylib actually binds
+    # against (mtime is a faithful proxy right after a successful build).
+    # Without this, stale copies (e.g. a second `regex` rlib) leak in and bloat
+    # the wheel — and a `--extern <crate>` glob in `build-plugin` could pick the
+    # wrong SVH.
     excluded = {_dylib_name("dead_cst_runtime"), _dylib_name("dead_cst_native")}
-    n_files = 0
+    newest: dict[tuple[str, str], Path] = {}
     for entry in deps_dir.iterdir():
         if not entry.is_file():
             continue
@@ -887,8 +919,14 @@ def bundle_plugin_host(
             and not entry.name.startswith("libstd-")
         )
         if entry.suffix == ".rlib" or is_proc_macro:
-            shutil.copy2(entry, bundle / entry.name)
-            n_files += 1
+            key = (_crate_key(entry.name), entry.suffix)
+            cur = newest.get(key)
+            if cur is None or entry.stat().st_mtime > cur.stat().st_mtime:
+                newest[key] = entry
+    n_files = 0
+    for entry in newest.values():
+        shutil.copy2(entry, bundle / entry.name)
+        n_files += 1
 
     typer.echo(f"plugin-host closure: {bundle}  (deps build: {deps_dir})", err=True)
     typer.echo(

--- a/runtime/src/native_plugins.rs
+++ b/runtime/src/native_plugins.rs
@@ -1371,6 +1371,32 @@ pub mod plugin_api {
             })
             .unwrap_or_default()
         }
+
+        /// Attr-method twin of [`PluginCtx::calls_with_string_arg`]: calls of
+        /// the form `<recv>.<attr>(...)` — *any* receiver shape
+        /// (`bot.load_extension(x)`, `self.bot.load_extension(x)`,
+        /// `get_bot().load_extension(x)`) — whose argument at `arg_index` is a
+        /// string literal. A list/tuple of string literals fans out to one row
+        /// per element. Returns `(owning_decl_idx, literal)` — the top-level
+        /// decl whose body makes the call (module-scope calls map to the module
+        /// node) and the literal's value. Keyed on the method name, so the
+        /// receiver is the plugin's concern (typically gated by a per-file
+        /// import check); the attr twin of
+        /// `query(ctx).calls().where_attr(attr).string_arg_at(arg_index)`. Calls
+        /// whose arg isn't a string literal (or string collection) are skipped.
+        pub fn calls_on_attr(&self, attr: &str, arg_index: usize) -> Vec<(usize, String)> {
+            Python::with_gil(|py| {
+                self.inner
+                    .find_calls_on_attr(py, attr, arg_index, None, false)
+            })
+            .map(|triples| {
+                triples
+                    .into_iter()
+                    .map(|(idx, literal, _args)| (idx, literal))
+                    .collect()
+            })
+            .unwrap_or_default()
+        }
     }
 
     /// Op sink for external plugins. Wraps the internal `PreparedOp` vec so

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,7 @@ import typer
 from typer.testing import CliRunner
 
 from dead_cst.cli import (
+    _crate_key,
     _dead_real,
     _rel_path,
     app,
@@ -177,6 +178,31 @@ def test_dead_real_filters_synthetic_nodes():
 
 def test_dead_real_empty_input_returns_empty_list():
     assert _dead_real([]) == []
+
+
+# ---------------------------------------------------------------------------
+# _crate_key (plugin-host closure dedup)
+# ---------------------------------------------------------------------------
+
+
+def test_crate_key_strips_lib_prefix_ext_and_svh():
+    # rlib, proc-macro dylib, and .so all reduce to the bare crate name.
+    assert _crate_key("libserde_json-1a2b3c4d5e6f7a8b.rlib") == "serde_json"
+    assert _crate_key("libserde_derive-9f8e7d6c.dylib") == "serde_derive"
+    assert _crate_key("libregex-abc123.so") == "regex"
+
+
+def test_crate_key_preserves_underscores_in_crate_name():
+    # Only the trailing `-<hash>` segment is dropped; internal `_` stays.
+    assert _crate_key("libregex_automata-deadbeefcafef00d.rlib") == "regex_automata"
+
+
+def test_crate_key_collapses_distinct_svh_of_same_crate():
+    # The dedup invariant: two SVH-distinct artifacts of one crate (the stale
+    # leftover scenario `bundle-plugin-host` must collapse) map to one key.
+    assert _crate_key("libregex-1111111111111111.rlib") == _crate_key(
+        "libregex-2222222222222222.rlib"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three follow-ups to the external native-plugin API (post-#260), bundled as one PR:

- **`PluginCtx::calls_on_attr(attr, arg_index)`** — the attr-method twin of `calls_with_string_arg`: matches `<recv>.<attr>(...)` calls of *any* receiver shape (`bot.load_extension(x)`, `self.bot.load_extension(x)`, `get_bot().load_extension(x)`) whose positional arg at `arg_index` is a string literal (list/tuple fans out). Thin delegation to the already-tested `find_calls_on_attr` core — the `query(ctx).calls().where_attr(...).string_arg_at(...)` DSL.
- **`bundle-plugin-host` closure dedup** — cargo's `deps/` accumulates multiple SVH-suffixed artifacts per crate across incremental rebuilds, and the copy loop shipped all of them (e.g. two `regex` rlibs), bloating the `dead-cst-plugin-host` payload. The closure is now deduped to exactly one artifact per `(crate, kind)` — the newest, which is the set this build's runtime dylib binds against.
- **`build-plugin` exposes `regex`** alongside `serde_json` via a curated `--extern` allowlist (`_PLUGIN_EXTERN_CRATES`). Both are direct runtime deps, so their rlibs are always in the closure; the rest of the dep tree stays unexposed.

Also documents the three readers #260 left out of the `NATIVE_PLUGINS.md` reader table (`find_subclasses_of_fqn`, `handler_decorators`, `calls_with_string_arg`).

## Test plan

- [x] `cargo build -p dead-cst-runtime` + `cargo clippy --all-targets --locked -- -D warnings`
- [x] `cargo fmt` clean
- [x] New `_crate_key` unit tests in `tests/test_cli.py` (rlib/proc-macro/`.so`, underscore crate names, SVH-collapse invariant)
- [x] Full suite: `uv run pytest` — 800 passed, 3 skipped (gated external-dylib), 10 deselected (e2e)
- [x] `uv run prek run --all-files` — all 16 hooks green
- [ ] End-to-end `build-plugin` / `bundle-plugin-host` exercised by the publish workflow (dynamic wheel; can't run from a static dev checkout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)