### PR TITLE
Eliminate mid-build AST re-parses to cut the memory peak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,16 @@ two versions.
   / `--extern regex` from a curated allowlist so a plugin can `use
   serde_json::Value;` / `use regex::Regex;` out of the box. The rest of the
   runtime's private dependency tree is intentionally not exposed.
+- **`Analysis.set_stack_size(bytes)` for deeply-nested ASTs.** Overrides the
+  rayon worker-thread stack size for *both* the per-file populate fan-out and
+  the project-wide plugin pass (the class-hierarchy re-walks subclass resolution
+  drives recurse as deep as file ingest). Call it before `materialize_all()`;
+  with no override both phases use rayon's default stack (2 MiB unless
+  `RAYON_STACK_SIZE` / `RUST_MIN_STACK` is set process-wide), which suffices for
+  typical code. Use it on projects with deeply-nested generated code (protobuf
+  modules, ML-generated ASTs, large nested literal dicts) that stack-overflow at
+  the default — the size is virtual address space, so a large value costs no
+  resident memory unless actually used.
 
 ### Changed
 
@@ -211,8 +221,13 @@ two versions.
   instead of staying resident through assembly and the project-wide plugin
   pass. On a 250-file synthetic project this takes the parsed-AST salsa heap
   from ~5 MB to ~0 at build-end (~30% of total salsa memory). Subclass
