### PR TITLE
Back the graph builder with pure-Rust node records; mint SymbolNode lazily

### DIFF
--- a/runtime/src/builder.rs
+++ b/runtime/src/builder.rs
@@ -11,7 +11,8 @@ use pyo3::prelude::*;
 use ruff_db::files::File;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::graph::{intern_kind, SymbolNode};
+use crate::file_payload::ImportPayload;
+use crate::graph::{intern_kind, Import, SymbolNode};
 use crate::helpers::NODE_FLAG_ENTRYPOINT;
 use crate::project::ProjectContext;
 
@@ -31,8 +32,78 @@ pub(crate) struct NodeKey {
     pub(crate) end_column: usize,
 }
 
+/// Pure-rust mirror of [`SymbolNode`]'s data fields.
+///
+/// The builder stores these instead of `Py<SymbolNode>` so node
+/// interning costs no GIL acquisition or Python heap allocation — the
+/// hot path during a build mints hundreds of thousands of nodes, the
+/// vast majority of which are never handed back to Python. A
+/// `Py<SymbolNode>` is materialized lazily by [`GraphNode::to_symbol`]
+/// only for the nodes a Python caller actually surfaces (`nodes()`,
+/// `nodes_at()`, the descendants / ancestors / reachable snapshots).
+/// Internal queries read the fields here directly with no borrow.
+pub(crate) struct GraphNode {
+    pub(crate) fqname: String,
+    pub(crate) kind: &'static str,
+    pub(crate) path: String,
+    pub(crate) start_line: usize,
+    pub(crate) start_column: usize,
+    pub(crate) end_line: usize,
+    pub(crate) end_column: usize,
+    pub(crate) flags: u32,
+    pub(crate) imports: Option<ImportPayload>,
+}
+
+impl GraphNode {
+    /// Positional identity for the intern table. Mirrors
+    /// [`node_key_of`] (which projects a `SymbolNode`) but reads the
+    /// pure-rust fields directly.
+    pub(crate) fn key(&self) -> NodeKey {
+        NodeKey {
+            fqname: self.fqname.clone(),
+            kind: self.kind,
+            path: self.path.clone(),
+            start_line: self.start_line,
+            start_column: self.start_column,
+            end_line: self.end_line,
+            end_column: self.end_column,
+        }
+    }
+
+    /// Mint the `Py<SymbolNode>` for this node. Called lazily, only at
+    /// the boundary where a node is actually handed to Python.
+    pub(crate) fn to_symbol(&self, py: Python<'_>) -> PyResult<Py<SymbolNode>> {
+        let imports = match &self.imports {
+            Some(ip) => Some(Py::new(
+                py,
+                Import {
+                    module: ip.module.clone(),
+                    decl: ip.decl.clone(),
+                    star: ip.star,
+                },
+            )?),
+            None => None,
+        };
+        Py::new(
+            py,
+            SymbolNode {
+                fqname: self.fqname.clone(),
+                kind: self.kind,
+                path: self.path.clone(),
+                start_line: self.start_line,
+                start_column: self.start_column,
+                end_line: self.end_line,
+                end_column: self.end_column,
+                flags: self.flags,
+                imports,
+                cached_hash: OnceLock::new(),
+            },
+        )
+    }
+}
+
 pub(crate) struct GraphBuilder {
-    pub(crate) nodes: Vec<Py<SymbolNode>>,
+    pub(crate) nodes: Vec<GraphNode>,
     pub(crate) node_index: FxHashMap<NodeKey, usize>,
     pub(crate) edges: Vec<(usize, usize, u32)>,
     pub(crate) edge_set: FxHashSet<(usize, usize, u32)>,
@@ -87,17 +158,17 @@ impl GraphBuilder {
         }
     }
 
