### PR TITLE
Add a plugin_api epoch segment to the native-plugin ABI fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ two versions.
 
 ### Added
 
+- **`plugin_api` epoch in the ABI fingerprint.** The native-plugin ABI
+  fingerprint gains a dedicated `api<N>` segment
+  (`native_plugins::plugin_api::PLUGIN_API_EPOCH`, bumped in
+  `runtime/build.rs`) tracking the curated `plugin_api` surface. Bumping it
+  rejects plugins compiled against an older API at load — distinct from a
+  rustc / runtime-version / target change — so an incompatible `plugin_api`
+  edit can invalidate stale plugins on its own.
 - **External native plugins (experimental).** The native crate is split
   into a `dead-cst-runtime` library (built as both `rlib` and `dylib`)
   and a thin `dead-cst-native` cdylib shim, so a plugin can dynamically

--- a/NATIVE_PLUGINS.md
+++ b/NATIVE_PLUGINS.md
@@ -323,8 +323,10 @@ A plugin is compiled against one exact dead-cst build, so it must be
 **recompiled for each release**. dead-cst enforces that without ever crashing:
 
 - Every plugin bakes an **ABI fingerprint** at compile time —
-  `epoch | rustc commit | runtime version | target` — taken from the runtime it
-  built against.
+  `epoch | api<plugin_api epoch> | rustc commit | runtime version | target` —
+  taken from the runtime it built against. The `api<N>` segment is a dedicated
+  epoch for the curated `plugin_api` surface: bumping it (in `runtime/build.rs`)
+  rejects plugins compiled against an older API even when nothing else changed.
 - `native.load_native_plugins(path)` opens the dylib lazily and reads a
   **self-contained manifest** (plain data + the baked fingerprint) *before*
   touching any version-hashed runtime symbol.
@@ -332,8 +334,8 @@ A plugin is compiled against one exact dead-cst build, so it must be
   match the running runtime, the load is **rejected with a clear error**:
 
   ```
-  ABI mismatch — plugin built against '1|commit-hash: …|v0.13.0|aarch64-apple-darwin',
-  this runtime is '1|…|v0.14.0|…'. Rebuild the plugin against this release.
+  ABI mismatch — plugin built against '1|api1|commit-hash: …|v0.13.0|aarch64-apple-darwin',
+  this runtime is '1|api2|…|v0.14.0|…'. Rebuild the plugin against this release.
   ```
 
 So a stale `.so` is refused, not segfaulted. Rebuild with `build-plugin` and

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -1,10 +1,20 @@
 use std::process::Command;
 
+/// Epoch of the curated `plugin_api` surface external plugins compile against.
+/// **Bump this** whenever that surface changes incompatibly — a trait method
+/// signature (`ExternalPlugin::run`, `PerFilePlugin::run_on_file`), a
+/// renamed/removed `PluginCtx`/`PluginOps` query, a changed re-exported type —
+/// so a plugin built against the old API is rejected at load, distinct from a
+/// plain version bump. Folded into the ABI fingerprint below and re-exported as
+/// `native_plugins::plugin_api::PLUGIN_API_EPOCH`.
+const PLUGIN_API_EPOCH: u32 = 1;
+
 /// Compose the ABI fingerprint that gates external native-plugin loading.
 /// It changes whenever anything that could break the dylib ABI changes:
-/// the compiler (commit hash), the runtime version, the target, or a manual
-/// epoch bump. A plugin bakes the runtime's fingerprint at compile time, so
-/// a plugin built against a different runtime is rejected at load.
+/// the compiler (commit hash), the runtime version, the target, the curated
+/// [`PLUGIN_API_EPOCH`], or a manual `DEAD_CST_ABI_EPOCH` bump. A plugin bakes
+/// the runtime's fingerprint at compile time, so a plugin built against a
+/// different runtime is rejected at load.
 fn main() {
     let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
     let vv = Command::new(&rustc)
@@ -21,6 +31,9 @@ fn main() {
     let version = std::env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0".into());
     let epoch = std::env::var("DEAD_CST_ABI_EPOCH").unwrap_or_else(|_| "1".into());
 
-    println!("cargo:rustc-env=RUNTIME_ABI_FINGERPRINT={epoch}|{commit}|v{version}|{target}");
+    println!("cargo:rustc-env=PLUGIN_API_EPOCH={PLUGIN_API_EPOCH}");
+    println!(
+        "cargo:rustc-env=RUNTIME_ABI_FINGERPRINT={epoch}|api{PLUGIN_API_EPOCH}|{commit}|v{version}|{target}"
+    );
     println!("cargo:rerun-if-env-changed=DEAD_CST_ABI_EPOCH");
 }

--- a/runtime/src/native_plugins.rs
+++ b/runtime/src/native_plugins.rs
@@ -1230,6 +1230,15 @@ pub mod plugin_api {
     /// fan-out, the same bit the visitor stamps on dynamic-import edges.
     pub const FLAG_DYNAMIC_IMPORT: u32 = EdgeFlags::DYNAMIC_IMPORT;
 
+    /// Epoch of this curated `plugin_api` surface — the author-facing contract
+    /// version, baked into the [ABI fingerprint](super::PLUGIN_ABI_FINGERPRINT)
+    /// (the `api<N>` segment). It is **bumped in `runtime/build.rs`** whenever
+    /// this surface changes incompatibly, so a plugin compiled against an older
+    /// `plugin_api` is rejected at load even if nothing else (rustc, version,
+    /// target) changed. Exposed for plugin authors and diagnostics; the
+    /// load-time gate compares the whole fingerprint, not this value alone.
+    pub const PLUGIN_API_EPOCH: &str = env!("PLUGIN_API_EPOCH");
+
     /// Error a plugin returns from [`ExternalPlugin::run`]. **Pyo3-free by
     /// design** — the curated surface never names a `PyErr`, so a plugin author
     /// depends only on this crate's API, not on pyo3. The host maps it to a
@@ -2296,9 +2305,11 @@ pub mod plugin_api {
     }
 }
 
-/// ABI fingerprint this runtime accepts (see `build.rs`). An external plugin
-/// bakes this exact string at compile time; the airlock rejects any plugin
-/// whose baked fingerprint differs.
+/// ABI fingerprint this runtime accepts (see `build.rs`):
+/// `<abi-epoch>|api<plugin-api-epoch>|<rustc-commit>|v<version>|<target>`. An
+/// external plugin bakes this exact string at compile time; the airlock rejects
+/// any plugin whose baked fingerprint differs. The `api<N>` segment tracks
+/// [`plugin_api::PLUGIN_API_EPOCH`].
 pub const PLUGIN_ABI_FINGERPRINT: &str = env!("RUNTIME_ABI_FINGERPRINT");
 
 /// Magic number prefixing a valid plugin manifest.
@@ -4266,5 +4277,23 @@ mod dynamic_import_glob_tests {
     fn path_match_literal_filename() {
         assert!(path_match("pkg/legacy/b.py", "pkg/legacy/b.py"));
         assert!(!path_match("pkg/legacy/a.py", "pkg/legacy/b.py"));
+    }
+}
+
+#[cfg(test)]
+mod fingerprint_tests {
+    use super::plugin_api::PLUGIN_API_EPOCH;
+    use super::PLUGIN_ABI_FINGERPRINT;
+
+    #[test]
+    fn fingerprint_embeds_plugin_api_epoch() {
+        // The curated-API epoch is part of the load-time gate, so bumping it
+        // invalidates plugins built against an older `plugin_api`. Lock the
+        // wiring: build.rs must keep the `api<N>` segment in the fingerprint.
+        let seg = format!("|api{PLUGIN_API_EPOCH}|");
+        assert!(
+            PLUGIN_ABI_FINGERPRINT.contains(&seg),
+            "fingerprint {PLUGIN_ABI_FINGERPRINT:?} missing segment {seg:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- The native-plugin ABI fingerprint already gates external plugins on `rustc` commit + runtime version + target + a manual `DEAD_CST_ABI_EPOCH`. This adds a **dedicated epoch for the curated `plugin_api` surface**, so an incompatible change to the author-facing API (a trait method signature like `ExternalPlugin::run`, a renamed/removed `PluginCtx`/`PluginOps` query) can invalidate stale plugins on its own — independent of a version bump.
- `PLUGIN_API_EPOCH` is the source-of-truth knob in `runtime/build.rs` (a `const` you bump). It's folded into the fingerprint as a labeled `api<N>` segment and re-exported as `native_plugins::plugin_api::PLUGIN_API_EPOCH` (mirroring how `PLUGIN_ABI_FINGERPRINT` is already `env!`-sourced from build.rs).
- New fingerprint format: `<abi-epoch>|api<N>|<rustc-commit>|v<version>|<target>`.

### Touch points
- `runtime/build.rs` — `PLUGIN_API_EPOCH` const + the `api<N>` fingerprint segment + a `rustc-env` emit.
- `runtime/src/native_plugins.rs` — `pub const plugin_api::PLUGIN_API_EPOCH`, updated `PLUGIN_ABI_FINGERPRINT` doc, and a `fingerprint_tests` module asserting the `|api<N>|` segment is present.
- `NATIVE_PLUGINS.md`, `CHANGELOG.md` — docs + `[Unreleased]` entry.

> Note: this changes the fingerprint, so any already-built external plugin is rejected at load until rebuilt. Expected for the experimental external-plugin API (plugins must be recompiled per release anyway).

## Test plan

- [x] `cargo build -p dead-cst-runtime` clean
- [x] `cargo test --no-default-features --locked -p dead-cst-runtime` — 139 passed, incl. new `fingerprint_embeds_plugin_api_epoch`
- [x] `prek run --all-files` — ruff, ruff-format, ty, cargo fmt, cargo clippy all pass
- [x] `uv run pytest` — 691 passed, 3 skipped
- [ ] CI matrix `pytest` (3.11–3.14) + `rust-test` + `lint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)