### PR TITLE
Ship the plugin-host closure xz-compressed to clear PyPI's size cap

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,6 +138,24 @@ jobs:
             python setup.py bdist_wheel \
             --plat-name "${{ matrix.platform.plat }}" \
             --dist-dir "$GITHUB_WORKSPACE/dist-host"
+      # Report-only: surface each wheel's size so the real per-platform numbers
+      # are visible (esp. the plugin-host wheel vs PyPI's 100 MB/file cap).
+      - name: Report wheel sizes
+        shell: bash
+        run: |
+          limit=100000000  # PyPI's per-file cap: 100 MB
+          {
+            echo "### Wheel sizes (${{ matrix.platform.target }})"
+            echo ""
+            echo "| wheel | size | PyPI 100 MB/file |"
+            echo "|---|---|---|"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+          for whl in dist/*.whl dist-host/*.whl; do
+            bytes=$(stat -c%s "$whl" 2>/dev/null || stat -f%z "$whl")
+            mb=$(awk "BEGIN{printf \"%.1f\", $bytes/1000000}")
+            if [ "$bytes" -gt "$limit" ]; then flag="OVER"; else flag="ok"; fi
+            echo "| $(basename "$whl") | ${mb} MB | ${flag} |" | tee -a "$GITHUB_STEP_SUMMARY"
+          done
       - uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ matrix.platform.target }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ two versions.
     <version>`) and shipped to TestPyPI on every push to `main` and PyPI
     on release. The lockstep is mandatory — the runtime version is part
     of the ABI fingerprint. No Windows plugin support (static wheel).
+  - The `dead-cst-plugin-host` closure is now stored **xz-compressed**
+    inside the wheel (each `.rlib` / proc-macro dylib as `<name>.xz`,
+    `ZIP_STORED`). The raw closure is ~320 MB and a deflate wheel lands at
+    ~107 MB — over PyPI's 100 MB/file cap; xz packs it to ~70 MB.
+    `build-plugin` decompresses to a temp dir (freed on exit) before
+    invoking `rustc`. Uses the stdlib `lzma` module, so the
+    `[build-plugin]` extra gains no dependency.
 - **Fleshed-out external native plugin API.** The curated
   `dead_cst_runtime::native_plugins::plugin_api` an external plugin
   compiles against grew from a single `PluginCtx::main_blocks()` /

--- a/NATIVE_PLUGINS.md
+++ b/NATIVE_PLUGINS.md
@@ -348,7 +348,7 @@ The split keeps the cost where it belongs:
 | install | download | installed | for |
 |---|---|---|---|
 | `dead-cst` | ~25 MB | ~60 MB | everyone — analysis, the CLI, the built-in plugins |
-| `dead-cst[build-plugin]` | +~130 MB | +~320 MB | authoring native plugins |
+| `dead-cst[build-plugin]` | +~70 MB | +~70 MB | authoring native plugins |
 
 The base `dead-cst` macOS/Linux wheel carries the shared runtime dylib + libstd
 alongside the `_native` shim (so it's a bit larger than a pure static build, and
@@ -356,8 +356,11 @@ the host runs the shared runtime). The `[build-plugin]` extra then pulls
 **`dead-cst-plugin-host`**, a data-only, platform-specific package shipping only
 the **compile closure**: the `.rlib` dependency archives + proc-macro dylibs
 `rustc` needs to validate the crate graph. `build-plugin` finds it via `import
-dead_cst_plugin_host`. It's large because `rustc` needs the full closure to
-compile against the runtime; nothing in it is needed at *runtime*.
+dead_cst_plugin_host`. Each artifact ships **xz-compressed** — the raw closure is
+~320 MB and zip's deflate only gets it to ~107 MB (over PyPI's 100 MB/file cap),
+while xz packs it to ~70 MB; `build-plugin` decompresses to a temp dir (~320 MB,
+freed on exit) before invoking `rustc`. It's large because `rustc` needs the full
+closure to compile against the runtime; nothing in it is needed at *runtime*.
 
 Maintainers produce both halves from **one** prefer-dynamic build, so the
 runtime dylib's SVH matches the rlib closure plugins compile against. **`dead-cst

--- a/plugin-host/pyproject.toml
+++ b/plugin-host/pyproject.toml
@@ -17,9 +17,11 @@ requires-python = ">=3.11"
 packages = ["dead_cst_plugin_host"]
 
 # The payload is binary + platform-specific: the `.rlib` dependency closure +
-# proc-macro dylibs that `rustc` needs to compile a plugin against the runtime.
-# (The runtime dylib + libstd ship in the base `dead_cst` wheel.) `dead-cst
+# proc-macro dylibs that `rustc` needs to compile a plugin against the runtime,
+# each stored xz-compressed (`<name>.rlib.xz` / `…dylib.xz`) so the wheel clears
+# PyPI's 100 MB/file cap — `build-plugin` decompresses them before rustc. (The
+# runtime dylib + libstd ship in the base `dead_cst` wheel.) `dead-cst
 # bundle-plugin-host` populates these; the publish workflow builds one platform
 # wheel per target.
 [tool.setuptools.package-data]
-dead_cst_plugin_host = ["*.rlib", "*.so", "*.dylib"]
+dead_cst_plugin_host = ["*.xz"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,9 @@ dependencies = [
 [project.optional-dependencies]
 # Authoring native plugins (`dead-cst build-plugin`) needs the `.rlib`
 # dependency closure to compile against (the runtime dylib itself ships in the
-# base macOS/Linux wheel). The closure is large (~130 MB compressed) and
-# platform-specific, so it ships as a SEPARATE package pulled in only on demand.
+# base macOS/Linux wheel). The closure is large (~70 MB xz-compressed,
+# decompressed on use) and platform-specific, so it ships as a SEPARATE package
+# pulled in only on demand.
 # (The publish workflow pins this to `== <this version>`; the load-time ABI
 # fingerprint rejects any mismatch regardless.)
 build-plugin = ["dead-cst-plugin-host"]

--- a/python/dead_cst/cli.py
+++ b/python/dead_cst/cli.py
@@ -17,12 +17,15 @@ them as additional module-resolution search paths.
 
 from __future__ import annotations
 
+import atexit
 import json
 import logging
+import lzma
 import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Iterable, Sequence
@@ -608,14 +611,33 @@ def _plugin_host_bundle() -> Path | None:
     """The compile-time payload shipped by the ``dead-cst[build-plugin]`` extra
     as the separate ``dead_cst_plugin_host`` package: the ``.rlib`` dependency
     closure + proc-macro dylibs ``rustc`` needs to compile a plugin against the
-    runtime. (The runtime dylib + libstd ship in the base ``dead_cst`` wheel.)
-    None if the extra isn't installed."""
+    runtime, each stored xz-compressed so the wheel clears PyPI's per-file size
+    cap. (The runtime dylib + libstd ship in the base ``dead_cst`` wheel.) None
+    if the extra isn't installed."""
     try:
         import dead_cst_plugin_host  # ty: ignore[unresolved-import]
     except Exception:
         return None
     bundle = Path(dead_cst_plugin_host.__file__).resolve().parent
-    return bundle if any(bundle.glob("*.rlib")) else None
+    return bundle if any(bundle.glob("*.rlib.xz")) else None
+
+
+def _materialize_dep_closure(dep_dir: Path) -> Path:
+    """``rustc`` needs the dependency closure uncompressed under its original
+    filenames, but the shipped ``dead_cst_plugin_host`` payload stores each
+    artifact xz-compressed (to keep the wheel under PyPI's per-file size cap).
+    Decompress any ``*.xz`` into a temp dir (cleaned at exit) and return it; a
+    raw deps dir (e.g. a local ``--runtime-dir`` build) has no ``*.xz`` and is
+    returned unchanged."""
+    compressed = sorted(dep_dir.glob("*.xz"))
+    if not compressed:
+        return dep_dir
+    staging = Path(tempfile.mkdtemp(prefix="dead-cst-plugin-host-"))
+    atexit.register(shutil.rmtree, staging, ignore_errors=True)
+    for src in compressed:
+        with lzma.open(src, "rb") as fsrc, open(staging / src.name[: -len(".xz")], "wb") as fdst:
+            shutil.copyfileobj(fsrc, fdst)
+    return staging
 
 
 def _build_runtime_from_source(root: Path, *, release: bool, std_lib: Path) -> Path:
@@ -741,6 +763,10 @@ def build_plugin(
             f"shared runtime dylib not found at {runtime_dylib}; build-plugin needs the "
             "dynamic-runtime wheel (pip install dead-cst[build-plugin])."
         )
+
+    # The shipped closure is xz-compressed (PyPI per-file size cap); rustc needs
+    # it decompressed. No-op for a raw local deps dir.
+    dep_dir = _materialize_dep_closure(dep_dir)
 
     # Resolve the plugin source (default: bundled example from a source checkout).
     if plugin_src is None:
@@ -871,7 +897,7 @@ def bundle_plugin_host(
 
     bundle.mkdir(parents=True, exist_ok=True)
     # Clean only prior build artifacts — keep package files like __init__.py.
-    for stale in (*bundle.glob("*.rlib"), *bundle.glob(f"*{suffix}")):
+    for stale in (*bundle.glob("*.rlib"), *bundle.glob(f"*{suffix}"), *bundle.glob("*.xz")):
         stale.unlink()
 
     # The plugin-compile closure: every dependency `.rlib` + the proc-macro
@@ -903,14 +929,31 @@ def bundle_plugin_host(
             cur = newest.get(key)
             if cur is None or entry.stat().st_mtime > cur.stat().st_mtime:
                 newest[key] = entry
+    # Store each artifact xz-compressed (`<name>.xz`). A wheel is a zip, and the
+    # raw `.rlib` closure deflates to ~107 MB — over PyPI's 100 MB/file cap. The
+    # bulk is `lib.rmeta` crate metadata embedded in each rlib, which can't be
+    # stripped without breaking `rustc --extern`. xz packs far tighter than zip's
+    # deflate (~70 MB here); `build-plugin` decompresses via `_materialize_dep_closure`
+    # before handing paths to rustc. stdlib `lzma` keeps `[build-plugin]` dep-free.
     n_files = 0
+    raw_bytes = 0
+    xz_bytes = 0
     for entry in newest.values():
-        shutil.copy2(entry, bundle / entry.name)
+        dest = bundle / f"{entry.name}.xz"
+        with (
+            open(entry, "rb") as fsrc,
+            lzma.open(dest, "wb", preset=9 | lzma.PRESET_EXTREME) as fdst,
+        ):
+            shutil.copyfileobj(fsrc, fdst)
         n_files += 1
+        raw_bytes += entry.stat().st_size
+        xz_bytes += dest.stat().st_size
 
     typer.echo(f"plugin-host closure: {bundle}  (deps build: {deps_dir})", err=True)
     typer.echo(
-        f"  {n_files} rlib / proc-macro artifacts (runtime dylib + libstd ship in dead_cst)",
+        f"  {n_files} rlib / proc-macro artifacts, xz-compressed "
+        f"{raw_bytes / 1_000_000:.1f} MB -> {xz_bytes / 1_000_000:.1f} MB "
+        f"(runtime dylib + libstd ship in dead_cst)",
         err=True,
     )
     typer.echo(str(bundle))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import lzma
 import textwrap
 from pathlib import Path
 
@@ -24,6 +25,7 @@ from typer.testing import CliRunner
 from dead_cst.cli import (
     _crate_key,
     _dead_real,
+    _materialize_dep_closure,
     _rel_path,
     app,
     build_plugins,
@@ -201,6 +203,41 @@ def test_crate_key_collapses_distinct_svh_of_same_crate():
     assert _crate_key("libregex-1111111111111111.rlib") == _crate_key(
         "libregex-2222222222222222.rlib"
     )
+
+
+# ---------------------------------------------------------------------------
+# _materialize_dep_closure
+# ---------------------------------------------------------------------------
+
+
+def test_materialize_dep_closure_decompresses_xz(tmp_path):
+    # The shipped plugin-host closure stores each artifact xz-compressed; the
+    # consumer must decompress to original filenames before handing paths to rustc.
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    payloads = {
+        "libregex-abc.rlib": b"rlib-bytes-" * 1000,
+        "libserde_derive-def.dylib": b"proc-macro-bytes-" * 1000,
+    }
+    for name, data in payloads.items():
+        (bundle / f"{name}.xz").write_bytes(lzma.compress(data))
+
+    staged = _materialize_dep_closure(bundle)
+
+    assert staged != bundle  # decompressed into a fresh temp dir
+    assert {p.name for p in staged.iterdir()} == set(payloads)
+    for name, data in payloads.items():
+        assert (staged / name).read_bytes() == data
+
+
+def test_materialize_dep_closure_passes_through_raw_dir(tmp_path):
+    # A raw local deps dir (e.g. a `--runtime-dir` build) has no `*.xz`; it must
+    # be returned unchanged so rustc reads the rlibs in place.
+    raw = tmp_path / "deps"
+    raw.mkdir()
+    (raw / "libregex-abc.rlib").write_bytes(b"plain")
+
+    assert _materialize_dep_closure(raw) == raw
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The `dead-cst-plugin-host` wheel bundles the `.rlib` + proc-macro compile closure `rustc` needs to build out-of-tree plugins. Under zip's deflate it lands at **~107 MB locally — over PyPI's 100 MB/file limit**, which blocks publishing it. The bulk is `lib.rmeta` crate metadata embedded in each rlib, which can't be stripped without breaking `rustc --extern`.
- Store each artifact **xz-compressed** (`<name>.xz`, `ZIP_STORED`) instead of re-deflating. Measured locally: deflate ~107 MB (OVER) → **xz -9e ~70 MB (UNDER)**. `build-plugin` decompresses to a temp dir (freed on exit) before invoking `rustc`; a raw local `--runtime-dir` deps dir has no `.xz` and is passed through unchanged.
- Uses the stdlib `lzma` module, so the `[build-plugin]` extra gains **no new dependency** (zstd would have needed a third-party package).
- Adds a **report-only** CI step in the `dynamic` job that prints each built wheel's size against the 100 MB cap, so the real per-platform numbers (esp. the Linux closure) are visible.

### Touch points
- `python/dead_cst/cli.py` — producer `bundle_plugin_host` xz-compresses each deduped artifact; consumer `build_plugin` calls the new `_materialize_dep_closure` to decompress; `_plugin_host_bundle` sentinel now checks `*.rlib.xz`.
- `plugin-host/pyproject.toml` — package-data glob `*.rlib`/`*.so`/`*.dylib` → `*.xz`.
- `pyproject.toml`, `NATIVE_PLUGINS.md`, `CHANGELOG.md` — size/docs updates.
- `.github/workflows/publish.yml` — wheel-size readout step.

> Note: the wheel-size readout lives in the `Publish` workflow, which only runs on push to `main` / release — **not on this PR**. The real per-platform sizes will show up after merge.

## Test plan

- [x] `uv run pytest` — 691 passed, 3 skipped
- [x] New `tests/test_cli.py` round-trip tests for `_materialize_dep_closure` (xz decompress + raw passthrough)
- [x] `uv run prek run --all-files` — ruff, ruff-format, ty, cargo fmt, cargo clippy all pass
- [ ] CI matrix `pytest` (3.11–3.14) + `prek` green
- [ ] After merge: confirm the publish run's "Report wheel sizes" step shows the plugin-host wheel UNDER 100 MB on macOS arm64 + Linux x86_64/aarch64

🤖 Generated with [Claude Code](https://claude.com/claude-code)