-    pub(crate) fn intern_node(&mut self, py: Python<'_>, node: SymbolNode) -> PyResult<usize> {
-        let key = node_key_of(&node);
+    pub(crate) fn intern_node(&mut self, node: GraphNode) -> usize {
+        let key = node.key();
         if let Some(&idx) = self.node_index.get(&key) {
-            return Ok(idx);
+            return idx;
         }
         let idx = self.nodes.len();
-        self.nodes.push(Py::new(py, node)?);
+        self.nodes.push(node);
         self.node_index.insert(key, idx);
         self.forward_adj.push(Vec::new());
         self.reverse_adj.push(Vec::new());
-        Ok(idx)
+        idx
     }
 
     /// Get (or mint) the deduplicated synthetic node with the given
@@ -107,16 +178,18 @@ impl GraphBuilder {
     /// genuinely-missing top-level names. Path is empty (synthetics
     /// don't correspond to a file in the project tree) and position
     /// is the (0, 0) sentinel.
-    pub(crate) fn intern_synthetic(&mut self, py: Python<'_>, fqname: String) -> PyResult<usize> {
+    pub(crate) fn intern_synthetic(&mut self, fqname: String) -> usize {
         if let Some(&idx) = self.synthetic_nodes.get(&fqname) {
-            return Ok(idx);
+            return idx;
         }
-        let idx = self.intern_node(
-            py,
-            synthetic_node(fqname.clone(), "synthetic", String::new(), 0),
-        )?;
+        let idx = self.intern_node(synthetic_node(
+            fqname.clone(),
+            "synthetic",
+            String::new(),
+            0,
+        ));
         self.synthetic_nodes.insert(fqname, idx);
-        Ok(idx)
+        idx
     }
 
     pub(crate) fn add_edge(&mut self, src: usize, dst: usize, flags: u32) {
@@ -416,7 +489,7 @@ pub(crate) fn bfs(
     visited
 }
 
-/// Construct a position-less `SymbolNode` (start/end zeroed, `imports`
+/// Construct a position-less [`GraphNode`] (start/end zeroed, `imports`
 /// absent) for ops minted at plugin-apply time. The four
 /// caller-supplied fields are the only ones that vary across the
 /// synthetic / entrypoint / `AddNode` shapes.
@@ -425,8 +498,8 @@ pub(crate) fn synthetic_node(
     kind: &'static str,
     path: String,
     flags: u32,
-) -> SymbolNode {
-    SymbolNode {
+) -> GraphNode {
+    GraphNode {
         fqname,
         kind,
         path,
@@ -436,7 +509,6 @@ pub(crate) fn synthetic_node(
         end_column: 0,
         flags,
         imports: None,
-        cached_hash: OnceLock::new(),
     }
 }
 
@@ -597,10 +669,10 @@ pub(crate) fn prepare_graph_op(py: Python<'_>, op: &Bound<'_, PyAny>) -> PyResul
 }
 
 /// Apply a batch of pre-prepared ops to the graph in a single
-/// write-lock window. The GIL is released before contending for the
-/// write lock and re-acquired only inside [`apply_prepared`] for the
-/// ops that actually need it — amortised across the whole batch
-/// rather than per-op as the legacy single-op apply did.
+/// write-lock window. The GIL is released for the entire apply pass:
+/// every op is pure-rust now — node interning stores [`GraphNode`]s
+/// with no `Py<SymbolNode>` allocation — so the apply never needs the
+/// GIL back.
 ///
 /// Ops apply in input order; an error in any op fails the whole
 /// batch with that op's error. Earlier ops in the batch still land
@@ -613,10 +685,9 @@ pub(crate) fn apply_prepared_batch(
     if prepared.is_empty() {
         return Ok(());
     }
-    // The ``write()`` MUST happen with the GIL released, then the
-    // GIL re-acquired *after* we own the write guard. Otherwise a
+    // The ``write()`` MUST happen with the GIL released. Otherwise a
     // concurrent reader returning from ``allow_threads`` and waiting
-    // on ``take_gil`` will deadlock against us — we'd be holding the
+    // on ``take_gil`` would deadlock against us — we'd be holding the
     // GIL while blocked on ``wait_for_readers``, and the reader
     // can't drop its read guard without first re-attaching the GIL.
     //
@@ -630,18 +701,15 @@ pub(crate) fn apply_prepared_batch(
         let outputs = outputs
             .as_mut()
             .ok_or_else(|| not_materialized("apply_ops_batched"))?;
-        Python::with_gil(|py| {
-            for op in prepared {
-                apply_prepared(outputs, py, op)?;
-            }
-            Ok(())
-        })
+        for op in prepared {
+            apply_prepared(outputs, op)?;
+        }
+        Ok(())
     })
 }
 
 fn apply_prepared(
     outputs: &mut crate::project::BuildOutputs,
-    py: Python<'_>,
     prepared: PreparedOp,
 ) -> PyResult<()> {
     match prepared {
@@ -670,10 +738,12 @@ fn apply_prepared(
         } => {
             let decl_idx = lookup_idx_by_key(&outputs.builder, &decl, "decl")?;
             let marker_fqname = format!("{marker}:{decl_fqname}");
-            let marker_idx = outputs.builder.intern_node(
-                py,
-                synthetic_node(marker_fqname, "synthetic", decl_path, NODE_FLAG_ENTRYPOINT),
-            )?;
+            let marker_idx = outputs.builder.intern_node(synthetic_node(
+                marker_fqname,
+                "synthetic",
+                decl_path,
+                NODE_FLAG_ENTRYPOINT,
+            ));
             outputs.builder.add_edge(marker_idx, decl_idx, 0);
             Ok(())
         }
@@ -681,17 +751,18 @@ fn apply_prepared(
             let len = outputs.builder.nodes.len();
             check_idx_in_range(len, decl_idx, "AddEntrypointByIdx", "decl_idx")?;
             // Read fqname / path off the existing node — same shape
-            // the ``AddEntrypoint`` arm gets from the prepare step,
-            // but without a ``Py<SymbolNode>`` round-trip.
+            // the ``AddEntrypoint`` arm gets from the prepare step.
             let (decl_fqname, decl_path) = {
-                let node = outputs.builder.nodes[decl_idx].borrow(py);
+                let node = &outputs.builder.nodes[decl_idx];
                 (node.fqname.clone(), node.path.clone())
             };
             let marker_fqname = format!("{marker}:{decl_fqname}");
-            let marker_idx = outputs.builder.intern_node(
-                py,
-                synthetic_node(marker_fqname, "synthetic", decl_path, NODE_FLAG_ENTRYPOINT),
-            )?;
+            let marker_idx = outputs.builder.intern_node(synthetic_node(
+                marker_fqname,
+                "synthetic",
+                decl_path,
+                NODE_FLAG_ENTRYPOINT,
+            ));
             outputs.builder.add_edge(marker_idx, decl_idx, 0);
             Ok(())
         }
@@ -712,7 +783,7 @@ fn apply_prepared(
             let to_idxs = resolve_edge_keys(&outputs.builder, &edges_to, "edges_to")?;
             let node_idx = outputs
                 .builder
-                .intern_node(py, synthetic_node(fqname, kind, path, flags))?;
+                .intern_node(synthetic_node(fqname, kind, path, flags));
             wire_synthetic_edges(&mut outputs.builder, node_idx, &from_idxs, &to_idxs);
             Ok(())
         }
@@ -735,7 +806,7 @@ fn apply_prepared(
             check_idx_slice_in_range(len, &edges_to_idx, "AddNodeByIdx", "edges_to_idx")?;
             let node_idx = outputs
                 .builder
-                .intern_node(py, synthetic_node(fqname, kind, path, flags))?;
+                .intern_node(synthetic_node(fqname, kind, path, flags));
             wire_synthetic_edges(
                 &mut outputs.builder,
                 node_idx,

--- a/runtime/src/helpers.rs
+++ b/runtime/src/helpers.rs
@@ -22,6 +22,7 @@ use ty_module_resolver::{
 use ty_project::metadata::value::RelativePathBuf;
 use ty_project::{Db as ProjectDb, ProjectDatabase};
 
+use crate::builder::GraphNode;
 use crate::graph::{EdgeFlags, NodeFlags, SymbolNode};
 use crate::ingest::collapse_attribute_chain;
 use crate::project::BuildOutputs;
@@ -119,7 +120,7 @@ pub(crate) fn locate_class_def(
     db: &ProjectDatabase,
     path_to_file: &FxHashMap<String, File>,
     path: &str,
-    class_node: &SymbolNode,
+    class_node: &GraphNode,
 ) -> Option<(File, TextRange)> {
     let &file = path_to_file.get(path)?;
     let parsed = parsed_module(db, file).load(db);
@@ -512,18 +513,17 @@ pub(crate) fn class_def_named<'a>(
 pub(crate) fn locate_class_seed(
     db: &ProjectDatabase,
     outputs: &BuildOutputs,
-    py: Python<'_>,
     fqn: &str,
 ) -> Option<(File, TextRange)> {
     // Project class: cheap path through the existing indices.
     if let Some(idxs) = outputs.decl_by_fqname.get(fqn) {
         for &idx in idxs {
-            let node = outputs.builder.nodes[idx].borrow(py);
+            let node = &outputs.builder.nodes[idx];
             if node.kind != "class" {
                 continue;
             }
             let path = node.path.clone();
-            if let Some(seed) = locate_class_def(db, &outputs.path_to_file, &path, &node) {
+            if let Some(seed) = locate_class_def(db, &outputs.path_to_file, &path, node) {
                 return Some(seed);
             }
         }

--- a/runtime/src/native_plugins.rs
+++ b/runtime/src/native_plugins.rs
@@ -1154,7 +1154,7 @@ pub mod plugin_api {
         /// the underlying `SymbolNode`.
         pub fn node(&self, idx: usize) -> Option<NodeView> {
             let outputs = self.inner.materialized("plugin").ok()?;
-            let node = outputs.builder.nodes.get(idx)?.get();
+            let node = outputs.builder.nodes.get(idx)?;
             Some(NodeView {
                 idx,
                 fqname: node.fqname.clone(),
@@ -1196,14 +1196,16 @@ pub mod plugin_api {
         /// Every node whose source path starts with `path_prefix` — a
         /// cheap way to scope a plugin to one package/directory.
         pub fn decls_under(&self, path_prefix: &str) -> Vec<usize> {
-            Python::with_gil(|py| self.inner.decls_under_indices(py, path_prefix))
+            self.inner
+                .decls_under_indices(path_prefix)
                 .unwrap_or_default()
         }
 
         /// Transitive subclasses of the class at `class_idx` (empty when
         /// `class_idx` isn't a class node).
         pub fn find_subclasses_of(&self, class_idx: usize) -> Vec<usize> {
-            Python::with_gil(|py| self.inner.find_subclasses_of_idx(py, class_idx))
+            self.inner
+                .find_subclasses_of_idx(class_idx)
                 .unwrap_or_default()
         }
 
@@ -1265,7 +1267,8 @@ pub mod plugin_api {
         /// surface (honoring `__all__` when present). Empty when the module
         /// isn't found.
         pub fn module_surface(&self, module_fqn: &str) -> Vec<usize> {
-            Python::with_gil(|py| self.inner.module_surface_indices(py, module_fqn))
+            self.inner
+                .module_surface_indices(module_fqn)
                 .unwrap_or_default()
         }
 
@@ -1291,7 +1294,8 @@ pub mod plugin_api {
         /// type_alias) whose simple name matches the regular expression
         /// `pattern`. An invalid pattern yields an empty result.
         pub fn decls_matching_name(&self, pattern: &str) -> Vec<usize> {
-            Python::with_gil(|py| self.inner.decls_matching_name_indices(py, pattern))
+            self.inner
+                .decls_matching_name_indices(pattern)
                 .unwrap_or_default()
         }
 
@@ -1942,7 +1946,7 @@ impl NativePluginImpl for InitSubclassPluginImpl {
             let attrs = ctx.node_attrs(parents.clone())?;
             let synthetic = intern_kind("synthetic").expect("'synthetic' is a valid kind");
             for (parent_idx, attr) in parents.iter().zip(attrs.iter()) {
-                let subclass_idxs = ctx.find_subclasses_of_idx(py, *parent_idx)?;
+                let subclass_idxs = ctx.find_subclasses_of_idx(*parent_idx)?;
                 sink.push(PreparedOp::NodeByIdx {
                     fqname: format!("{INIT_SUBCLASS_PREFIX}{}", attr.fqname),
                     kind: synthetic,
@@ -2071,8 +2075,7 @@ impl NativePluginImpl for UnittestPluginImpl {
         // trailing fqname segment is one of the module hooks.
         {
             let outputs = ctx.materialized("UnittestPlugin")?;
-            for (idx, node_py) in outputs.builder.nodes.iter().enumerate() {
-                let node = node_py.get();
+            for (idx, node) in outputs.builder.nodes.iter().enumerate() {
                 if node.kind != "function" || !importer_paths.contains(node.path.as_str()) {
                     continue;
                 }
@@ -2337,8 +2340,7 @@ impl NativePluginImpl for DispatchAppPluginImpl {
 
             // vars_by_file: (path, simple var name) -> first var idx wins.
             let mut vars_by_file: FxHashMap<(String, String), usize> = FxHashMap::default();
-            for (idx, node_py) in nodes.iter().enumerate() {
-                let node = node_py.get();
+            for (idx, node) in nodes.iter().enumerate() {
                 if node.kind != "variable" {
                     continue;
                 }
@@ -2351,7 +2353,7 @@ impl NativePluginImpl for DispatchAppPluginImpl {
             // direct construction (the latter only under seed_as_entrypoint).
             let mut direct_by_owner: FxHashMap<(String, String), Vec<usize>> = FxHashMap::default();
             for &var_idx in &direct {
-                let node = nodes[var_idx].get();
+                let node = &nodes[var_idx];
                 direct_by_owner
                     .entry((node.path.clone(), simple_name(&node.fqname).to_string()))
                     .or_default()
@@ -2371,7 +2373,7 @@ impl NativePluginImpl for DispatchAppPluginImpl {
             // Step 4: factory markers so step 6's reachability walk can find
             // them. `factory_decls` is empty unless seed_as_entrypoint.
             for (decl_idx, kind) in &factory_decls {
-                let node = nodes[*decl_idx].get();
+                let node = &nodes[*decl_idx];
                 sink.push(PreparedOp::NodeByIdx {
                     fqname: format!("{factory_prefix}{kind}:{}", node.fqname),
                     kind: synthetic,
@@ -2387,7 +2389,7 @@ impl NativePluginImpl for DispatchAppPluginImpl {
             // edges); pure-dispatch mode wires only to direct constructions (so
             // a star-imported `app = App()` stays invisible).
             for (owner, decorated_idx) in &handlers {
-                let key = (nodes[*decorated_idx].get().path.clone(), owner.clone());
+                let key = (nodes[*decorated_idx].path.clone(), owner.clone());
                 if cfg.seed_as_entrypoint {
                     if let Some(&var_idx) = vars_by_file.get(&key) {
                         sink.push(PreparedOp::EdgeByIdx {
@@ -2414,7 +2416,7 @@ impl NativePluginImpl for DispatchAppPluginImpl {
             if cfg.seed_as_entrypoint && !factory_decls.is_empty() {
                 let mut classified: FxHashSet<(String, String)> = FxHashSet::default();
                 for (owner, decorated_idx) in &handlers {
-                    let key = (nodes[*decorated_idx].get().path.clone(), owner.clone());
+                    let key = (nodes[*decorated_idx].path.clone(), owner.clone());
                     if direct_by_owner.contains_key(&key) || classified.contains(&key) {
                         continue;
                     }
@@ -2425,7 +2427,7 @@ impl NativePluginImpl for DispatchAppPluginImpl {
                         continue;
                     }
                     classified.insert(key);
-                    let node = nodes[var_idx].get();
+                    let node = &nodes[var_idx];
                     sink.push(PreparedOp::NodeByIdx {
                         fqname: format!("{app_prefix}{}", node.fqname),
                         kind: synthetic,
@@ -2443,7 +2445,7 @@ impl NativePluginImpl for DispatchAppPluginImpl {
                 let mut by_path: FxHashMap<String, Vec<usize>> = FxHashMap::default();
                 let mut path_order: Vec<String> = Vec::new();
                 for &decl_idx in &shared_idxs {
-                    let path = nodes[decl_idx].get().path.clone();
+                    let path = nodes[decl_idx].path.clone();
                     if !by_path.contains_key(&path) {
                         path_order.push(path.clone());
                     }

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -32,11 +32,11 @@ use ty_python_core::semantic_index;
 
 use crate::builder::{
     apply_prepared_batch, bfs, lookup_idx, not_materialized, prepare_graph_op, synthetic_node,
-    CollectedOps, Direction, GraphBuilder, PreparedOp,
+    CollectedOps, Direction, GraphBuilder, GraphNode, PreparedOp,
 };
 use crate::file_payload::{file_to_edges, file_to_nodes, FileEdges, NodeKind, NodeRef};
 use crate::file_ref_edges::{file_to_ref_edges, FileRefEdges};
-use crate::graph::{intern_kind, DeclIndex, Import, NativeGraph, SymbolNode};
+use crate::graph::{intern_kind, DeclIndex, NativeGraph, SymbolNode};
 use crate::helpers::{
     call_callee_matches_var, class_body_defines_method, collect_all_imports_local,
     collect_modules_imports_local, decorators_match_imports, extract_call_args_kwargs,
@@ -56,7 +56,6 @@ use crate::query::{
     QueryBuilder,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::sync::OnceLock as StdOnceLock;
 
 /// A ty-backed analysis project with explicitly-injected configuration.
 #[pyclass(unsendable)]
@@ -93,8 +92,14 @@ impl Project {
     pub(crate) fn build(&mut self, py: Python<'_>) -> PyResult<NativeGraph> {
         let counters = Arc::new(ProgressCounters::new());
         let outputs = build_project_graph(py, &mut self.db, false, None, &counters, &[])?;
+        let nodes = outputs
+            .builder
+            .nodes
+            .iter()
+            .map(|n| n.to_symbol(py))
+            .collect::<PyResult<Vec<_>>>()?;
         Ok(NativeGraph {
-            nodes: outputs.builder.nodes,
+            nodes,
             edges: outputs.builder.edges,
         })
     }
@@ -422,7 +427,7 @@ pub(crate) fn build_project_graph(
     counters.start_phase(PHASE_FQNAME, Some(builder.nodes.len()));
     let t4 = std::time::Instant::now();
     let (decl_by_fqname, module_by_fqname, imports_by_module, children_by_parent) =
-        build_fqname_indices(py, &builder, counters);
+        build_fqname_indices(&builder, counters);
     let t_fqname = t4.elapsed();
     counters.finish_phase(PHASE_FQNAME);
 
@@ -439,7 +444,6 @@ pub(crate) fn build_project_graph(
         &class_by_selection,
         &ref_to_global,
         &decl_by_fqname,
-        py,
         &builder.nodes,
     );
     let t_hierarchy_elapsed = t_hierarchy.elapsed();
@@ -621,22 +625,7 @@ fn assemble_graph<'db>(
                 }
             }
 
-            let imports = node_data
-                .imports
-                .as_ref()
-                .map(|ip| {
-                    Py::new(
-                        py,
-                        Import {
-                            module: ip.module.clone(),
-                            decl: ip.decl.clone(),
-                            star: ip.star,
-                        },
-                    )
-                })
-                .transpose()?;
-
-            let symbol = SymbolNode {
+            let node = GraphNode {
                 fqname: node_data.fqname.clone(),
                 kind: intern_kind(node_data.kind.as_static_str())?,
                 path: node_data.path.clone(),
@@ -645,10 +634,9 @@ fn assemble_graph<'db>(
                 end_line: node_data.end_line,
                 end_column: node_data.end_column,
                 flags,
-                imports,
-                cached_hash: StdOnceLock::new(),
+                imports: node_data.imports.clone(),
             };
-            let global_idx = builder.intern_node(py, symbol)?;
+            let global_idx = builder.intern_node(node);
             ref_to_global.insert(node_ref, global_idx);
             local_to_global.insert((file, local_idx as u32), global_idx);
 
@@ -722,12 +710,12 @@ fn assemble_graph<'db>(
         for payload in &edge_payloads {
             for &(src, dst, flags) in &payload.edges {
                 let Some(src_idx) =
-                    serial_lookup_or_mint(py, db, &mut builder, &mut ref_to_global, src)?
+                    serial_lookup_or_mint(db, &mut builder, &mut ref_to_global, src)?
                 else {
                     continue;
                 };
                 let Some(dst_idx) =
-                    serial_lookup_or_mint(py, db, &mut builder, &mut ref_to_global, dst)?
+                    serial_lookup_or_mint(db, &mut builder, &mut ref_to_global, dst)?
                 else {
                     continue;
                 };
@@ -737,12 +725,12 @@ fn assemble_graph<'db>(
         for payload in &ref_edge_payloads {
             for &(src, dst, flags) in &payload.edges {
                 let Some(src_idx) =
-                    serial_lookup_or_mint(py, db, &mut builder, &mut ref_to_global, src)?
+                    serial_lookup_or_mint(db, &mut builder, &mut ref_to_global, src)?
                 else {
                     continue;
                 };
                 let Some(dst_idx) =
-                    serial_lookup_or_mint(py, db, &mut builder, &mut ref_to_global, dst)?
+                    serial_lookup_or_mint(db, &mut builder, &mut ref_to_global, dst)?
                 else {
                     continue;
                 };
@@ -778,7 +766,7 @@ fn assemble_graph<'db>(
         for r in external_keys {
             if let NodeRef::External(key) = r {
                 let fqname = key.fqname(db).clone();
-                let idx = builder.intern_synthetic(py, fqname)?;
+                let idx = builder.intern_synthetic(fqname);
                 ref_to_global.insert(r, idx);
             }
         }
@@ -864,7 +852,6 @@ fn assemble_graph<'db>(
     // pass produced. Synthetic nodes still dedup by fqname, so a
     // later project-wide plugin emitting the same node merges.
     fold_per_file_plugin_ops(
-        py,
         db,
         &mut builder,
         project_files,
@@ -909,7 +896,6 @@ fn assemble_graph<'db>(
 /// is GIL-free and intra-file, so nothing in this fold needs the salsa
 /// DB beyond the cached lookup.
 fn fold_per_file_plugin_ops(
-    py: Python<'_>,
     db: &ProjectDatabase,
     builder: &mut GraphBuilder,
     project_files: &[File],
@@ -937,10 +923,12 @@ fn fold_per_file_plugin_ops(
                         edges_to_local_idx,
                         edges_from_local_idx,
                     } => {
-                        let node_idx = builder.intern_node(
-                            py,
-                            synthetic_node(fqname.clone(), kind, path.clone(), *flags),
-                        )?;
+                        let node_idx = builder.intern_node(synthetic_node(
+                            fqname.clone(),
+                            kind,
+                            path.clone(),
+                            *flags,
+                        ));
                         for &local in edges_from_local_idx {
                             if let Some(src_idx) = to_global(local) {
                                 builder.add_edge(src_idx, node_idx, 0);
@@ -971,19 +959,16 @@ fn fold_per_file_plugin_ops(
                             continue;
                         };
                         let (decl_fqname, decl_path) = {
-                            let node = builder.nodes[decl_idx].borrow(py);
+                            let node = &builder.nodes[decl_idx];
                             (node.fqname.clone(), node.path.clone())
                         };
                         let marker_fqname = format!("{marker}:{decl_fqname}");
-                        let marker_idx = builder.intern_node(
-                            py,
-                            synthetic_node(
-                                marker_fqname,
-                                "synthetic",
-                                decl_path,
-                                NODE_FLAG_ENTRYPOINT,
-                            ),
-                        )?;
+                        let marker_idx = builder.intern_node(synthetic_node(
+                            marker_fqname,
+                            "synthetic",
+                            decl_path,
+                            NODE_FLAG_ENTRYPOINT,
+                        ));
                         builder.add_edge(marker_idx, decl_idx, 0);
                     }
                 }
@@ -1060,8 +1045,7 @@ fn build_class_hierarchy_indices<'db>(
     class_by_selection: &FxHashMap<(File, (u32, u32)), usize>,
     ref_to_global: &FxHashMap<NodeRef<'db>, usize>,
     decl_by_fqname: &FxHashMap<String, Vec<usize>>,
-    py: Python<'_>,
-    nodes: &[Py<SymbolNode>],
+    nodes: &[GraphNode],
 ) -> (FxHashMap<usize, Vec<usize>>, FxHashMap<String, Vec<usize>>) {
     use crate::file_payload::ResolvedBase;
     let mut by_node: FxHashMap<usize, Vec<usize>> = FxHashMap::default();
@@ -1078,7 +1062,7 @@ fn build_class_hierarchy_indices<'db>(
                     ResolvedBase::LocalSameFileClass(local_idx) => {
                         let r = payload.refs[*local_idx as usize];
                         if let Some(&parent_idx) = ref_to_global.get(&r) {
-                            if nodes[parent_idx].borrow(py).kind == "class" {
+                            if nodes[parent_idx].kind == "class" {
                                 by_node.entry(parent_idx).or_default().push(child_idx);
                             }
                         }
@@ -1087,7 +1071,7 @@ fn build_class_hierarchy_indices<'db>(
                         by_fqn.entry(fqn.clone()).or_default().push(child_idx);
                         if let Some(idxs) = decl_by_fqname.get(fqn) {
                             for &parent_idx in idxs {
-                                if nodes[parent_idx].borrow(py).kind == "class" {
+                                if nodes[parent_idx].kind == "class" {
                                     by_node.entry(parent_idx).or_default().push(child_idx);
                                 }
                             }
@@ -1108,7 +1092,7 @@ fn build_class_hierarchy_indices<'db>(
                         // `exports_by_name`.
                         if let Some(idxs) = decl_by_fqname.get(&composed) {
                             for &parent_idx in idxs {
-                                if nodes[parent_idx].borrow(py).kind == "class" {
+                                if nodes[parent_idx].kind == "class" {
                                     by_node.entry(parent_idx).or_default().push(child_idx);
                                 }
                             }
@@ -1135,7 +1119,6 @@ fn build_class_hierarchy_indices<'db>(
 /// its global graph index. Only used when `DEAD_CST_PASS2_SERIAL=1`
 /// is set (kept for A/B comparison and as a kill switch).
 fn serial_lookup_or_mint<'db>(
-    py: Python<'_>,
     db: &'db ProjectDatabase,
     builder: &mut GraphBuilder,
     ref_to_global: &mut FxHashMap<NodeRef<'db>, usize>,
@@ -1147,7 +1130,7 @@ fn serial_lookup_or_mint<'db>(
     match r {
         NodeRef::External(key) => {
             let fqname = key.fqname(db).clone();
-            let idx = builder.intern_synthetic(py, fqname)?;
+            let idx = builder.intern_synthetic(fqname);
             ref_to_global.insert(r, idx);
             Ok(Some(idx))
         }
@@ -1171,7 +1154,6 @@ fn serial_lookup_or_mint<'db>(
 /// names keyed under the empty string.
 #[allow(clippy::type_complexity)]
 pub(crate) fn build_fqname_indices(
-    py: Python<'_>,
     builder: &GraphBuilder,
     counters: &Arc<ProgressCounters>,
 ) -> (
@@ -1184,9 +1166,8 @@ pub(crate) fn build_fqname_indices(
     let mut modules: FxHashMap<String, usize> = FxHashMap::default();
     let mut imports_by_module: FxHashMap<String, Vec<usize>> = FxHashMap::default();
     let mut children_by_parent: FxHashMap<String, Vec<usize>> = FxHashMap::default();
-    for (idx, node_py) in builder.nodes.iter().enumerate() {
+    for (idx, node) in builder.nodes.iter().enumerate() {
         counters.fqname_inc();
-        let node = node_py.borrow(py);
         // `OVERLOAD`-flagged decls (the `@typing.overload`-decorated
         // stubs of an in-file overload group) are excluded from the
         // fqname trie so cross-module `from mod import f` resolves to
@@ -1207,9 +1188,9 @@ pub(crate) fn build_fqname_indices(
             }
             "import" => {
                 decls.entry(node.fqname.clone()).or_default().push(idx);
-                if let Some(import_py) = node.imports.as_ref() {
+                if let Some(import) = node.imports.as_ref() {
                     imports_by_module
-                        .entry(import_py.borrow(py).module.clone())
+                        .entry(import.module.clone())
                         .or_default()
                         .push(idx);
                 }
@@ -1696,13 +1677,14 @@ impl ProjectContext {
         let outputs = outputs_ref
             .as_ref()
             .ok_or_else(|| PyRuntimeError::new_err("ProjectContext lost its outputs"))?;
+        let nodes = outputs
+            .builder
+            .nodes
+            .iter()
+            .map(|n| n.to_symbol(py))
+            .collect::<PyResult<Vec<_>>>()?;
         Ok(NativeGraph {
-            nodes: outputs
-                .builder
-                .nodes
-                .iter()
-                .map(|n| n.clone_ref(py))
-                .collect(),
+            nodes,
             edges: outputs.builder.edges.clone(),
         })
     }
@@ -1771,13 +1753,14 @@ impl ProjectContext {
         let outputs = outputs_ref
             .as_ref()
             .ok_or_else(|| PyRuntimeError::new_err("ProjectContext lost its outputs"))?;
+        let nodes = outputs
+            .builder
+            .nodes
+            .iter()
+            .map(|n| n.to_symbol(py))
+            .collect::<PyResult<Vec<_>>>()?;
         Ok(NativeGraph {
-            nodes: outputs
-                .builder
-                .nodes
-                .iter()
-                .map(|n| n.clone_ref(py))
-                .collect(),
+            nodes,
             edges: outputs.builder.edges.clone(),
         })
     }
@@ -2048,11 +2031,10 @@ impl ProjectContext {
     /// machinery and must be kept alive even when no source reference
     /// points at them. Plugins use the DSL form:
     /// ``native.query(ctx).modules().with_dunders().indices()``.
-    pub(crate) fn find_module_dunders_indices(&self, py: Python<'_>) -> PyResult<Vec<usize>> {
+    pub(crate) fn find_module_dunders_indices(&self) -> PyResult<Vec<usize>> {
         let outputs = self.materialized("find_module_dunders_indices")?;
         let mut out = Vec::new();
-        for (idx, node_py) in outputs.builder.nodes.iter().enumerate() {
-            let node = node_py.borrow(py);
+        for (idx, node) in outputs.builder.nodes.iter().enumerate() {
             if !matches!(node.kind, "variable" | "function") {
                 continue;
             }
@@ -2081,7 +2063,6 @@ impl ProjectContext {
     ///   absolute path.
     pub(crate) fn find_nodes_matching_specs_indices(
         &self,
-        py: Python<'_>,
         project_root: &str,
         regexes: Vec<String>,
         str_specs: Vec<String>,
@@ -2106,8 +2087,7 @@ impl ProjectContext {
 
         let outputs = self.materialized("find_nodes_matching_specs_indices")?;
         let mut out: Vec<usize> = Vec::new();
-        for (idx, node_py) in outputs.builder.nodes.iter().enumerate() {
-            let node = node_py.borrow(py);
+        for (idx, node) in outputs.builder.nodes.iter().enumerate() {
             let path = node.path.as_str();
             if abs_set.contains(path) {
                 out.push(idx);
@@ -2263,13 +2243,9 @@ impl ProjectContext {
     /// BFS over the fqname tree from ``module_fqn``: the module idx
     /// + every transitive descendant idx. Plugins use the DSL:
     /// ``native.query(ctx).modules().with_fqn(fqn).surface().indices()``.
-    pub(crate) fn module_surface_indices(
-        &self,
-        py: Python<'_>,
-        module_fqn: &str,
-    ) -> PyResult<Vec<usize>> {
+    pub(crate) fn module_surface_indices(&self, module_fqn: &str) -> PyResult<Vec<usize>> {
         let outputs = self.materialized("module_surface_indices")?;
-        Ok(module_surface_indices_in(&outputs, py, module_fqn))
+        Ok(module_surface_indices_in(&outputs, module_fqn))
     }
 
     /// Bulk form: resolve every fqname in ``module_fqns`` in a single
@@ -2302,7 +2278,6 @@ impl ProjectContext {
     /// ``native.query(ctx).modules().with_fqn(fqn).top_level().indices()``.
     pub(crate) fn find_module_top_level_decls_indices(
         &self,
-        py: Python<'_>,
         module_fqn: &str,
     ) -> PyResult<Vec<usize>> {
         let outputs = self.materialized("find_module_top_level_decls_indices")?;
@@ -2316,7 +2291,7 @@ impl ProjectContext {
         let mut out: Vec<usize> = Vec::new();
         if let Some(children) = outputs.children_by_parent.get(module_fqn) {
             for &idx in children {
-                if outputs.builder.nodes[idx].borrow(py).kind == "module" {
+                if outputs.builder.nodes[idx].kind == "module" {
                     continue;
                 }
                 out.push(idx);
@@ -2390,8 +2365,7 @@ impl ProjectContext {
         let mut out: Vec<String> = Vec::new();
         let mut found_any = false;
         for &idx in idxs {
-            let path =
-                pyo3::Python::with_gil(|py| outputs.builder.nodes[idx].borrow(py).path.clone());
+            let path = outputs.builder.nodes[idx].path.clone();
             let Some(&file) = outputs.path_to_file.get(&path) else {
                 continue;
             };
@@ -2425,18 +2399,14 @@ impl ProjectContext {
 impl ProjectContext {
     /// Every node whose ``path`` starts with ``path_prefix``. Plugins
     /// use the DSL: ``native.query(ctx).decls().with_path_prefix(p)``.
-    pub(crate) fn decls_under_indices(
-        &self,
-        py: Python<'_>,
-        path_prefix: &str,
-    ) -> PyResult<Vec<usize>> {
+    pub(crate) fn decls_under_indices(&self, path_prefix: &str) -> PyResult<Vec<usize>> {
         let outputs = self.materialized("decls_under_indices")?;
         Ok(outputs
             .builder
             .nodes
             .iter()
             .enumerate()
-            .filter(|(_i, n)| n.borrow(py).path.starts_with(path_prefix))
+            .filter(|(_i, n)| n.path.starts_with(path_prefix))
             .map(|(i, _n)| i)
             .collect())
     }
@@ -2444,18 +2414,14 @@ impl ProjectContext {
     /// Every node whose ``path`` contains ``substring`` anywhere.
     /// Plugins use the DSL:
     /// ``native.query(ctx).decls().with_path_contains(s)``.
-    pub(crate) fn decls_matching_indices(
-        &self,
-        py: Python<'_>,
-        substring: &str,
-    ) -> PyResult<Vec<usize>> {
+    pub(crate) fn decls_matching_indices(&self, substring: &str) -> PyResult<Vec<usize>> {
         let outputs = self.materialized("decls_matching_indices")?;
         Ok(outputs
             .builder
             .nodes
             .iter()
             .enumerate()
-            .filter(|(_i, n)| n.borrow(py).path.contains(substring))
+            .filter(|(_i, n)| n.path.contains(substring))
             .map(|(i, _n)| i)
             .collect())
     }
@@ -2464,16 +2430,11 @@ impl ProjectContext {
     /// type_alias) whose simple name matches ``pattern``. Plugins use
     /// the DSL — compose
     /// ``decls().with_simple_name_regex(p).with_kinds([...])``.
-    pub(crate) fn decls_matching_name_indices(
-        &self,
-        py: Python<'_>,
-        pattern: &str,
-    ) -> PyResult<Vec<usize>> {
+    pub(crate) fn decls_matching_name_indices(&self, pattern: &str) -> PyResult<Vec<usize>> {
         let regex = self.compile_regex(pattern)?;
         let outputs = self.materialized("decls_matching_name_indices")?;
         let mut out: Vec<usize> = Vec::new();
-        for (idx, node_py) in outputs.builder.nodes.iter().enumerate() {
-            let node = node_py.borrow(py);
+        for (idx, node) in outputs.builder.nodes.iter().enumerate() {
             if !matches!(
                 node.kind,
                 "function" | "class" | "variable" | "import" | "type_alias"
@@ -2501,12 +2462,10 @@ impl ProjectContext {
     ) -> PyResult<Vec<Py<SymbolNode>>> {
         let outputs = self.materialized("descendants")?;
         let root_idx = lookup_idx(&outputs.builder, root, "root")?;
-        Ok(
-            bfs(&outputs.builder, [root_idx], Direction::Forward, skip_flags)
-                .into_iter()
-                .map(|i| outputs.builder.nodes[i].clone_ref(py))
-                .collect(),
-        )
+        bfs(&outputs.builder, [root_idx], Direction::Forward, skip_flags)
+            .into_iter()
+            .map(|i| outputs.builder.nodes[i].to_symbol(py))
+            .collect()
     }
 
     /// Idx-keyed variant of :meth:`descendants`. Takes a positional
@@ -2544,10 +2503,10 @@ impl ProjectContext {
     ) -> PyResult<Vec<Py<SymbolNode>>> {
         let outputs = self.materialized("ancestors")?;
         let idx = lookup_idx(&outputs.builder, decl, "decl")?;
-        Ok(bfs(&outputs.builder, [idx], Direction::Reverse, skip_flags)
+        bfs(&outputs.builder, [idx], Direction::Reverse, skip_flags)
             .into_iter()
-            .map(|i| outputs.builder.nodes[i].clone_ref(py))
-            .collect())
+            .map(|i| outputs.builder.nodes[i].to_symbol(py))
+            .collect()
     }
 
     /// Idx-keyed variant of :meth:`ancestors`. Takes a positional
@@ -2612,11 +2571,11 @@ impl ProjectContext {
             .nodes
             .iter()
             .enumerate()
-            .filter_map(|(idx, n)| (n.borrow(py).flags & seed_flags != 0).then_some(idx));
-        Ok(bfs(&outputs.builder, seeds, Direction::Forward, skip_flags)
+            .filter_map(|(idx, n)| (n.flags & seed_flags != 0).then_some(idx));
+        bfs(&outputs.builder, seeds, Direction::Forward, skip_flags)
             .into_iter()
-            .map(|i| outputs.builder.nodes[i].clone_ref(py))
-            .collect())
+            .map(|i| outputs.builder.nodes[i].to_symbol(py))
+            .collect()
     }
 }
 
@@ -3403,11 +3362,7 @@ impl ProjectContext {
     /// ``ctx.nodes()``. Bounds-checks the index and raises
     /// :class:`IndexError` when out of range; returns an empty list
     /// when the seed isn't a class node.
-    pub(crate) fn find_subclasses_of_idx(
-        &self,
-        py: Python<'_>,
-        class_idx: usize,
-    ) -> PyResult<Vec<usize>> {
+    pub(crate) fn find_subclasses_of_idx(&self, class_idx: usize) -> PyResult<Vec<usize>> {
         let outputs = self.materialized("find_subclasses_of_idx")?;
         let len = outputs.builder.nodes.len();
         if class_idx >= len {
@@ -3417,7 +3372,7 @@ impl ProjectContext {
         }
         // Snapshot the node fields the inner helper reads — same shape
         // it gets when called from the node-form ``find_subclasses_of``.
-        let class_node = outputs.builder.nodes[class_idx].borrow(py);
+        let class_node = &outputs.builder.nodes[class_idx];
         if class_node.kind != "class" {
             return Ok(Vec::new());
         }
@@ -3425,7 +3380,7 @@ impl ProjectContext {
             &self.db,
             &outputs.path_to_file,
             &class_node.path,
-            &class_node,
+            class_node,
         ) {
             let rk = (seed_range.start().to_u32(), seed_range.end().to_u32());
             if let Some(&seed_idx) = outputs.class_by_selection.get(&(seed_file, rk)) {
@@ -3460,11 +3415,7 @@ fn direct_predecessors_idxs_in(outputs: &BuildOutputs, idx: usize, skip_flags: u
 /// :meth:`module_surface_indices` — the module index, then every
 /// transitive child node (modules recursed into; non-module decls
 /// surfaced but not chased for sub-fqnames).
-fn module_surface_indices_in(
-    outputs: &BuildOutputs,
-    py: Python<'_>,
-    module_fqn: &str,
-) -> Vec<usize> {
+fn module_surface_indices_in(outputs: &BuildOutputs, module_fqn: &str) -> Vec<usize> {
     let Some(&module_idx) = outputs.module_by_fqname.get(module_fqn) else {
         return Vec::new();
     };
@@ -3476,15 +3427,13 @@ fn module_surface_indices_in(
             continue;
         };
         for &child_idx in children {
-            let child_py = &outputs.builder.nodes[child_idx];
-            let child = child_py.borrow(py);
+            let child = &outputs.builder.nodes[child_idx];
             let is_module = child.kind == "module";
             let child_fqname = if is_module {
                 Some(child.fqname.clone())
             } else {
                 None
             };
-            drop(child);
             out.push(child_idx);
             if let Some(fqn) = child_fqname {
                 queue.push_back(fqn);
@@ -3658,7 +3607,6 @@ impl ProjectContext {
             let outputs = self.materialized("find_constructions.subclasses")?;
             for idx in sub_idxs {
                 let simple = outputs.builder.nodes[idx]
-                    .borrow(py)
                     .fqname
                     .rsplit('.')
                     .next()
@@ -3682,7 +3630,7 @@ impl ProjectContext {
     pub(crate) fn find_decorations_on(
         &self,
         py: Python<'_>,
-        instance: &SymbolNode,
+        instance: &GraphNode,
         method_names: Vec<String>,
         path_regex: Option<&str>,
         extract_args: bool,
@@ -3695,7 +3643,7 @@ impl ProjectContext {
             if owner_name != instance_simple {
                 continue;
             }
-            if outputs.builder.nodes[handler_idx].borrow(py).path != instance.path {
+            if outputs.builder.nodes[handler_idx].path != instance.path {
                 continue;
             }
             out.push((handler_idx, call_args));
@@ -3724,8 +3672,7 @@ impl ProjectContext {
         transitive: bool,
     ) -> PyResult<Vec<usize>> {
         let outputs = self.materialized("find_subclasses_indices")?;
-        let Some((seed_file, seed_range)) = locate_class_seed(&self.db, &outputs, py, base_fqn)
-        else {
+        let Some((seed_file, seed_range)) = locate_class_seed(&self.db, &outputs, base_fqn) else {
             return Ok(Vec::new());
         };
         // Project seeds: use the in-memory class-hierarchy index for
@@ -3886,7 +3833,7 @@ impl ProjectContext {
                     continue;
                 };
                 out.push((
-                    outputs.builder.nodes[decl_idx].clone_ref(py),
+                    outputs.builder.nodes[decl_idx].to_symbol(py)?,
                     text.to_string(),
                 ));
             }
@@ -3902,12 +3849,12 @@ impl ProjectContext {
     /// Live nodes in the in-progress graph. Cheap, no copy.
     pub(crate) fn nodes(&self, py: Python<'_>) -> PyResult<Vec<Py<SymbolNode>>> {
         let outputs = self.materialized("nodes")?;
-        Ok(outputs
+        outputs
             .builder
             .nodes
             .iter()
-            .map(|n| n.clone_ref(py))
-            .collect())
+            .map(|n| n.to_symbol(py))
+            .collect()
     }
 
     /// Live edges as `(src_idx, dst_idx, flags)` triples.
@@ -3927,7 +3874,6 @@ impl ProjectContext {
     #[pyo3(signature = (*, skip_flags = 0, seed_flags = NODE_FLAG_ENTRYPOINT))]
     pub(crate) fn reachable_indices(
         &self,
-        py: Python<'_>,
         skip_flags: u32,
         seed_flags: u32,
     ) -> PyResult<Vec<usize>> {
@@ -3937,7 +3883,7 @@ impl ProjectContext {
             .nodes
             .iter()
             .enumerate()
-            .filter_map(|(idx, n)| (n.borrow(py).flags & seed_flags != 0).then_some(idx));
+            .filter_map(|(idx, n)| (n.flags & seed_flags != 0).then_some(idx));
         Ok(bfs(&outputs.builder, seeds, Direction::Forward, skip_flags)
             .into_iter()
             .collect())
@@ -3973,7 +3919,6 @@ impl ProjectContext {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn indices_where(
         &self,
-        py: Python<'_>,
         kind: Option<String>,
         kinds: Option<Vec<String>>,
         filename: Option<String>,
@@ -4041,8 +3986,7 @@ impl ProjectContext {
         // should be passed; if both are given, AND them (require all
         // bits in ``flags`` AND any bit in ``flags_any``).
         let mut out: Vec<usize> = Vec::new();
-        for (idx, node_py) in outputs.builder.nodes.iter().enumerate() {
-            let node = node_py.borrow(py);
+        for (idx, node) in outputs.builder.nodes.iter().enumerate() {
             if let Some(k) = &kinds_set {
                 if !k.contains(node.kind) {
                     continue;
@@ -4113,7 +4057,7 @@ impl ProjectContext {
                     "node index {idx} out of range (len={len})"
                 )));
             }
-            out.push(outputs.builder.nodes[idx].clone_ref(py));
+            out.push(outputs.builder.nodes[idx].to_symbol(py)?);
         }
         Ok(out)
     }
@@ -4143,11 +4087,9 @@ impl ProjectContext {
                     "node index {idx} out of range (len={len})"
                 )));
             }
-            // ``Py<T>::get`` is GIL-free for frozen pyclasses with
-            // ``Sync`` fields. ``SymbolNode`` is ``#[pyclass(frozen)]``
-            // with all-``Sync`` fields, so we read its data without
-            // threading ``Python<'_>`` through every internal helper.
-            let node = outputs.builder.nodes[idx].get();
+            // The builder stores pure-rust ``GraphNode``s, so reading a
+            // node's fields needs neither the GIL nor a ``Py`` borrow.
+            let node = &outputs.builder.nodes[idx];
             out.push(crate::helpers::NodeAttrs {
                 kind: node.kind.to_string(),
                 path: node.path.clone(),
@@ -4176,10 +4118,9 @@ impl ProjectContext {
                     "node index {idx} out of range (len={len})"
                 )));
             }
-            // ``Py::get`` is GIL-free on ``#[pyclass(frozen)]`` types
-            // with ``Sync`` fields; SymbolNode qualifies. See
-            // :meth:`node_attrs` for the rationale.
-            out.push(outputs.builder.nodes[idx].get().path.clone());
+            // Pure-rust ``GraphNode`` read — no GIL, no ``Py`` borrow.
+            // See :meth:`node_attrs` for the rationale.
+            out.push(outputs.builder.nodes[idx].path.clone());
         }
         Ok(out)
     }

--- a/runtime/src/query.rs
+++ b/runtime/src/query.rs
@@ -13,7 +13,6 @@ use ruff_db::files::File;
 use rustc_hash::{FxHashMap, FxHashSet};
 use ty_project::Db as ProjectDb;
 
-use crate::graph::SymbolNode;
 use crate::helpers::{
     call_args_match_kwargs, file_path_string, kwarg_matcher_from_py, KwargMatcher,
 };
@@ -230,8 +229,8 @@ impl QueryBuilder {
     ) -> PyResult<Vec<usize>> {
         let ctx = self.ctx.borrow(py);
         match seed_flags {
-            Some(sf) => ctx.reachable_indices(py, skip_flags, sf),
-            None => ctx.reachable_indices(py, skip_flags, crate::helpers::NODE_FLAG_ENTRYPOINT),
+            Some(sf) => ctx.reachable_indices(skip_flags, sf),
+            None => ctx.reachable_indices(skip_flags, crate::helpers::NODE_FLAG_ENTRYPOINT),
         }
     }
 
@@ -256,7 +255,7 @@ impl QueryBuilder {
         abs_paths: Vec<String>,
     ) -> PyResult<Vec<usize>> {
         let ctx = self.ctx.borrow(py);
-        ctx.find_nodes_matching_specs_indices(py, project_root, regexes, str_specs, abs_paths)
+        ctx.find_nodes_matching_specs_indices(project_root, regexes, str_specs, abs_paths)
     }
 }
 
@@ -640,10 +639,10 @@ impl DecoratorQuery {
         let rows = self.decorator_rows(py)?;
         let ctx = self.ctx.borrow(py);
         let outputs = ctx.materialized("DecoratorQuery.collect")?;
-        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let nodes = &outputs.builder.nodes;
         let mut out: Vec<Py<DecoratorIdxRef>> = Vec::with_capacity(rows.len());
         for row in rows {
-            let path = nodes[row.decorated_idx].borrow(py).path.clone();
+            let path = nodes[row.decorated_idx].path.clone();
             out.push(Py::new(
                 py,
                 DecoratorIdxRef {
@@ -667,10 +666,10 @@ impl DecoratorQuery {
         let rows = self.decorator_rows(py)?;
         let ctx = self.ctx.borrow(py);
         let outputs = ctx.materialized("DecoratorQuery.indices_by_path")?;
-        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let nodes = &outputs.builder.nodes;
         let mut buckets: FxHashMap<String, Vec<usize>> = FxHashMap::default();
         for row in rows {
-            let path = nodes[row.decorated_idx].borrow(py).path.clone();
+            let path = nodes[row.decorated_idx].path.clone();
             buckets.entry(path).or_default().push(row.decorated_idx);
         }
         Ok(buckets)
@@ -737,16 +736,15 @@ impl DecoratorQuery {
                     "DecoratorQuery.in_decl_idx: idx {in_decl_idx} out of range (len={len})"
                 )));
             }
-            let in_decl_ref = outputs.builder.nodes[in_decl_idx].borrow(py);
+            let in_decl_ref = &outputs.builder.nodes[in_decl_idx];
             let decls =
-                ctx.find_decorations_on(py, &in_decl_ref, names.clone(), path_regex, extract_args)?;
+                ctx.find_decorations_on(py, in_decl_ref, names.clone(), path_regex, extract_args)?;
             let owner_simple = in_decl_ref
                 .fqname
                 .rsplit('.')
                 .next()
                 .unwrap_or("")
                 .to_string();
-            drop(in_decl_ref);
             for (decorated_idx, call_args) in decls {
                 if !call_args_match_kwargs(&call_args, kwarg_matchers) {
                     continue;
@@ -888,10 +886,10 @@ impl ConstructionQuery {
         let rows = self.construction_rows(py)?;
         let ctx = self.ctx.borrow(py);
         let outputs = ctx.materialized("ConstructionQuery.collect")?;
-        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let nodes = &outputs.builder.nodes;
         let mut out: Vec<Py<ConstructionIdxRef>> = Vec::with_capacity(rows.len());
         for row in rows {
-            let path = nodes[row.var_idx].borrow(py).path.clone();
+            let path = nodes[row.var_idx].path.clone();
             out.push(Py::new(
                 py,
                 ConstructionIdxRef {
@@ -912,10 +910,10 @@ impl ConstructionQuery {
         let rows = self.construction_rows(py)?;
         let ctx = self.ctx.borrow(py);
         let outputs = ctx.materialized("ConstructionQuery.indices_by_path")?;
-        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let nodes = &outputs.builder.nodes;
         let mut buckets: FxHashMap<String, Vec<usize>> = FxHashMap::default();
         for row in rows {
-            let path = nodes[row.var_idx].borrow(py).path.clone();
+            let path = nodes[row.var_idx].path.clone();
             buckets.entry(path).or_default().push(row.var_idx);
         }
         Ok(buckets)
@@ -1089,10 +1087,10 @@ impl CallQuery {
         let rows = self.call_rows(py)?;
         let ctx = self.ctx.borrow(py);
         let outputs = ctx.materialized("CallQuery.collect")?;
-        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let nodes = &outputs.builder.nodes;
         let mut out: Vec<Py<CallIdxRef>> = Vec::with_capacity(rows.len());
         for row in rows {
-            let path = nodes[row.owner_idx].borrow(py).path.clone();
+            let path = nodes[row.owner_idx].path.clone();
             out.push(Py::new(
                 py,
                 CallIdxRef {
@@ -1113,10 +1111,10 @@ impl CallQuery {
         let rows = self.call_rows(py)?;
         let ctx = self.ctx.borrow(py);
         let outputs = ctx.materialized("CallQuery.indices_by_path")?;
-        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let nodes = &outputs.builder.nodes;
         let mut buckets: FxHashMap<String, Vec<usize>> = FxHashMap::default();
         for row in rows {
-            let path = nodes[row.owner_idx].borrow(py).path.clone();
+            let path = nodes[row.owner_idx].path.clone();
             buckets.entry(path).or_default().push(row.owner_idx);
         }
         Ok(buckets)
@@ -1233,7 +1231,7 @@ impl SubclassQuery {
         if let Some(fqn) = &self.base_fqn {
             ctx.find_subclasses_indices(py, fqn, self.transitive)
         } else if let Some(idx) = self.base_idx {
-            ctx.find_subclasses_of_idx(py, idx)
+            ctx.find_subclasses_of_idx(idx)
         } else {
             Err(PyValueError::new_err(
                 "SubclassQuery requires .of_fqn(...) or .of_idx(...)",
@@ -1419,7 +1417,7 @@ impl ModuleQuery {
     fn indices(&self, py: Python<'_>) -> PyResult<Vec<usize>> {
         let ctx = self.ctx.borrow(py);
         if self.all_dunders {
-            return ctx.find_module_dunders_indices(py);
+            return ctx.find_module_dunders_indices();
         }
         let fqn = self.resolve_fqn(&ctx)?;
         let Some(fqn) = fqn else {
@@ -1430,8 +1428,8 @@ impl ModuleQuery {
                 .find_module_idx(&fqn)?
                 .map(|i| vec![i])
                 .unwrap_or_default()),
-            ModuleTransform::Surface => ctx.module_surface_indices(py, &fqn),
-            ModuleTransform::TopLevel => ctx.find_module_top_level_decls_indices(py, &fqn),
+            ModuleTransform::Surface => ctx.module_surface_indices(&fqn),
+            ModuleTransform::TopLevel => ctx.find_module_top_level_decls_indices(&fqn),
         }
     }
 
@@ -1622,10 +1620,10 @@ impl FactoryQuery {
         let pairs = self.factory_rows(py)?;
         let ctx = self.ctx.borrow(py);
         let outputs = ctx.materialized("FactoryQuery.collect")?;
-        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let nodes = &outputs.builder.nodes;
         let mut out: Vec<Py<FactoryIdxRef>> = Vec::with_capacity(pairs.len());
         for (decl_idx, kinds) in pairs {
-            let path = nodes[decl_idx].borrow(py).path.clone();
+            let path = nodes[decl_idx].path.clone();
             out.push(Py::new(
                 py,
                 FactoryIdxRef {
@@ -1645,10 +1643,10 @@ impl FactoryQuery {
         let pairs = self.factory_rows(py)?;
         let ctx = self.ctx.borrow(py);
         let outputs = ctx.materialized("FactoryQuery.indices_by_path")?;
-        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let nodes = &outputs.builder.nodes;
         let mut buckets: FxHashMap<String, Vec<usize>> = FxHashMap::default();
         for (decl_idx, _kinds) in pairs {
-            let path = nodes[decl_idx].borrow(py).path.clone();
+            let path = nodes[decl_idx].path.clone();
             buckets.entry(path).or_default().push(decl_idx);
         }
         Ok(buckets)
@@ -1737,7 +1735,7 @@ impl EdgeQuery {
     fn index_triples(&self, py: Python<'_>) -> PyResult<Vec<(usize, usize, u32)>> {
         let ctx = self.ctx.borrow(py);
         let outputs = ctx.materialized("EdgeQuery.index_triples")?;
-        let nodes: &[Py<SymbolNode>] = &outputs.builder.nodes;
+        let nodes = &outputs.builder.nodes;
         let edges: &[(usize, usize, u32)] = &outputs.builder.edges;
         let flag_mask = self.flag_mask;
         let src_kind = self.src_kind.as_deref();
@@ -1750,12 +1748,12 @@ impl EdgeQuery {
                 }
             }
             if let Some(needle) = src_kind {
-                if nodes[src_idx].borrow(py).kind != needle {
+                if nodes[src_idx].kind != needle {
                     continue;
                 }
             }
             if let Some(needle) = dst_kind {
-                if nodes[dst_idx].borrow(py).kind != needle {
+                if nodes[dst_idx].kind != needle {
                     continue;
                 }
             }
@@ -2076,7 +2074,7 @@ impl DeclQuery {
                         if !set.insert(child_idx) {
                             continue;
                         }
-                        let child = outputs.builder.nodes[child_idx].borrow(py);
+                        let child = &outputs.builder.nodes[child_idx];
                         if child.kind == "module" {
                             queue.push_back(child.fqname.clone());
                         }
@@ -2086,7 +2084,7 @@ impl DeclQuery {
             });
 
         let mut out = Vec::new();
-        for (node_idx, node_py) in outputs.builder.nodes.iter().enumerate() {
+        for (node_idx, node) in outputs.builder.nodes.iter().enumerate() {
             // fqname-under (cheapest gate first when set — restricts
             // to a tiny candidate set out of all nodes).
             if let Some(set) = &fqname_under_indices {
@@ -2094,7 +2092,6 @@ impl DeclQuery {
                     continue;
                 }
             }
-            let node = node_py.borrow(py);
             // kind
             if let Some(k) = &kinds_set {
                 if !k.contains(node.kind) {


### PR DESCRIPTION
## Summary

- `GraphBuilder` now stores nodes as a pure-Rust `Vec<GraphNode>` instead of eagerly minting one `Py<SymbolNode>` pyclass per node during the build. Eager minting forced a GIL acquisition + Python heap allocation for **every** node, even though most are never surfaced to Python.
- `Py<SymbolNode>` is now created lazily via `GraphNode::to_symbol(py)`, only at the real Python boundaries (`nodes()`, query results, reachability results).
- Internal queries read `GraphNode` fields directly — no GIL, no `borrow(py)`. The apply pass and most query paths are now GIL-free.

## Details

- Dropped 10 now-unused `py: Python<'_>` params from internal `ProjectContext` methods and updated all Rust callers. pyo3 auto-injects `py`, so the **Python-visible signatures are unchanged**.
- Removed 4 redundant `Python::with_gil(...)` wrappers in native plugins that only existed to call those methods.
- Internal helpers (`find_decorations_on`, `locate_class_def`/`locate_class_seed`, `NodeView`) switched from `&SymbolNode` to `&GraphNode`.

No public API or behavior change.

## Test plan

- [x] `cargo build -p dead-cst-runtime && cargo clippy -p dead-cst-runtime` (clean)
- [x] clippy `--all-targets --locked -- -D warnings` (pre-commit, clean)
- [x] `uv run --with maturin maturin develop --uv`
- [x] `uv run pytest` — 800 passed, 3 skipped
- [x] `uv run prek run --all-files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)