-  resolution and the `find_comment_patterns` query re-parse the specific files
-  they touch on demand, so all results are unchanged.
+  resolution no longer re-parses: per-file class bases captured during the
+  fan-out feed an external-base→subclass index and an idx→name-range reverse
+  map, so both the in-project and external-seed paths resolve from those cached
+  facts (re-export / alias chains still walk ty's own `find_references`). That
+  fallback is the one remaining on-demand reloader — it can pull a file's AST
+  back in during the project-wide plugin pass — so any AST it reloads is dropped
+  again once the pass completes. All results are unchanged.
 - **Built-in plugins are migrating to native (Rust) implementations.**
   The `main_block`, `module_dunders`, `init_subclass`, `server_config`,
   and `unittest` built-ins now resolve to native `NativePlugin`
@@ -284,6 +299,10 @@ two versions.
 
 ### Removed
 
+- `ProjectContext.find_comment_patterns(pattern)` (the regex-over-comments
+  query) and its `_native.pyi` stub. It had no in-tree callers and was the last
+  graph query that re-parsed files on demand after the build; removing it drops
+  that re-parse path entirely.
 - The Python `ServerConfigPlugin` (`dead_cst.contrib.ServerConfigPlugin`).
   `server_config` is now native-only: use `NativePlugin.server_config()` (the
   CLI's `server_config` key already resolves to it), passing `filenames=[…]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,13 +221,24 @@ two versions.
   instead of staying resident through assembly and the project-wide plugin
   pass. On a 250-file synthetic project this takes the parsed-AST salsa heap
   from ~5 MB to ~0 at build-end (~30% of total salsa memory). Subclass
-  resolution no longer re-parses: per-file class bases captured during the
-  fan-out feed an external-base→subclass index and an idx→name-range reverse
-  map, so both the in-project and external-seed paths resolve from those cached
-  facts (re-export / alias chains still walk ty's own `find_references`). That
-  fallback is the one remaining on-demand reloader — it can pull a file's AST
-  back in during the project-wide plugin pass — so any AST it reloads is dropped
-  again once the pass completes. All results are unchanged.
+  resolution no longer re-parses **and no longer runs ty's `find_references`
+  walk by default**: each file captures its module-level name bindings during
+  the fan-out, and every class base — just a name, bound one of four ways
+  (local class, explicit import, `from … import *`, or a module-level alias
+  `Base = Imported`) — resolves through that one uniform binder ladder. At
+  assemble time the per-file bindings fold into a project-wide alias/re-export
+  chain that is chased cross-file to each base's terminal class, so subclasses
+  reached through a star import, a module-level alias, or an *absolute*
+  re-export now resolve statically from those cached facts. The
+  `find_references` re-export/alias walk — previously always run, and the one
+  remaining on-demand AST reloader — is now an opt-in fallback gated behind
+  `DEAD_CST_SUBCLASS_REF_FALLBACK`, needed only for bases re-exported through a
+  *relative* import (which the static import table doesn't resolve); only when
+  enabled can it pull a file's AST back in during the project-wide plugin pass.
+  The memory and no-re-parse mechanics are results-neutral; the one behavioral
+  change is that the static chase now keeps star-import / module-alias /
+  absolute-re-export subclasses alive where the default path previously dropped
+  them.
 - **Built-in plugins are migrating to native (Rust) implementations.**
   The `main_block`, `module_dunders`, `init_subclass`, `server_config`,
   and `unittest` built-ins now resolve to native `NativePlugin`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,23 +222,21 @@ two versions.
   pass. On a 250-file synthetic project this takes the parsed-AST salsa heap
   from ~5 MB to ~0 at build-end (~30% of total salsa memory). Subclass
   resolution no longer re-parses **and no longer runs ty's `find_references`
-  walk by default**: each file captures its module-level name bindings during
+  walk at all**: each file captures its module-level name bindings during
   the fan-out, and every class base — just a name, bound one of four ways
   (local class, explicit import, `from … import *`, or a module-level alias
-  `Base = Imported`) — resolves through that one uniform binder ladder. At
-  assemble time the per-file bindings fold into a project-wide alias/re-export
-  chain that is chased cross-file to each base's terminal class, so subclasses
-  reached through a star import, a module-level alias, or an *absolute*
-  re-export now resolve statically from those cached facts. The
-  `find_references` re-export/alias walk — previously always run, and the one
-  remaining on-demand AST reloader — is now an opt-in fallback gated behind
-  `DEAD_CST_SUBCLASS_REF_FALLBACK`, needed only for bases re-exported through a
-  *relative* import (which the static import table doesn't resolve); only when
-  enabled can it pull a file's AST back in during the project-wide plugin pass.
-  The memory and no-re-parse mechanics are results-neutral; the one behavioral
-  change is that the static chase now keeps star-import / module-alias /
-  absolute-re-export subclasses alive where the default path previously dropped
-  them.
+  `Base = Imported`) — resolves through that one uniform binder ladder. The
+  import table reads each `from … import` statement's leading-dot level, so
+  *relative* re-exports (`from .bases import TestCase`) resolve to the same
+  terminal class as absolute ones. At assemble time the per-file bindings fold
+  into a project-wide alias/re-export chain that is chased cross-file to each
+  base's terminal class, so subclasses reached through a star import, a
+  module-level alias, or an absolute *or* relative re-export now resolve
+  statically from those cached facts — no on-demand AST reload, no env-var
+  fallback. The memory and no-re-parse mechanics are results-neutral; the one
+  behavioral change is that the static chase now keeps star-import /
+  module-alias / re-export subclasses alive where the default path previously
+  dropped them.
 - **Built-in plugins are migrating to native (Rust) implementations.**
   The `main_block`, `module_dunders`, `init_subclass`, `server_config`,
   and `unittest` built-ins now resolve to native `NativePlugin`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,18 @@ two versions.
 
 ### Changed
 
+- **Per-file parsed ASTs are freed mid-build to cut the memory peak.** The
+  project-wide plugin queries that used to re-walk each file's AST (parameters,
+  class-defining-method, decorators, constructions, factories, and the
+  call-site family) now read precomputed per-file facts from a salsa-cached
+  `FileExtraction`, warmed during the per-file fan-out alongside the existing
+  node/edge payloads. Once a file's payloads, `FileExtraction`, and per-file
+  plugins are computed, its parsed AST is dropped (`ParsedModule::clear`)
+  instead of staying resident through assembly and the project-wide plugin
+  pass. On a 250-file synthetic project this takes the parsed-AST salsa heap
+  from ~5 MB to ~0 at build-end (~30% of total salsa memory). Subclass
+  resolution and the `find_comment_patterns` query re-parse the specific files
+  they touch on demand, so all results are unchanged.
 - **Built-in plugins are migrating to native (Rust) implementations.**
   The `main_block`, `module_dunders`, `init_subclass`, `server_config`,
   and `unittest` built-ins now resolve to native `NativePlugin`

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -1058,19 +1058,6 @@ class ProjectContext:
         """
         ...
 
-    # ----- Comment-driven patterns --------------------------------------
-
-    def find_comment_patterns(self, pattern: str) -> list[tuple[SymbolNode, str]]:
-        """``(decl_node, comment_text)`` for every comment in the
-        project matching ``pattern`` (a regex), paired with the next
-        declaration that follows it in the same file.
-
-        Comments are scanned from the parser's ``Tokens`` stream (no
-        re-lexing); regex matching is full-text against the comment
-        content (leading ``#`` included).
-        """
-        ...
-
     # ----- Read-only graph accessors ------------------------------------
 
     def nodes(self) -> list[SymbolNode]:

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -495,11 +495,15 @@ class Analysis:
 
     def set_stack_size(self, bytes_: int) -> None:
         """Override the rayon worker stack size (bytes) used by the
-        populate phase. Call BEFORE :meth:`materialize_all`; calls
-        after the graph is materialized have no effect on the
-        already-built graph.
+        populate phase AND the project-wide plugin pass. Call BEFORE
+        :meth:`materialize_all`; calls after the graph is materialized
+        have no effect on the already-built graph.
 
-        With no override set, the populate phase uses rayon's global
+        Both fan-outs honour the override because the deep recursion
+        spans both: file ingest in populate, and the class-hierarchy
+        re-walks subclass-resolution plugins drive in the plugin pass.
+
+        With no override set, both phases use rayon's global
         pool with rayon's own default stack (2 MiB unless
         ``RAYON_STACK_SIZE`` / ``RUST_MIN_STACK`` are set
         process-wide), which is sufficient for typical Python code.

--- a/runtime/src/file_extraction.rs
+++ b/runtime/src/file_extraction.rs
@@ -1,0 +1,704 @@
+//! Per-file owned facts, extracted from the AST once during the
+//! fan-out. Project-wide plugin queries read these facts (a salsa cache
+//! hit) instead of re-walking live ASTs, which lets the parsed modules
+//! be freed before the project-wide plugin pass runs — cutting the
+//! in-build memory peak rather than just the post-build steady state.
+//!
+//! Every field is plain owned data — ranges as `(u32, u32)`, names and
+//! values as `String` — keyed by name-range so the project-wide query
+//! can fan in to a global graph index via `outputs.global_index` /
+//! `outputs.decl_by_name_range` without holding anything that points
+//! into the AST allocation. That ownership is what makes clearing the
+//! parsed module behind this query sound.
+//!
+//! Sibling of [`crate::file_payload::file_to_nodes`] /
+//! [`crate::file_payload::file_to_edges`] /
+//! [`crate::file_ref_edges::file_to_ref_edges`]; unlike `file_to_nodes`
+//! (the cross-file lookup primitive) this query is never called
+//! cross-file, so it carries no `'db` lifetime and absorbs facts freely.
+
+use ruff_db::files::File;
+use ruff_db::parsed::parsed_module;
+use ruff_db::source::source_text;
+use ruff_python_ast::visitor::{walk_expr, walk_stmt, Visitor};
+use ruff_python_ast::{Decorator, Expr, ExprCall, Stmt};
+use ruff_text_size::{Ranged, TextRange};
+use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
+use ty_project::Db as ProjectDb;
+
+use crate::helpers::{
+    extract_call_kwargs, find_main_block_range, range_key, resolve_relative_import,
+    top_level_assign_to_name, unwrap_subscripted_callee, CallArgs, MODULE_ALIAS_MARKER,
+};
+use crate::ingest::{collapse_attribute_chain, file_package_name, string_literal_list};
+
+/// `(name_range_key, value)` pair. The range key matches the `(start,
+/// end)` `u32` pair the assemble pass stores in `decl_by_name_range` /
+/// `class_by_selection`, so a project-wide query fans in with a hashmap
+/// probe — no second AST walk.
+type ByNameRange<T> = Vec<((u32, u32), T)>;
+
+/// A callee (or decorator) peeled to its `Name`-rooted attribute chain
+/// plus any captured keyword args. `root_name` is the bare name at the
+/// root (`app` in `@app.route(...)`, `unittest` in `unittest.mock.patch(...)`,
+/// `route` in `@route`); `attrs` are the trailing attribute segments in
+/// source order (closest-to-root first, so `@owner.via.outer` yields
+/// `["via", "outer"]`); `kwargs` holds the call's string-literal keyword
+/// args (empty when there is no call form or when the consumer doesn't
+/// need them).
+///
+/// This is the config-independent shape behind the decorator, instance
+/// construction, and factory-call queries: the decorator matchers resolve
+/// `root_name`/`attrs` through the file's imports (or syntactically), and
+/// [`match_callee_descriptor`] reproduces `matched_call_target_any` for
+/// the construction/factory queries. We only record callees that bottom
+/// out at a bare `Name` (via [`collapse_attribute_chain`]) — every matcher
+/// rejects non-`Name` roots, so deeper shapes can't match anyway.
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) struct CalleeDescriptor {
+    pub(crate) root_name: String,
+    pub(crate) attrs: SmallVec<[String; 2]>,
+    pub(crate) kwargs: CallArgs,
+}
+
+/// One top-level `import` / `from … import …` statement, resolved to
+/// config-independent owned data so the project-wide queries can
+/// rebuild a `{local → target}` map ([`imports_local_from_facts`])
+/// without re-walking the AST. Relative `from` imports are resolved to
+/// their absolute module here (the only file-local input is the file's
+/// own package), so the fact carries no `level`/relativity.
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) enum ImportFact {
+    /// `from <absolute> import <name> [as <local>], …` — `names` is
+    /// `(imported_name, local_name)` for each alias.
+    From {
+        absolute: String,
+        names: Vec<(String, String)>,
+    },
+    /// `import <module> [as <local>], …` — `entries` is
+    /// `(module_name, local_name)` for each alias.
+    Plain { entries: Vec<(String, String)> },
+}
+
+/// The `Name`-rooted callee chain of a call — root name + trailing
+/// attribute segments, without captured args. The matchable core of a
+/// call site: `find_calls_to_imported` resolves it through the file's
+/// imports (via [`match_callee_chain`]) and `find_calls_on_var` matches
+/// the `<owner>.<attr>` shape (`attrs == [attr]`, `root_name == owner`).
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) struct CalleeChain {
+    pub(crate) root_name: String,
+    pub(crate) attrs: SmallVec<[String; 2]>,
+}
+
+/// String content of a positional call argument, recorded so the
+/// `nth_positional_string` / `string_or_string_collection` reads can be
+/// replayed at a query-time `arg_index` without the AST.
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) enum StringArg {
+    /// A single `"…"` literal — `nth_positional_string` returns it; a
+    /// collection read sees a one-element list.
+    Lit(String),
+    /// A list/tuple of string literals (non-string elements dropped, as
+    /// `string_or_string_collection` does) — `nth_positional_string`
+    /// returns `None`; a collection read sees every element.
+    Coll(Vec<String>),
+}
+
+/// One call site reduced to the config-independent data the three
+/// call-site queries replay. Only calls carrying at least one
+/// string-bearing positional argument are recorded — every query captures
+/// such an argument, so a call without one can never produce a result.
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) struct CallSiteFact {
+    /// Last attribute segment of the callee (`load_extension` in
+    /// `bot.load_extension(x)`), for *any* receiver shape; `None` when the
+    /// callee isn't an attribute access. Powers `find_calls_on_attr`.
+    pub(crate) callee_attr: Option<String>,
+    /// `Name`-rooted callee chain, when the callee bottoms out at a bare
+    /// `Name`. Powers `find_calls_to_imported` / `find_calls_on_var`.
+    pub(crate) callee: Option<CalleeChain>,
+    /// Positional-argument arity (for `find_calls_on_var`'s
+    /// `required_positional` disambiguation).
+    pub(crate) positional_len: usize,
+    /// String-bearing positional args by index (sparse — non-string args
+    /// are omitted). Non-empty by construction.
+    pub(crate) string_args: SmallVec<[(usize, StringArg); 1]>,
+    /// String-literal keyword args (for `extract_args`).
+    pub(crate) kwargs: CallArgs,
+}
+
+impl CallSiteFact {
+    /// Replay `helpers::nth_positional_string` for `arg_index`: the single
+    /// string-literal value, or `None` (missing, non-string, or a
+    /// collection).
+    pub(crate) fn nth_positional_string(&self, arg_index: usize) -> Option<&str> {
+        self.string_args.iter().find_map(|(i, arg)| match arg {
+            StringArg::Lit(s) if *i == arg_index => Some(s.as_str()),
+            _ => None,
+        })
+    }
+
+    /// Replay `helpers::string_or_string_collection` for `arg_index`: the
+    /// string values (one for a single literal, many for a list/tuple),
+    /// or empty.
+    pub(crate) fn string_or_collection(&self, arg_index: usize) -> &[String] {
+        self.string_args
+            .iter()
+            .find_map(|(i, arg)| {
+                (*i == arg_index).then(|| match arg {
+                    StringArg::Lit(s) => std::slice::from_ref(s),
+                    StringArg::Coll(v) => v.as_slice(),
+                })
+            })
+            .unwrap_or(&[])
+    }
+}
+
+/// Owned, AST-free per-file facts that power the project-wide plugin
+/// queries. Grows one field per migrated query; see the module docs for
+/// the ownership contract that lets the parsed module be cleared behind
+/// this query.
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) struct FileExtraction {
+    /// Byte range of the `if __name__ == "__main__":` block, if the
+    /// file has one. Powers `find_main_blocks_indices`.
+    pub(crate) main_block_range: Option<(u32, u32)>,
+    /// Top-level `NAME = [str, ...]` / `NAME: T = [str, ...]`
+    /// assignments whose RHS is a list/tuple of string literals, as
+    /// `(target_name, entries)`. Powers `find_literal_list_entries` and
+    /// the `__all__` export query.
+    pub(crate) literal_list_rows: Vec<(String, Vec<String>)>,
+    /// Per top-level `def`, its positional + keyword-only parameter
+    /// names in source order. Powers `function_parameters`.
+    pub(crate) function_params: ByNameRange<Vec<String>>,
+    /// Per top-level `class`, the de-duplicated parameter names across
+    /// all its methods, excluding `self` / `cls`. Powers
+    /// `class_method_parameters`.
+    pub(crate) class_method_params: ByNameRange<Vec<String>>,
+    /// Per `class` *anywhere* in the file (not just top level), the
+    /// names of the methods defined directly in its body. Powers
+    /// `find_classes_defining_method`, whose original enumeration went
+    /// through the semantic index (so it caught classes nested in
+    /// module-level `if`/`try` blocks). We over-collect every class and
+    /// let the `class_by_selection` fan-in keep only the global-scope
+    /// ones — name-ranges never collide, so nested classes never
+    /// produce a false match.
+    pub(crate) class_method_defs: ByNameRange<Vec<String>>,
+    /// Every top-level `import` / `from … import …` statement, resolved
+    /// to absolute modules. Powers the import-resolving decorator /
+    /// construction / call queries via [`imports_local_from_facts`].
+    pub(crate) import_facts: Vec<ImportFact>,
+    /// Per top-level `def` that carries at least one `Name`-rooted
+    /// decorator, the decorators on it (source order). Powers
+    /// `find_decorated_decls`, `find_handler_decorators`, and
+    /// `find_handler_decorators_via`.
+    pub(crate) decorator_rows: ByNameRange<Vec<CalleeDescriptor>>,
+    /// Per top-level `NAME = <callee>(...)` / `NAME: T = <callee>(...)`
+    /// assignment whose callee bottoms out at a bare `Name`, the callee
+    /// descriptor keyed by the target's name-range. Powers
+    /// `find_instance_constructions`.
+    pub(crate) construction_rows: ByNameRange<CalleeDescriptor>,
+    /// Per top-level `def` / `class`, every `Name`-rooted call descriptor
+    /// found anywhere in its body subtree (recursive). Powers
+    /// `find_factory_decls`, which resolves each descriptor through the
+    /// file's imports at fan-in and reports the matched constructor kinds.
+    /// Kwargs are not captured here (the factory query never reads them).
+    pub(crate) factory_rows: ByNameRange<Vec<CalleeDescriptor>>,
+    /// Per top-level `def` / `class`, every string-bearing call site found
+    /// anywhere in its subtree (recursive, decorators included). Keyed by
+    /// the decl's name-range so the project-wide fan-in attributes the call
+    /// to that decl. Powers `find_calls_on_attr`, `find_calls_to_imported`,
+    /// and `find_calls_on_var`.
+    pub(crate) call_sites_by_decl: ByNameRange<Vec<CallSiteFact>>,
+    /// Every string-bearing call site reached from a top-level statement
+    /// that is *not* a `def` / `class` (module-level assignments,
+    /// expressions, `if`/`try`/`with`, …). The fan-in attributes these to
+    /// the file's module node, matching `owner_idx_for_stmt_with`.
+    pub(crate) module_call_sites: Vec<CallSiteFact>,
+}
+
+/// Collects, for every `ClassDef` reachable in the module, the names of
+/// the methods defined directly in its body. Recurses through every
+/// scope (including function bodies) so module-level conditionally
+/// defined classes are captured; the project-wide fan-in filters to
+/// global-scope classes via `class_by_selection`.
+struct ClassMethodDefsCollector {
+    rows: ByNameRange<Vec<String>>,
+}
+
+impl<'a> Visitor<'a> for ClassMethodDefsCollector {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        if let Stmt::ClassDef(cls) = stmt {
+            let methods: Vec<String> = cls
+                .body
+                .iter()
+                .filter_map(|s| match s {
+                    Stmt::FunctionDef(f) => Some(f.name.as_str().to_string()),
+                    _ => None,
+                })
+                .collect();
+            self.rows.push((range_key(cls.name.range()), methods));
+        }
+        walk_stmt(self, stmt);
+    }
+}
+
+/// Collects every `Name`-rooted call descriptor reachable in a decl's
+/// body subtree (recursively), for `find_factory_decls`. Mirrors
+/// `helpers::FactoryCallFinder` but captures the config-independent
+/// descriptor instead of matching against imports — the project-wide
+/// query resolves each descriptor through the file's imports at fan-in.
+struct FactoryCalleeCollector {
+    descriptors: Vec<CalleeDescriptor>,
+}
+
+impl<'a> Visitor<'a> for FactoryCalleeCollector {
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        if let Expr::Call(call) = expr {
+            if let Some(desc) = callee_descriptor(call, /*capture_kwargs=*/ false) {
+                self.descriptors.push(desc);
+            }
+        }
+        walk_expr(self, expr);
+    }
+}
+
+/// Walk a top-level decl's body, collecting every `Name`-rooted call
+/// descriptor, and push a `factory_rows` entry keyed by the decl's
+/// name-range when the body contains any. Skips the push for bodies with
+/// no resolvable callee so the fan-in query can short-circuit on empty.
+fn collect_factory_row(
+    rows: &mut ByNameRange<Vec<CalleeDescriptor>>,
+    name_range: TextRange,
+    body: &[Stmt],
+) {
+    let mut collector = FactoryCalleeCollector {
+        descriptors: Vec::new(),
+    };
+    for stmt in body {
+        collector.visit_stmt(stmt);
+    }
+    if !collector.descriptors.is_empty() {
+        rows.push((range_key(name_range), collector.descriptors));
+    }
+}
+
+/// Collects every string-bearing call site reachable in a statement's
+/// subtree (recursively), for the three call-site queries. Mirrors the
+/// live-AST `StringArgCallFinder` / `AttrCallFinder` walk but records the
+/// config-independent [`CallSiteFact`] instead of matching against a
+/// query's `attr` / imports / owner — the project-wide queries replay the
+/// match at fan-in.
+struct CallSiteCollector {
+    sites: Vec<CallSiteFact>,
+}
+
+impl<'a> Visitor<'a> for CallSiteCollector {
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        if let Expr::Call(call) = expr {
+            if let Some(fact) = build_call_site_fact(call) {
+                self.sites.push(fact);
+            }
+        }
+        walk_expr(self, expr);
+    }
+}
+
+/// Reduce one call to a [`CallSiteFact`], or `None` when the call carries
+/// no string-bearing positional argument — every call-site query captures
+/// such an argument, so a call without one can never produce a result and
+/// is pruned at extraction time.
+fn build_call_site_fact(call: &ExprCall) -> Option<CallSiteFact> {
+    let mut string_args: SmallVec<[(usize, StringArg); 1]> = SmallVec::new();
+    for (i, arg) in call.arguments.args.iter().enumerate() {
+        if let Some(sa) = string_arg(arg) {
+            string_args.push((i, sa));
+        }
+    }
+    if string_args.is_empty() {
+        return None;
+    }
+    // `callee_attr` mirrors `AttrCallFinder`: the last attribute segment for
+    // *any* receiver shape (incl. `foo().attr(…)`), so it is computed off the
+    // unwrapped callee directly rather than the `Name`-rooted chain.
+    let callee_attr = match unwrap_subscripted_callee(call.func.as_ref()) {
+        Expr::Attribute(attr) => Some(attr.attr.as_str().to_string()),
+        _ => None,
+    };
+    let callee = collapse_callee(call.func.as_ref())
+        .map(|(root_name, attrs)| CalleeChain { root_name, attrs });
+    Some(CallSiteFact {
+        callee_attr,
+        callee,
+        positional_len: call.arguments.args.len(),
+        string_args,
+        kwargs: extract_call_kwargs(call),
+    })
+}
+
+/// Classify a positional argument expression as a string-bearing
+/// [`StringArg`], or `None` when it carries no string literal. Mirrors the
+/// union of `helpers::nth_positional_string` (single literal) and
+/// `helpers::string_or_string_collection` (list/tuple of literals): a
+/// list/tuple with no string elements yields `None` (it can never produce
+/// a hit), so the call isn't recorded on its account.
+fn string_arg(expr: &Expr) -> Option<StringArg> {
+    match expr {
+        Expr::StringLiteral(s) => Some(StringArg::Lit(s.value.to_str().to_string())),
+        Expr::List(list) => {
+            let elems = collect_string_elems(&list.elts);
+            (!elems.is_empty()).then_some(StringArg::Coll(elems))
+        }
+        Expr::Tuple(tup) => {
+            let elems = collect_string_elems(&tup.elts);
+            (!elems.is_empty()).then_some(StringArg::Coll(elems))
+        }
+        _ => None,
+    }
+}
+
+/// String-literal elements of a list/tuple, non-string elements dropped —
+/// the collection half of `helpers::string_or_string_collection`.
+fn collect_string_elems(elts: &[Expr]) -> Vec<String> {
+    elts.iter()
+        .filter_map(|e| match e {
+            Expr::StringLiteral(s) => Some(s.value.to_str().to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Walk a top-level statement, collecting every string-bearing call site,
+/// and bucket the result the way `owner_idx_for_stmt_with` attributes
+/// ownership: a `def` / `class` owns the calls in its subtree (keyed by
+/// name-range); every other statement attributes its calls to the module.
+fn collect_call_sites(
+    stmt: &Stmt,
+    by_decl: &mut ByNameRange<Vec<CallSiteFact>>,
+    module_sites: &mut Vec<CallSiteFact>,
+) {
+    let mut collector = CallSiteCollector { sites: Vec::new() };
+    collector.visit_stmt(stmt);
+    if collector.sites.is_empty() {
+        return;
+    }
+    match stmt {
+        Stmt::FunctionDef(f) => by_decl.push((range_key(f.name.range()), collector.sites)),
+        Stmt::ClassDef(c) => by_decl.push((range_key(c.name.range()), collector.sites)),
+        _ => module_sites.extend(collector.sites),
+    }
+}
+
+/// Collect a function's positional + keyword-only parameter names in
+/// source order (posonly, then args, then kwonly) — matching the order
+/// `function_parameters` / `class_method_parameters` produced from the
+/// live AST.
+fn param_names(params: &ruff_python_ast::Parameters) -> impl Iterator<Item = &str> {
+    params
+        .posonlyargs
+        .iter()
+        .chain(params.args.iter())
+        .chain(params.kwonlyargs.iter())
+        .map(|p| p.parameter.name.id.as_str())
+}
+
+/// Peel a callee expression to its `Name` root + trailing attribute
+/// segments. Mirrors the live-AST preamble every matcher ran: unwrap a
+/// single subscripted-generic callee, then collapse the attribute chain.
+/// Returns `None` when the callee doesn't bottom out at a bare `Name`
+/// (a call result, a subscript mid chain, …) — those never matched.
+fn collapse_callee(expr: &Expr) -> Option<(String, SmallVec<[String; 2]>)> {
+    let (root, segs) = collapse_attribute_chain(unwrap_subscripted_callee(expr))?;
+    Some((
+        root.id.as_str().to_string(),
+        segs.iter().map(|s| s.to_string()).collect(),
+    ))
+}
+
+/// Peel one decorator to a [`CalleeDescriptor`]. Strips the call form
+/// (capturing its kwargs) before collapsing the callee; bare decorators
+/// (`@route`) carry empty kwargs.
+fn decorator_descriptor(dec: &Decorator) -> Option<CalleeDescriptor> {
+    let (root_expr, call_form) = match &dec.expression {
+        Expr::Call(call) => (&*call.func, Some(call)),
+        other => (other, None),
+    };
+    let (root_name, attrs) = collapse_callee(root_expr)?;
+    Some(CalleeDescriptor {
+        root_name,
+        attrs,
+        kwargs: call_form.map(extract_call_kwargs).unwrap_or_default(),
+    })
+}
+
+/// Peel a call expression's callee to a [`CalleeDescriptor`]. When
+/// `capture_kwargs` is false the descriptor's `kwargs` is left empty (the
+/// factory walk never reads them, so we skip the work and the alloc).
+fn callee_descriptor(call: &ExprCall, capture_kwargs: bool) -> Option<CalleeDescriptor> {
+    let (root_name, attrs) = collapse_callee(call.func.as_ref())?;
+    Some(CalleeDescriptor {
+        root_name,
+        attrs,
+        kwargs: if capture_kwargs {
+            extract_call_kwargs(call)
+        } else {
+            CallArgs::default()
+        },
+    })
+}
+
+/// Extract every owned fact from a single file's AST in one top-level
+/// walk. Warmed during the fan-out (see `project.rs`) so that by the
+/// time the project-wide plugin pass runs, this is a pure salsa cache
+/// read and the parsed module can already be gone.
+#[salsa::tracked(returns(ref), heap_size = ruff_memory_usage::heap_size)]
+pub(crate) fn file_extraction(db: &dyn ProjectDb, file: File) -> FileExtraction {
+    let parsed = parsed_module(db, file).load(db);
+    let source = source_text(db, file);
+
+    let main_block_range = if source.contains("__main__") {
+        find_main_block_range(&parsed).map(|r| (r.start().to_u32(), r.end().to_u32()))
+    } else {
+        None
+    };
+
+    let mut literal_list_rows: Vec<(String, Vec<String>)> = Vec::new();
+    let mut function_params: ByNameRange<Vec<String>> = Vec::new();
+    let mut class_method_params: ByNameRange<Vec<String>> = Vec::new();
+    let mut class_defs = ClassMethodDefsCollector { rows: Vec::new() };
+    let mut import_facts: Vec<ImportFact> = Vec::new();
+    let mut decorator_rows: ByNameRange<Vec<CalleeDescriptor>> = Vec::new();
+    let mut construction_rows: ByNameRange<CalleeDescriptor> = Vec::new();
+    let mut factory_rows: ByNameRange<Vec<CalleeDescriptor>> = Vec::new();
+    let mut call_sites_by_decl: ByNameRange<Vec<CallSiteFact>> = Vec::new();
+    let mut module_call_sites: Vec<CallSiteFact> = Vec::new();
+    // Enclosing package, used to resolve relative `from` imports to
+    // absolute modules so the stored facts are relativity-free.
+    let file_package = file_package_name(db, file);
+
+    for stmt in &parsed.syntax().body {
+        class_defs.visit_stmt(stmt);
+        collect_call_sites(stmt, &mut call_sites_by_decl, &mut module_call_sites);
+        match stmt {
+            Stmt::FunctionDef(func) => {
+                let names: Vec<String> =
+                    param_names(&func.parameters).map(str::to_string).collect();
+                function_params.push((range_key(func.name.range()), names));
+                let descriptors: Vec<CalleeDescriptor> = func
+                    .decorator_list
+                    .iter()
+                    .filter_map(decorator_descriptor)
+                    .collect();
+                if !descriptors.is_empty() {
+                    decorator_rows.push((range_key(func.name.range()), descriptors));
+                }
+                collect_factory_row(&mut factory_rows, func.name.range(), &func.body);
+            }
+            Stmt::ClassDef(cls) => {
+                let mut seen: FxHashSet<&str> = FxHashSet::default();
+                let mut names: Vec<String> = Vec::new();
+                for body_stmt in &cls.body {
+                    let Stmt::FunctionDef(method) = body_stmt else {
+                        continue;
+                    };
+                    for n in param_names(&method.parameters) {
+                        if n == "self" || n == "cls" {
+                            continue;
+                        }
+                        if seen.insert(n) {
+                            names.push(n.to_string());
+                        }
+                    }
+                }
+                class_method_params.push((range_key(cls.name.range()), names));
+                collect_factory_row(&mut factory_rows, cls.name.range(), &cls.body);
+            }
+            Stmt::ImportFrom(im) => {
+                let tail = im.module.as_ref().map(|n| n.as_str()).unwrap_or("");
+                let absolute = if im.level == 0 {
+                    (!tail.is_empty()).then(|| tail.to_string())
+                } else {
+                    resolve_relative_import(im.level, tail, file_package.as_deref())
+                };
+                if let Some(absolute) = absolute {
+                    let names = im
+                        .names
+                        .iter()
+                        .map(|alias| {
+                            let name = alias.name.as_str().to_string();
+                            let local = alias
+                                .asname
+                                .as_ref()
+                                .map(|n| n.as_str())
+                                .unwrap_or(alias.name.as_str())
+                                .to_string();
+                            (name, local)
+                        })
+                        .collect();
+                    import_facts.push(ImportFact::From { absolute, names });
+                }
+            }
+            Stmt::Import(im) => {
+                let entries = im
+                    .names
+                    .iter()
+                    .map(|alias| {
+                        let module_name = alias.name.as_str().to_string();
+                        let local = alias
+                            .asname
+                            .as_ref()
+                            .map(|n| n.as_str())
+                            .unwrap_or(alias.name.as_str())
+                            .to_string();
+                        (module_name, local)
+                    })
+                    .collect();
+                import_facts.push(ImportFact::Plain { entries });
+            }
+            _ => {
+                let Some((target_range, value)) = top_level_assign_to_name(stmt) else {
+                    continue;
+                };
+                if let Some(entries) = string_literal_list(value) {
+                    let name = source
+                        [target_range.start().to_usize()..target_range.end().to_usize()]
+                        .to_string();
+                    literal_list_rows.push((name, entries.into_iter().map(String::from).collect()));
+                } else if let Expr::Call(call) = value {
+                    // `NAME = <callee>(...)` — record the callee descriptor so
+                    // `find_instance_constructions` can resolve it at fan-in.
+                    if let Some(desc) = callee_descriptor(call, /*capture_kwargs=*/ true) {
+                        construction_rows.push((range_key(target_range), desc));
+                    }
+                }
+            }
+        }
+    }
+
+    FileExtraction {
+        main_block_range,
+        literal_list_rows,
+        function_params,
+        class_method_params,
+        class_method_defs: class_defs.rows,
+        import_facts,
+        decorator_rows,
+        construction_rows,
+        factory_rows,
+        call_sites_by_decl,
+        module_call_sites,
+    }
+}
+
+/// Rebuild the `{local_name → target}` map a decorator/construction/call
+/// query needs from a file's [`ImportFact`]s — the AST-free counterpart
+/// of `helpers::collect_modules_imports_local`. `target` is the upstream
+/// name (`Flask` for `from flask import Flask`) or [`MODULE_ALIAS_MARKER`]
+/// for a module binding (`import flask` / `from unittest import mock`
+/// when querying `unittest.mock`). Only entries whose target is in
+/// `allowed` survive; later `modules` win on local-name collisions
+/// (matching the live-AST helper).
+pub(crate) fn imports_local_from_facts(
+    facts: &[ImportFact],
+    modules: &[String],
+    allowed: &FxHashSet<&str>,
+) -> FxHashMap<String, String> {
+    let mut out: FxHashMap<String, String> = FxHashMap::default();
+    for module in modules {
+        let parent_last = module.rsplit_once('.');
+        for fact in facts {
+            match fact {
+                ImportFact::From { absolute, names } => {
+                    if absolute == module {
+                        for (name, local) in names {
+                            if allowed.contains(name.as_str()) {
+                                out.insert(local.clone(), name.clone());
+                            }
+                        }
+                    } else if let Some((parent, last)) = parent_last {
+                        if absolute == parent {
+                            for (name, local) in names {
+                                if name == last {
+                                    out.insert(local.clone(), MODULE_ALIAS_MARKER.to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+                ImportFact::Plain { entries } => {
+                    for (module_name, local) in entries {
+                        if module_name == module {
+                            out.insert(local.clone(), MODULE_ALIAS_MARKER.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Query-time port of `helpers::matched_call_target_any` operating on a
+/// precomputed `Name`-rooted callee chain (`root_name` + `attrs`) instead
+/// of a live AST callee. `imports` is the file's `{local → target}` map
+/// from [`imports_local_from_facts`]; `modules`/`allowed` are the configured
+/// target modules and constructor names. Returns the matched upstream name
+/// on hit, else `None`. The three arms mirror the live-AST matcher exactly:
+///
+/// * `[]` — `<local>(...)` bound via `from <module> import <name>`;
+/// * `[attr]` — `<alias>.<name>(...)` where `alias` is a module binding;
+/// * `[…, name]` (len ≥ 2) — literal dotted access of a multi-segment
+///   module (`unittest.mock.patch(...)`).
+///
+/// Backs both the descriptor queries (via [`match_callee_descriptor`]) and
+/// the call-site query (on [`CallSiteFact::callee`]).
+pub(crate) fn match_callee_chain(
+    root_name: &str,
+    attrs: &[String],
+    imports: &FxHashMap<String, String>,
+    modules: &[String],
+    allowed: &FxHashSet<&str>,
+) -> Option<String> {
+    match attrs {
+        [] => imports
+            .get(root_name)
+            .filter(|target| allowed.contains(target.as_str()))
+            .cloned(),
+        [attr] => (imports.get(root_name).map(String::as_str) == Some(MODULE_ALIAS_MARKER)
+            && allowed.contains(attr.as_str()))
+        .then(|| attr.clone()),
+        segs => {
+            let last = segs.last().expect("slice has len >= 2");
+            if !allowed.contains(last.as_str()) {
+                return None;
+            }
+            // Reconstruct the dotted module prefix: root + all but the
+            // final segment (the constructor name).
+            let mut dotted = String::with_capacity(root_name.len());
+            dotted.push_str(root_name);
+            for seg in &segs[..segs.len() - 1] {
+                dotted.push('.');
+                dotted.push_str(seg);
+            }
+            modules
+                .iter()
+                .any(|module| module.as_str() == dotted)
+                .then(|| last.clone())
+        }
+    }
+}
+
+/// [`match_callee_chain`] for a precomputed [`CalleeDescriptor`] — the
+/// decorator / construction / factory queries call this with the descriptor
+/// they stored; the call-site query calls `match_callee_chain` directly on a
+/// [`CalleeChain`].
+pub(crate) fn match_callee_descriptor(
+    desc: &CalleeDescriptor,
+    imports: &FxHashMap<String, String>,
+    modules: &[String],
+    allowed: &FxHashSet<&str>,
+) -> Option<String> {
+    match_callee_chain(&desc.root_name, &desc.attrs, imports, modules, allowed)
+}

--- a/runtime/src/file_payload.rs
+++ b/runtime/src/file_payload.rs
@@ -43,7 +43,7 @@ use crate::helpers::{
     module_fqname_for_file, position, range_key, resolve_base_fqn, scan_noqa_directives,
     NODE_FLAGS_NOQA_PIN,
 };
-use crate::ingest::{decl_kind_str, from_module_string};
+use crate::ingest::{decl_kind_str, file_package_name, from_module_string};
 
 /// Stable handle for a graph node, used as the public identity across
 /// the fan-out pipeline. Edge endpoints in `file_to_edges` are
@@ -487,7 +487,8 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
     // function's name TextRange (which is what `DefinitionKind::Function`
     // reports as its `target_range`), so we can flag the matching decl
     // when ty enumerates it below.
-    let local_imports = collect_all_imports_local(&parsed);
+    let file_package = file_package_name(db, file);
+    let local_imports = collect_all_imports_local(&parsed, file_package.as_deref());
     let mut overload_decorated: FxHashSet<TextRange> = FxHashSet::default();
     for stmt in &parsed.syntax().body {
         if let Stmt::FunctionDef(func) = stmt {
@@ -694,7 +695,7 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
     // needed here; the assemble pass folds `name_bindings` into the
     // cross-file re-export / alias chain and turns `class_bases` into the
     // global `children_by_node` / `external_base_children` indices.
-    let file_imports = collect_all_imports_local(&parsed);
+    let file_imports = collect_all_imports_local(&parsed, file_package.as_deref());
     let name_bindings = build_name_bindings(
         &parsed,
         &file_imports,

--- a/runtime/src/file_payload.rs
+++ b/runtime/src/file_payload.rs
@@ -234,6 +234,11 @@ pub(crate) struct ImportPayload {
 ///   walk. Same-file `LocalSameFileClass(local_idx)` bases reference
 ///   the file's own `refs[local_idx]`; assemble translates them via
 ///   the same `NodeRef -> global_idx` map used for edges.
+/// * `name_bindings` — per module-level name → how it's bound
+///   ([`NameBinding`]): local class, import, star import, or module
+///   alias. The single uniform ladder `build_class_bases` resolves every
+///   class base through, and the source the assemble pass folds into the
+///   project-wide re-export / alias chain.
 /// * `overload_anchors` — `(impl_local_idx, stub_local_idx)` pairs for
 ///   in-file `@typing.overload` groups. The assembly pass emits one
 ///   `impl → stub` edge per pair so reachability propagates from a
@@ -249,6 +254,7 @@ pub(crate) struct FileNodes<'db> {
     pub(crate) exports_by_name: FxHashMap<String, SmallVec<[u32; 2]>>,
     pub(crate) star_reexports: FxHashMap<String, String>,
     pub(crate) class_bases: Vec<ClassBaseEntry>,
+    pub(crate) name_bindings: FxHashMap<String, NameBinding>,
     pub(crate) overload_anchors: Box<[(u32, u32)]>,
 }
 
@@ -292,6 +298,37 @@ pub(crate) enum ResolvedBase {
         attr_name: String,
     },
     Unresolvable,
+}
+
+/// How a module-level name is bound in a single file, captured while the
+/// AST is hot in [`file_to_nodes`]. A class base is "just a name", and a
+/// module-scope name is bound exactly one of four ways; capturing all
+/// four (rather than only imports + same-file classes) means a base is
+/// never silently dropped — star-imported and module-aliased bases
+/// resolve through the same uniform ladder as direct imports.
+///
+/// The assemble pass folds these into a project-wide `{module}.{name} ->
+/// next_fqn` chain (see `build_class_hierarchy_indices`), so a base that
+/// hops through one or more re-export / alias bindings across files is
+/// chased to its terminal class without re-parsing.
+///
+/// Ladder precedence when a name is bound more than once (a rare shadow):
+/// `LocalClass` > `Import` > `StarImport` > `ModuleAlias`.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
+pub(crate) enum NameBinding {
+    /// `class Name: ...` — a top-level class in this file. Local idx into
+    /// `refs`/`nodes` (the live binding; first wins on rebind).
+    LocalClass(u32),
+    /// `from m import Name [as Name]` / `import m [as Name]` — the
+    /// upstream fqn produced by [`collect_all_imports_local`].
+    Import(String),
+    /// `from m import *` brought `Name` in — the source module `m`. The
+    /// name resolves to `{m}.{Name}`.
+    StarImport(String),
+    /// `Name = Other` at module scope — an alias to another module-level
+    /// name `Other` in this file. Resolves to `{this_module}.{Other}`,
+    /// whose own binding continues the chain.
+    ModuleAlias(String),
 }
 
 /// Resolve a `NodeRef` to its `NodeData` payload.
@@ -651,12 +688,21 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         }
     }
 
-    // Build per-file `class_bases`: walk every top-level ClassDef and
-    // resolve each base expression against the file's imports + the
-    // same-file class name table. No project-wide state needed; the
-    // assemble pass turns these into the global `children_by_node`
-    // index.
-    let class_bases = build_class_bases(&parsed, &exports_by_name, &nodes);
+    // Capture the module's name-binding table (all four binding kinds)
+    // while the AST is hot, then resolve every top-level class base
+    // against it through the uniform ladder. No project-wide state
+    // needed here; the assemble pass folds `name_bindings` into the
+    // cross-file re-export / alias chain and turns `class_bases` into the
+    // global `children_by_node` / `external_base_children` indices.
+    let file_imports = collect_all_imports_local(&parsed);
+    let name_bindings = build_name_bindings(
+        &parsed,
+        &file_imports,
+        &star_reexports,
+        &exports_by_name,
+        &nodes,
+    );
+    let class_bases = build_class_bases(&parsed, &name_bindings, &file_imports, &nodes);
 
     FileNodes {
         nodes: nodes.into_boxed_slice(),
@@ -665,55 +711,105 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         exports_by_name,
         star_reexports,
         class_bases,
+        name_bindings,
         overload_anchors: overload_anchors.into_boxed_slice(),
     }
 }
 
-/// Per-file class-hierarchy producer used by [`file_to_nodes`].
+/// Capture every module-level name binding in `parsed` as a uniform
+/// [`NameBinding`] table — the per-file half of the "a class base is just
+/// a name" model. Built once while the AST is hot and stored in
+/// [`FileNodes::name_bindings`]; consumed by both [`build_class_bases`]
+/// (within-file base resolution) and the assemble pass (cross-file chain
+/// following).
 ///
-/// For each top-level `ClassDef`, locate its corresponding graph node
-/// (via `exports_by_name` + `nodes[..]` kind probe) and resolve each
-/// base expression to a [`ResolvedBase`]. The result is a flat list of
-/// `(local_class_idx, bases)` pairs the assemble pass folds into the
-/// project-wide hierarchy without re-parsing.
-///
-/// Resolution mirrors today's `build_class_children` + `resolve_base_fqn`
-/// helpers but reads everything from the per-file state:
-///
-/// * `Name(Foo)` where `Foo` is in `file_imports` → `ImportedFqn`.
-/// * `Name(Foo)` where `Foo` is a top-level class earlier in this
-///   file → `LocalSameFileClass(local_idx)`.
-/// * `Attribute(Name(M).N)` where `M` is in `file_imports` →
-///   `Attribute { module_fqn, attr_name: N }`.
-/// * Deeper `a.b.c.N` chains rooted at an import → flattened into
-///   `ImportedFqn("<a-upstream>.b.c.N")` (matches today's
-///   `resolve_base_fqn` behaviour for the `find_subclasses_via_bases`
-///   path).
-/// * Anything else → `ResolvedBase::Unresolvable`.
-fn build_class_bases(
+/// All four binding kinds are recorded so no base is dropped: module-level
+/// aliases (`Base = Other`), `from m import *` names, explicit imports,
+/// and same-file classes. Higher-precedence rungs overwrite lower ones
+/// (see [`NameBinding`]): local class > import > star import > module
+/// alias.
+fn build_name_bindings(
     parsed: &ruff_db::parsed::ParsedModuleRef,
+    file_imports: &FxHashMap<String, String>,
+    star_reexports: &FxHashMap<String, String>,
     exports_by_name: &FxHashMap<String, SmallVec<[u32; 2]>>,
     nodes: &[NodeData],
-) -> Vec<ClassBaseEntry> {
+) -> FxHashMap<String, NameBinding> {
     use ruff_python_ast::Expr;
-    let file_imports = collect_all_imports_local(parsed);
+    let mut out: FxHashMap<String, NameBinding> = FxHashMap::default();
 
-    // Build name → local class idx for same-file class references.
-    // Multiple top-level `class Foo` rebinds at the same name keep
-    // the *first* (matching the historical libcst behaviour where a
-    // syntactic base reference resolves to the lexically-earliest
-    // class with that name). The cross-module case is unaffected —
-    // `subclasses_of_fqn` indexes by fqname, so shadowed declarations
-    // resolve through the import path, not this map.
-    let mut same_file_classes: FxHashMap<&str, u32> = FxHashMap::default();
+    // Rung 4 (lowest): module-level aliases `Name = Other`. Only the
+    // simple single-`Name` target = single-`Name` value form is a base
+    // alias; richer right-hand sides (calls, conditionals, attributes)
+    // aren't class aliases and stay unbound here.
+    for stmt in &parsed.syntax().body {
+        if let Stmt::Assign(assign) = stmt {
+            if let ([Expr::Name(target)], Expr::Name(value)) =
+                (assign.targets.as_slice(), assign.value.as_ref())
+            {
+                out.insert(
+                    target.id.as_str().to_string(),
+                    NameBinding::ModuleAlias(value.id.as_str().to_string()),
+                );
+            }
+        }
+    }
+
+    // Rung 3: `from m import *` names → source module.
+    for (name, module) in star_reexports {
+        out.insert(name.clone(), NameBinding::StarImport(module.clone()));
+    }
+
+    // Rung 2: explicit imports → upstream fqn.
+    for (name, fqn) in file_imports {
+        out.insert(name.clone(), NameBinding::Import(fqn.clone()));
+    }
+
+    // Rung 1 (highest): same-file top-level classes. The first class
+    // binding for a name wins (matching the lexically-earliest rule the
+    // cross-module path relies on).
     for (name, locals) in exports_by_name {
         for &local_idx in locals {
             if matches!(nodes[local_idx as usize].kind, NodeKind::Class) {
-                same_file_classes.entry(name.as_str()).or_insert(local_idx);
+                out.insert(name.clone(), NameBinding::LocalClass(local_idx));
                 break;
             }
         }
     }
+
+    out
+}
+
+/// Per-file class-hierarchy producer used by [`file_to_nodes`].
+///
+/// For each top-level `ClassDef`, key on its name range and resolve every
+/// base expression to a [`ResolvedBase`]. The result is a flat list of
+/// `(name_range_key, bases)` pairs the assemble pass folds into the
+/// project-wide hierarchy without re-parsing.
+///
+/// A bare-name base resolves through the uniform binder ladder
+/// (`name_bindings`); an attribute base keeps the dedicated `Attribute`
+/// shape via `resolve_base_fqn`:
+///
+/// * `Name(Foo)` → whatever `Foo`'s [`NameBinding`] resolves to (local
+///   class, import fqn, `{star_module}.Foo`, or `{this_module}.{alias}`).
+/// * `Attribute(Name(M).N)` where `M` is in `file_imports` →
+///   `Attribute { module_fqn, attr_name: N }`.
+/// * Deeper `a.b.c.N` chains rooted at an import → flattened into
+///   `ImportedFqn("<a-upstream>.b.c.N")`.
+/// * Anything else → `ResolvedBase::Unresolvable`.
+fn build_class_bases(
+    parsed: &ruff_db::parsed::ParsedModuleRef,
+    name_bindings: &FxHashMap<String, NameBinding>,
+    file_imports: &FxHashMap<String, String>,
+    nodes: &[NodeData],
+) -> Vec<ClassBaseEntry> {
+    use ruff_python_ast::Expr;
+
+    // `nodes[0]` is always the synthetic module node; its fqname is this
+    // file's module fqn, needed to express a `Base = Other` alias as the
+    // chaseable fqn `{module}.{Other}`.
+    let module_fqn = nodes[0].fqname.as_str();
 
     let mut out: Vec<ClassBaseEntry> = Vec::new();
     for cls in iter_top_level_classes(parsed) {
@@ -728,55 +824,62 @@ fn build_class_bases(
         };
         let mut bases: SmallVec<[ResolvedBase; 2]> = SmallVec::new();
         for raw_base in &args.args {
-            // Unwrap `Foo[T]`, `Generic[T]`, `Protocol[T]`, etc.
-            // The original `build_class_children` matched these
-            // before the fqn-aware resolver ran; preserve that
-            // behaviour so subscripted generic bases still feed
-            // the class hierarchy.
+            // Unwrap `Foo[T]`, `Generic[T]`, `Protocol[T]`, etc. so a
+            // subscripted generic base still feeds the class hierarchy.
             let base = match raw_base {
                 Expr::Subscript(s) => s.value.as_ref(),
                 other => other,
             };
-            // First-pass: try the fqn-aware resolver. It returns an
-            // upstream fqname for Name/Attribute chains rooted at an
-            // imported name. For a single Attribute(Name(M).N) we
-            // override to the `Attribute` variant so the assemble pass
-            // can probe the target module's `exports_by_name` for the
-            // project-side class lookup.
-            if let Some(fqn) = resolve_base_fqn(base, &file_imports) {
-                match base {
-                    Expr::Attribute(a) => {
-                        if let Expr::Name(root) = a.value.as_ref() {
-                            if let Some(module_fqn) = file_imports.get(root.id.as_str()) {
-                                bases.push(ResolvedBase::Attribute {
-                                    module_fqn: module_fqn.clone(),
-                                    attr_name: a.attr.as_str().to_string(),
-                                });
-                                continue;
+            let resolved = match base {
+                // A bare-name base resolves through the uniform binder
+                // ladder. Star and alias bindings produce a chaseable fqn
+                // the assemble pass follows across files.
+                Expr::Name(name) => resolve_name_base(name.id.as_str(), name_bindings, module_fqn),
+                // An attribute base `M.N` rooted at an imported module
+                // keeps the dedicated `Attribute` shape so assemble can
+                // probe the target module's exports; a deeper chain keeps
+                // the flat fqn.
+                Expr::Attribute(a) => match resolve_base_fqn(base, file_imports) {
+                    Some(fqn) => match a.value.as_ref() {
+                        Expr::Name(root) if file_imports.contains_key(root.id.as_str()) => {
+                            ResolvedBase::Attribute {
+                                module_fqn: file_imports[root.id.as_str()].clone(),
+                                attr_name: a.attr.as_str().to_string(),
                             }
                         }
-                        // Deeper chains: keep the flat fqn — used by
-                        // the fqn-keyed lookup.
-                        bases.push(ResolvedBase::ImportedFqn(fqn));
-                    }
-                    _ => {
-                        bases.push(ResolvedBase::ImportedFqn(fqn));
-                    }
-                }
-                continue;
-            }
-            // Fallback: same-file bare-name class reference.
-            if let Expr::Name(name) = base {
-                if let Some(&local_idx) = same_file_classes.get(name.id.as_str()) {
-                    bases.push(ResolvedBase::LocalSameFileClass(local_idx));
-                    continue;
-                }
-            }
-            bases.push(ResolvedBase::Unresolvable);
+                        _ => ResolvedBase::ImportedFqn(fqn),
+                    },
+                    None => ResolvedBase::Unresolvable,
+                },
+                _ => ResolvedBase::Unresolvable,
+            };
+            bases.push(resolved);
         }
         out.push((cls_rk, bases));
     }
     out
+}
+
+/// Resolve a bare-name class base through the uniform binder ladder.
+/// `LocalClass` → same-file class; `Import` → upstream fqn; `StarImport`
+/// → `{module}.{name}`; `ModuleAlias` → `{this_module}.{other}` (chased
+/// across files at assemble). An unbound name is `Unresolvable`.
+fn resolve_name_base(
+    name: &str,
+    name_bindings: &FxHashMap<String, NameBinding>,
+    module_fqn: &str,
+) -> ResolvedBase {
+    match name_bindings.get(name) {
+        Some(NameBinding::LocalClass(idx)) => ResolvedBase::LocalSameFileClass(*idx),
+        Some(NameBinding::Import(fqn)) => ResolvedBase::ImportedFqn(fqn.clone()),
+        Some(NameBinding::StarImport(module)) => {
+            ResolvedBase::ImportedFqn(format!("{module}.{name}"))
+        }
+        Some(NameBinding::ModuleAlias(other)) => {
+            ResolvedBase::ImportedFqn(format!("{module_fqn}.{other}"))
+        }
+        None => ResolvedBase::Unresolvable,
+    }
 }
 
 /// Pure-rust variant of `ingest::import_payload_for`. Returns the same

--- a/runtime/src/helpers.rs
+++ b/runtime/src/helpers.rs
@@ -39,13 +39,6 @@ pub(crate) fn is_dunder_name(fqname: &str) -> bool {
     name.len() > 4 && name.starts_with("__") && name.ends_with("__")
 }
 
-pub(crate) fn class_body_defines_method(class_def: &StmtClassDef, method_name: &str) -> bool {
-    class_def.body.iter().any(|stmt| match stmt {
-        Stmt::FunctionDef(f) => f.name.as_str() == method_name,
-        _ => false,
-    })
-}
-
 /// Return ``true`` if any decorator in ``decorators`` matches
 /// ``@<module>.<name>`` (literal module name) or ``@<name>`` for
 /// any ``name`` in ``names``. Trailing ``(...)`` is unwrapped before
@@ -1008,54 +1001,13 @@ impl<'ast, 'a> Visitor<'ast> for FactoryCallFinder<'a> {
     }
 }
 
-/// Owner-resolution helper shared by the call-finder queries.
-/// Top-level ``FunctionDef`` / ``ClassDef`` own calls inside their
-/// subtree (decorators included via the walk); other top-level stmts
-/// attribute their calls to the module node.
-/// Look up the owning decl index for a top-level statement. Takes
-/// the two hashmaps directly (rather than ``&BuildOutputs``) because
-/// ``BuildOutputs`` carries ``Vec<Py<SymbolNode>>`` and is therefore
-/// ``!Sync`` — these maps are ``Sync`` on their own, which lets the
-/// callers borrow them across rayon thread boundaries.
-pub(crate) fn owner_idx_for_stmt_with(
-    decl_by_name_range: &FxHashMap<(File, (u32, u32)), usize>,
-    module_nodes_by_file: &FxHashMap<File, usize>,
-    file: File,
-    stmt: &Stmt,
-) -> Option<usize> {
-    let module_idx = module_nodes_by_file.get(&file).copied();
-    let name_range = match stmt {
-        Stmt::FunctionDef(f) => f.name.range(),
-        Stmt::ClassDef(c) => c.name.range(),
-        _ => return module_idx,
-    };
-    decl_by_name_range
-        .get(&(file, range_key(name_range)))
-        .copied()
-        .or(module_idx)
-}
-
-/// Extract the string-literal value of a call's ``args[arg_index]``
-/// positional argument. ``None`` when out of range or not a single
-/// string literal — concatenated / f-string / b-string forms don't
-/// project to a static fqname and are deliberately rejected.
-pub(crate) fn nth_positional_string(
-    call: &ruff_python_ast::ExprCall,
-    arg_index: usize,
-) -> Option<String> {
-    match call.arguments.args.get(arg_index)? {
-        Expr::StringLiteral(s) => Some(s.value.to_str().to_string()),
-        _ => None,
-    }
-}
-
 /// A string literal extracted from a call keyword argument, or
 /// ``Unknown`` for anything else. The only in-tree consumer is the
 /// pytest plugin, which reads the ``name=`` alias on ``@pytest.fixture``;
 /// every non-string expression collapses to ``Unknown``. Re-exported from
 /// [`crate::native_plugins::plugin_api`] (pyo3-free) so external plugins
 /// can read decorator/constructor arguments too.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 pub enum ArgValue {
     Str(String),
     Unknown,
@@ -1065,7 +1017,7 @@ pub enum ArgValue {
 /// The map itself is crate-internal (it carries an `FxHashMap`, which the
 /// curated airlock doesn't expose); external plugins read values through
 /// the [`CallArgs::get`] / [`CallArgs::str_value`] accessors.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 pub struct CallArgs {
     pub(crate) kwargs: FxHashMap<String, ArgValue>,
 }
@@ -1168,131 +1120,6 @@ pub(crate) fn extract_call_kwargs(call: &ruff_python_ast::ExprCall) -> CallArgs 
         kwargs.insert(name.as_str().to_string(), extract_arg_value(&kw.value));
     }
     CallArgs { kwargs }
-}
-
-/// Match ``<owner>.<attr>(...)`` where ``<owner>`` is a bare ``Name``
-/// equal to the given owner string and ``<attr>`` matches. No import
-/// resolution — meant for pytest fixture conventions (``mocker``,
-/// ``monkeypatch``) whose names come from function parameters.
-pub(crate) fn call_callee_matches_var(
-    call: &ruff_python_ast::ExprCall,
-    owner: &str,
-    attr: &str,
-    required_positional: Option<usize>,
-) -> bool {
-    let Expr::Attribute(attribute) = unwrap_subscripted_callee(call.func.as_ref()) else {
-        return false;
-    };
-    if attribute.attr.as_str() != attr {
-        return false;
-    }
-    let Expr::Name(name) = attribute.value.as_ref() else {
-        return false;
-    };
-    if name.id.as_str() != owner {
-        return false;
-    }
-    if let Some(expected) = required_positional {
-        if call.arguments.args.len() != expected {
-            return false;
-        }
-    }
-    true
-}
-
-/// Visit every Call expression in a subtree, push
-/// ``(string_arg_at_index, CallArgs)`` whenever ``predicate(call)``
-/// returns ``true``. Backs both call-finder queries.
-pub(crate) struct StringArgCallFinder<F>
-where
-    F: FnMut(&ruff_python_ast::ExprCall) -> bool,
-{
-    pub(crate) predicate: F,
-    pub(crate) arg_index: usize,
-    /// When ``false``, every result row gets a default-constructed
-    /// (empty) :struct:`CallArgs`. The caller pays for the rust-side
-    /// kwarg walk only when ``extract_args = true``.
-    pub(crate) extract_args: bool,
-    pub(crate) results: Vec<(String, CallArgs)>,
-}
-
-impl<'ast, F> Visitor<'ast> for StringArgCallFinder<F>
-where
-    F: FnMut(&ruff_python_ast::ExprCall) -> bool,
-{
-    fn visit_expr(&mut self, expr: &'ast Expr) {
-        if let Expr::Call(call) = expr {
-            if (self.predicate)(call) {
-                if let Some(value) = nth_positional_string(call, self.arg_index) {
-                    let call_args = if self.extract_args {
-                        extract_call_kwargs(call)
-                    } else {
-                        CallArgs::default()
-                    };
-                    self.results.push((value, call_args));
-                }
-            }
-        }
-        walk_expr(self, expr);
-    }
-}
-
-/// Visit every Call expression in a subtree, capture string-literal
-/// args at ``arg_index`` for calls whose callee is ``<expr>.<attr>(...)``
-/// regardless of receiver shape. The captured arg can be a single
-/// string literal **or** a list/tuple of string literals (the latter
-/// produces multiple results for one call). Backs ``find_calls_on_attr``.
-///
-/// Each emitted row is ``(captured_string, CallArgs)``. Multiple rows
-/// from one call (list/tuple shape) share the same ``CallArgs``.
-pub(crate) struct AttrCallFinder<'a> {
-    pub(crate) attr: &'a str,
-    pub(crate) arg_index: usize,
-    /// See :struct:`StringArgCallFinder` — same gate.
-    pub(crate) extract_args: bool,
-    pub(crate) results: Vec<(String, CallArgs)>,
-}
-
-impl<'ast, 'a> Visitor<'ast> for AttrCallFinder<'a> {
-    fn visit_expr(&mut self, expr: &'ast Expr) {
-        if let Expr::Call(call) = expr {
-            if let Expr::Attribute(attribute) = unwrap_subscripted_callee(call.func.as_ref()) {
-                if attribute.attr.as_str() == self.attr {
-                    if let Some(arg) = call.arguments.args.get(self.arg_index) {
-                        let hits = string_or_string_collection(arg);
-                        if !hits.is_empty() {
-                            let call_args = if self.extract_args {
-                                extract_call_kwargs(call)
-                            } else {
-                                CallArgs::default()
-                            };
-                            for s in hits {
-                                self.results.push((s, call_args.clone()));
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        walk_expr(self, expr);
-    }
-}
-
-/// Pull string-literal values out of either a single ``"..."`` or a
-/// homogeneous list/tuple of string literals. Non-string elements in a
-/// list/tuple are silently dropped; non-matching expressions yield an
-/// empty vec.
-fn string_or_string_collection(arg: &Expr) -> Vec<String> {
-    let lit = |e: &Expr| match e {
-        Expr::StringLiteral(s) => Some(s.value.to_str().to_string()),
-        _ => None,
-    };
-    match arg {
-        Expr::StringLiteral(s) => vec![s.value.to_str().to_string()],
-        Expr::List(list) => list.elts.iter().filter_map(lit).collect(),
-        Expr::Tuple(tup) => tup.elts.iter().filter_map(lit).collect(),
-        _ => Vec::new(),
-    }
 }
 
 pub(crate) fn rel_path<P: AsRef<str>>(path: P) -> RelativePathBuf {
@@ -2280,32 +2107,7 @@ mod tests {
         assert!(top_level_assign_to_name(&stmts[0]).is_none());
     }
 
-    // -- class_body_defines_method -----------------------------------------
-
-    #[test]
-    fn class_body_defines_method_finds_named_method() {
-        let stmts = parse_stmts("class C:\n    def m(self): pass\n    def n(self): pass\n");
-        let cls = match &stmts[0] {
-            Stmt::ClassDef(c) => c,
-            _ => unreachable!(),
-        };
-        assert!(class_body_defines_method(cls, "m"));
-        assert!(class_body_defines_method(cls, "n"));
-        assert!(!class_body_defines_method(cls, "missing"));
-    }
-
-    #[test]
-    fn class_body_defines_method_ignores_non_function_members() {
-        let stmts = parse_stmts("class C:\n    x = 1\n    class Inner: pass\n");
-        let cls = match &stmts[0] {
-            Stmt::ClassDef(c) => c,
-            _ => unreachable!(),
-        };
-        assert!(!class_body_defines_method(cls, "x"));
-        assert!(!class_body_defines_method(cls, "Inner"));
-    }
-
-    // -- nth_positional_string --------------------------------------------
+    // -- first_call: shared call-parsing helper for the call-target tests --
 
     fn first_call(source: &str) -> ruff_python_ast::ExprCall {
         let expr = parse_expr(source);
@@ -2313,64 +2115,6 @@ mod tests {
             Expr::Call(c) => c,
             _ => panic!("expected a call expression"),
         }
-    }
-
-    #[test]
-    fn nth_positional_string_returns_literal_value() {
-        let call = first_call("f('hello', 'world')");
-        assert_eq!(nth_positional_string(&call, 0), Some("hello".to_string()));
-        assert_eq!(nth_positional_string(&call, 1), Some("world".to_string()));
-    }
-
-    #[test]
-    fn nth_positional_string_returns_none_for_non_string() {
-        let call = first_call("f(42, foo)");
-        assert_eq!(nth_positional_string(&call, 0), None);
-        assert_eq!(nth_positional_string(&call, 1), None);
-    }
-
-    #[test]
-    fn nth_positional_string_out_of_range_returns_none() {
-        let call = first_call("f('a')");
-        assert_eq!(nth_positional_string(&call, 5), None);
-    }
-
-    #[test]
-    fn nth_positional_string_rejects_f_string() {
-        // f-strings are not StringLiteral nodes — should be rejected.
-        let call = first_call("f(f'value-{x}')");
-        assert_eq!(nth_positional_string(&call, 0), None);
-    }
-
-    // -- call_callee_matches_var ------------------------------------------
-
-    #[test]
-    fn call_callee_matches_var_matches_owner_attr() {
-        let call = first_call("mocker.patch('x')");
-        assert!(call_callee_matches_var(&call, "mocker", "patch", None));
-        assert!(call_callee_matches_var(&call, "mocker", "patch", Some(1)));
-        assert!(!call_callee_matches_var(&call, "mocker", "patch", Some(2)));
-    }
-
-    #[test]
-    fn call_callee_matches_var_rejects_wrong_owner_or_attr() {
-        let call = first_call("mocker.patch('x')");
-        assert!(!call_callee_matches_var(&call, "other", "patch", None));
-        assert!(!call_callee_matches_var(&call, "mocker", "spy", None));
-    }
-
-    #[test]
-    fn call_callee_matches_var_rejects_non_attribute_callee() {
-        let call = first_call("f('x')");
-        assert!(!call_callee_matches_var(&call, "f", "patch", None));
-    }
-
-    #[test]
-    fn call_callee_matches_var_rejects_chained_receiver() {
-        // ``a.b.patch(...)`` has ``a.b`` (Attribute) as the receiver, not
-        // a bare Name — should not match.
-        let call = first_call("a.b.patch('x')");
-        assert!(!call_callee_matches_var(&call, "b", "patch", None));
     }
 
     // -- range_key ---------------------------------------------------------

--- a/runtime/src/helpers.rs
+++ b/runtime/src/helpers.rs
@@ -97,183 +97,6 @@ pub(crate) fn iter_top_level_classes(
     })
 }
 
-/// Find a top-level `StmtClassDef` whose name range equals `selection_range`.
-/// Return the top-level ``StmtClassDef`` (if any) that uses
-/// ``ref_range`` as one of its direct base-list arguments.
-///
-/// Used by the find_references-based subclass walk: each
-/// :func:`ty_ide::find_references` hit gives us a ``(File, range)``
-/// for a use of the seed class; if that range falls inside a top-level
-/// class's ``arguments.args`` list, the surrounding class is a direct
-/// subclass.
-///
-/// Note: this is a syntactic match (range containment), so a use of
-/// ``TestCase`` inside a parameterized generic base
-/// (``class X(SomeGeneric[TestCase]):``) will falsely flag ``X`` as a
-/// subclass of ``TestCase``. ty's :func:`type_hierarchy_subtypes`
-/// avoids that via real type inference; we trade that accuracy for
-/// the prefilter+rayon scan ty_ide's find_references provides.
-pub(crate) fn class_base_arg_owner(
-    parsed: &ParsedModuleRef,
-    ref_range: TextRange,
-) -> Option<&StmtClassDef> {
-    for stmt in &parsed.syntax().body {
-        let Stmt::ClassDef(class_def) = stmt else {
-            continue;
-        };
-        let Some(arguments) = &class_def.arguments else {
-            continue;
-        };
-        for arg in &arguments.args {
-            if arg.range().contains_range(ref_range) {
-                return Some(class_def);
-            }
-        }
-    }
-    None
-}
-
-/// If ``ref_range`` covers the "original name" of an aliased
-/// ``from M import Name as Alias`` (or ``import M as Alias``), return
-/// the alias's local-binding name range so the BFS can follow the
-/// re-binding to its uses.
-///
-/// ty_ide's :func:`find_references` is designed for IDE rename
-/// semantics: it does NOT follow aliased imports across the
-/// re-binding (renaming ``TestCase`` should not rename uses of
-/// ``TC`` from ``from unittest import TestCase as TC``). For our
-/// subclass walk we DO want the alias's uses — they're the
-/// subclasses we'd otherwise miss — so we seed the BFS with the
-/// alias's local name range and call find_references on that.
-pub(crate) fn aliased_import_local_name_range(
-    parsed: &ParsedModuleRef,
-    ref_range: TextRange,
-) -> Option<TextRange> {
-    for stmt in &parsed.syntax().body {
-        let aliases: &[ruff_python_ast::Alias] = match stmt {
-            Stmt::ImportFrom(import_from) => &import_from.names,
-            Stmt::Import(import) => &import.names,
-            _ => continue,
-        };
-        for alias in aliases {
-            let Some(asname) = &alias.asname else {
-                continue;
-            };
-            if alias.name.range() == ref_range {
-                return Some(asname.range());
-            }
-        }
-    }
-    None
-}
-
-/// Walk transitive subclasses of the seed class via
-/// :func:`ty_ide::find_references`, which carries an
-/// identifier-aware text prefilter and per-file rayon parallelism for
-/// free. Each find_references hit is filtered to "syntactically in a
-/// class base list"; matched classes seed the next round when
-/// ``transitive`` is set.
-///
-/// Returns ``Vec<usize>`` of indices into
-/// ``BuildOutputs::builder.nodes`` (only project classes — typeshed
-/// / external matches are dropped because they don't have a
-/// :attr:`class_by_selection` entry).
-#[allow(dead_code)]
-pub(crate) fn find_subclass_indices_via_refs(
-    db: &ProjectDatabase,
-    outputs: &BuildOutputs,
-    seed_file: File,
-    seed_name_range: TextRange,
-    transitive: bool,
-) -> Vec<usize> {
-    find_subclass_indices_via_refs_with_queue(
-        db,
-        &outputs.class_by_selection,
-        vec![(seed_file, seed_name_range)],
-        &[],
-        transitive,
-    )
-}
-
-/// Lower-level entry point for [`find_subclass_indices_via_refs`] that
-/// takes a pre-built initial BFS queue + a "pre-found" set of direct
-/// subclasses and just the ``class_by_selection`` index. Used by
-/// [`find_subclasses`](crate::project::ProjectContext::find_subclasses)
-/// after the fast-path parallel scan has produced the first-hop
-/// frontier from an external seed.
-///
-/// ``prefound_direct_subclasses`` is the list of
-/// ``(File, class_name_range)`` pairs the fast path already classified
-/// as direct subclasses; they're recorded as hits up-front *and*
-/// seeded into the BFS so transitive subclasses + alias chains are
-/// still walked through find_references. ``initial_queue`` is the
-/// remaining seeds to run find_references on (typically the original
-/// external seed range, so re-exports through project modules / star
-/// imports are still caught).
-pub(crate) fn find_subclass_indices_via_refs_with_queue(
-    db: &dyn ProjectDb,
-    class_by_selection: &FxHashMap<(File, (u32, u32)), usize>,
-    initial_queue: Vec<(File, TextRange)>,
-    prefound_direct_subclasses: &[(File, TextRange)],
-    transitive: bool,
-) -> Vec<usize> {
-    let mut out_idx: FxHashSet<usize> = FxHashSet::default();
-    let mut visited_seeds: FxHashSet<(File, (u32, u32))> = FxHashSet::default();
-    let mut queue: Vec<(File, TextRange)> = initial_queue;
-
-    // Record the fast-path direct subclasses as hits up-front. When
-    // transitive=true also seed the BFS with them so subclasses of
-    // these local classes get walked through find_references.
-    for &(f, r) in prefound_direct_subclasses {
-        let key = (f, range_key(r));
-        if let Some(&idx) = class_by_selection.get(&key) {
-            if out_idx.insert(idx) && transitive {
-                queue.push((f, r));
-            }
-        }
-    }
-
-    while let Some((cur_file, cur_range)) = queue.pop() {
-        if !visited_seeds.insert((cur_file, range_key(cur_range))) {
-            continue;
-        }
-        // Cursor offset inside the identifier (start can sit on the
-        // token boundary and ty_ide's tokens.at_offset has edge-cases
-        // there). Anywhere inside the identifier resolves the same
-        // goto target.
-        let offset =
-            cur_range.start() + ruff_text_size::TextSize::from(u32::from(cur_range.len()) / 2);
-        // Pass include_declaration=true: skip-declaration mode filters
-        // out re-binding declarations like `from M import Name as Alias`
-        // alongside the seed itself. We need that import-line entry to
-        // detect the alias and recurse, so we take the full list and
-        // drop the seed in class_base_arg_owner / via the visited_seeds
-        // dedup.
-        let Some(refs) = ty_ide::find_references(db, cur_file, offset, true) else {
-            continue;
-        };
-        for r in refs {
-            let r_file = r.file();
-            let r_range = r.range();
-            let parsed = parsed_module(db, r_file).load(db);
-            if let Some(class_def) = class_base_arg_owner(&parsed, r_range) {
-                let class_name_range = class_def.name.range();
-                let key = (r_file, range_key(class_name_range));
-                let Some(&idx) = class_by_selection.get(&key) else {
-                    continue;
-                };
-                if out_idx.insert(idx) && transitive {
-                    queue.push((r_file, class_name_range));
-                }
-            } else if let Some(alias_range) = aliased_import_local_name_range(&parsed, r_range) {
-                queue.push((r_file, alias_range));
-            }
-        }
-    }
-
-    out_idx.into_iter().collect()
-}
-
 /// Find a top-level ``StmtClassDef`` by its bound name.
 pub(crate) fn class_def_named<'a>(
     parsed: &'a ParsedModuleRef,
@@ -473,27 +296,41 @@ pub(crate) fn resolve_base_fqn(
 /// Mappings produced:
 /// * ``from foo.bar import Baz`` → ``"Baz" -> "foo.bar.Baz"``
 /// * ``from foo.bar import Baz as B`` → ``"B" -> "foo.bar.Baz"``
+/// * ``from .bases import Baz`` (in package ``pkg``) →
+///   ``"Baz" -> "pkg.bases.Baz"`` — relative dots are resolved against
+///   ``file_package`` via ``im.level``. ``file_package`` is the
+///   importing file's enclosing package (``None`` for a top-level
+///   module, in which case a relative import is dropped).
 /// * ``import foo`` → ``"foo" -> "foo"``
 /// * ``import foo.bar as fb`` → ``"fb" -> "foo.bar"``
 /// * ``import foo.bar`` → ``"foo" -> "foo"`` (Python binds the
 ///   leftmost segment; the runtime module ``foo`` is what the name
 ///   resolves to).
-pub(crate) fn collect_all_imports_local(parsed: &ParsedModuleRef) -> FxHashMap<String, String> {
+pub(crate) fn collect_all_imports_local(
+    parsed: &ParsedModuleRef,
+    file_package: Option<&str>,
+) -> FxHashMap<String, String> {
     let mut out: FxHashMap<String, String> = FxHashMap::default();
     for stmt in &parsed.syntax().body {
         match stmt {
             Stmt::ImportFrom(im) => {
-                let Some(mod_name) = &im.module else { continue };
-                let module = mod_name.as_str();
+                // Resolve the source module to an absolute dotted path.
+                // `im.module` is only the suffix after the dots; the dot
+                // count lives in `im.level`, so a relative re-export like
+                // `from .bases import TestCase` resolves against the
+                // importing file's package instead of being mis-keyed to
+                // a bogus top-level `bases.TestCase`.
+                let tail = im.module.as_ref().map(|n| n.as_str()).unwrap_or("");
+                let module = if im.level == 0 {
+                    (!tail.is_empty()).then(|| tail.to_string())
+                } else {
+                    resolve_relative_import(im.level, tail, file_package)
+                };
+                let Some(module) = module else { continue };
                 for alias in &im.names {
                     let target = alias.name.as_str();
                     let local = alias.asname.as_ref().map(|n| n.as_str()).unwrap_or(target);
-                    let upstream = if module.is_empty() {
-                        target.to_string()
-                    } else {
-                        format!("{module}.{target}")
-                    };
-                    out.insert(local.to_string(), upstream);
+                    out.insert(local.to_string(), format!("{module}.{target}"));
                 }
             }
             Stmt::Import(im) => {

--- a/runtime/src/helpers.rs
+++ b/runtime/src/helpers.rs
@@ -6,7 +6,6 @@
 use pyo3::prelude::*;
 use ruff_db::files::{File, FilePath};
 use ruff_db::parsed::{parsed_module, ParsedModuleRef};
-use ruff_db::source::{line_index, source_text};
 use ruff_db::system::SystemPath;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::visitor::{walk_expr, Visitor};
@@ -21,7 +20,6 @@ use ty_module_resolver::{
 use ty_project::metadata::value::RelativePathBuf;
 use ty_project::{Db as ProjectDb, ProjectDatabase};
 
-use crate::builder::GraphNode;
 use crate::graph::{EdgeFlags, NodeFlags};
 use crate::ingest::collapse_attribute_chain;
 use crate::project::BuildOutputs;
@@ -97,35 +95,6 @@ pub(crate) fn iter_top_level_classes(
         Stmt::ClassDef(cls) => Some(cls),
         _ => None,
     })
-}
-
-/// Locate a class's File + name TextRange from its SymbolNode positions.
-///
-/// We don't store ty `Definition<'db>` references across plugin calls
-/// (the `'db` lifetime is tied to the active borrow), so this re-walks
-/// the matching file's top-level classes for one whose name lands on
-/// the node's start line. Match-by-line (not line+column) because
-/// Function / Class / TypeAlias node columns are snapped to the line's
-/// indent — not the bound name's column — to align with libcst, and
-/// two top-level classes can't share a source line.
-pub(crate) fn locate_class_def(
-    db: &ProjectDatabase,
-    path_to_file: &FxHashMap<String, File>,
-    path: &str,
-    class_node: &GraphNode,
-) -> Option<(File, TextRange)> {
-    let &file = path_to_file.get(path)?;
-    let parsed = parsed_module(db, file).load(db);
-    let source = source_text(db, file);
-    let line_index = line_index(db, file);
-    for cls in iter_top_level_classes(&parsed) {
-        let name_range = cls.name.range();
-        let (sl, _, _, _) = position(&line_index, &source, name_range);
-        if sl == class_node.start_line {
-            return Some((file, name_range));
-        }
-    }
-    None
 }
 
 /// Find a top-level `StmtClassDef` whose name range equals `selection_range`.
@@ -305,190 +274,6 @@ pub(crate) fn find_subclass_indices_via_refs_with_queue(
     out_idx.into_iter().collect()
 }
 
-/// Fast first-hop scan for the external-seed branch of
-/// [`crate::project::ProjectContext::find_subclasses`]. Returns the
-/// ``(File, class_name_range)`` of every top-level project class whose
-/// base-arg list resolves (through the file's local imports) to
-/// ``<seed_module>.<seed_simple_name>``.
-///
-/// This intentionally bypasses [`ty_ide::find_references`] (which is
-/// the dominant cost when the seed is in an external package — e.g.
-/// ``typer.Typer`` or ``fastapi.FastAPI``) and instead does a parallel
-/// per-file text-prefilter + AST walk over project files. The result
-/// seeds the BFS so transitive subclasses + alias chains are still
-/// walked through the existing find_references path.
-///
-/// Recognized base shapes (mirroring
-/// [`decorators_match_imports`]'s import-aware matcher):
-///
-/// * ``class X(SimpleName): ...`` where the file has
-///   ``from <seed_module> import <seed_simple_name>`` (with or without
-///   an ``as`` alias, so ``SimpleName`` may be the alias).
-/// * ``class X(<alias>.<simple_name>): ...`` where ``<alias>`` is
-///   bound to ``seed_module`` via ``import <seed_module>`` or
-///   ``import <seed_module> as <alias>``.
-///
-/// Subscripted generics (``class X(SomeGeneric[<base>]): ...``) and
-/// nested attribute chains are NOT matched — these are the rare
-/// shapes the upstream ``find_references`` walk would catch via
-/// semantic resolution. Callers run the historic find_references
-/// path as a fallback when the fast path returns empty.
-///
-/// Trade-off vs the find_references walk: this is a *syntactic*
-/// match against the file's import map. It can miss a subclass
-/// whose base is bound via a re-export through an intermediate
-/// project module (``from my_lib import Typer`` where ``my_lib``
-/// re-exports ``typer.Typer``). Callers wishing to keep that path
-/// must compose with find_references.
-///
-/// Caller must wrap in [`pyo3::Python::allow_threads`] — the inner
-/// per-file scan uses rayon and is GIL-free.
-/// Per-file fast-path result. ``direct_classes`` is the list of
-/// class-name ranges identified as direct subclasses of the external
-/// seed. ``has_module_import`` is ``true`` if this file imports the
-/// seed module in any form (``from <module> import ...``,
-/// ``import <module>``, ``from <module> import *``) — used by the
-/// caller as a presence signal: if no file in the project has a
-/// module import, the find_references fallback can be skipped (a
-/// re-export chain through a project module would still surface here).
-pub(crate) struct ExternalSeedFastPathResult {
-    pub(crate) direct_classes: Vec<(File, TextRange)>,
-    pub(crate) any_project_file_imports_seed_module: bool,
-}
-
-pub(crate) fn find_external_seed_direct_subclasses_par(
-    db: &dyn ProjectDb,
-    project_files: &[File],
-    seed_module: &str,
-    seed_simple_name: &str,
-) -> ExternalSeedFastPathResult {
-    use crate::query::{_contains_identifier, par_scan_files};
-    let db_handle: Box<dyn ProjectDb> = ProjectDb::dyn_clone(db);
-    let needle: &str = seed_simple_name;
-    let module: &str = seed_module;
-    // Per-file output: (class subclass ranges, file-imports-seed-module).
-    let per_file: Vec<(Vec<(File, TextRange)>, bool)> =
-        par_scan_files(db_handle, project_files, &None, |db, file| {
-            // Cheap text prefilter on the seed module's leftmost
-            // segment — every form of seed-module import (``import
-            // <module>``, ``from <module> import …``, ``from <module>
-            // import *``) mentions that segment in the source.
-            let source = source_text(db, file);
-            let module_root = module.split('.').next().unwrap_or(module);
-            if !_contains_identifier(&source, module_root) {
-                return Vec::new();
-            }
-            let parsed = parsed_module(db, file).load(db);
-            let has_module_import = file_imports_module(&parsed, module);
-            let mentions_name = _contains_identifier(&source, needle);
-            // Only build the imports map + walk class bases when the
-            // file textually mentions the simple name — the typical
-            // shortcut.
-            let direct: Vec<(File, TextRange)> = if mentions_name {
-                let allowed: FxHashSet<&str> = std::iter::once(needle).collect();
-                // ``file_package`` is `None`: relative imports of
-                // external framework names (``from .foo import
-                // Typer``) are vanishingly rare; the
-                // ``find_references`` fallback covers them when
-                // ``any_project_file_imports_seed_module`` flips on.
-                let imports = collect_module_imports_local(&parsed, module, &allowed, None);
-                if imports.is_empty() {
-                    Vec::new()
-                } else {
-                    let mut out: Vec<(File, TextRange)> = Vec::new();
-                    for cls in iter_top_level_classes(&parsed) {
-                        let Some(arguments) = &cls.arguments else {
-                            continue;
-                        };
-                        for arg in &arguments.args {
-                            if base_arg_resolves_to_seed(arg, &imports, needle) {
-                                out.push((file, cls.name.range()));
-                                break;
-                            }
-                        }
-                    }
-                    out
-                }
-            } else {
-                Vec::new()
-            };
-            vec![(direct, has_module_import)]
-        });
-    let mut direct_classes: Vec<(File, TextRange)> = Vec::new();
-    let mut any_project_file_imports_seed_module = false;
-    for (per, imports_seed) in per_file {
-        direct_classes.extend(per);
-        any_project_file_imports_seed_module |= imports_seed;
-    }
-    ExternalSeedFastPathResult {
-        direct_classes,
-        any_project_file_imports_seed_module,
-    }
-}
-
-/// Returns ``true`` if ``parsed`` imports ``module`` in any of:
-/// ``from <module> import …``, ``from <module> import *``,
-/// ``import <module>``, or ``import <module> as …``. Used as the
-/// presence-signal for the fast-path "no project file imports the
-/// seed module" shortcut.
-fn file_imports_module(parsed: &ParsedModuleRef, module: &str) -> bool {
-    for stmt in &parsed.syntax().body {
-        match stmt {
-            Stmt::ImportFrom(im) => {
-                if let Some(name) = &im.module {
-                    if name.as_str() == module {
-                        return true;
-                    }
-                }
-            }
-            Stmt::Import(im) => {
-                for alias in &im.names {
-                    if alias.name.as_str() == module {
-                        return true;
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-    false
-}
-
-/// Return ``true`` if ``arg`` is a base-list reference that, after
-/// resolving through the file's local imports, names the seed class.
-/// Recognized shapes (matching what
-/// [`find_external_seed_direct_subclasses_par`] documents):
-///
-/// * ``Name(local)`` where ``imports[local] == seed_simple_name``
-///   (the local binding is the imported class).
-/// * ``Attribute(Name(local).attr)`` where ``imports[local] ==
-///   MODULE_ALIAS_MARKER`` and ``attr == seed_simple_name`` (the
-///   local binding is the module alias and we're accessing the class
-///   through it).
-fn base_arg_resolves_to_seed(
-    arg: &Expr,
-    imports: &FxHashMap<String, String>,
-    seed_simple_name: &str,
-) -> bool {
-    match arg {
-        Expr::Name(n) => imports
-            .get(n.id.as_str())
-            .is_some_and(|target| target == seed_simple_name),
-        Expr::Attribute(attr) => {
-            if attr.attr.as_str() != seed_simple_name {
-                return false;
-            }
-            let Expr::Name(prefix) = attr.value.as_ref() else {
-                return false;
-            };
-            imports
-                .get(prefix.id.as_str())
-                .is_some_and(|t| t == MODULE_ALIAS_MARKER)
-        }
-        _ => false,
-    }
-}
-
 /// Find a top-level ``StmtClassDef`` by its bound name.
 pub(crate) fn class_def_named<'a>(
     parsed: &'a ParsedModuleRef,
@@ -507,15 +292,15 @@ pub(crate) fn locate_class_seed(
     outputs: &BuildOutputs,
     fqn: &str,
 ) -> Option<(File, TextRange)> {
-    // Project class: cheap path through the existing indices.
+    // Project class: cheap path through the existing indices. The
+    // inverted `class_by_selection` hands back the name range directly,
+    // so no AST re-parse is needed to relocate the def.
     if let Some(idxs) = outputs.decl_by_fqname.get(fqn) {
         for &idx in idxs {
-            let node = &outputs.builder.nodes[idx];
-            if node.kind != "class" {
+            if outputs.builder.nodes[idx].kind != "class" {
                 continue;
             }
-            let path = node.path.clone();
-            if let Some(seed) = locate_class_def(db, &outputs.path_to_file, &path, node) {
+            if let Some(&seed) = outputs.class_selection_by_idx.get(&idx) {
                 return Some(seed);
             }
         }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -26,6 +26,7 @@
 #![allow(clippy::useless_conversion)]
 
 mod builder;
+mod file_extraction;
 mod file_payload;
 mod file_ref_edges;
 mod graph;

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -17,41 +17,36 @@ use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
 use ruff_db::system::{OsSystem, SystemPathBuf};
 use ruff_python_ast::token::TokenKind;
-use ruff_python_ast::visitor::Visitor;
-use ruff_python_ast::{Expr, Stmt};
 use ruff_text_size::{Ranged, TextRange};
 use ty_project::metadata::options::{EnvironmentOptions, Options};
 use ty_project::metadata::python_version::SupportedPythonVersion;
 use ty_project::metadata::value::RangedValue;
 use ty_project::watch::{ChangeEvent as TyChangeEvent, ChangedKind, CreatedKind, DeletedKind};
 use ty_project::{Db as ProjectDb, ProjectDatabase, ProjectMetadata};
-use ty_python_core::definition::DefinitionState;
 use ty_python_core::program::UseDefaultStrategy;
-use ty_python_core::scope::FileScopeId;
-use ty_python_core::semantic_index;
 
 use crate::builder::{
     apply_prepared_batch, bfs, lookup_idx, not_materialized, synthetic_node, Direction,
     GraphBuilder, GraphNode, PreparedOp,
 };
+use crate::file_extraction::{
+    file_extraction, imports_local_from_facts, match_callee_chain, match_callee_descriptor,
+    CallSiteFact, FileExtraction,
+};
 use crate::file_payload::{file_to_edges, file_to_nodes, FileEdges, NodeKind, NodeRef};
 use crate::file_ref_edges::{file_to_ref_edges, FileRefEdges};
 use crate::graph::{intern_kind, DeclIndex, NativeGraph, SymbolNode};
 use crate::helpers::{
-    call_callee_matches_var, class_body_defines_method, collect_modules_imports_local,
-    decorators_match_imports, extract_call_kwargs, file_path_string,
-    find_external_seed_direct_subclasses_par, find_main_block_range,
+    file_path_string, find_external_seed_direct_subclasses_par,
     find_subclass_indices_via_refs_with_queue, is_dunder_name, locate_class_def, locate_class_seed,
-    matched_call_target_any, owner_idx_for_stmt_with, range_key, rel_path,
-    top_level_assign_to_name, unwrap_subscripted_callee, AttrCallFinder, CallArgs,
-    FactoryCallFinder, StringArgCallFinder, NODE_FLAG_ENTRYPOINT,
+    rel_path, CallArgs, MODULE_ALIAS_MARKER, NODE_FLAG_ENTRYPOINT,
 };
-use crate::ingest::{emit_visitor_warning, file_package_name, string_literal_list};
+use crate::ingest::emit_visitor_warning;
 use crate::progress::{
     ProgressCounters, ProgressHandle, ProgressSnapshot, PHASE_ASSEMBLE, PHASE_ENUM, PHASE_FQNAME,
     PHASE_PLUGINS, PHASE_POPULATE,
 };
-use crate::query::{_contains_any_identifier, _contains_identifier, par_scan_files};
+use crate::query::_path_re_matches;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 /// A ty-backed analysis project with explicitly-injected configuration.
@@ -352,6 +347,11 @@ pub(crate) fn build_project_graph(
                             let _ = file_to_nodes(local_db, file);
                             let _ = file_to_edges(local_db, file);
                             let _ = file_to_ref_edges(local_db, file);
+                            // Owned per-file facts for the project-wide
+                            // plugin queries. Warmed here, while the AST
+                            // is live, so the queries below run as cache
+                            // reads.
+                            let _ = file_extraction(local_db, file);
                             // Per-file native plugins: warm the salsa-cached
                             // `per_file_plugin_ops(file, id)` query on this
                             // worker so the serial assembly fold below is a
@@ -362,6 +362,19 @@ pub(crate) fn build_project_graph(
                                 let _ =
                                     crate::native_plugins::per_file_plugin_ops(local_db, file, id);
                             }
+                            // Every per-file AST consumer for this file has
+                            // now run and memoized its result, so drop the
+                            // parsed AST rather than let it sit resident
+                            // through assembly and the project-wide plugin
+                            // pass — that's the memory win. Assembly, fqname,
+                            // and class-hierarchy read only the cached
+                            // payloads, never the AST. Subclass-resolution
+                            // plugins and the `find_comment_patterns` pymethod
+                            // re-parse the specific files they touch on demand
+                            // (`ParsedModule::load`), so only that subset
+                            // re-materializes; the all-ASTs-resident peak
+                            // never forms.
+                            parsed_module(local_db, file).clear();
                         });
                         db_tx.send(local_db).expect("channel open");
                         counters_inner.populate_inc();
@@ -2629,22 +2642,12 @@ fn find_literal_list_entries_in(
         let Some(&file) = outputs.path_to_file.get(&path) else {
             continue;
         };
-        let source = source_text(db, file);
-        let parsed = parsed_module(db, file).load(db);
-        for stmt in &parsed.syntax().body {
-            let Some((target_range, value)) = top_level_assign_to_name(stmt) else {
-                continue;
-            };
-            let start: usize = target_range.start().to_usize();
-            let end: usize = target_range.end().to_usize();
-            if &source[start..end] != bare_name {
+        for (name, entries) in &file_extraction(db, file).literal_list_rows {
+            if name != bare_name {
                 continue;
             }
-            let Some(entries) = string_literal_list(value) else {
-                continue;
-            };
             found_any = true;
-            out.extend(entries.into_iter().map(String::from));
+            out.extend(entries.iter().cloned());
         }
     }
     found_any.then_some(out)
@@ -2677,19 +2680,10 @@ fn find_main_blocks_indices_in(
 ) -> Vec<(usize, Vec<usize>)> {
     let mut hits: Vec<(File, usize, (u32, u32))> = Vec::new();
     for (&file, &module_idx) in &outputs.module_nodes_by_file {
-        let source = source_text(db, file);
-        if !source.contains("__main__") {
-            continue;
-        }
-        let parsed = parsed_module(db, file).load(db);
-        let Some(block_range) = find_main_block_range(&parsed) else {
+        let Some(range) = file_extraction(db, file).main_block_range else {
             continue;
         };
-        hits.push((
-            file,
-            module_idx,
-            (block_range.start().to_u32(), block_range.end().to_u32()),
-        ));
+        hits.push((file, module_idx, range));
     }
     if hits.is_empty() {
         return Vec::new();
@@ -2752,29 +2746,10 @@ fn function_parameters_in(
     let mut params_for_idx: FxHashMap<usize, Vec<String>> =
         FxHashMap::with_capacity_and_hasher(wanted.len(), Default::default());
     for (&file, rk_to_idx) in &by_file {
-        let parsed = parsed_module(db, file).load(db);
-        for stmt in &parsed.syntax().body {
-            let Stmt::FunctionDef(func) = stmt else {
-                continue;
-            };
-            let rk = crate::helpers::range_key(func.name.range());
-            let Some(&idx) = rk_to_idx.get(&rk) else {
-                continue;
-            };
-            let params = &func.parameters;
-            let mut names: Vec<String> = Vec::with_capacity(
-                params.posonlyargs.len() + params.args.len() + params.kwonlyargs.len(),
-            );
-            for p in &params.posonlyargs {
-                names.push(p.parameter.name.id.to_string());
+        for (rk, names) in &file_extraction(db, file).function_params {
+            if let Some(&idx) = rk_to_idx.get(rk) {
+                params_for_idx.insert(idx, names.clone());
             }
-            for p in &params.args {
-                names.push(p.parameter.name.id.to_string());
-            }
-            for p in &params.kwonlyargs {
-                names.push(p.parameter.name.id.to_string());
-            }
-            params_for_idx.insert(idx, names);
         }
     }
     Some(
@@ -2816,38 +2791,10 @@ fn class_method_parameters_in(
     let mut params_for_idx: FxHashMap<usize, Vec<String>> =
         FxHashMap::with_capacity_and_hasher(wanted.len(), Default::default());
     for (&file, rk_to_idx) in &by_file {
-        let parsed = parsed_module(db, file).load(db);
-        for stmt in &parsed.syntax().body {
-            let Stmt::ClassDef(cls) = stmt else {
-                continue;
-            };
-            let rk = crate::helpers::range_key(cls.name.range());
-            let Some(&idx) = rk_to_idx.get(&rk) else {
-                continue;
-            };
-            let mut seen: FxHashSet<String> = FxHashSet::default();
-            let mut names: Vec<String> = Vec::new();
-            for body_stmt in &cls.body {
-                let Stmt::FunctionDef(method) = body_stmt else {
-                    continue;
-                };
-                let params = &method.parameters;
-                for p in params
-                    .posonlyargs
-                    .iter()
-                    .chain(params.args.iter())
-                    .chain(params.kwonlyargs.iter())
-                {
-                    let n = p.parameter.name.id.as_str();
-                    if n == "self" || n == "cls" {
-                        continue;
-                    }
-                    if seen.insert(n.to_string()) {
-                        names.push(n.to_string());
-                    }
-                }
+        for (rk, names) in &file_extraction(db, file).class_method_params {
+            if let Some(&idx) = rk_to_idx.get(rk) {
+                params_for_idx.insert(idx, names.clone());
             }
-            params_for_idx.insert(idx, names);
         }
     }
     Some(
@@ -2900,47 +2847,51 @@ fn find_decorated_decls_core(
     extract_args: bool,
     path_re: &Option<regex::Regex>,
 ) -> Vec<(usize, CallArgs)> {
+    let db: &dyn ProjectDb = &*db;
     let names: FxHashSet<&str> = decorator_names.iter().map(String::as_str).collect();
-    let needle_strs: Vec<&str> = decorator_names.iter().map(String::as_str).collect();
-    let decl_by_name_range = &outputs.decl_by_name_range;
-    let project_files = &outputs.project_files;
-    let names_ref = &names;
-    let needles_ref: &[&str] = &needle_strs;
-    let modules_ref: &[String] = decorator_modules;
-    par_scan_files(db, project_files, path_re, |db, file| {
-        let source = source_text(db, file);
-        if !_contains_any_identifier(&source, needles_ref) {
-            return Vec::new();
+    let mut out: Vec<(usize, CallArgs)> = Vec::new();
+    for &file in &outputs.project_files {
+        if !_path_re_matches(path_re, db, file) {
+            continue;
         }
-        let parsed = parsed_module(db, file).load(db);
-        let file_package = file_package_name(db, file);
-        let imports =
-            collect_modules_imports_local(&parsed, modules_ref, names_ref, file_package.as_deref());
+        let facts = file_extraction(db, file);
+        let imports = imports_local_from_facts(&facts.import_facts, decorator_modules, &names);
         if imports.is_empty() {
-            return Vec::new();
+            continue;
         }
-        let mut local = Vec::new();
-        for stmt in &parsed.syntax().body {
-            let Stmt::FunctionDef(func) = stmt else {
+        for (rk, descriptors) in &facts.decorator_rows {
+            let Some(&idx) = outputs.decl_by_name_range.get(&(file, *rk)) else {
                 continue;
             };
-            let Some(call_form) =
-                decorators_match_imports(&func.decorator_list, &imports, names_ref)
-            else {
-                continue;
-            };
-            let key = (file, range_key(func.name.range()));
-            if let Some(&idx) = decl_by_name_range.get(&key) {
-                let call_args = if extract_args {
-                    call_form.map(extract_call_kwargs).unwrap_or_default()
-                } else {
-                    CallArgs::default()
+            // First matching decorator wins (mirrors `decorators_match_imports`).
+            for desc in descriptors {
+                let matched = match desc.attrs.as_slice() {
+                    // `@name` / `@name(...)` bound via `from <module> import name`.
+                    [] => imports
+                        .get(&desc.root_name)
+                        .is_some_and(|target| names.contains(target.as_str())),
+                    // `@alias.attr` / `@alias.attr(...)` where `alias` is the
+                    // module (`import <module> [as alias]`).
+                    [attr] => {
+                        imports.get(&desc.root_name).map(String::as_str)
+                            == Some(MODULE_ALIAS_MARKER)
+                            && names.contains(attr.as_str())
+                    }
+                    _ => false,
                 };
-                local.push((idx, call_args));
+                if matched {
+                    let call_args = if extract_args {
+                        desc.kwargs.clone()
+                    } else {
+                        CallArgs::default()
+                    };
+                    out.push((idx, call_args));
+                    break;
+                }
             }
         }
-        local
-    })
+    }
+    out
 }
 
 #[allow(clippy::type_complexity)]
@@ -2952,51 +2903,37 @@ fn find_instance_constructions_core(
     extract_args: bool,
     path_re: &Option<regex::Regex>,
 ) -> Vec<(usize, String, CallArgs)> {
+    let db: &dyn ProjectDb = &*db;
     let allowed: FxHashSet<&str> = ctor_names.iter().map(String::as_str).collect();
-    let needle_strs: Vec<&str> = ctor_names.iter().map(String::as_str).collect();
-    let decl_by_name_range = &outputs.decl_by_name_range;
-    let project_files: &[File] = &outputs.project_files;
-    let allowed_ref = &allowed;
-    let needles_ref: &[&str] = &needle_strs;
-    let modules_ref: &[String] = modules;
-    par_scan_files(db, project_files, path_re, |db, file| {
-        let source = source_text(db, file);
-        if !_contains_any_identifier(&source, needles_ref) {
-            return Vec::new();
+    let mut out: Vec<(usize, String, CallArgs)> = Vec::new();
+    for &file in &outputs.project_files {
+        if !_path_re_matches(path_re, db, file) {
+            continue;
         }
-        let parsed = parsed_module(db, file).load(db);
-        let file_package = file_package_name(db, file);
-        let imports = collect_modules_imports_local(
-            &parsed,
-            modules_ref,
-            allowed_ref,
-            file_package.as_deref(),
-        );
+        let facts = file_extraction(db, file);
+        if facts.construction_rows.is_empty() {
+            continue;
+        }
+        let imports = imports_local_from_facts(&facts.import_facts, modules, &allowed);
         if imports.is_empty() {
-            return Vec::new();
+            continue;
         }
-        let mut local: Vec<(usize, String, CallArgs)> = Vec::new();
-        for stmt in &parsed.syntax().body {
-            let (target_range, value) = match top_level_assign_to_name(stmt) {
-                Some(pair) => pair,
-                None => continue,
+        for (rk, desc) in &facts.construction_rows {
+            let Some(matched) = match_callee_descriptor(desc, &imports, modules, &allowed) else {
+                continue;
             };
-            let Expr::Call(call) = value else { continue };
-            if let Some(matched) = matched_call_target_any(call, &imports, modules_ref, allowed_ref)
-            {
-                let key = (file, range_key(target_range));
-                if let Some(&idx) = decl_by_name_range.get(&key) {
-                    let call_args = if extract_args {
-                        extract_call_kwargs(call)
-                    } else {
-                        CallArgs::default()
-                    };
-                    local.push((idx, matched, call_args));
-                }
-            }
+            let Some(&idx) = outputs.decl_by_name_range.get(&(file, *rk)) else {
+                continue;
+            };
+            let call_args = if extract_args {
+                desc.kwargs.clone()
+            } else {
+                CallArgs::default()
+            };
+            out.push((idx, matched, call_args));
         }
-        local
-    })
+    }
+    out
 }
 
 #[allow(clippy::type_complexity)]
@@ -3007,57 +2944,41 @@ fn find_handler_decorators_core(
     extract_args: bool,
     path_re: &Option<regex::Regex>,
 ) -> Vec<(String, usize, CallArgs)> {
+    let db: &dyn ProjectDb = &*db;
     let attrs: FxHashSet<&str> = decorator_attrs.iter().map(String::as_str).collect();
-    let needle_strs: Vec<&str> = decorator_attrs.iter().map(String::as_str).collect();
-    let decl_by_name_range = &outputs.decl_by_name_range;
-    let project_files: &[File] = &outputs.project_files;
-    let attrs_ref = &attrs;
-    let needles_ref: &[&str] = &needle_strs;
-    par_scan_files(db, project_files, path_re, |db, file| {
-        let source = source_text(db, file);
-        if !_contains_any_identifier(&source, needles_ref) {
-            return Vec::new();
+    let mut out: Vec<(String, usize, CallArgs)> = Vec::new();
+    for &file in &outputs.project_files {
+        if !_path_re_matches(path_re, db, file) {
+            continue;
         }
-        let parsed = parsed_module(db, file).load(db);
-        let mut local: Vec<(String, usize, CallArgs)> = Vec::new();
-        for stmt in &parsed.syntax().body {
-            let Stmt::FunctionDef(func) = stmt else {
+        let facts = file_extraction(db, file);
+        for (rk, descriptors) in &facts.decorator_rows {
+            let Some(&idx) = outputs.decl_by_name_range.get(&(file, *rk)) else {
                 continue;
             };
-            let mut seen_owners: FxHashSet<String> = FxHashSet::default();
-            for dec in &func.decorator_list {
-                let (root_expr, call_form): (&Expr, Option<&ruff_python_ast::ExprCall>) =
-                    match &dec.expression {
-                        Expr::Call(call) => (&*call.func, Some(call)),
-                        other => (other, None),
-                    };
-                let root_expr = unwrap_subscripted_callee(root_expr);
-                let Expr::Attribute(attr) = root_expr else {
+            // One row per distinct owner with a matching `<owner>.<attr>`
+            // decorator on this function (dedup in source order).
+            let mut seen_owners: FxHashSet<&str> = FxHashSet::default();
+            for desc in descriptors {
+                let [attr] = desc.attrs.as_slice() else {
                     continue;
                 };
-                if !attrs_ref.contains(attr.attr.as_str()) {
+                if !attrs.contains(attr.as_str()) {
                     continue;
                 }
-                let Expr::Name(owner) = attr.value.as_ref() else {
+                if !seen_owners.insert(desc.root_name.as_str()) {
                     continue;
+                }
+                let call_args = if extract_args {
+                    desc.kwargs.clone()
+                } else {
+                    CallArgs::default()
                 };
-                let owner_name = owner.id.as_str().to_string();
-                if !seen_owners.insert(owner_name.clone()) {
-                    continue;
-                }
-                let key = (file, range_key(func.name.range()));
-                if let Some(&idx) = decl_by_name_range.get(&key) {
-                    let call_args = if extract_args {
-                        call_form.map(extract_call_kwargs).unwrap_or_default()
-                    } else {
-                        CallArgs::default()
-                    };
-                    local.push((owner_name, idx, call_args));
-                }
+                out.push((desc.root_name.clone(), idx, call_args));
             }
         }
-        local
-    })
+    }
+    out
 }
 
 #[allow(clippy::type_complexity)]
@@ -3069,61 +2990,74 @@ fn find_handler_decorators_via_core(
     extract_args: bool,
     path_re: &Option<regex::Regex>,
 ) -> Vec<(String, usize, CallArgs)> {
+    let db: &dyn ProjectDb = &*db;
     let attrs: FxHashSet<&str> = decorator_attrs.iter().map(String::as_str).collect();
-    let decl_by_name_range = &outputs.decl_by_name_range;
-    let project_files: &[File] = &outputs.project_files;
-    let attrs_ref = &attrs;
-    par_scan_files(db, project_files, path_re, |db, file| {
-        let source = source_text(db, file);
-        if !_contains_identifier(&source, via_attr) {
-            return Vec::new();
+    let mut out: Vec<(String, usize, CallArgs)> = Vec::new();
+    for &file in &outputs.project_files {
+        if !_path_re_matches(path_re, db, file) {
+            continue;
         }
-        let parsed = parsed_module(db, file).load(db);
-        let mut local: Vec<(String, usize, CallArgs)> = Vec::new();
-        for stmt in &parsed.syntax().body {
-            let Stmt::FunctionDef(func) = stmt else {
+        let facts = file_extraction(db, file);
+        for (rk, descriptors) in &facts.decorator_rows {
+            let Some(&idx) = outputs.decl_by_name_range.get(&(file, *rk)) else {
                 continue;
             };
-            let mut seen_owners: FxHashSet<String> = FxHashSet::default();
-            for dec in &func.decorator_list {
-                let (root_expr, call_form): (&Expr, Option<&ruff_python_ast::ExprCall>) =
-                    match &dec.expression {
-                        Expr::Call(call) => (&*call.func, Some(call)),
-                        other => (other, None),
-                    };
-                let root_expr = unwrap_subscripted_callee(root_expr);
-                let Expr::Attribute(outer) = root_expr else {
+            // One row per distinct owner with a matching
+            // `<owner>.<via_attr>.<attr>` decorator (dedup in source order).
+            let mut seen_owners: FxHashSet<&str> = FxHashSet::default();
+            for desc in descriptors {
+                let [via, outer] = desc.attrs.as_slice() else {
                     continue;
                 };
-                if !attrs_ref.contains(outer.attr.as_str()) {
+                if via.as_str() != via_attr || !attrs.contains(outer.as_str()) {
                     continue;
                 }
-                let Expr::Attribute(middle) = outer.value.as_ref() else {
+                if !seen_owners.insert(desc.root_name.as_str()) {
                     continue;
+                }
+                let call_args = if extract_args {
+                    desc.kwargs.clone()
+                } else {
+                    CallArgs::default()
                 };
-                if middle.attr.as_str() != via_attr {
-                    continue;
-                }
-                let Expr::Name(owner) = middle.value.as_ref() else {
-                    continue;
-                };
-                let owner_name = owner.id.as_str().to_string();
-                if !seen_owners.insert(owner_name.clone()) {
-                    continue;
-                }
-                let key = (file, range_key(func.name.range()));
-                if let Some(&idx) = decl_by_name_range.get(&key) {
-                    let call_args = if extract_args {
-                        call_form.map(extract_call_kwargs).unwrap_or_default()
-                    } else {
-                        CallArgs::default()
-                    };
-                    local.push((owner_name, idx, call_args));
-                }
+                out.push((desc.root_name.clone(), idx, call_args));
             }
         }
-        local
-    })
+    }
+    out
+}
+
+/// Fan a file's [`CallSiteFact`]s in to their owning node index, the way
+/// `owner_idx_for_stmt_with` did over the live AST: each `def` / `class`
+/// owns the calls in its subtree (keyed by name-range, falling back to the
+/// module node), and every other top-level statement attributes its calls
+/// to the module node. Skips a bucket whose owner can't be resolved (no
+/// decl index and no module node), matching the old `else { continue }`.
+fn for_each_call_site(
+    facts: &FileExtraction,
+    outputs: &BuildOutputs,
+    file: File,
+    mut f: impl FnMut(usize, &CallSiteFact),
+) {
+    let module_idx = outputs.module_nodes_by_file.get(&file).copied();
+    for (rk, sites) in &facts.call_sites_by_decl {
+        let Some(owner_idx) = outputs
+            .decl_by_name_range
+            .get(&(file, *rk))
+            .copied()
+            .or(module_idx)
+        else {
+            continue;
+        };
+        for site in sites {
+            f(owner_idx, site);
+        }
+    }
+    if let Some(module_idx) = module_idx {
+        for site in &facts.module_call_sites {
+            f(module_idx, site);
+        }
+    }
 }
 
 #[allow(clippy::type_complexity)]
@@ -3135,35 +3069,34 @@ fn find_calls_on_attr_core(
     extract_args: bool,
     path_re: &Option<regex::Regex>,
 ) -> Vec<(usize, String, CallArgs)> {
-    let decl_by_name_range = &outputs.decl_by_name_range;
-    let module_nodes_by_file = &outputs.module_nodes_by_file;
-    let project_files: &[File] = &outputs.project_files;
-    par_scan_files(db, project_files, path_re, |db, file| {
-        let source = source_text(db, file);
-        if !_contains_identifier(&source, attr) {
-            return Vec::new();
+    let db: &dyn ProjectDb = &*db;
+    let mut out: Vec<(usize, String, CallArgs)> = Vec::new();
+    for &file in &outputs.project_files {
+        if !_path_re_matches(path_re, db, file) {
+            continue;
         }
-        let parsed = parsed_module(db, file).load(db);
-        let mut local: Vec<(usize, String, CallArgs)> = Vec::new();
-        for stmt in &parsed.syntax().body {
-            let Some(owner_idx) =
-                owner_idx_for_stmt_with(decl_by_name_range, module_nodes_by_file, file, stmt)
-            else {
-                continue;
-            };
-            let mut finder = AttrCallFinder {
-                attr,
-                arg_index,
-                extract_args,
-                results: Vec::new(),
-            };
-            finder.visit_stmt(stmt);
-            for (arg, call_args) in finder.results {
-                local.push((owner_idx, arg, call_args));
+        let facts = file_extraction(db, file);
+        for_each_call_site(facts, outputs, file, |owner_idx, site| {
+            // `find_calls_on_attr` matches `<any-receiver>.<attr>(...)`, so it
+            // keys off the recorded `callee_attr` (set for any receiver shape).
+            if site.callee_attr.as_deref() != Some(attr) {
+                return;
             }
-        }
-        local
-    })
+            let hits = site.string_or_collection(arg_index);
+            if hits.is_empty() {
+                return;
+            }
+            let call_args = if extract_args {
+                site.kwargs.clone()
+            } else {
+                CallArgs::default()
+            };
+            for s in hits {
+                out.push((owner_idx, s.clone(), call_args.clone()));
+            }
+        });
+    }
+    out
 }
 
 #[allow(clippy::type_complexity)]
@@ -3173,57 +3106,37 @@ fn find_factory_decls_core(
     modules: &[String],
     ctor_names: &[String],
 ) -> Vec<(usize, Vec<String>)> {
+    let db: &dyn ProjectDb = &*db;
     let allowed: FxHashSet<&str> = ctor_names.iter().map(String::as_str).collect();
-    let needle_strs: Vec<&str> = ctor_names.iter().map(String::as_str).collect();
-    let decl_by_name_range = &outputs.decl_by_name_range;
-    let project_files: &[File] = &outputs.project_files;
-    let allowed_ref = &allowed;
-    let needles_ref: &[&str] = &needle_strs;
-    let modules_ref: &[String] = modules;
-    par_scan_files(db, project_files, &None, |db, file| {
-        let source = source_text(db, file);
-        if !_contains_any_identifier(&source, needles_ref) {
-            return Vec::new();
+    let mut out: Vec<(usize, Vec<String>)> = Vec::new();
+    for &file in &outputs.project_files {
+        let facts = file_extraction(db, file);
+        if facts.factory_rows.is_empty() {
+            continue;
         }
-        let parsed = parsed_module(db, file).load(db);
-        let file_package = file_package_name(db, file);
-        let imports = collect_modules_imports_local(
-            &parsed,
-            modules_ref,
-            allowed_ref,
-            file_package.as_deref(),
-        );
+        let imports = imports_local_from_facts(&facts.import_facts, modules, &allowed);
         if imports.is_empty() {
-            return Vec::new();
+            continue;
         }
-        let mut local: Vec<(usize, Vec<String>)> = Vec::new();
-        for stmt in &parsed.syntax().body {
-            let (name_range, body): (TextRange, &[Stmt]) = match stmt {
-                Stmt::FunctionDef(f) => (f.name.range(), &f.body),
-                Stmt::ClassDef(c) => (c.name.range(), &c.body),
-                _ => continue,
+        for (rk, descriptors) in &facts.factory_rows {
+            let Some(&idx) = outputs.decl_by_name_range.get(&(file, *rk)) else {
+                continue;
             };
-            let mut finder = FactoryCallFinder {
-                imports: &imports,
-                modules: modules_ref,
-                allowed: allowed_ref,
-                kinds: FxHashSet::default(),
-            };
-            for inner in body {
-                finder.visit_stmt(inner);
+            let mut kinds: FxHashSet<String> = FxHashSet::default();
+            for desc in descriptors {
+                if let Some(name) = match_callee_descriptor(desc, &imports, modules, &allowed) {
+                    kinds.insert(name);
+                }
             }
-            if finder.kinds.is_empty() {
+            if kinds.is_empty() {
                 continue;
             }
-            let key = (file, range_key(name_range));
-            if let Some(&idx) = decl_by_name_range.get(&key) {
-                let mut kinds_vec: Vec<String> = finder.kinds.into_iter().collect();
-                kinds_vec.sort();
-                local.push((idx, kinds_vec));
-            }
+            let mut kinds_vec: Vec<String> = kinds.into_iter().collect();
+            kinds_vec.sort();
+            out.push((idx, kinds_vec));
         }
-        local
-    })
+    }
+    out
 }
 
 #[allow(clippy::type_complexity)]
@@ -3236,50 +3149,41 @@ fn find_calls_to_imported_core(
     extract_args: bool,
     path_re: &Option<regex::Regex>,
 ) -> Vec<(usize, String, CallArgs)> {
+    let db: &dyn ProjectDb = &*db;
     let allowed: FxHashSet<&str> = [name].into_iter().collect();
-    let decl_by_name_range = &outputs.decl_by_name_range;
-    let module_nodes_by_file = &outputs.module_nodes_by_file;
-    let project_files: &[File] = &outputs.project_files;
-    let allowed_ref = &allowed;
-    let modules_ref: &[String] = modules;
-    par_scan_files(db, project_files, path_re, |db, file| {
-        let source = source_text(db, file);
-        if !_contains_identifier(&source, name) {
-            return Vec::new();
+    let mut out: Vec<(usize, String, CallArgs)> = Vec::new();
+    for &file in &outputs.project_files {
+        if !_path_re_matches(path_re, db, file) {
+            continue;
         }
-        let parsed = parsed_module(db, file).load(db);
-        let file_package = file_package_name(db, file);
-        let imports = collect_modules_imports_local(
-            &parsed,
-            modules_ref,
-            allowed_ref,
-            file_package.as_deref(),
-        );
+        let facts = file_extraction(db, file);
+        // The imported name has to be bound in this file for any call to
+        // resolve; an empty map subsumes the old `_contains_identifier` skip.
+        let imports = imports_local_from_facts(&facts.import_facts, modules, &allowed);
         if imports.is_empty() {
-            return Vec::new();
+            continue;
         }
-        let mut local: Vec<(usize, String, CallArgs)> = Vec::new();
-        for stmt in &parsed.syntax().body {
-            let Some(owner_idx) =
-                owner_idx_for_stmt_with(decl_by_name_range, module_nodes_by_file, file, stmt)
-            else {
-                continue;
+        for_each_call_site(facts, outputs, file, |owner_idx, site| {
+            let Some(chain) = &site.callee else {
+                return;
             };
-            let mut finder = StringArgCallFinder {
-                predicate: |call: &ruff_python_ast::ExprCall| {
-                    matched_call_target_any(call, &imports, modules_ref, allowed_ref).is_some()
-                },
-                arg_index,
-                extract_args,
-                results: Vec::new(),
-            };
-            finder.visit_stmt(stmt);
-            for (arg, call_args) in finder.results {
-                local.push((owner_idx, arg, call_args));
+            if match_callee_chain(&chain.root_name, &chain.attrs, &imports, modules, &allowed)
+                .is_none()
+            {
+                return;
             }
-        }
-        local
-    })
+            let Some(arg) = site.nth_positional_string(arg_index) else {
+                return;
+            };
+            let call_args = if extract_args {
+                site.kwargs.clone()
+            } else {
+                CallArgs::default()
+            };
+            out.push((owner_idx, arg.to_string(), call_args));
+        });
+    }
+    out
 }
 
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
@@ -3293,37 +3197,42 @@ fn find_calls_on_var_core(
     extract_args: bool,
     path_re: &Option<regex::Regex>,
 ) -> Vec<(usize, String, CallArgs)> {
-    let decl_by_name_range = &outputs.decl_by_name_range;
-    let module_nodes_by_file = &outputs.module_nodes_by_file;
-    let project_files: &[File] = &outputs.project_files;
-    par_scan_files(db, project_files, path_re, |db, file| {
-        let source = source_text(db, file);
-        if !_contains_identifier(&source, owner) {
-            return Vec::new();
+    let db: &dyn ProjectDb = &*db;
+    let mut out: Vec<(usize, String, CallArgs)> = Vec::new();
+    for &file in &outputs.project_files {
+        if !_path_re_matches(path_re, db, file) {
+            continue;
         }
-        let parsed = parsed_module(db, file).load(db);
-        let mut local: Vec<(usize, String, CallArgs)> = Vec::new();
-        for stmt in &parsed.syntax().body {
-            let Some(owner_idx) =
-                owner_idx_for_stmt_with(decl_by_name_range, module_nodes_by_file, file, stmt)
-            else {
-                continue;
+        let facts = file_extraction(db, file);
+        for_each_call_site(facts, outputs, file, |owner_idx, site| {
+            // `call_callee_matches_var`: `<owner>.<attr>(...)` with a bare-name
+            // receiver — i.e. a `Name`-rooted chain of exactly `[attr]`.
+            let Some(chain) = &site.callee else {
+                return;
             };
-            let mut finder = StringArgCallFinder {
-                predicate: |call: &ruff_python_ast::ExprCall| {
-                    call_callee_matches_var(call, owner, attr, required_positional)
-                },
-                arg_index,
-                extract_args,
-                results: Vec::new(),
+            let [only] = chain.attrs.as_slice() else {
+                return;
             };
-            finder.visit_stmt(stmt);
-            for (arg, call_args) in finder.results {
-                local.push((owner_idx, arg, call_args));
+            if chain.root_name.as_str() != owner || only.as_str() != attr {
+                return;
             }
-        }
-        local
-    })
+            if let Some(expected) = required_positional {
+                if site.positional_len != expected {
+                    return;
+                }
+            }
+            let Some(arg) = site.nth_positional_string(arg_index) else {
+                return;
+            };
+            let call_args = if extract_args {
+                site.kwargs.clone()
+            } else {
+                CallArgs::default()
+            };
+            out.push((owner_idx, arg.to_string(), call_args));
+        });
+    }
+    out
 }
 
 fn find_classes_defining_method_indices_core(
@@ -3331,40 +3240,18 @@ fn find_classes_defining_method_indices_core(
     outputs: &BuildOutputs,
     method_name: &str,
 ) -> Vec<usize> {
-    let global_index = &outputs.global_index;
-    let project_files: &[File] = &outputs.project_files;
-    par_scan_files(db, project_files, &None, |db, file| {
-        let source = source_text(db, file);
-        if !_contains_identifier(&source, method_name) {
-            return Vec::new();
-        }
-        let parsed = parsed_module(db, file).load(db);
-        let index = semantic_index(db, file);
-        let global = FileScopeId::global();
-        let use_def_map = index.use_def_map(global);
-        let mut local: Vec<usize> = Vec::new();
-        for (_def_id, state, _used) in use_def_map.all_definitions_with_usage() {
-            let DefinitionState::Defined(def) = state else {
-                continue;
-            };
-            if def.file(db) != file || def.file_scope(db) != global {
-                continue;
-            }
-            let kind = def.kind(db);
-            let Some(class_ref) = kind.as_class() else {
-                continue;
-            };
-            let class_def = class_ref.node(&parsed);
-            if !class_body_defines_method(class_def, method_name) {
-                continue;
-            }
-            let key = (file, def.place(db), range_key(kind.target_range(&parsed)));
-            if let Some(&idx) = global_index.get(&key) {
-                local.push(idx);
+    let db: &dyn ProjectDb = &*db;
+    let mut out: Vec<usize> = Vec::new();
+    for &file in &outputs.project_files {
+        for (rk, methods) in &file_extraction(db, file).class_method_defs {
+            if methods.iter().any(|m| m == method_name) {
+                if let Some(&idx) = outputs.class_by_selection.get(&(file, *rk)) {
+                    out.push(idx);
+                }
             }
         }
-        local
-    })
+    }
+    out
 }
 
 /// Subclasses of the class addressed by ``base_fqn`` (project or

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -35,8 +35,8 @@ use crate::file_payload::{file_to_edges, file_to_nodes, FileEdges, NodeKind, Nod
 use crate::file_ref_edges::{file_to_ref_edges, FileRefEdges};
 use crate::graph::{intern_kind, DeclIndex, NativeGraph, SymbolNode};
 use crate::helpers::{
-    file_path_string, find_subclass_indices_via_refs_with_queue, is_dunder_name, locate_class_seed,
-    rel_path, CallArgs, MODULE_ALIAS_MARKER, NODE_FLAG_ENTRYPOINT,
+    file_path_string, is_dunder_name, locate_class_seed, rel_path, CallArgs, MODULE_ALIAS_MARKER,
+    NODE_FLAG_ENTRYPOINT,
 };
 use crate::ingest::emit_visitor_warning;
 use crate::progress::{
@@ -157,10 +157,9 @@ pub(crate) struct BuildOutputs {
     ///
     /// Lets ``UnittestPlugin`` / ``InitSubclassPlugin`` do an O(N) BFS
     /// over this map instead of calling ``find_references`` per class.
-    /// External seeds (e.g. ``unittest.TestCase``) still need
-    /// ``find_subclass_indices_via_refs`` for the first hop into the
-    /// project; once a project class is found, transitive walks use
-    /// this map.
+    /// External seeds (e.g. ``unittest.TestCase``) get their first hop
+    /// into the project from the cached ``external_base_children`` index;
+    /// once a project class is found, transitive walks use this map.
     pub(crate) children_by_node: FxHashMap<usize, Vec<usize>>,
     /// External base fqn (e.g. ``"unittest.TestCase"``) -> direct
     /// subclass class graph idxs. Derived in the same
@@ -172,10 +171,9 @@ pub(crate) struct BuildOutputs {
     /// per-file payloads, instead of a full re-parse over every project
     /// file. Re-export / alias chains through project modules are folded
     /// in statically by `chase_base_fqn` (which walks the per-file
-    /// `name_bindings`), so a subclass reached only through a re-export is
-    /// keyed here under the terminal external fqn. The `find_references`
-    /// walk is now only an opt-in fallback for chains the static ladder
-    /// can't see (`DEAD_CST_SUBCLASS_REF_FALLBACK`).
+    /// `name_bindings`, resolving explicit, star, alias, and relative
+    /// re-export rungs), so a subclass reached only through a re-export is
+    /// keyed here under the terminal external fqn.
     pub(crate) external_base_children: FxHashMap<String, Vec<usize>>,
 }
 
@@ -384,12 +382,13 @@ pub(crate) fn build_project_graph(
                             // parsed AST rather than let it sit resident
                             // through assembly and the project-wide plugin
                             // pass — that's the memory win. Assembly, fqname,
-                            // and class-hierarchy read only the cached
-                            // payloads, never the AST. The gated re-export
-                            // fallback in subclass resolution can still reload a
-                            // file on demand through ty's `find_references`, so
-                            // only that subset re-materializes; the
-                            // all-ASTs-resident peak never forms.
+                            // and the class hierarchy read only the cached
+                            // payloads (`name_bindings`, `external_base_children`,
+                            // `children_by_node`), never the AST, so the
+                            // all-ASTs-resident peak never forms. Subclass
+                            // resolution can still pull an individual file's AST
+                            // back on demand to relocate a class seed; that rare
+                            // reload is re-cleared right after the plugin pass.
                             parsed_module(local_db, file).clear();
                         });
                         db_tx.send(local_db).expect("channel open");
@@ -1845,9 +1844,11 @@ impl ProjectContext {
         counters.mark_finished();
         plugin_result?;
 
-        // The plugin pass can reload individual files on demand (the gated
-        // re-export fallback in subclass resolution walks ty's
-        // `find_references`), repopulating those files' salsa `parsed_module`
+        // The plugin pass can still reload individual files on demand:
+        // subclass resolution's `locate_class_seed` / `follow_class_through_module`
+        // chase calls `parsed_module(..).load()` to relocate a class seed (and
+        // follow its re-export chain) when the base resolves to a file rather
+        // than a cached decl, repopulating those files' salsa `parsed_module`
         // slots. Clear them again so the post-build resident set stays at the
         // lean post-populate level instead of creeping back up — the same
         // memory win `build_project_graph`'s populate phase secures.
@@ -3439,15 +3440,13 @@ fn find_classes_defining_method_indices_core(
 
 /// Subclasses of the class addressed by ``base_fqn`` (project or
 /// external seed). Takes an owned ``ProjectDatabase`` so it can resolve
-/// the seed serially (``locate_class_seed`` needs a concrete db) and, when
-/// opted in, run the ``find_references`` re-export fallback. A project
-/// seed walks the cached ``children_by_node`` index directly; an external
-/// seed reads its direct project subclasses from the cached
+/// the seed serially (``locate_class_seed`` needs a concrete db). A
+/// project seed walks the cached ``children_by_node`` index directly; an
+/// external seed reads its direct project subclasses from the cached
 /// ``external_base_children`` index (no re-parse — re-export / alias
-/// chains are now resolved statically into that index by
-/// ``chase_base_fqn``). The ``find_references`` walk is an opt-in fallback
-/// (``DEAD_CST_SUBCLASS_REF_FALLBACK``) for chains the static ladder can't
-/// see. See ``FrozenView::find_subclasses_indices`` for the fast/slow-path
+/// chains, including relative re-exports, are resolved statically into
+/// that index by ``chase_base_fqn``). See
+/// ``FrozenView::find_subclasses_indices`` for the fast/slow-path
 /// rationale.
 fn find_subclasses_indices_core(
     db: ProjectDatabase,
@@ -3475,34 +3474,14 @@ fn find_subclasses_indices_core(
     // project subclasses are cached in `external_base_children` (folded
     // from the per-file `class_bases` payloads — no re-parse). Re-export /
     // alias chains that bind the external class through one or more
-    // project modules are now resolved statically by `chase_base_fqn` at
-    // assemble time, so they too land in `external_base_children` without
-    // a walk.
-    let mut direct: FxHashSet<usize> = outputs
+    // project modules — including relative re-exports — are resolved
+    // statically by `chase_base_fqn` at assemble time, so they too land in
+    // `external_base_children`.
+    let direct: FxHashSet<usize> = outputs
         .external_base_children
         .get(base_fqn)
         .map(|idxs| idxs.iter().copied().collect())
         .unwrap_or_default();
-    // Opt-in `find_references` fallback. The cached index above covers
-    // every statically-resolvable subclass; the ref walk additionally
-    // catches chains ty's resolver reaches but the static binder ladder
-    // can't (e.g. relative-import or conditional re-exports). It re-parses
-    // on demand, so it is gated behind `DEAD_CST_SUBCLASS_REF_FALLBACK`
-    // and still only runs when some project file imports the seed module
-    // (otherwise there is provably no reference for the walk to find).
-    let ref_fallback = std::env::var_os("DEAD_CST_SUBCLASS_REF_FALLBACK").is_some();
-    let imports_seed_module = base_fqn
-        .rsplit_once('.')
-        .is_some_and(|(module, _)| outputs.imports_by_module.contains_key(module));
-    if ref_fallback && imports_seed_module {
-        direct.extend(find_subclass_indices_via_refs_with_queue(
-            &db,
-            &outputs.class_by_selection,
-            vec![(seed_file, seed_range)],
-            &[],
-            /*transitive=*/ false,
-        ));
-    }
     let mut out_idx: FxHashSet<usize> = direct.iter().copied().collect();
     if transitive {
         for &d in &direct {

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -14,10 +14,8 @@ use pyo3::prelude::*;
 use pyo3::types::PyType;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
-use ruff_db::source::source_text;
 use ruff_db::system::{OsSystem, SystemPathBuf};
-use ruff_python_ast::token::TokenKind;
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::TextRange;
 use ty_project::metadata::options::{EnvironmentOptions, Options};
 use ty_project::metadata::python_version::SupportedPythonVersion;
 use ty_project::metadata::value::RangedValue;
@@ -37,8 +35,7 @@ use crate::file_payload::{file_to_edges, file_to_nodes, FileEdges, NodeKind, Nod
 use crate::file_ref_edges::{file_to_ref_edges, FileRefEdges};
 use crate::graph::{intern_kind, DeclIndex, NativeGraph, SymbolNode};
 use crate::helpers::{
-    file_path_string, find_external_seed_direct_subclasses_par,
-    find_subclass_indices_via_refs_with_queue, is_dunder_name, locate_class_def, locate_class_seed,
+    file_path_string, find_subclass_indices_via_refs_with_queue, is_dunder_name, locate_class_seed,
     rel_path, CallArgs, MODULE_ALIAS_MARKER, NODE_FLAG_ENTRYPOINT,
 };
 use crate::ingest::emit_visitor_warning;
@@ -113,6 +110,11 @@ pub(crate) struct BuildOutputs {
     /// `find_subclasses_of` map ty's `TypeHierarchyClass.selection_range`
     /// back to a graph node in O(1).
     pub(crate) class_by_selection: FxHashMap<(File, (u32, u32)), usize>,
+    /// Inverse of `class_by_selection`: `class node idx -> (file, name
+    /// TextRange)`. Lets `locate_class_seed` recover a project class's
+    /// name range for ty `Type` lookups (`class_def_at` + `inferred_type`)
+    /// without re-parsing the file to re-find the def by line.
+    pub(crate) class_selection_by_idx: FxHashMap<usize, (File, TextRange)>,
     /// `file -> module node idx`. Lets `find_main_blocks` reach the
     /// file's module node without a linear scan over `builder.nodes`.
     pub(crate) module_nodes_by_file: FxHashMap<File, usize>,
@@ -160,6 +162,17 @@ pub(crate) struct BuildOutputs {
     /// project; once a project class is found, transitive walks use
     /// this map.
     pub(crate) children_by_node: FxHashMap<usize, Vec<usize>>,
+    /// External base fqn (e.g. ``"unittest.TestCase"``) -> direct
+    /// subclass class graph idxs. Derived in the same
+    /// `class_bases` fan-in as `children_by_node`, but keyed by the
+    /// resolved *external* base fqn rather than a project node idx.
+    ///
+    /// Lets the external-seed branch of `find_subclasses_indices_core`
+    /// recover the first hop into the project straight from the cached
+    /// per-file payloads, instead of a full re-parse over every project
+    /// file. Re-export / alias chains through project modules are still
+    /// walked via `find_references` (gated on `imports_by_module`).
+    pub(crate) external_base_children: FxHashMap<String, Vec<usize>>,
 }
 
 /// Run the three build phases (ingest → hierarchy+imports → references)
@@ -368,12 +381,11 @@ pub(crate) fn build_project_graph(
                             // through assembly and the project-wide plugin
                             // pass — that's the memory win. Assembly, fqname,
                             // and class-hierarchy read only the cached
-                            // payloads, never the AST. Subclass-resolution
-                            // plugins and the `find_comment_patterns` pymethod
-                            // re-parse the specific files they touch on demand
-                            // (`ParsedModule::load`), so only that subset
-                            // re-materializes; the all-ASTs-resident peak
-                            // never forms.
+                            // payloads, never the AST. The gated re-export
+                            // fallback in subclass resolution can still reload a
+                            // file on demand through ty's `find_references`, so
+                            // only that subset re-materializes; the
+                            // all-ASTs-resident peak never forms.
                             parsed_module(local_db, file).clear();
                         });
                         db_tx.send(local_db).expect("channel open");
@@ -439,7 +451,10 @@ pub(crate) fn build_project_graph(
     // node-keyed project-wide subclass index. One pass over the
     // per-file payloads + one pass per base; no AST re-walk.
     let t_hierarchy = std::time::Instant::now();
-    let children_by_node = build_class_hierarchy_indices(
+    let ClassHierarchyIndices {
+        children_by_node,
+        external_base_children,
+    } = build_class_hierarchy_indices(
         db,
         &project_files,
         &class_by_selection,
@@ -471,6 +486,17 @@ pub(crate) fn build_project_graph(
             eprintln!("{}", dump.display_short());
         }
     }
+    // Invert `class_by_selection` once so per-class name-range lookups
+    // (subclass seed resolution) are O(1) cache reads instead of an AST
+    // re-parse. It's a bijection — one class node per `(file, range)` —
+    // so no value is clobbered.
+    let class_selection_by_idx: FxHashMap<usize, (File, TextRange)> = class_by_selection
+        .iter()
+        .map(|(&(file, (start, end)), &idx)| {
+            (idx, (file, TextRange::new(start.into(), end.into())))
+        })
+        .collect();
+
     builder.peer_pyi_to_py = peer_pyi_to_py;
     Ok(BuildOutputs {
         builder,
@@ -478,12 +504,14 @@ pub(crate) fn build_project_graph(
         global_index,
         path_to_file,
         class_by_selection,
+        class_selection_by_idx,
         module_nodes_by_file,
         decl_by_name_range,
         decl_by_fqname,
         module_by_fqname,
         imports_by_module,
         children_by_node,
+        external_base_children,
         children_by_parent,
     })
 }
@@ -1003,13 +1031,28 @@ fn extract_per_file_plugin_ids(
     ids
 }
 
+/// Project-wide class-hierarchy indices produced in a single pass over
+/// the per-file `class_bases` payloads by [`build_class_hierarchy_indices`].
+pub(crate) struct ClassHierarchyIndices {
+    /// Parent class graph idx → direct subclass graph idxs (project
+    /// bases only). See [`BuildOutputs::children_by_node`].
+    pub(crate) children_by_node: FxHashMap<usize, Vec<usize>>,
+    /// External base fqn → direct subclass graph idxs. See
+    /// [`BuildOutputs::external_base_children`].
+    pub(crate) external_base_children: FxHashMap<String, Vec<usize>>,
+}
+
 /// Fold every file's per-file `class_bases` payload (see
-/// [`crate::file_payload::FileNodes::class_bases`]) into the
-/// node-keyed project-wide subclass index:
+/// [`crate::file_payload::FileNodes::class_bases`]) into the project-wide
+/// subclass indices:
 ///
 /// * `children_by_node` — parent class graph idx → direct subclass
 ///   graph idxs. Drives intra-project BFS for both project and
 ///   external seeds (once the first hop lands a project class).
+/// * `external_base_children` — external base fqn (a base not present in
+///   `decl_by_fqname`, e.g. `unittest.TestCase`) → direct subclass graph
+///   idxs. Lets the external-seed query recover the first project hop
+///   from cached payloads instead of re-parsing every file.
 ///
 /// Resolution rules per `ResolvedBase` variant:
 ///
@@ -1019,10 +1062,12 @@ fn extract_per_file_plugin_ids(
 /// * `ImportedFqn(fqn)` — when the fqn resolves in `decl_by_fqname` to
 ///   a project class node, emit a `children_by_node` entry (so a
 ///   project base imported via `from m import C` participates in
-///   node-keyed walks).
+///   node-keyed walks). When the fqn is absent from `decl_by_fqname`
+///   (an external base), emit an `external_base_children` entry instead.
 /// * `Attribute { module_fqn, attr_name }` — resolve
 ///   `{module_fqn}.{attr_name}` via `decl_by_fqname`; project class
-///   hits emit `children_by_node` entries.
+///   hits emit `children_by_node` entries, an absent fqn emits an
+///   `external_base_children` entry.
 /// * `Unresolvable` — dropped.
 fn build_class_hierarchy_indices<'db>(
     db: &'db ProjectDatabase,
@@ -1031,9 +1076,10 @@ fn build_class_hierarchy_indices<'db>(
     ref_to_global: &FxHashMap<NodeRef<'db>, usize>,
     decl_by_fqname: &FxHashMap<String, Vec<usize>>,
     nodes: &[GraphNode],
-) -> FxHashMap<usize, Vec<usize>> {
+) -> ClassHierarchyIndices {
     use crate::file_payload::ResolvedBase;
     let mut by_node: FxHashMap<usize, Vec<usize>> = FxHashMap::default();
+    let mut external_base_children: FxHashMap<String, Vec<usize>> = FxHashMap::default();
 
     for &file in project_files {
         let payload = file_to_nodes(db, file);
@@ -1051,30 +1097,47 @@ fn build_class_hierarchy_indices<'db>(
                             }
                         }
                     }
-                    ResolvedBase::ImportedFqn(fqn) => {
-                        if let Some(idxs) = decl_by_fqname.get(fqn) {
+                    ResolvedBase::ImportedFqn(fqn) => match decl_by_fqname.get(fqn) {
+                        Some(idxs) => {
                             for &parent_idx in idxs {
                                 if nodes[parent_idx].kind == "class" {
                                     by_node.entry(parent_idx).or_default().push(child_idx);
                                 }
                             }
                         }
-                    }
+                        // Not a project decl at all → an external base.
+                        // Key it by the resolved fqn so the external-seed
+                        // query can recover this subclass without a
+                        // re-parse. (A project decl that exists but isn't
+                        // a class is intentionally dropped: its subclass
+                        // set is empty either way.)
+                        None => external_base_children
+                            .entry(fqn.clone())
+                            .or_default()
+                            .push(child_idx),
+                    },
                     ResolvedBase::Attribute {
                         module_fqn,
                         attr_name,
                     } => {
-                        // Project-side: resolve `module_fqn.attr_name`
-                        // via `decl_by_fqname` (handles the common
-                        // case where the target module's class is in
-                        // the project).
+                        // Resolve `module_fqn.attr_name` via
+                        // `decl_by_fqname` (the common case where the
+                        // target module's class is in the project); an
+                        // absent fqn is an external base, keyed for the
+                        // external-seed query.
                         let composed = format!("{module_fqn}.{attr_name}");
-                        if let Some(idxs) = decl_by_fqname.get(&composed) {
-                            for &parent_idx in idxs {
-                                if nodes[parent_idx].kind == "class" {
-                                    by_node.entry(parent_idx).or_default().push(child_idx);
+                        match decl_by_fqname.get(&composed) {
+                            Some(idxs) => {
+                                for &parent_idx in idxs {
+                                    if nodes[parent_idx].kind == "class" {
+                                        by_node.entry(parent_idx).or_default().push(child_idx);
+                                    }
                                 }
                             }
+                            None => external_base_children
+                                .entry(composed)
+                                .or_default()
+                                .push(child_idx),
                         }
                     }
                     ResolvedBase::Unresolvable => {}
@@ -1087,7 +1150,14 @@ fn build_class_hierarchy_indices<'db>(
         v.sort_unstable();
         v.dedup();
     }
-    by_node
+    for v in external_base_children.values_mut() {
+        v.sort_unstable();
+        v.dedup();
+    }
+    ClassHierarchyIndices {
+        children_by_node: by_node,
+        external_base_children,
+    }
 }
 
 /// Serial pre-parallel Pass-2 helper: lookup-or-mint a `NodeRef` into
@@ -1367,7 +1437,7 @@ pub(crate) struct ProjectContext {
     /// it re-attaches).
     pub(crate) outputs: Arc<RwLock<Option<BuildOutputs>>>,
     /// Compiled regexes keyed by the source pattern. Plugins call
-    /// :meth:`decls_matching_name` / :meth:`find_comment_patterns`
+    /// :meth:`decls_matching_name`
     /// repeatedly across files with the same pattern, so caching keeps
     /// us off the regex compiler in the hot path. Mutex (rather than
     /// RwLock) because the cache write path is cheap and the hot path
@@ -1591,7 +1661,7 @@ impl ProjectContext {
 
         // Project-wide plugin pass — fan out across a GIL-free
         // ``rayon`` scope, one task per plugin, mirroring the per-file
-        // fan-out (:func:`crate::query::par_scan_files`). Each worker
+        // query fan-out. Each worker
         // owns a cheap salsa clone of the db wrapped in a
         // [`FrozenView`], so every plugin query runs with the GIL
         // released; the frozen ``BuildOutputs`` is shared read-only
@@ -1612,6 +1682,9 @@ impl ProjectContext {
         let plugin_bar = ProgressBars::plugin_bar(show_progress, n_plugins as u64);
         counters.init_plugin_slots(plugin_names);
         counters.start_phase(PHASE_PLUGINS, Some(n_plugins));
+        let num_workers = std::thread::available_parallelism()
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(4);
 
         // Clone the salsa db + project root + outputs handle out of the
         // pyclass *before* releasing the GIL — no ``PyRef`` may cross
@@ -1636,27 +1709,46 @@ impl ProjectContext {
             let results_ref = &results;
             // ``base_db`` + ``outputs_lock`` move *into* the closure: a
             // ``&ProjectDatabase`` is ``!Send`` (salsa's ``ZalsaLocal`` is
-            // ``!Sync``), so — exactly as in ``par_scan_files`` — we move an
-            // owned db in and ``.clone()`` a cheap snapshot per worker.
+            // ``!Sync``), so — like every GIL-free per-file scan here — we
+            // move an owned db in and ``.clone()`` a cheap snapshot per worker.
             py.allow_threads(move || {
                 let guard = outputs_lock.read();
                 let outputs_ref: &BuildOutputs =
                     guard.as_ref().expect("materialize stored outputs above");
-                rayon::scope(move |s| {
-                    for (idx, job) in jobs_ref.iter().enumerate() {
-                        let db_t = base_db.clone();
-                        s.spawn(move |_| {
-                            counters_ref.plugin_started(idx);
-                            let view = FrozenView::new(db_t, outputs_ref, root_ref);
-                            let mut sink: Vec<PreparedOp> = Vec::new();
-                            let res = job.run(&view, &mut sink).map(|()| sink);
-                            results_ref.lock().unwrap().push((idx, res));
-                            counters_ref.plugin_finished(idx);
-                            counters_ref.plugins_inc();
-                            bar_ref.inc(1);
-                        });
+                // `move` so it owns `base_db` (`ProjectDatabase` is `Send`,
+                // a borrow would not be) and thus satisfies `install`'s
+                // `Send` bound — same shape as `run_populate`.
+                let run_plugins = move || {
+                    rayon::scope(move |s| {
+                        for (idx, job) in jobs_ref.iter().enumerate() {
+                            let db_t = base_db.clone();
+                            s.spawn(move |_| {
+                                counters_ref.plugin_started(idx);
+                                let view = FrozenView::new(db_t, outputs_ref, root_ref);
+                                let mut sink: Vec<PreparedOp> = Vec::new();
+                                let res = job.run(&view, &mut sink).map(|()| sink);
+                                results_ref.lock().unwrap().push((idx, res));
+                                counters_ref.plugin_finished(idx);
+                                counters_ref.plugins_inc();
+                                bar_ref.inc(1);
+                            });
+                        }
+                    });
+                };
+                // Honour `set_stack_size` here too: subclass-resolution
+                // plugins recurse over the class hierarchy, so the deep
+                // stack lives in this pass, not only the populate phase.
+                match stack_size {
+                    Some(n) => {
+                        let pool = rayon::ThreadPoolBuilder::new()
+                            .num_threads(num_workers)
+                            .stack_size(n)
+                            .build()
+                            .expect("build rayon thread pool");
+                        pool.install(run_plugins);
                     }
-                });
+                    None => run_plugins(),
+                }
             });
         }
         plugin_bar.finish_and_clear();
@@ -1677,6 +1769,22 @@ impl ProjectContext {
         counters.finish_phase(PHASE_PLUGINS);
         counters.mark_finished();
         plugin_result?;
+
+        // The plugin pass can reload individual files on demand (the gated
+        // re-export fallback in subclass resolution walks ty's
+        // `find_references`), repopulating those files' salsa `parsed_module`
+        // slots. Clear them again so the post-build resident set stays at the
+        // lean post-populate level instead of creeping back up — the same
+        // memory win `build_project_graph`'s populate phase secures.
+        {
+            let this = slf.borrow(py);
+            let outputs_ref = this.outputs.read();
+            if let Some(outputs) = outputs_ref.as_ref() {
+                for &file in &outputs.project_files {
+                    parsed_module(&this.db, file).clear();
+                }
+            }
+        }
 
         // Snapshot a fresh ``NativeGraph`` from the builder's
         // interned node + edge vecs; the originals stay put.
@@ -3255,11 +3363,14 @@ fn find_classes_defining_method_indices_core(
 }
 
 /// Subclasses of the class addressed by ``base_fqn`` (project or
-/// external seed). Takes an owned ``ProjectDatabase`` so it can both
-/// resolve the seed serially (``locate_class_seed`` needs a concrete
-/// db) and hand a ``Box<dyn ProjectDb>`` snapshot to the parallel
-/// ``find_references`` fallback. See ``FrozenView::find_subclasses_indices``
-/// for the fast/slow-path rationale.
+/// external seed). Takes an owned ``ProjectDatabase`` so it can resolve
+/// the seed serially (``locate_class_seed`` needs a concrete db) and run
+/// the ``find_references`` re-export fallback. A project seed walks the
+/// cached ``children_by_node`` index directly; an external seed reads its
+/// direct project subclasses from the cached ``external_base_children``
+/// index (no re-parse) and only walks ``find_references`` when a project
+/// file actually imports the seed module. See
+/// ``FrozenView::find_subclasses_indices`` for the fast/slow-path rationale.
 fn find_subclasses_indices_core(
     db: ProjectDatabase,
     outputs: &BuildOutputs,
@@ -3281,42 +3392,36 @@ fn find_subclasses_indices_core(
                 .unwrap_or_default()
         };
     }
-    let class_by_selection = &outputs.class_by_selection;
     let children_by_node = &outputs.children_by_node;
-    let project_files: &[File] = &outputs.project_files;
-    let seed_split: Option<(String, String)> = base_fqn
+    // External seed: the class lives outside the project. Its direct
+    // project subclasses are cached in `external_base_children` (folded
+    // from the per-file `class_bases` payloads — no re-parse). A re-export
+    // / alias chain that binds the external class through a project module
+    // resolves the base to that *project* fqn, so it isn't keyed here;
+    // walk those via find_references — but only when some project file
+    // imports the seed module (the `imports_by_module` gate), since
+    // otherwise there is provably no reference for the walk to find.
+    let mut direct: FxHashSet<usize> = outputs
+        .external_base_children
+        .get(base_fqn)
+        .map(|idxs| idxs.iter().copied().collect())
+        .unwrap_or_default();
+    let imports_seed_module = base_fqn
         .rsplit_once('.')
-        .map(|(m, n)| (m.to_string(), n.to_string()));
-    let db_handle: Box<dyn ProjectDb> = ProjectDb::dyn_clone(&db);
-    let direct: Vec<usize> = {
-        let db: &dyn ProjectDb = &*db_handle;
-        type FileRangeList = Vec<(File, TextRange)>;
-        let (initial_queue, prefound): (FileRangeList, FileRangeList) =
-            if let Some((module, name)) = seed_split.as_ref() {
-                let res = find_external_seed_direct_subclasses_par(db, project_files, module, name);
-                let initial = if res.any_project_file_imports_seed_module {
-                    vec![(seed_file, seed_range)]
-                } else {
-                    Vec::new()
-                };
-                (initial, res.direct_classes)
-            } else {
-                (vec![(seed_file, seed_range)], Vec::new())
-            };
-        find_subclass_indices_via_refs_with_queue(
-            db,
-            class_by_selection,
-            initial_queue,
-            &prefound,
+        .is_some_and(|(module, _)| outputs.imports_by_module.contains_key(module));
+    if imports_seed_module {
+        direct.extend(find_subclass_indices_via_refs_with_queue(
+            &db,
+            &outputs.class_by_selection,
+            vec![(seed_file, seed_range)],
+            &[],
             /*transitive=*/ false,
-        )
-    };
+        ));
+    }
     let mut out_idx: FxHashSet<usize> = direct.iter().copied().collect();
     if transitive {
         for &d in &direct {
-            for idx in transitive_subclasses_via_index(d, children_by_node) {
-                out_idx.insert(idx);
-            }
+            out_idx.extend(transitive_subclasses_via_index(d, children_by_node));
         }
     }
     out_idx.into_iter().collect()
@@ -3326,31 +3431,24 @@ fn find_subclasses_indices_core(
 /// ``None`` when ``class_idx`` is out of range (callers map that to an
 /// ``IndexError``); ``Some(vec)`` otherwise (empty when the node isn't
 /// a class or has no subclasses).
-fn find_subclasses_of_idx_in(
-    db: &ProjectDatabase,
-    outputs: &BuildOutputs,
-    class_idx: usize,
-) -> Option<Vec<usize>> {
+fn find_subclasses_of_idx_in(outputs: &BuildOutputs, class_idx: usize) -> Option<Vec<usize>> {
     let len = outputs.builder.nodes.len();
     if class_idx >= len {
         return None;
     }
-    let class_node = &outputs.builder.nodes[class_idx];
-    if class_node.kind != "class" {
+    if outputs.builder.nodes[class_idx].kind != "class" {
         return Some(Vec::new());
     }
-    if let Some((seed_file, seed_range)) =
-        locate_class_def(db, &outputs.path_to_file, &class_node.path, class_node)
-    {
-        let rk = (seed_range.start().to_u32(), seed_range.end().to_u32());
-        if let Some(&seed_idx) = outputs.class_by_selection.get(&(seed_file, rk)) {
-            return Some(transitive_subclasses_via_index(
-                seed_idx,
-                &outputs.children_by_node,
-            ));
-        }
-    }
-    Some(Vec::new())
+    // `class_idx` is its own hierarchy seed: assemble records every
+    // class node in `class_by_selection`, and `children_by_node` is
+    // keyed by those same global indices. The former locate-by-line
+    // round trip (re-parse → name range → `class_by_selection`) always
+    // resolved straight back to `class_idx`, so walk the cached
+    // hierarchy from it directly.
+    Some(transitive_subclasses_via_index(
+        class_idx,
+        &outputs.children_by_node,
+    ))
 }
 
 // ============================================================
@@ -3598,7 +3696,7 @@ impl<'a> FrozenView<'a> {
     /// Subclasses of the class at `class_idx`, or `None` on out-of-range
     /// (an empty vec means "not a class node").
     pub(crate) fn find_subclasses_of_idx(&self, class_idx: usize) -> Option<Vec<usize>> {
-        find_subclasses_of_idx_in(&self.db, self.outputs, class_idx)
+        find_subclasses_of_idx_in(self.outputs, class_idx)
     }
 
     pub(crate) fn find_subclasses_indices(&self, base_fqn: &str, transitive: bool) -> Vec<usize> {
@@ -3607,8 +3705,8 @@ impl<'a> FrozenView<'a> {
 
     // --- parallel file-walk matchers ------------------------------------
     //
-    // Each `dyn_clone`s the owned db for the inner `par_scan_files`
-    // rayon scope. Nested inside the project-wide plugin scope, this is
+    // Each `dyn_clone`s the owned db for the inner rayon scope.
+    // Nested inside the project-wide plugin scope, this is
     // safe: rayon scopes compose. These are GIL-free: no path filtering,
     // no `PyResult` — the curated plugin surface is the only caller and
     // it never path-scopes, so the matchers walk every project file.
@@ -3755,68 +3853,6 @@ impl<'a> FrozenView<'a> {
             self.outputs,
             method_name,
         )
-    }
-}
-
-#[pymethods]
-impl ProjectContext {
-    /// Return `(decl_node, comment_text)` for every comment in the
-    /// project that matches `pattern` (a regex), paired with the next
-    /// declaration that follows it in the same file.
-    ///
-    /// Comments are scanned from the parser's `Tokens` stream (no
-    /// re-lexing); regex matching is full-text against the comment
-    /// content (leading `#` included).
-    pub(crate) fn find_comment_patterns(
-        &self,
-        py: Python<'_>,
-        pattern: &str,
-    ) -> PyResult<Vec<(Py<SymbolNode>, String)>> {
-        let regex = self.compile_regex(pattern)?;
-        let outputs = self.materialized("find_comment_patterns")?;
-        let mut out = Vec::new();
-        // Per-file bucketed view of `global_index`, materialized lazily on
-        // the first matching comment anywhere in the project. The naive
-        // approach filtered `global_index` once per matched file — O(F × N).
-        // Bucketing once flips that to O(N) + O(1) per matched file.
-        let mut decls_by_file: Option<FxHashMap<File, Vec<(u32, usize)>>> = None;
-        for &file in &outputs.project_files {
-            let parsed = parsed_module(&self.db, file).load(&self.db);
-            let source = source_text(&self.db, file);
-            for token in parsed.tokens() {
-                if token.kind() != TokenKind::Comment {
-                    continue;
-                }
-                let range = token.range();
-                let text = &source[range];
-                if !regex.is_match(text) {
-                    continue;
-                }
-                let bucket = decls_by_file.get_or_insert_with(|| {
-                    let mut m: FxHashMap<File, Vec<(u32, usize)>> = FxHashMap::default();
-                    for ((f, _, (start, _)), &idx) in &outputs.global_index {
-                        m.entry(*f).or_default().push((*start, idx));
-                    }
-                    for sites in m.values_mut() {
-                        sites.sort_by_key(|(s, _)| *s);
-                    }
-                    m
-                });
-                let Some(decls) = bucket.get(&file) else {
-                    continue;
-                };
-                let comment_end = range.end().to_u32();
-                let i = decls.partition_point(|(start, _)| *start < comment_end);
-                let Some(&(_, decl_idx)) = decls.get(i) else {
-                    continue;
-                };
-                out.push((
-                    outputs.builder.nodes[decl_idx].to_symbol(py)?,
-                    text.to_string(),
-                ));
-            }
-        }
-        Ok(out)
     }
 }
 

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -170,8 +170,12 @@ pub(crate) struct BuildOutputs {
     /// Lets the external-seed branch of `find_subclasses_indices_core`
     /// recover the first hop into the project straight from the cached
     /// per-file payloads, instead of a full re-parse over every project
-    /// file. Re-export / alias chains through project modules are still
-    /// walked via `find_references` (gated on `imports_by_module`).
+    /// file. Re-export / alias chains through project modules are folded
+    /// in statically by `chase_base_fqn` (which walks the per-file
+    /// `name_bindings`), so a subclass reached only through a re-export is
+    /// keyed here under the terminal external fqn. The `find_references`
+    /// walk is now only an opt-in fallback for chains the static ladder
+    /// can't see (`DEAD_CST_SUBCLASS_REF_FALLBACK`).
     pub(crate) external_base_children: FxHashMap<String, Vec<usize>>,
 }
 
@@ -1054,20 +1058,23 @@ pub(crate) struct ClassHierarchyIndices {
 ///   idxs. Lets the external-seed query recover the first project hop
 ///   from cached payloads instead of re-parsing every file.
 ///
+/// A first pass folds every file's per-file `name_bindings` into a
+/// project-wide re-export / alias chain (`{module_fqn}.{name} ->
+/// next_fqn`); the second pass resolves each base through it so a base
+/// that hops across files (re-export, star-import, module-level alias)
+/// is chased to its terminal class. See [`chase_base_fqn`].
+///
 /// Resolution rules per `ResolvedBase` variant:
 ///
 /// * `LocalSameFileClass(local_idx)` — translate via the file's
 ///   `refs[local_idx]` + `ref_to_global` to a parent class graph idx
 ///   and emit a `children_by_node` entry.
-/// * `ImportedFqn(fqn)` — when the fqn resolves in `decl_by_fqname` to
-///   a project class node, emit a `children_by_node` entry (so a
-///   project base imported via `from m import C` participates in
-///   node-keyed walks). When the fqn is absent from `decl_by_fqname`
-///   (an external base), emit an `external_base_children` entry instead.
-/// * `Attribute { module_fqn, attr_name }` — resolve
-///   `{module_fqn}.{attr_name}` via `decl_by_fqname`; project class
-///   hits emit `children_by_node` entries, an absent fqn emits an
-///   `external_base_children` entry.
+/// * `ImportedFqn(fqn)` / `Attribute { module_fqn, attr_name }` — chase
+///   the (composed) fqn through the alias chain to its terminal, then:
+///   a project class hit emits `children_by_node` entries; a terminal
+///   absent from `decl_by_fqname` (an external base, possibly reached
+///   through a project re-export) emits an `external_base_children`
+///   entry keyed by that terminal fqn. See [`register_chased_base`].
 /// * `Unresolvable` — dropped.
 fn build_class_hierarchy_indices<'db>(
     db: &'db ProjectDatabase,
@@ -1077,9 +1084,34 @@ fn build_class_hierarchy_indices<'db>(
     decl_by_fqname: &FxHashMap<String, Vec<usize>>,
     nodes: &[GraphNode],
 ) -> ClassHierarchyIndices {
-    use crate::file_payload::ResolvedBase;
+    use crate::file_payload::{NameBinding, ResolvedBase};
     let mut by_node: FxHashMap<usize, Vec<usize>> = FxHashMap::default();
     let mut external_base_children: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+
+    // First pass: fold every file's per-file `name_bindings` into a
+    // project-wide re-export / alias chain, `{module_fqn}.{name} ->
+    // next_fqn`. This is the cross-file half of the uniform binder
+    // ladder: a base that resolves (in its own file) to a name which is
+    // itself an import, star-import, or module-level alias is chased
+    // through this map to the terminal class fqn, so a class reached only
+    // via one or more re-export hops still lands in `children_by_node` /
+    // `external_base_children` without re-parsing. `LocalClass` bindings
+    // are terminal (the class itself, found in `decl_by_fqname`) so they
+    // need no chain edge.
+    let mut alias_chain: FxHashMap<String, String> = FxHashMap::default();
+    for &file in project_files {
+        let payload = file_to_nodes(db, file);
+        let module_fqn = payload.nodes[0].fqname.as_str();
+        for (name, binding) in &payload.name_bindings {
+            let next = match binding {
+                NameBinding::LocalClass(_) => continue,
+                NameBinding::Import(fqn) => fqn.clone(),
+                NameBinding::StarImport(module) => format!("{module}.{name}"),
+                NameBinding::ModuleAlias(other) => format!("{module_fqn}.{other}"),
+            };
+            alias_chain.insert(format!("{module_fqn}.{name}"), next);
+        }
+    }
 
     for &file in project_files {
         let payload = file_to_nodes(db, file);
@@ -1097,48 +1129,32 @@ fn build_class_hierarchy_indices<'db>(
                             }
                         }
                     }
-                    ResolvedBase::ImportedFqn(fqn) => match decl_by_fqname.get(fqn) {
-                        Some(idxs) => {
-                            for &parent_idx in idxs {
-                                if nodes[parent_idx].kind == "class" {
-                                    by_node.entry(parent_idx).or_default().push(child_idx);
-                                }
-                            }
-                        }
-                        // Not a project decl at all → an external base.
-                        // Key it by the resolved fqn so the external-seed
-                        // query can recover this subclass without a
-                        // re-parse. (A project decl that exists but isn't
-                        // a class is intentionally dropped: its subclass
-                        // set is empty either way.)
-                        None => external_base_children
-                            .entry(fqn.clone())
-                            .or_default()
-                            .push(child_idx),
-                    },
+                    ResolvedBase::ImportedFqn(fqn) => {
+                        let terminal = chase_base_fqn(fqn, &alias_chain, decl_by_fqname, nodes);
+                        register_chased_base(
+                            terminal,
+                            child_idx,
+                            decl_by_fqname,
+                            nodes,
+                            &mut by_node,
+                            &mut external_base_children,
+                        );
+                    }
                     ResolvedBase::Attribute {
                         module_fqn,
                         attr_name,
                     } => {
-                        // Resolve `module_fqn.attr_name` via
-                        // `decl_by_fqname` (the common case where the
-                        // target module's class is in the project); an
-                        // absent fqn is an external base, keyed for the
-                        // external-seed query.
                         let composed = format!("{module_fqn}.{attr_name}");
-                        match decl_by_fqname.get(&composed) {
-                            Some(idxs) => {
-                                for &parent_idx in idxs {
-                                    if nodes[parent_idx].kind == "class" {
-                                        by_node.entry(parent_idx).or_default().push(child_idx);
-                                    }
-                                }
-                            }
-                            None => external_base_children
-                                .entry(composed)
-                                .or_default()
-                                .push(child_idx),
-                        }
+                        let terminal =
+                            chase_base_fqn(&composed, &alias_chain, decl_by_fqname, nodes);
+                        register_chased_base(
+                            terminal,
+                            child_idx,
+                            decl_by_fqname,
+                            nodes,
+                            &mut by_node,
+                            &mut external_base_children,
+                        );
                     }
                     ResolvedBase::Unresolvable => {}
                 }
@@ -1157,6 +1173,65 @@ fn build_class_hierarchy_indices<'db>(
     ClassHierarchyIndices {
         children_by_node: by_node,
         external_base_children,
+    }
+}
+
+/// Follow a base-class fqn through the project-wide re-export / alias
+/// chain (`alias_chain`, built by [`build_class_hierarchy_indices`]) to
+/// its terminal fqn. Stops at the first fqn that names a live project
+/// class — so a re-exported project base resolves to the class itself,
+/// not the intermediate import node — or at a fqn that isn't a project
+/// re-export (an external base, or an unresolvable leaf). Cycle-guarded.
+fn chase_base_fqn<'a>(
+    start: &'a str,
+    alias_chain: &'a FxHashMap<String, String>,
+    decl_by_fqname: &FxHashMap<String, Vec<usize>>,
+    nodes: &[GraphNode],
+) -> &'a str {
+    let mut cur = start;
+    let mut seen: FxHashSet<&str> = FxHashSet::default();
+    loop {
+        // A fqn that already names a live project class is the terminal:
+        // don't chase past it through a same-name re-export shadow.
+        if decl_by_fqname
+            .get(cur)
+            .is_some_and(|idxs| idxs.iter().any(|&i| nodes[i].kind == "class"))
+        {
+            return cur;
+        }
+        match alias_chain.get(cur) {
+            Some(next) if seen.insert(cur) => cur = next.as_str(),
+            _ => return cur,
+        }
+    }
+}
+
+/// Fold a chased terminal base fqn into the project-wide subclass
+/// indices. A project class hit emits `children_by_node` entries; a
+/// terminal absent from `decl_by_fqname` is an external base, keyed into
+/// `external_base_children`. A project decl that exists but isn't a class
+/// is dropped (its subclass set is empty either way), matching the
+/// pre-chase behaviour.
+fn register_chased_base(
+    terminal: &str,
+    child_idx: usize,
+    decl_by_fqname: &FxHashMap<String, Vec<usize>>,
+    nodes: &[GraphNode],
+    by_node: &mut FxHashMap<usize, Vec<usize>>,
+    external_base_children: &mut FxHashMap<String, Vec<usize>>,
+) {
+    match decl_by_fqname.get(terminal) {
+        Some(idxs) => {
+            for &parent_idx in idxs {
+                if nodes[parent_idx].kind == "class" {
+                    by_node.entry(parent_idx).or_default().push(child_idx);
+                }
+            }
+        }
+        None => external_base_children
+            .entry(terminal.to_string())
+            .or_default()
+            .push(child_idx),
     }
 }
 
@@ -3364,13 +3439,16 @@ fn find_classes_defining_method_indices_core(
 
 /// Subclasses of the class addressed by ``base_fqn`` (project or
 /// external seed). Takes an owned ``ProjectDatabase`` so it can resolve
-/// the seed serially (``locate_class_seed`` needs a concrete db) and run
-/// the ``find_references`` re-export fallback. A project seed walks the
-/// cached ``children_by_node`` index directly; an external seed reads its
-/// direct project subclasses from the cached ``external_base_children``
-/// index (no re-parse) and only walks ``find_references`` when a project
-/// file actually imports the seed module. See
-/// ``FrozenView::find_subclasses_indices`` for the fast/slow-path rationale.
+/// the seed serially (``locate_class_seed`` needs a concrete db) and, when
+/// opted in, run the ``find_references`` re-export fallback. A project
+/// seed walks the cached ``children_by_node`` index directly; an external
+/// seed reads its direct project subclasses from the cached
+/// ``external_base_children`` index (no re-parse — re-export / alias
+/// chains are now resolved statically into that index by
+/// ``chase_base_fqn``). The ``find_references`` walk is an opt-in fallback
+/// (``DEAD_CST_SUBCLASS_REF_FALLBACK``) for chains the static ladder can't
+/// see. See ``FrozenView::find_subclasses_indices`` for the fast/slow-path
+/// rationale.
 fn find_subclasses_indices_core(
     db: ProjectDatabase,
     outputs: &BuildOutputs,
@@ -3395,21 +3473,28 @@ fn find_subclasses_indices_core(
     let children_by_node = &outputs.children_by_node;
     // External seed: the class lives outside the project. Its direct
     // project subclasses are cached in `external_base_children` (folded
-    // from the per-file `class_bases` payloads — no re-parse). A re-export
-    // / alias chain that binds the external class through a project module
-    // resolves the base to that *project* fqn, so it isn't keyed here;
-    // walk those via find_references — but only when some project file
-    // imports the seed module (the `imports_by_module` gate), since
-    // otherwise there is provably no reference for the walk to find.
+    // from the per-file `class_bases` payloads — no re-parse). Re-export /
+    // alias chains that bind the external class through one or more
+    // project modules are now resolved statically by `chase_base_fqn` at
+    // assemble time, so they too land in `external_base_children` without
+    // a walk.
     let mut direct: FxHashSet<usize> = outputs
         .external_base_children
         .get(base_fqn)
         .map(|idxs| idxs.iter().copied().collect())
         .unwrap_or_default();
+    // Opt-in `find_references` fallback. The cached index above covers
+    // every statically-resolvable subclass; the ref walk additionally
+    // catches chains ty's resolver reaches but the static binder ladder
+    // can't (e.g. relative-import or conditional re-exports). It re-parses
+    // on demand, so it is gated behind `DEAD_CST_SUBCLASS_REF_FALLBACK`
+    // and still only runs when some project file imports the seed module
+    // (otherwise there is provably no reference for the walk to find).
+    let ref_fallback = std::env::var_os("DEAD_CST_SUBCLASS_REF_FALLBACK").is_some();
     let imports_seed_module = base_fqn
         .rsplit_once('.')
         .is_some_and(|(module, _)| outputs.imports_by_module.contains_key(module));
-    if imports_seed_module {
+    if ref_fallback && imports_seed_module {
         direct.extend(find_subclass_indices_via_refs_with_queue(
             &db,
             &outputs.class_by_selection,

--- a/runtime/src/query.rs
+++ b/runtime/src/query.rs
@@ -1,13 +1,11 @@
 //! Shared per-file scan helpers for the native query surface.
 //!
-//! What remains here after the chainable `query()` DSL was retired:
-//! the identifier prefilter (`_contains_identifier` and friends) that
-//! lets a per-file walk skip the parse on files that don't even
-//! mention the target name, the `_path_re_matches` path-scoping check,
-//! and `par_scan_files` — the generic GIL-free parallel per-file walk
-//! that every `find_*` query on [`crate::project::ProjectContext`]
-//! drives. These are pure-rust, Salsa-snapshot-based, and shared by
-//! `project.rs` and `helpers.rs`.
+//! What remains here after the chainable `query()` DSL was retired and
+//! the `find_*` queries moved onto the cached per-file payloads: the
+//! identifier prefilter (`_contains_identifier` and friends) that lets a
+//! per-file walk skip the parse on files that don't even mention the
+//! target name, and the `_path_re_matches` path-scoping check. These are
+//! pure-rust, Salsa-snapshot-based, and shared by `project.rs`.
 
 use ruff_db::files::File;
 use ty_project::Db as ProjectDb;
@@ -67,51 +65,6 @@ pub(crate) fn _is_ident_continue(byte: u8) -> bool {
 /// per-file prefilter passes when the file mentions any of them.
 pub(crate) fn _contains_any_identifier(source: &str, needles: &[&str]) -> bool {
     needles.iter().any(|n| _contains_identifier(source, n))
-}
-
-/// Generic parallel per-file walk. ``per_file`` runs on a Salsa
-/// snapshot of ``db`` (one ``Db::dyn_clone`` per worker, mirroring
-/// the ty_ide find_references pattern at
-/// ``vendor/ruff/crates/ty_ide/src/references.rs:107-130``) and
-/// returns a ``Vec<T>`` of opaque per-file results.
-///
-/// Caller is responsible for releasing the GIL with
-/// :meth:`pyo3::Python::allow_threads` — the closure passed in must
-/// be ``Send + Sync`` and ``T`` must be ``Send``. Materializing
-/// ``Py<SymbolNode>`` values (which are GIL-bound) belongs in the
-/// caller AFTER ``allow_threads`` returns.
-pub(crate) fn par_scan_files<T, F>(
-    db: Box<dyn ProjectDb>,
-    files: &[File],
-    path_re: &Option<regex::Regex>,
-    per_file: F,
-) -> Vec<T>
-where
-    T: Send,
-    F: Fn(&dyn ProjectDb, File) -> Vec<T> + Send + Sync,
-{
-    let result = std::sync::Mutex::new(Vec::<T>::new());
-    let per_file_ref = &per_file;
-    let result_ref = &result;
-    // `move` captures `db: Box<dyn ProjectDb>` by value — `dyn Db`
-    // has a `Send` supertrait via `salsa::Database`, so the box is
-    // Send, but `&dyn Db` is NOT Send (the trait isn't Sync), which
-    // is why the box can't be borrowed across the rayon scope.
-    rayon::scope(move |s| {
-        for &file in files {
-            if !_path_re_matches(path_re, &*db, file) {
-                continue;
-            }
-            let db_t: Box<dyn ProjectDb> = ProjectDb::dyn_clone(&*db);
-            s.spawn(move |_| {
-                let local = per_file_ref(&*db_t, file);
-                if !local.is_empty() {
-                    result_ref.lock().unwrap().extend(local);
-                }
-            });
-        }
-    });
-    result.into_inner().unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/tests/test_plugins/test_unittest.py
+++ b/tests/test_plugins/test_unittest.py
@@ -310,12 +310,9 @@ def test_unittest_plugin_marks_three_level_subclass_chain(build_plugin_graph, re
     assert "tests.c.L3" in reached
 
 
-def test_unittest_plugin_marks_subclass_via_module_alias(
-    build_plugin_graph, reachable_fqnames, monkeypatch
-):
+def test_unittest_plugin_marks_subclass_via_module_alias(build_plugin_graph, reachable_fqnames):
     """A module-level alias of an imported ``TestCase`` (``Base = TestCase``)
-    resolves through the uniform binder ladder — no ``find_references`` walk."""
-    monkeypatch.delenv("DEAD_CST_SUBCLASS_REF_FALLBACK", raising=False)
+    resolves statically through the uniform binder ladder."""
     graph = build_plugin_graph(
         {
             "pkg/__init__.py": "",
@@ -333,28 +330,25 @@ def test_unittest_plugin_marks_subclass_via_module_alias(
     assert "pkg.things.MyThings" in reachable_fqnames(graph)
 
 
-def test_unittest_plugin_relative_reexport_needs_ref_fallback(
-    build_plugin_graph, reachable_fqnames, monkeypatch
+def test_unittest_plugin_marks_subclass_via_relative_reexport(
+    build_plugin_graph, reachable_fqnames
 ):
-    """A ``TestCase`` re-exported through a *relative* import can't be resolved
-    by the static binder ladder (``collect_all_imports_local`` doesn't apply
-    relative-import resolution), so the subclass is found only when the opt-in
-    ``DEAD_CST_SUBCLASS_REF_FALLBACK`` ``find_references`` walk is enabled."""
-    files = {
-        "pkg/__init__.py": "",
-        "pkg/bases.py": "from unittest import TestCase\n",
-        "pkg/things.py": """
-        from .bases import TestCase
+    """A ``TestCase`` re-exported through a *relative* import
+    (``from .bases import TestCase``) resolves statically: the binder ladder
+    reads ``im.level`` and resolves the dotted prefix against the importing
+    file's package, so the cross-file chase reaches the external seed with no
+    ``find_references`` walk."""
+    graph = build_plugin_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/bases.py": "from unittest import TestCase\n",
+            "pkg/things.py": """
+            from .bases import TestCase
 
-        class MyThings(TestCase):
-            def test_one(self): pass
-        """,
-    }
-
-    monkeypatch.delenv("DEAD_CST_SUBCLASS_REF_FALLBACK", raising=False)
-    reached_off = reachable_fqnames(build_plugin_graph(files, [native.NativePlugin.unittest()]))
-    assert "pkg.things.MyThings" not in reached_off
-
-    monkeypatch.setenv("DEAD_CST_SUBCLASS_REF_FALLBACK", "1")
-    reached_on = reachable_fqnames(build_plugin_graph(files, [native.NativePlugin.unittest()]))
-    assert "pkg.things.MyThings" in reached_on
+            class MyThings(TestCase):
+                def test_one(self): pass
+            """,
+        },
+        [native.NativePlugin.unittest()],
+    )
+    assert "pkg.things.MyThings" in reachable_fqnames(graph)

--- a/tests/test_plugins/test_unittest.py
+++ b/tests/test_plugins/test_unittest.py
@@ -308,3 +308,53 @@ def test_unittest_plugin_marks_three_level_subclass_chain(build_plugin_graph, re
     assert "tests.a.L1" in reached
     assert "tests.b.L2" in reached
     assert "tests.c.L3" in reached
+
+
+def test_unittest_plugin_marks_subclass_via_module_alias(
+    build_plugin_graph, reachable_fqnames, monkeypatch
+):
+    """A module-level alias of an imported ``TestCase`` (``Base = TestCase``)
+    resolves through the uniform binder ladder — no ``find_references`` walk."""
+    monkeypatch.delenv("DEAD_CST_SUBCLASS_REF_FALLBACK", raising=False)
+    graph = build_plugin_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/things.py": """
+            from unittest import TestCase
+
+            Base = TestCase
+
+            class MyThings(Base):
+                def test_one(self): pass
+            """,
+        },
+        [native.NativePlugin.unittest()],
+    )
+    assert "pkg.things.MyThings" in reachable_fqnames(graph)
+
+
+def test_unittest_plugin_relative_reexport_needs_ref_fallback(
+    build_plugin_graph, reachable_fqnames, monkeypatch
+):
+    """A ``TestCase`` re-exported through a *relative* import can't be resolved
+    by the static binder ladder (``collect_all_imports_local`` doesn't apply
+    relative-import resolution), so the subclass is found only when the opt-in
+    ``DEAD_CST_SUBCLASS_REF_FALLBACK`` ``find_references`` walk is enabled."""
+    files = {
+        "pkg/__init__.py": "",
+        "pkg/bases.py": "from unittest import TestCase\n",
+        "pkg/things.py": """
+        from .bases import TestCase
+
+        class MyThings(TestCase):
+            def test_one(self): pass
+        """,
+    }
+
+    monkeypatch.delenv("DEAD_CST_SUBCLASS_REF_FALLBACK", raising=False)
+    reached_off = reachable_fqnames(build_plugin_graph(files, [native.NativePlugin.unittest()]))
+    assert "pkg.things.MyThings" not in reached_off
+
+    monkeypatch.setenv("DEAD_CST_SUBCLASS_REF_FALLBACK", "1")
+    reached_on = reachable_fqnames(build_plugin_graph(files, [native.NativePlugin.unittest()]))
+    assert "pkg.things.MyThings" in reached_on


### PR DESCRIPTION
## Summary

Two related changes that together free the entire parsed-AST mass before assembly and let every project-wide query read cached per-file facts instead of re-parsing.

**Free per-file ASTs mid-build.** Project-wide plugin queries that re-walked each file's AST at query time (parameters, class-defining-method, decorators, constructions, factories, and the call-site family) now read a salsa-cached per-file `FileExtraction`, warmed during the existing per-file fan-out alongside the node/edge payloads. The query cores became pure fan-in filters over those facts, and the now-orphaned AST-walking helpers are deleted. With no project-wide query left walking a live AST during assembly, each file's parsed AST is freed (`ParsedModule::clear`) as soon as its payloads, `FileExtraction`, and per-file plugins are computed.

**Resolve class bases through a uniform binder ladder.** A class base is just a name, bound at module scope one of four ways — a local class, an explicit import, a `from … import *` star import, or a module-level alias (`Base = Imported`). Each file captures all four as per-file name bindings while its AST is hot; at assemble time the bindings fold into a project-wide alias/re-export chain chased cross-file (`chase_base_fqn`) to each base's terminal class. The import table reads each `from`-import's leading-dot level, so **relative** re-exports (`from .bases import TestCase`) resolve to the same terminal class as absolute ones. This retires ty's `find_references` subclass walk — previously the last query that re-parsed project files on demand — and the `DEAD_CST_SUBCLASS_REF_FALLBACK` env var that briefly gated it.

Also drops the unused `find_comment_patterns` query (and its `.pyi` stub) and adds `Analysis.set_stack_size(bytes)` to raise the rayon worker stack for deeply-nested ASTs.

## Memory win

Measured on a 250-file synthetic project via the `DEAD_CST_DUMP_HEAP` salsa dump at build-end:

| | `parsed_module` fields | Total salsa memory |
|---|---|---|
| Before | 4.96 MB | 15.90 MB |
| After | **0.00 MB** | 10.94 MB |

The entire parsed-AST mass is freed before assembly and the plugin pass (~30% of build-end salsa memory here; the absolute win scales with file count/size on real projects). The only on-demand AST loads that remain happen during the plugin pass — subclass resolution relocating a class seed (typically an external one, e.g. typeshed's `unittest`) — and are re-cleared immediately after, so the build-end resident set stays at the level shown above.

## Behavior change

Subclasses reached only through a star import, a module-level alias, or an absolute **or relative** re-export are now kept alive — previously they were dropped unless ty's `find_references` walk happened to recover them. This is the one results-affecting change; the memory and no-re-parse mechanics are otherwise results-neutral.

## Test plan

- [x] `cargo build -p dead-cst-runtime` + `cargo clippy -p dead-cst-runtime --all-targets` — clean
- [x] `cargo test --no-default-features --locked -p dead-cst-runtime` — 129 passed
- [x] `uv run pytest` — 693 passed, 3 skipped, 5 deselected (e2e)
- [x] `uv run prek run --all-files` — ruff, ruff-format, ty, cargo fmt, cargo clippy all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)