### PR TITLE
Drop stale dead_code allows on the NativePluginImpl trait

### DIFF
--- a/runtime/src/native_plugins.rs
+++ b/runtime/src/native_plugins.rs
@@ -78,14 +78,12 @@ pub(crate) trait NativePluginImpl: Send + Sync {
     // Borrowed (not `&'static`) so an impl can own a runtime-built name —
     // the custom `DispatchAppPluginImpl` carries a caller-supplied `String`.
     // The bundled impls still return string literals.
-    #[allow(dead_code)]
     fn name(&self) -> &str;
 
     /// Walk the frozen ``ctx`` and append the plugin's ops to
     /// ``sink``. Same frozen-graph contract as the Python path: the
     /// impl observes the base graph only; its emissions are folded in
     /// by the apply pass after every plugin returns.
-    #[allow(dead_code)]
     fn run(&self, ctx: &FrozenView<'_>, sink: &mut Vec<PreparedOp>) -> PyResult<()>;
 
     /// Pre-graph hook, mirroring the Python ``Plugin.prepare`` contract:
@@ -93,7 +91,6 @@ pub(crate) trait NativePluginImpl: Send + Sync {
     /// the impl can scan for config files / framework manifests. Default
     /// no-op. Runs before the graph exists, so it must not touch
     /// ``ProjectContext``.
-    #[allow(dead_code)]
     fn prepare(&self, _project_root: &str) {}
 }
 


### PR DESCRIPTION
## Summary

- `NativePluginImpl::name` / `run` / `prepare` carried `#[allow(dead_code)]` left over from the mid-migration state (added 2026-05-28/05-30, before the harness called them).
- All three are now statically reachable through the `Arc<dyn NativePluginImpl>` trait object: the rayon fan-out calls `run()`, progress reporting calls `name()`, and `prepare()` is dispatched from `NativePluginKind`.
- Remove the three suppressions; `clippy --all-targets -- -D warnings` stays clean without them. No behavior change.

## Test plan

- [x] `cargo build -p dead-cst-runtime`
- [x] `cargo clippy -p dead-cst-runtime --all-targets --locked -- -D warnings` (clean — no resurfaced dead_code warning)
- [x] `cargo fmt --all -- --check` (clean)
- [ ] CI: full pytest matrix + lint + rust-test (no-op behaviorally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)