### PR TITLE
Resolve class bases through ty, not a hand-rolled binder ladder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,26 +222,32 @@ two versions.
   pass. On a 250-file synthetic project this takes the parsed-AST salsa heap
   from ~5 MB to ~0 at build-end (~30% of total salsa memory). Subclass
   resolution no longer re-parses **and no longer runs ty's `find_references`
-  walk at all**: each top-level class base is resolved during the per-file
-  fan-out straight through ty's type inference. The base expression's inferred
-  type, when it names a statically-known class, yields that class's canonical
-  `ClassLiteral`, keyed by its definition's `(file, name-range)` — the same key
-  the project's class index is built on. Because ty follows imports, aliases,
-  and re-exports while inferring the type, every spelling of one base collapses
-  to a single key by construction: an external base's sibling spellings
-  (`unittest.TestCase` and `unittest.case.TestCase` both name the single
-  `class TestCase`), relative re-exports (`from .bases import TestCase`),
-  `from … import *` names, and module-level aliases (`Base = Imported` *or* the
-  attribute form `Base = mod.Imported`) all resolve to the same `ClassLiteral`
-  as the original spelling. At assemble time each base is a single hashmap probe
-  against the class index — a hit is a project parent, a miss is an external
-  base, keyed by that same `(file, name-range)` so the subclass query is an O(1)
-  lookup with no scan. No per-file name-binding table, no cross-file fqn chase,
-  no on-demand AST reload, no env-var fallback. The memory and no-re-parse
-  mechanics are results-neutral; the one behavioral change is that subclasses
-  reached through a star import, a module-level alias, or an absolute *or*
-  relative re-export are kept alive where the default path previously dropped
-  them.
+  walk at all**: during the per-file fan-out each top-level class base is
+  decomposed — via ty's use-def chain, not type inference — into a lightweight
+  symbolic spec: a same-file class (keyed by its name-range) or a
+  `module` + `name` member reference for anything imported. These specs are
+  deliberately *not* resolved across files at store time, so a file's cached
+  payload stays salsa-invalidation-local. Cross-file resolution happens later,
+  at both assemble and query time, through one shared member resolver
+  (`resolve_member_def`) built on ty's module resolver plus the same use-def
+  decomposition the store side runs (ty's `global_scope`/`place_table`/
+  `use_def_map` primitives), which follows re-export and alias chains.
+  Because the observed bases (at assemble) and the subclass query both funnel
+  every member reference through that same resolver, every spelling of one base
+  collapses to a single `(file, name-range)` key by construction: an external
+  base's sibling spellings (`unittest.TestCase` and `unittest.case.TestCase`
+  both name the single `class TestCase`), relative re-exports
+  (`from .bases import TestCase`), `from … import *` names, and module-level
+  aliases (`Base = Imported` *or* the attribute form `Base = mod.Imported`) all
+  resolve to the same decl as the original spelling. At assemble time each
+  resolved base is a single hashmap probe against the class index — a hit is a
+  project parent, a miss is an external base, keyed by that same
+  `(file, name-range)` so the subclass query is an O(1) lookup with no scan. No
+  per-file name-binding table, no eager cross-file resolution, no hand-rolled
+  fqn chase, no env-var fallback. The memory and no-re-parse mechanics are
+  results-neutral; the one behavioral change is that subclasses reached through
+  a star import, a module-level alias, or an absolute *or* relative re-export
+  are kept alive where the default path previously dropped them.
 - **Built-in plugins are migrating to native (Rust) implementations.**
   The `main_block`, `module_dunders`, `init_subclass`, `server_config`,
   and `unittest` built-ins now resolve to native `NativePlugin`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,26 +222,26 @@ two versions.
   pass. On a 250-file synthetic project this takes the parsed-AST salsa heap
   from ~5 MB to ~0 at build-end (~30% of total salsa memory). Subclass
   resolution no longer re-parses **and no longer runs ty's `find_references`
-  walk at all**: each file captures its module-level name bindings during
-  the fan-out, and every class base — just a name, bound one of four ways
-  (local class, explicit import, `from … import *`, or a module-level alias,
-  `Base = Imported` *or* the attribute form `Base = mod.Imported`) — resolves
-  through that one uniform binder ladder. The
-  import table reads each `from … import` statement's leading-dot level, so
-  *relative* re-exports (`from .bases import TestCase`) resolve to the same
-  terminal class as absolute ones. Sibling spellings of one external base
+  walk at all**: each top-level class base is resolved during the per-file
+  fan-out straight through ty's type inference. The base expression's inferred
+  type, when it names a statically-known class, yields that class's canonical
+  `ClassLiteral`, keyed by its definition's `(file, name-range)` — the same key
+  the project's class index is built on. Because ty follows imports, aliases,
+  and re-exports while inferring the type, every spelling of one base collapses
+  to a single key by construction: an external base's sibling spellings
   (`unittest.TestCase` and `unittest.case.TestCase` both name the single
-  `class TestCase`) fold together, so a subclass written against either
-  spelling is found regardless of which spelling a plugin queries. At assemble
-  time the per-file bindings fold
-  into a project-wide alias/re-export chain that is chased cross-file to each
-  base's terminal class, so subclasses reached through a star import, a
-  module-level alias, or an absolute *or* relative re-export now resolve
-  statically from those cached facts — no on-demand AST reload, no env-var
-  fallback. The memory and no-re-parse mechanics are results-neutral; the one
-  behavioral change is that the static chase now keeps star-import /
-  module-alias / re-export subclasses alive where the default path previously
-  dropped them.
+  `class TestCase`), relative re-exports (`from .bases import TestCase`),
+  `from … import *` names, and module-level aliases (`Base = Imported` *or* the
+  attribute form `Base = mod.Imported`) all resolve to the same `ClassLiteral`
+  as the original spelling. At assemble time each base is a single hashmap probe
+  against the class index — a hit is a project parent, a miss is an external
+  base, keyed by that same `(file, name-range)` so the subclass query is an O(1)
+  lookup with no scan. No per-file name-binding table, no cross-file fqn chase,
+  no on-demand AST reload, no env-var fallback. The memory and no-re-parse
+  mechanics are results-neutral; the one behavioral change is that subclasses
+  reached through a star import, a module-level alias, or an absolute *or*
+  relative re-export are kept alive where the default path previously dropped
+  them.
 - **Built-in plugins are migrating to native (Rust) implementations.**
   The `main_block`, `module_dunders`, `init_subclass`, `server_config`,
   and `unittest` built-ins now resolve to native `NativePlugin`

--- a/runtime/src/file_payload.rs
+++ b/runtime/src/file_payload.rs
@@ -36,11 +36,12 @@ use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
 use ty_python_core::place::{PlaceExprRef, ScopedPlaceId};
 use ty_python_core::scope::FileScopeId;
 use ty_python_core::semantic_index;
+use ty_python_semantic::{HasType, SemanticModel};
 
 use crate::graph::NodeFlags;
 use crate::helpers::{
-    collect_all_imports_local, file_default_flags, file_path_string, iter_top_level_classes,
-    module_fqname_for_file, position, range_key, resolve_base_fqn, scan_noqa_directives,
+    class_literal_seed, collect_all_imports_local, file_default_flags, file_path_string,
+    iter_top_level_classes, module_fqname_for_file, position, range_key, scan_noqa_directives,
     NODE_FLAGS_NOQA_PIN,
 };
 use crate::ingest::{decl_kind_str, file_package_name, from_module_string};
@@ -225,20 +226,19 @@ pub(crate) struct ImportPayload {
 /// * `star_reexports` — per-name → upstream absolute module name when
 ///   `name` is bound in this file by `from <upstream> import *`. Lets
 ///   downstream chain walks hop through this file.
-/// * `class_bases` — per top-level class declaration, the resolved
-///   base list. Each entry is `(name_range_key, bases)` where
-///   `name_range_key` matches the `(start, end)` `u32` pair the
-///   assemble pass stores in `class_by_selection`, and `bases` is a
-///   small-vec of [`ResolvedBase`] entries. Drives the project-wide
-///   class-hierarchy fan-in at assemble time without a second AST
-///   walk. Same-file `LocalSameFileClass(local_idx)` bases reference
-///   the file's own `refs[local_idx]`; assemble translates them via
-///   the same `NodeRef -> global_idx` map used for edges.
-/// * `name_bindings` — per module-level name → how it's bound
-///   ([`NameBinding`]): local class, import, star import, or module
-///   alias. The single uniform ladder `build_class_bases` resolves every
-///   class base through, and the source the assemble pass folds into the
-///   project-wide re-export / alias chain.
+/// * `class_bases` — per top-level class declaration with at least one
+///   statically-resolvable base, the resolved base list. Each entry is
+///   `(name_range_key, bases)` where `name_range_key` matches the
+///   `(start, end)` `u32` pair the assemble pass stores in
+///   `class_by_selection`, and `bases` is a small-vec of [`ClassBaseKey`]
+///   `(File, name_range)` pairs — each the canonical `ClassLiteral`'s
+///   `focus_range`, resolved through ty's type system
+///   ([`crate::helpers::class_literal_seed`]). A same-file base lands on
+///   this file's own selection key; a project base in another file lands
+///   on that file's; an external base (`unittest.TestCase`) lands on
+///   typeshed's. Assemble dispatches each key against `class_by_selection`
+///   with no chasing — sibling spellings collapse to one key because they
+///   share a `ClassLiteral`. Classes with no resolvable base are omitted.
 /// * `overload_anchors` — `(impl_local_idx, stub_local_idx)` pairs for
 ///   in-file `@typing.overload` groups. The assembly pass emits one
 ///   `impl → stub` edge per pair so reachability propagates from a
@@ -254,82 +254,25 @@ pub(crate) struct FileNodes<'db> {
     pub(crate) exports_by_name: FxHashMap<String, SmallVec<[u32; 2]>>,
     pub(crate) star_reexports: FxHashMap<String, String>,
     pub(crate) class_bases: Vec<ClassBaseEntry>,
-    pub(crate) name_bindings: FxHashMap<String, NameBinding>,
     pub(crate) overload_anchors: Box<[(u32, u32)]>,
 }
 
-/// `(name_range_key, resolved_bases)` pair stored in
+/// `(name_range_key, base_keys)` pair stored in
 /// [`FileNodes::class_bases`]. The range key matches what the
 /// assemble pass writes into `class_by_selection`, so the project-wide
 /// fan-in is a hashmap probe.
-pub(crate) type ClassBaseEntry = ((u32, u32), SmallVec<[ResolvedBase; 2]>);
+pub(crate) type ClassBaseEntry = ((u32, u32), SmallVec<[ClassBaseKey; 2]>);
 
-/// One base-class expression resolved against a single file's
-/// imports + same-file class bindings. Computed purely from per-file
-/// state so it lives inside the salsa-tracked [`FileNodes`] payload —
-/// project-wide fan-in happens at assemble time.
-///
-/// Four shapes cover today's class headers:
-///
-/// * `LocalSameFileClass(local_idx)` — `class Sub(Base): ...` where
-///   `Base` is a top-level class earlier in the same file. The
-///   `local_idx` indexes into the per-file `refs`/`nodes` arrays;
-///   assemble translates it to a global graph index via the same
-///   `ref_to_global` map used for edges.
-/// * `ImportedFqn(fqn)` — `from <module> import Base` (or aliased)
-///   followed by `class Sub(Base): ...`. The fqn is fully qualified
-///   after relative-import resolution. Matches both project and
-///   external bases by string equality with no per-file state.
-/// * `Attribute { module_fqn, attr_name }` — `import <module> [as M];
-///   class Sub(M.Base): ...`. We resolve `M` to its absolute module
-///   name via the file's imports and keep `attr_name` separate so the
-///   assemble pass can probe the target module's `exports_by_name`
-///   (project-side) and synthesize the canonical `<module>.<attr>`
-///   fqn (external-side) without re-parsing.
-/// * `Unresolvable` — `Generic[T]`, dynamic constructions, any base
-///   shape outside the static-resolution contract. Kept as an entry
-///   so the parent class still appears in the index.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
-pub(crate) enum ResolvedBase {
-    LocalSameFileClass(u32),
-    ImportedFqn(String),
-    Attribute {
-        module_fqn: String,
-        attr_name: String,
-    },
-    Unresolvable,
-}
-
-/// How a module-level name is bound in a single file, captured while the
-/// AST is hot in [`file_to_nodes`]. A class base is "just a name", and a
-/// module-scope name is bound exactly one of four ways; capturing all
-/// four (rather than only imports + same-file classes) means a base is
-/// never silently dropped — star-imported and module-aliased bases
-/// resolve through the same uniform ladder as direct imports.
-///
-/// The assemble pass folds these into a project-wide `{module}.{name} ->
-/// next_fqn` chain (see `build_class_hierarchy_indices`), so a base that
-/// hops through one or more re-export / alias bindings across files is
-/// chased to its terminal class without re-parsing.
-///
-/// Ladder precedence when a name is bound more than once (a rare shadow):
-/// `LocalClass` > `Import` > `StarImport` > `ModuleAlias`.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
-pub(crate) enum NameBinding {
-    /// `class Name: ...` — a top-level class in this file. Local idx into
-    /// `refs`/`nodes` (the live binding; first wins on rebind).
-    LocalClass(u32),
-    /// `from m import Name [as Name]` / `import m [as Name]` — the
-    /// upstream fqn produced by [`collect_all_imports_local`].
-    Import(String),
-    /// `from m import *` brought `Name` in — the source module `m`. The
-    /// name resolves to `{m}.{Name}`.
-    StarImport(String),
-    /// `Name = Other` at module scope — an alias to another module-level
-    /// name `Other` in this file. Resolves to `{this_module}.{Other}`,
-    /// whose own binding continues the chain.
-    ModuleAlias(String),
-}
+/// A resolved class base: the `(File, name_range)` of the canonical
+/// `ClassLiteral` the base expression evaluates to, as computed by
+/// [`crate::helpers::class_literal_seed`] from ty's inferred type. This
+/// is byte-identical to the key the assemble pass writes into
+/// `class_by_selection` for a project class, and to the key the query
+/// side derives for an external base — so resolution, not chasing,
+/// collapses every spelling of one class (direct, aliased, re-exported,
+/// sibling-module) to a single key. The `(u32, u32)` is the name range's
+/// `(start, end)` byte offsets; `File` is lifetime-free (a salsa input).
+pub(crate) type ClassBaseKey = (File, (u32, u32));
 
 /// Resolve a `NodeRef` to its `NodeData` payload.
 ///
@@ -689,21 +632,15 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         }
     }
 
-    // Capture the module's name-binding table (all four binding kinds)
-    // while the AST is hot, then resolve every top-level class base
-    // against it through the uniform ladder. No project-wide state
-    // needed here; the assemble pass folds `name_bindings` into the
-    // cross-file re-export / alias chain and turns `class_bases` into the
-    // global `children_by_node` / `external_base_children` indices.
-    let file_imports = collect_all_imports_local(&parsed, file_package.as_deref());
-    let name_bindings = build_name_bindings(
-        &parsed,
-        &file_imports,
-        &star_reexports,
-        &exports_by_name,
-        &nodes,
-    );
-    let class_bases = build_class_bases(&parsed, &name_bindings, &file_imports, &nodes);
+    // Resolve every top-level class base through ty's type system: each
+    // base expression's inferred type, when it names a statically-known
+    // class, yields that `ClassLiteral`'s `(File, name_range)` — the same
+    // key the assemble pass writes into `class_by_selection`. A cheap
+    // `SemanticModel` over this file drives it; classes with no
+    // resolvable base contribute nothing, so no project-wide chasing or
+    // re-parse is needed downstream.
+    let model = SemanticModel::new(db, file);
+    let class_bases = build_class_bases(&model, &parsed);
 
     FileNodes {
         nodes: nodes.into_boxed_slice(),
@@ -712,188 +649,65 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         exports_by_name,
         star_reexports,
         class_bases,
-        name_bindings,
         overload_anchors: overload_anchors.into_boxed_slice(),
     }
 }
 
-/// Capture every module-level name binding in `parsed` as a uniform
-/// [`NameBinding`] table — the per-file half of the "a class base is just
-/// a name" model. Built once while the AST is hot and stored in
-/// [`FileNodes::name_bindings`]; consumed by both [`build_class_bases`]
-/// (within-file base resolution) and the assemble pass (cross-file chain
-/// following).
-///
-/// All four binding kinds are recorded so no base is dropped: module-level
-/// aliases (`Base = Other`), `from m import *` names, explicit imports,
-/// and same-file classes. Higher-precedence rungs overwrite lower ones
-/// (see [`NameBinding`]): local class > import > star import > module
-/// alias.
-fn build_name_bindings(
-    parsed: &ruff_db::parsed::ParsedModuleRef,
-    file_imports: &FxHashMap<String, String>,
-    star_reexports: &FxHashMap<String, String>,
-    exports_by_name: &FxHashMap<String, SmallVec<[u32; 2]>>,
-    nodes: &[NodeData],
-) -> FxHashMap<String, NameBinding> {
-    use ruff_python_ast::Expr;
-    let mut out: FxHashMap<String, NameBinding> = FxHashMap::default();
-
-    // Rung 4 (lowest): module-level aliases `Name = Other`. A single-`Name`
-    // target with a single-`Name` value (`Base = Other`) is a within-file
-    // alias; a target with an attribute value rooted at an imported module
-    // (`Base = mod.Class`) resolves to an absolute fqn just like
-    // `from mod import Class as Base`, so it binds as an `Import` rung.
-    // Richer right-hand sides (calls, conditionals) aren't class aliases
-    // and stay unbound here.
-    for stmt in &parsed.syntax().body {
-        let Stmt::Assign(assign) = stmt else {
-            continue;
-        };
-        let [Expr::Name(target)] = assign.targets.as_slice() else {
-            continue;
-        };
-        match assign.value.as_ref() {
-            Expr::Name(value) => {
-                out.insert(
-                    target.id.as_str().to_string(),
-                    NameBinding::ModuleAlias(value.id.as_str().to_string()),
-                );
-            }
-            Expr::Attribute(_) => {
-                if let Some(fqn) = resolve_base_fqn(assign.value.as_ref(), file_imports) {
-                    out.insert(target.id.as_str().to_string(), NameBinding::Import(fqn));
-                }
-            }
-            _ => {}
-        }
-    }
-
-    // Rung 3: `from m import *` names → source module.
-    for (name, module) in star_reexports {
-        out.insert(name.clone(), NameBinding::StarImport(module.clone()));
-    }
-
-    // Rung 2: explicit imports → upstream fqn.
-    for (name, fqn) in file_imports {
-        out.insert(name.clone(), NameBinding::Import(fqn.clone()));
-    }
-
-    // Rung 1 (highest): same-file top-level classes. The first class
-    // binding for a name wins (matching the lexically-earliest rule the
-    // cross-module path relies on).
-    for (name, locals) in exports_by_name {
-        for &local_idx in locals {
-            if matches!(nodes[local_idx as usize].kind, NodeKind::Class) {
-                out.insert(name.clone(), NameBinding::LocalClass(local_idx));
-                break;
-            }
-        }
-    }
-
-    out
-}
-
 /// Per-file class-hierarchy producer used by [`file_to_nodes`].
 ///
-/// For each top-level `ClassDef`, key on its name range and resolve every
-/// base expression to a [`ResolvedBase`]. The result is a flat list of
-/// `(name_range_key, bases)` pairs the assemble pass folds into the
-/// project-wide hierarchy without re-parsing.
+/// For each top-level `ClassDef` with at least one statically-resolvable
+/// base, key on its name range and resolve every base expression through
+/// ty's type system to the `(File, name_range)` of the canonical
+/// `ClassLiteral` it names (see [`crate::helpers::class_literal_seed`]).
+/// The result is a flat list of `(name_range_key, base_keys)` pairs the
+/// assemble pass dispatches against `class_by_selection` with no chasing
+/// — one mechanism for every base shape:
 ///
-/// A bare-name base resolves through the uniform binder ladder
-/// (`name_bindings`); an attribute base keeps the dedicated `Attribute`
-/// shape via `resolve_base_fqn`:
+/// * `Name(Base)`, whether `Base` is a same-file class, a direct import,
+///   a star import, or a module-level alias — ty infers the bound
+///   `ClassLiteral` directly.
+/// * `Attribute(mod.Base)` / deeper `a.b.Base` — ty resolves the
+///   attribute access to the same `ClassLiteral`, so a sibling-module
+///   spelling collapses onto the canonical class.
+/// * `Base[T]` — the subscript is unwrapped to `Base` so the bare class
+///   resolves (the specialized alias type wouldn't be a `ClassLiteral`).
 ///
-/// * `Name(Foo)` → whatever `Foo`'s [`NameBinding`] resolves to (local
-///   class, import fqn, `{star_module}.Foo`, or `{this_module}.{alias}`).
-/// * `Attribute(Name(M).N)` where `M` is in `file_imports` →
-///   `Attribute { module_fqn, attr_name: N }`.
-/// * Deeper `a.b.c.N` chains rooted at an import → flattened into
-///   `ImportedFqn("<a-upstream>.b.c.N")`.
-/// * Anything else → `ResolvedBase::Unresolvable`.
-fn build_class_bases(
+/// Anything ty can't pin to a single statically-known class (a dynamic
+/// base, `Generic[T]`/`Protocol[T]`, a union) yields no key and is
+/// dropped; a class left with no keys is omitted entirely.
+fn build_class_bases<'db>(
+    model: &SemanticModel<'db>,
     parsed: &ruff_db::parsed::ParsedModuleRef,
-    name_bindings: &FxHashMap<String, NameBinding>,
-    file_imports: &FxHashMap<String, String>,
-    nodes: &[NodeData],
 ) -> Vec<ClassBaseEntry> {
     use ruff_python_ast::Expr;
-
-    // `nodes[0]` is always the synthetic module node; its fqname is this
-    // file's module fqn, needed to express a `Base = Other` alias as the
-    // chaseable fqn `{module}.{Other}`.
-    let module_fqn = nodes[0].fqname.as_str();
-
     let mut out: Vec<ClassBaseEntry> = Vec::new();
     for cls in iter_top_level_classes(parsed) {
-        // Key on the class name's `(start, end)` byte range — same
-        // tuple the assemble pass uses to populate `class_by_selection`,
-        // so the assemble-side fan-in is an O(1) hashmap probe.
-        let cls_rk = range_key(cls.name.range());
-
         let Some(args) = &cls.arguments else {
-            out.push((cls_rk, SmallVec::new()));
             continue;
         };
-        let mut bases: SmallVec<[ResolvedBase; 2]> = SmallVec::new();
+        let mut bases: SmallVec<[ClassBaseKey; 2]> = SmallVec::new();
         for raw_base in &args.args {
-            // Unwrap `Foo[T]`, `Generic[T]`, `Protocol[T]`, etc. so a
-            // subscripted generic base still feeds the class hierarchy.
-            let base = match raw_base {
+            // Unwrap `Foo[T]`, `Generic[T]`, `Protocol[T]` to the bare
+            // class so a subscripted generic base still resolves to its
+            // `ClassLiteral`; the specialized alias type would not.
+            let base_expr = match raw_base {
                 Expr::Subscript(s) => s.value.as_ref(),
                 other => other,
             };
-            let resolved = match base {
-                // A bare-name base resolves through the uniform binder
-                // ladder. Star and alias bindings produce a chaseable fqn
-                // the assemble pass follows across files.
-                Expr::Name(name) => resolve_name_base(name.id.as_str(), name_bindings, module_fqn),
-                // An attribute base `M.N` rooted at an imported module
-                // keeps the dedicated `Attribute` shape so assemble can
-                // probe the target module's exports; a deeper chain keeps
-                // the flat fqn.
-                Expr::Attribute(a) => match resolve_base_fqn(base, file_imports) {
-                    Some(fqn) => match a.value.as_ref() {
-                        Expr::Name(root) if file_imports.contains_key(root.id.as_str()) => {
-                            ResolvedBase::Attribute {
-                                module_fqn: file_imports[root.id.as_str()].clone(),
-                                attr_name: a.attr.as_str().to_string(),
-                            }
-                        }
-                        _ => ResolvedBase::ImportedFqn(fqn),
-                    },
-                    None => ResolvedBase::Unresolvable,
-                },
-                _ => ResolvedBase::Unresolvable,
-            };
-            bases.push(resolved);
+            if let Some(ty) = base_expr.inferred_type(model) {
+                if let Some((file, rng)) = class_literal_seed(model.db(), ty) {
+                    bases.push((file, range_key(rng)));
+                }
+            }
         }
-        out.push((cls_rk, bases));
+        if !bases.is_empty() {
+            // Key on the class name's `(start, end)` byte range — same
+            // tuple the assemble pass uses to populate `class_by_selection`,
+            // so the assemble-side fan-in is an O(1) hashmap probe.
+            out.push((range_key(cls.name.range()), bases));
+        }
     }
     out
-}
-
-/// Resolve a bare-name class base through the uniform binder ladder.
-/// `LocalClass` → same-file class; `Import` → upstream fqn; `StarImport`
-/// → `{module}.{name}`; `ModuleAlias` → `{this_module}.{other}` (chased
-/// across files at assemble). An unbound name is `Unresolvable`.
-fn resolve_name_base(
-    name: &str,
-    name_bindings: &FxHashMap<String, NameBinding>,
-    module_fqn: &str,
-) -> ResolvedBase {
-    match name_bindings.get(name) {
-        Some(NameBinding::LocalClass(idx)) => ResolvedBase::LocalSameFileClass(*idx),
-        Some(NameBinding::Import(fqn)) => ResolvedBase::ImportedFqn(fqn.clone()),
-        Some(NameBinding::StarImport(module)) => {
-            ResolvedBase::ImportedFqn(format!("{module}.{name}"))
-        }
-        Some(NameBinding::ModuleAlias(other)) => {
-            ResolvedBase::ImportedFqn(format!("{module_fqn}.{other}"))
-        }
-        None => ResolvedBase::Unresolvable,
-    }
 }
 
 /// Pure-rust variant of `ingest::import_payload_for`. Returns the same

--- a/runtime/src/file_payload.rs
+++ b/runtime/src/file_payload.rs
@@ -36,11 +36,10 @@ use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
 use ty_python_core::place::{PlaceExprRef, ScopedPlaceId};
 use ty_python_core::scope::FileScopeId;
 use ty_python_core::semantic_index;
-use ty_python_semantic::{HasType, SemanticModel};
 
 use crate::graph::NodeFlags;
 use crate::helpers::{
-    class_literal_seed, collect_all_imports_local, file_default_flags, file_path_string,
+    classify_base, collect_all_imports_local, file_default_flags, file_path_string,
     iter_top_level_classes, module_fqname_for_file, position, range_key, scan_noqa_directives,
     NODE_FLAGS_NOQA_PIN,
 };
@@ -227,18 +226,20 @@ pub(crate) struct ImportPayload {
 ///   `name` is bound in this file by `from <upstream> import *`. Lets
 ///   downstream chain walks hop through this file.
 /// * `class_bases` — per top-level class declaration with at least one
-///   statically-resolvable base, the resolved base list. Each entry is
-///   `(name_range_key, bases)` where `name_range_key` matches the
+///   statically-describable base, the symbolic base list. Each entry is
+///   `(name_range_key, specs)` where `name_range_key` matches the
 ///   `(start, end)` `u32` pair the assemble pass stores in
-///   `class_by_selection`, and `bases` is a small-vec of [`ClassBaseKey`]
-///   `(File, name_range)` pairs — each the canonical `ClassLiteral`'s
-///   `focus_range`, resolved through ty's type system
-///   ([`crate::helpers::class_literal_seed`]). A same-file base lands on
-///   this file's own selection key; a project base in another file lands
-///   on that file's; an external base (`unittest.TestCase`) lands on
-///   typeshed's. Assemble dispatches each key against `class_by_selection`
-///   with no chasing — sibling spellings collapse to one key because they
-///   share a `ClassLiteral`. Classes with no resolvable base are omitted.
+///   `class_by_selection`, and `specs` is a small-vec of [`ClassBaseSpec`]
+///   first-hop descriptors derived from each base expression via ty's
+///   use-def chain ([`crate::helpers::classify_base`]). The spec carries
+///   only this file's view — a same-file class name range, or an
+///   `(absolute module, member)` pair — never a resolved cross-file
+///   target, so editing the base's defining file doesn't dirty this
+///   payload. Assemble resolves each spec through
+///   [`crate::helpers::resolve_member_def`] and dispatches the resulting
+///   `(File, name_range)` against `class_by_selection`; sibling spellings
+///   collapse to one key because resolution lands them on the same
+///   canonical definition. Classes with no describable base are omitted.
 /// * `overload_anchors` — `(impl_local_idx, stub_local_idx)` pairs for
 ///   in-file `@typing.overload` groups. The assembly pass emits one
 ///   `impl → stub` edge per pair so reachability propagates from a
@@ -257,22 +258,34 @@ pub(crate) struct FileNodes<'db> {
     pub(crate) overload_anchors: Box<[(u32, u32)]>,
 }
 
-/// `(name_range_key, base_keys)` pair stored in
+/// `(name_range_key, base_specs)` pair stored in
 /// [`FileNodes::class_bases`]. The range key matches what the
 /// assemble pass writes into `class_by_selection`, so the project-wide
-/// fan-in is a hashmap probe.
-pub(crate) type ClassBaseEntry = ((u32, u32), SmallVec<[ClassBaseKey; 2]>);
+/// fan-in is a hashmap probe once each [`ClassBaseSpec`] is resolved.
+pub(crate) type ClassBaseEntry = ((u32, u32), SmallVec<[ClassBaseSpec; 2]>);
 
-/// A resolved class base: the `(File, name_range)` of the canonical
-/// `ClassLiteral` the base expression evaluates to, as computed by
-/// [`crate::helpers::class_literal_seed`] from ty's inferred type. This
-/// is byte-identical to the key the assemble pass writes into
-/// `class_by_selection` for a project class, and to the key the query
-/// side derives for an external base — so resolution, not chasing,
-/// collapses every spelling of one class (direct, aliased, re-exported,
-/// sibling-module) to a single key. The `(u32, u32)` is the name range's
-/// `(start, end)` byte offsets; `File` is lifetime-free (a salsa input).
-pub(crate) type ClassBaseKey = (File, (u32, u32));
+/// A symbolic, per-file description of one class base — the first hop
+/// only, with no cross-file resolution, so a file's payload stays
+/// invalidation-local (editing the base's defining file never dirties
+/// this one). [`crate::helpers::classify_base`] derives it from the base
+/// expression via ty's use-def chain; both the assemble pass and the
+/// query side then resolve it through
+/// [`crate::helpers::resolve_member_def`], so every spelling of one base
+/// (direct, aliased, re-exported, sibling-module) lands on the same
+/// `(File, name_range)` key by construction.
+///
+/// * `LocalClass` — the base name binds a class defined in *this* file;
+///   the `(start, end)` is that class's name range, byte-identical to the
+///   `class_by_selection` key the assemble pass mints for it.
+/// * `ModuleMember` — the base is a member `name` of absolute module
+///   `module` (a `from`-import, an attribute access on an imported
+///   module, or a same-file alias of one). Resolution maps it to the
+///   member's canonical definition range.
+#[derive(Debug, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+pub(crate) enum ClassBaseSpec {
+    LocalClass((u32, u32)),
+    ModuleMember { module: String, name: String },
+}
 
 /// Resolve a `NodeRef` to its `NodeData` payload.
 ///
@@ -632,15 +645,14 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         }
     }
 
-    // Resolve every top-level class base through ty's type system: each
-    // base expression's inferred type, when it names a statically-known
-    // class, yields that `ClassLiteral`'s `(File, name_range)` — the same
-    // key the assemble pass writes into `class_by_selection`. A cheap
-    // `SemanticModel` over this file drives it; classes with no
-    // resolvable base contribute nothing, so no project-wide chasing or
-    // re-parse is needed downstream.
-    let model = SemanticModel::new(db, file);
-    let class_bases = build_class_bases(&model, &parsed);
+    // Describe every top-level class base symbolically via ty's use-def
+    // chain: each base expression becomes a first-hop `ClassBaseSpec`
+    // (this file's view only — a same-file class range or an
+    // `(absolute module, member)` pair), never an eagerly-resolved
+    // cross-file target. Classes with no describable base contribute
+    // nothing; resolution is deferred to the assemble/query side, which
+    // keeps this payload invalidation-local.
+    let class_bases = build_class_bases(db, file, &parsed);
 
     FileNodes {
         nodes: nodes.into_boxed_slice(),
@@ -655,49 +667,38 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
 
 /// Per-file class-hierarchy producer used by [`file_to_nodes`].
 ///
-/// For each top-level `ClassDef` with at least one statically-resolvable
-/// base, key on its name range and resolve every base expression through
-/// ty's type system to the `(File, name_range)` of the canonical
-/// `ClassLiteral` it names (see [`crate::helpers::class_literal_seed`]).
-/// The result is a flat list of `(name_range_key, base_keys)` pairs the
-/// assemble pass dispatches against `class_by_selection` with no chasing
-/// — one mechanism for every base shape:
+/// For each top-level `ClassDef` with at least one statically-describable
+/// base, key on its name range and describe every base expression
+/// symbolically via [`crate::helpers::classify_base`] — ty's use-def
+/// chain, this file's scope only. Each base becomes a [`ClassBaseSpec`]:
 ///
-/// * `Name(Base)`, whether `Base` is a same-file class, a direct import,
-///   a star import, or a module-level alias — ty infers the bound
-///   `ClassLiteral` directly.
-/// * `Attribute(mod.Base)` / deeper `a.b.Base` — ty resolves the
-///   attribute access to the same `ClassLiteral`, so a sibling-module
-///   spelling collapses onto the canonical class.
-/// * `Base[T]` — the subscript is unwrapped to `Base` so the bare class
-///   resolves (the specialized alias type wouldn't be a `ClassLiteral`).
+/// * a same-file class name → `LocalClass(range)` (the
+///   `class_by_selection` key the assemble pass mints for that class);
+/// * a `from`-import, an attribute access on an imported module
+///   (`mod.Base`, `a.b.Base`), or a same-file alias chain that bottoms
+///   out at one → `ModuleMember { module, name }` with an *absolute*
+///   module string.
 ///
-/// Anything ty can't pin to a single statically-known class (a dynamic
-/// base, `Generic[T]`/`Protocol[T]`, a union) yields no key and is
-/// dropped; a class left with no keys is omitted entirely.
-fn build_class_bases<'db>(
-    model: &SemanticModel<'db>,
+/// `Base[T]` is unwrapped to `Base` inside `classify_base`. Anything that
+/// doesn't bottom out at a class name or an importable member (a dynamic
+/// base, a bare imported module, a union) yields no spec and is dropped;
+/// a class left with no specs is omitted entirely. No cross-file
+/// resolution happens here — that's deferred to
+/// [`crate::helpers::resolve_member_def`] at assemble/query time.
+fn build_class_bases(
+    db: &dyn ProjectDb,
+    file: File,
     parsed: &ruff_db::parsed::ParsedModuleRef,
 ) -> Vec<ClassBaseEntry> {
-    use ruff_python_ast::Expr;
     let mut out: Vec<ClassBaseEntry> = Vec::new();
     for cls in iter_top_level_classes(parsed) {
         let Some(args) = &cls.arguments else {
             continue;
         };
-        let mut bases: SmallVec<[ClassBaseKey; 2]> = SmallVec::new();
+        let mut bases: SmallVec<[ClassBaseSpec; 2]> = SmallVec::new();
         for raw_base in &args.args {
-            // Unwrap `Foo[T]`, `Generic[T]`, `Protocol[T]` to the bare
-            // class so a subscripted generic base still resolves to its
-            // `ClassLiteral`; the specialized alias type would not.
-            let base_expr = match raw_base {
-                Expr::Subscript(s) => s.value.as_ref(),
-                other => other,
-            };
-            if let Some(ty) = base_expr.inferred_type(model) {
-                if let Some((file, rng)) = class_literal_seed(model.db(), ty) {
-                    bases.push((file, range_key(rng)));
-                }
+            if let Some(spec) = classify_base(db, file, parsed, raw_base, 0) {
+                bases.push(spec);
             }
         }
         if !bases.is_empty() {

--- a/runtime/src/helpers.rs
+++ b/runtime/src/helpers.rs
@@ -5,11 +5,11 @@
 
 use pyo3::prelude::*;
 use ruff_db::files::{File, FilePath};
-use ruff_db::parsed::ParsedModuleRef;
+use ruff_db::parsed::{parsed_module, ParsedModuleRef};
 use ruff_db::system::SystemPath;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::visitor::{walk_expr, Visitor};
-use ruff_python_ast::{Expr, Stmt, StmtClassDef};
+use ruff_python_ast::{Expr, ExprName, Stmt, StmtClassDef};
 use ruff_source_file::LineIndex;
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -19,12 +19,12 @@ use ty_module_resolver::{
 };
 use ty_project::metadata::value::RelativePathBuf;
 use ty_project::{Db as ProjectDb, ProjectDatabase};
-use ty_python_semantic::types::list_members::all_members;
-use ty_python_semantic::types::Type;
-use ty_python_semantic::SemanticModel;
+use ty_python_core::definition::{Definition, DefinitionKind};
+use ty_python_core::{global_scope, place_table, use_def_map};
 
+use crate::file_payload::ClassBaseSpec;
 use crate::graph::{EdgeFlags, NodeFlags};
-use crate::ingest::collapse_attribute_chain;
+use crate::ingest::{collapse_attribute_chain, from_module_string};
 use crate::project::BuildOutputs;
 
 /// Sentinel value stored in a file's local imports map (the value half
@@ -102,8 +102,8 @@ pub(crate) fn iter_top_level_classes(
 
 /// Resolve a dotted class fqn to ``(File, name_range)``. Handles both
 /// project classes (looked up via ``decl_by_fqname`` + the inverted
-/// ``class_by_selection``) and external classes (resolved through ty's
-/// type system by [`external_class_seed_via_ty`]).
+/// ``class_by_selection``) and external classes (resolved through
+/// [`resolve_member_def`]).
 pub(crate) fn locate_class_seed(
     db: &ProjectDatabase,
     outputs: &BuildOutputs,
@@ -122,53 +122,250 @@ pub(crate) fn locate_class_seed(
             }
         }
     }
-    // External class: resolve through ty's type system. The store side
-    // (`build_class_bases`) resolves every observed base the same way —
-    // both land on the canonical `ClassLiteral`'s `focus_range` — so
-    // sibling spellings (`unittest.TestCase` vs `unittest.case.TestCase`)
-    // and renamed re-exports collapse to one `external_base_children`
-    // key by construction, not a query-time string scan.
+    // External class: split the fqn into `(module, member)` and resolve
+    // through the same `resolve_member_def` the store/assemble side uses,
+    // so a query for `unittest.TestCase` lands on the identical
+    // `(File, name_range)` key the assemble pass recorded in
+    // `external_base_children` — sibling spellings and re-exports collapse
+    // by construction, not via a query-time string scan.
     let anchor = *outputs.project_files.first()?;
-    external_class_seed_via_ty(db, anchor, fqn)
+    let (seed_module, seed_name) = fqn.rsplit_once('.')?;
+    resolve_member_def(db, seed_module, seed_name, anchor, 0)
 }
 
-/// Resolve a dotted *external* class fqn to ``(File, name_range)`` via
-/// ty: resolve the owning module to a module-literal type, find the
-/// member bound to the final segment, and take its ``ClassLiteral``'s
-/// definition. Because the member's type is the canonical class object,
-/// re-exports (`unittest` re-exporting `unittest.case.TestCase`) and
-/// renamed aliases resolve to the same class as their original
-/// spelling — the normalization that makes co-reference structural.
-fn external_class_seed_via_ty(
-    db: &ProjectDatabase,
-    anchor: File,
-    fqn: &str,
-) -> Option<(File, TextRange)> {
-    let (module_str, class_name) = fqn.rsplit_once('.')?;
-    let model = SemanticModel::new(db, anchor);
-    let module_ty = model.resolve_module_type(Some(module_str), 0)?;
-    let member = all_members(db, module_ty)
+/// Maximum hops [`resolve_member_def`] / [`classify_base`] follow through
+/// assignment-style re-export chains before giving up. ty's import
+/// resolution has its own cycle guard; this only bounds the
+/// assignment-following recursion (which ty does *not* perform), so a
+/// pathological `A = B; B = A` can't loop. Legitimate re-export chains are
+/// only a hop or two deep.
+const MEMBER_RESOLVE_DEPTH_CAP: u32 = 16;
+
+/// Raw, *local-scope-only* definitions bound to `name` in `file`'s global
+/// scope — bindings and declarations, no cross-file alias resolution.
+/// Mirrors ty's internal `find_symbol_in_scope` (which is private to
+/// `ide_support`), the building block for the store-side first-hop
+/// classification.
+fn local_member_defs<'db>(db: &'db dyn ProjectDb, file: File, name: &str) -> Vec<Definition<'db>> {
+    let scope = global_scope(db, file);
+    let table = place_table(db, scope);
+    let Some(symbol_id) = table.symbol_id(name) else {
+        return Vec::new();
+    };
+    let use_def = use_def_map(db, scope);
+    let mut defs = Vec::new();
+    for binding in use_def.reachable_symbol_bindings(symbol_id) {
+        if let Some(def) = binding.binding.definition() {
+            defs.push(def);
+        }
+    }
+    for declaration in use_def.reachable_symbol_declarations(symbol_id) {
+        if let Some(def) = declaration.declaration.definition() {
+            defs.push(def);
+        }
+    }
+    defs
+}
+
+/// Describe one class-base expression as a [`ClassBaseSpec`] using only
+/// `file`'s own use-def chain — the first symbolic hop, no cross-file
+/// resolution (that's [`resolve_member_def`]'s job). Subscripted bases
+/// (`Base[T]`, `Generic[T]`) are unwrapped to the bare callee. `depth`
+/// bounds same-file alias chains (`Z = Y; class C(Z)`).
+pub(crate) fn classify_base(
+    db: &dyn ProjectDb,
+    file: File,
+    parsed: &ParsedModuleRef,
+    expr: &Expr,
+    depth: u32,
+) -> Option<ClassBaseSpec> {
+    if depth > MEMBER_RESOLVE_DEPTH_CAP {
+        return None;
+    }
+    let expr = match expr {
+        Expr::Subscript(subscript) => subscript.value.as_ref(),
+        other => other,
+    };
+    match expr {
+        Expr::Name(name) => {
+            let symbol = name.id.as_str();
+            local_member_defs(db, file, symbol)
+                .into_iter()
+                .find_map(|def| classify_name_def(db, file, parsed, def, symbol, depth))
+        }
+        Expr::Attribute(_) => {
+            let (module, name) = attribute_to_module_member(db, file, parsed, expr)?;
+            Some(ClassBaseSpec::ModuleMember { module, name })
+        }
+        _ => None,
+    }
+}
+
+/// Classify one local definition of a bare-name base (`name`, the symbol
+/// being referenced) into a [`ClassBaseSpec`]: a same-file class, a
+/// `from`-import member, a `from X import *` member, or a same-file
+/// assignment alias whose RHS is followed recursively.
+fn classify_name_def<'db>(
+    db: &'db dyn ProjectDb,
+    file: File,
+    parsed: &ParsedModuleRef,
+    def: Definition<'db>,
+    name: &str,
+    depth: u32,
+) -> Option<ClassBaseSpec> {
+    match def.kind(db) {
+        DefinitionKind::Class(class) => Some(ClassBaseSpec::LocalClass(range_key(
+            class.node(parsed).name.range(),
+        ))),
+        DefinitionKind::ImportFrom(import_from) => {
+            let module = from_module_string(db, file, import_from.import(parsed));
+            if module.is_empty() {
+                return None;
+            }
+            Some(ClassBaseSpec::ModuleMember {
+                module,
+                name: import_from.alias(parsed).name.as_str().to_string(),
+            })
+        }
+        DefinitionKind::StarImport(star_import) => {
+            let module = from_module_string(db, file, star_import.import(parsed));
+            if module.is_empty() {
+                return None;
+            }
+            Some(ClassBaseSpec::ModuleMember {
+                module,
+                name: name.to_string(),
+            })
+        }
+        DefinitionKind::Assignment(assign) => {
+            classify_base(db, file, parsed, assign.value(parsed), depth + 1)
+        }
+        DefinitionKind::AnnotatedAssignment(assign) => {
+            classify_base(db, file, parsed, assign.value(parsed)?, depth + 1)
+        }
+        _ => None,
+    }
+}
+
+/// Decompose an attribute-form base (`mod.Base`, `pkg.mod.Base`,
+/// `alias.Base`) into `(absolute_module, member_name)`, resolving the
+/// chain root to a module prefix via `file`'s imports and extending it
+/// with every segment but the last.
+fn attribute_to_module_member(
+    db: &dyn ProjectDb,
+    file: File,
+    parsed: &ParsedModuleRef,
+    expr: &Expr,
+) -> Option<(String, String)> {
+    let (root, segments) = collapse_attribute_chain(expr)?;
+    let (member, middle) = segments.split_last()?;
+    let prefix = root_module_prefix(db, file, parsed, root)?;
+    let module = if middle.is_empty() {
+        prefix
+    } else {
+        format!("{prefix}.{}", middle.join("."))
+    };
+    Some((module, (*member).to_string()))
+}
+
+/// Resolve the chain-root name of an attribute-form base to the absolute
+/// module it refers to: an `import a.b[ as r]` binding (→ `a.b`), or a
+/// `from pkg import mod` binding (→ `pkg.mod`). Returns `None` for
+/// anything that isn't an import of a module.
+fn root_module_prefix(
+    db: &dyn ProjectDb,
+    file: File,
+    parsed: &ParsedModuleRef,
+    root: &ExprName,
+) -> Option<String> {
+    local_member_defs(db, file, root.id.as_str())
         .into_iter()
-        .find(|m| m.name.as_str() == class_name)?;
-    class_literal_seed(db, member.ty)
+        .find_map(|def| match def.kind(db) {
+            DefinitionKind::Import(import) => {
+                let alias = import.alias(parsed);
+                Some(if alias.asname.is_some() {
+                    alias.name.as_str().to_string()
+                } else {
+                    root.id.as_str().to_string()
+                })
+            }
+            DefinitionKind::ImportFrom(import_from) => {
+                let from_module = from_module_string(db, file, import_from.import(parsed));
+                if from_module.is_empty() {
+                    return None;
+                }
+                Some(format!(
+                    "{from_module}.{}",
+                    import_from.alias(parsed).name.as_str()
+                ))
+            }
+            _ => None,
+        })
 }
 
-/// Resolve a ``Type`` to the ``(File, name_range)`` of the class it
-/// names, when it names a statically-known class — returns ``None`` for
-/// any non-class type (`Generic`, a function, a module, an instance, a
-/// dynamic base ty can't pin down). The range is the class's *name*
-/// (`TypeDefinition::focus_range`), which is exactly the key
-/// `class_by_selection` is built on. Both the store side (resolving a
-/// base *expression*) and the query side (resolving a base *fqn*) funnel
-/// through this helper, so the same class produces the same key from
-/// either entry point.
-pub(crate) fn class_literal_seed<'db>(
-    db: &'db dyn ty_python_semantic::Db,
-    ty: Type<'db>,
+/// Resolve a [`ClassBaseSpec`] to the canonical `(File, name_range)` of
+/// the definition it names. `LocalClass` lands on `local_file` (the file
+/// the spec was produced/followed in); `ModuleMember` resolves through
+/// [`resolve_member_def`] from `anchor`. Both the assemble pass and the
+/// assignment-following path funnel through here.
+pub(crate) fn resolve_base_spec(
+    db: &dyn ProjectDb,
+    spec: &ClassBaseSpec,
+    local_file: File,
+    anchor: File,
+    depth: u32,
 ) -> Option<(File, TextRange)> {
-    ty.as_class_literal()?;
-    let frange = ty.definition(db)?.focus_range(db)?;
-    Some((frange.file(), frange.range()))
+    match spec {
+        ClassBaseSpec::LocalClass((start, end)) => {
+            Some((local_file, TextRange::new((*start).into(), (*end).into())))
+        }
+        ClassBaseSpec::ModuleMember { module, name } => {
+            resolve_member_def(db, module, name, anchor, depth)
+        }
+    }
+}
+
+/// Resolve an absolute `module` string + member `name` to the canonical
+/// `(File, name_range)` of the definition it ultimately names, as seen
+/// from `anchor`. Re-exports are followed by [`resolve_member_in_file`],
+/// which reuses the store-side decomposition. `depth` bounds the chase.
+pub(crate) fn resolve_member_def(
+    db: &dyn ProjectDb,
+    module: &str,
+    name: &str,
+    anchor: File,
+    depth: u32,
+) -> Option<(File, TextRange)> {
+    if depth > MEMBER_RESOLVE_DEPTH_CAP {
+        return None;
+    }
+    let module_name = ModuleName::new(module)?;
+    let module_file = resolve_module(db, anchor, &module_name)?.file(db)?;
+    resolve_member_in_file(db, module_file, name, anchor, depth)
+}
+
+/// Resolve `name` in `file`'s global scope to a canonical
+/// `(File, name_range)`, reusing [`classify_name_def`] — the same
+/// decomposition the store side runs on observed bases. A class binding
+/// lands directly; an import re-export (`from x import name`,
+/// `from x import *`) recurses cross-file through [`resolve_member_def`];
+/// an assignment binding (`Alias = Real`) follows its RHS. `depth` bounds
+/// the recursion (cross-file import hops and assignment chains both
+/// increment it), standing in for ty's visited-set cycle guard.
+fn resolve_member_in_file(
+    db: &dyn ProjectDb,
+    file: File,
+    name: &str,
+    anchor: File,
+    depth: u32,
+) -> Option<(File, TextRange)> {
+    let parsed = parsed_module(db, file).load(db);
+    local_member_defs(db, file, name)
+        .into_iter()
+        .find_map(|def| {
+            let spec = classify_name_def(db, file, &parsed, def, name, depth)?;
+            resolve_base_spec(db, &spec, file, anchor, depth + 1)
+        })
 }
 
 /// Locate the top-level ``if __name__ == "__main__":`` block in a

--- a/runtime/src/helpers.rs
+++ b/runtime/src/helpers.rs
@@ -5,7 +5,7 @@
 
 use pyo3::prelude::*;
 use ruff_db::files::{File, FilePath};
-use ruff_db::parsed::{parsed_module, ParsedModuleRef};
+use ruff_db::parsed::ParsedModuleRef;
 use ruff_db::system::SystemPath;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::visitor::{walk_expr, Visitor};
@@ -19,6 +19,9 @@ use ty_module_resolver::{
 };
 use ty_project::metadata::value::RelativePathBuf;
 use ty_project::{Db as ProjectDb, ProjectDatabase};
+use ty_python_semantic::types::list_members::all_members;
+use ty_python_semantic::types::Type;
+use ty_python_semantic::SemanticModel;
 
 use crate::graph::{EdgeFlags, NodeFlags};
 use crate::ingest::collapse_attribute_chain;
@@ -97,19 +100,10 @@ pub(crate) fn iter_top_level_classes(
     })
 }
 
-/// Find a top-level ``StmtClassDef`` by its bound name.
-pub(crate) fn class_def_named<'a>(
-    parsed: &'a ParsedModuleRef,
-    name: &str,
-) -> Option<&'a StmtClassDef> {
-    iter_top_level_classes(parsed).find(|cls| cls.name.as_str() == name)
-}
-
-/// Resolve a dotted class fqn to ``(File, name_range)`` so the caller
-/// can fetch the corresponding ``Type`` via ``class_def_at`` +
-/// ``inferred_type``. Handles both project classes (looked up via
-/// ``decl_by_fqname``) and external classes (ty's ``resolve_module``
-/// + AST scan by name in the resolved module).
+/// Resolve a dotted class fqn to ``(File, name_range)``. Handles both
+/// project classes (looked up via ``decl_by_fqname`` + the inverted
+/// ``class_by_selection``) and external classes (resolved through ty's
+/// type system by [`external_class_seed_via_ty`]).
 pub(crate) fn locate_class_seed(
     db: &ProjectDatabase,
     outputs: &BuildOutputs,
@@ -128,93 +122,53 @@ pub(crate) fn locate_class_seed(
             }
         }
     }
-    // External class: resolve the module via ty, then follow any
-    // re-export chains until we find the actual class def. Shared with the
-    // subclass-index store side (`build_class_hierarchy_indices`) so both
-    // the observed bases and the query input normalize through one
-    // resolver, collapsing sibling spellings by construction.
+    // External class: resolve through ty's type system. The store side
+    // (`build_class_bases`) resolves every observed base the same way —
+    // both land on the canonical `ClassLiteral`'s `focus_range` — so
+    // sibling spellings (`unittest.TestCase` vs `unittest.case.TestCase`)
+    // and renamed re-exports collapse to one `external_base_children`
+    // key by construction, not a query-time string scan.
     let anchor = *outputs.project_files.first()?;
-    locate_external_class_seed(db, anchor, fqn)
+    external_class_seed_via_ty(db, anchor, fqn)
 }
 
-/// Resolve a dotted *external* class fqn to ``(File, name_range)`` by
-/// resolving its module via ty and following re-export / alias chains
-/// (see [`follow_class_through_module`]). Sibling spellings of the same
-/// class (``unittest.TestCase`` vs ``unittest.case.TestCase``) resolve to
-/// the *same* ``(File, name_range)``, so this is the normalization both
-/// the subclass-index store side and the query side funnel through —
-/// co-reference becomes structural (one key), not a query-time string
-/// scan.
-pub(crate) fn locate_external_class_seed(
+/// Resolve a dotted *external* class fqn to ``(File, name_range)`` via
+/// ty: resolve the owning module to a module-literal type, find the
+/// member bound to the final segment, and take its ``ClassLiteral``'s
+/// definition. Because the member's type is the canonical class object,
+/// re-exports (`unittest` re-exporting `unittest.case.TestCase`) and
+/// renamed aliases resolve to the same class as their original
+/// spelling — the normalization that makes co-reference structural.
+fn external_class_seed_via_ty(
     db: &ProjectDatabase,
     anchor: File,
     fqn: &str,
 ) -> Option<(File, TextRange)> {
     let (module_str, class_name) = fqn.rsplit_once('.')?;
-    let module_name = ModuleName::new(module_str)?;
-    let module = resolve_module(db, anchor, &module_name)?;
-    let module_file = module.file(db)?;
-    let mut visited: FxHashSet<File> = FxHashSet::default();
-    follow_class_through_module(db, module_file, class_name, &mut visited)
+    let model = SemanticModel::new(db, anchor);
+    let module_ty = model.resolve_module_type(Some(module_str), 0)?;
+    let member = all_members(db, module_ty)
+        .into_iter()
+        .find(|m| m.name.as_str() == class_name)?;
+    class_literal_seed(db, member.ty)
 }
 
-/// Walk through a module looking for ``class_name``. Handles three
-/// re-export shapes: a direct ``class class_name: ...`` definition,
-/// an explicit ``from .other import class_name [as class_name]``
-/// re-export, and ``from .other import *`` (which exposes everything
-/// the source module defines at the top level). Bounded by a
-/// visited-file set so cycles can't loop forever.
-pub(crate) fn follow_class_through_module(
-    db: &ProjectDatabase,
-    start_file: File,
-    class_name: &str,
-    visited: &mut FxHashSet<File>,
+/// Resolve a ``Type`` to the ``(File, name_range)`` of the class it
+/// names, when it names a statically-known class — returns ``None`` for
+/// any non-class type (`Generic`, a function, a module, an instance, a
+/// dynamic base ty can't pin down). The range is the class's *name*
+/// (`TypeDefinition::focus_range`), which is exactly the key
+/// `class_by_selection` is built on. Both the store side (resolving a
+/// base *expression*) and the query side (resolving a base *fqn*) funnel
+/// through this helper, so the same class produces the same key from
+/// either entry point.
+pub(crate) fn class_literal_seed<'db>(
+    db: &'db dyn ty_python_semantic::Db,
+    ty: Type<'db>,
 ) -> Option<(File, TextRange)> {
-    if !visited.insert(start_file) {
-        return None;
-    }
-    let parsed = parsed_module(db, start_file).load(db);
-    if let Some(cls) = class_def_named(&parsed, class_name) {
-        return Some((start_file, cls.name.range()));
-    }
-    for stmt in &parsed.syntax().body {
-        let Stmt::ImportFrom(im) = stmt else {
-            continue;
-        };
-        let Ok(module_name) = ModuleName::from_import_statement(db, start_file, im) else {
-            continue;
-        };
-        let Some(resolved) = resolve_module(db, start_file, &module_name) else {
-            continue;
-        };
-        let Some(source_file) = resolved.file(db) else {
-            continue;
-        };
-        for alias in &im.names {
-            let imported_name = alias.name.as_str();
-            if imported_name == "*" {
-                if let Some(seed) =
-                    follow_class_through_module(db, source_file, class_name, visited)
-                {
-                    return Some(seed);
-                }
-                continue;
-            }
-            let local_name = alias
-                .asname
-                .as_ref()
-                .map(|n| n.as_str())
-                .unwrap_or(imported_name);
-            if local_name != class_name {
-                continue;
-            }
-            if let Some(seed) = follow_class_through_module(db, source_file, imported_name, visited)
-            {
-                return Some(seed);
-            }
-        }
-    }
-    None
+    ty.as_class_literal()?;
+    let frange = ty.definition(db)?.focus_range(db)?;
+    Some((frange.file(), frange.range()))
 }
 
 /// Locate the top-level ``if __name__ == "__main__":`` block in a
@@ -260,48 +214,6 @@ pub(crate) fn is_name(expr: &Expr, value: &str) -> bool {
 
 pub(crate) fn is_string_literal(expr: &Expr, value: &str) -> bool {
     matches!(expr, Expr::StringLiteral(s) if s.value.to_str() == value)
-}
-
-/// Resolve a class-base expression to an upstream fqname using the
-/// file's full imports map (as produced by
-/// :func:`collect_all_imports_local`).
-///
-/// Supported expression shapes:
-/// * ``Name(X)`` — looked up in ``file_imports``; returns the upstream
-///   fqname when ``X`` is an imported name.
-/// * ``Attribute(Name(M).N)`` — when ``M`` is bound to a module via
-///   ``import <module> [as M]``, returns ``<module>.N``.
-/// * Deeper attribute chain ``a.b.c.N`` rooted at an imported name
-///   ``a`` — appends segments to reach ``<a-upstream>.b.c.N``.
-///
-/// Returns ``None`` when the expression doesn't have a single
-/// recognized identifier shape, the root isn't imported, or the chain
-/// can't be resolved. Generics (``Base[T]``) are not supported (the
-/// caller is matching against `class C(Base[T]): ...` only to the
-/// extent ``ruff_python_ast`` exposes ``Base[T]`` as an
-/// ``ExprSubscript`` — those drop here, which is the correct
-/// behavior).
-pub(crate) fn resolve_base_fqn(
-    expr: &Expr,
-    file_imports: &FxHashMap<String, String>,
-) -> Option<String> {
-    match expr {
-        Expr::Name(name) => file_imports.get(name.id.as_str()).cloned(),
-        Expr::Attribute(_) => {
-            let (root, segs) = collapse_attribute_chain(expr)?;
-            let root_target = file_imports.get(root.id.as_str())?;
-            let mut out = String::with_capacity(
-                root_target.len() + segs.iter().map(|s| s.len() + 1).sum::<usize>(),
-            );
-            out.push_str(root_target);
-            for seg in &segs {
-                out.push('.');
-                out.push_str(seg);
-            }
-            Some(out)
-        }
-        _ => None,
-    }
 }
 
 /// Walk every `Stmt::Import` / `Stmt::ImportFrom` in `parsed` and

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -35,8 +35,8 @@ use crate::file_payload::{file_to_edges, file_to_nodes, FileEdges, NodeKind, Nod
 use crate::file_ref_edges::{file_to_ref_edges, FileRefEdges};
 use crate::graph::{intern_kind, DeclIndex, NativeGraph, SymbolNode};
 use crate::helpers::{
-    file_path_string, is_dunder_name, locate_class_seed, rel_path, CallArgs, MODULE_ALIAS_MARKER,
-    NODE_FLAG_ENTRYPOINT,
+    file_path_string, is_dunder_name, locate_class_seed, range_key, rel_path, resolve_base_spec,
+    CallArgs, MODULE_ALIAS_MARKER, NODE_FLAG_ENTRYPOINT,
 };
 use crate::ingest::emit_visitor_warning;
 use crate::progress::{
@@ -162,23 +162,22 @@ pub(crate) struct BuildOutputs {
     /// into the project from the cached ``external_base_children`` index;
     /// once a project class is found, transitive walks use this map.
     pub(crate) children_by_node: FxHashMap<usize, Vec<usize>>,
-    /// Resolved *external* base class (a base whose `ClassLiteral` lives
+    /// Resolved *external* base class (a base whose definition lives
     /// outside the project, e.g. ``unittest.TestCase`` in typeshed) ->
     /// direct subclass class graph idxs. Derived in the same `class_bases`
     /// fan-in as `children_by_node`, but keyed by the external class's
     /// resolved decl ``(File, name_range)`` rather than a project node idx.
     ///
-    /// The key is the canonical `ClassLiteral`'s `focus_range`, produced by
-    /// [`crate::helpers::class_literal_seed`] — the same resolver the
-    /// external-seed branch of `find_subclasses_indices_core` runs on its
-    /// query input (via `locate_class_seed`). Funneling both the observed
-    /// bases and the query through ty's type system collapses sibling
-    /// spellings (`unittest.TestCase` vs `unittest.case.TestCase`) and
-    /// renamed re-exports to a single key by construction, so the query is
-    /// an O(1) lookup with no scan. A base reached through a project
-    /// re-export or module-level alias resolves to the same `ClassLiteral`
-    /// directly — ty follows the alias — so no separate chase step is
-    /// needed.
+    /// The key is the resolved decl's name-token range, produced by
+    /// [`crate::helpers::resolve_member_def`] (ty's module resolver plus the
+    /// same use-def decomposition the store side runs, which follows re-export
+    /// and assignment-alias chains) — the same resolver the external-seed
+    /// branch of `find_subclasses_indices_core` runs on its query input (via
+    /// `locate_class_seed`). Funneling both the observed bases (via
+    /// [`crate::helpers::resolve_base_spec`]) and the query through
+    /// `resolve_member_def` collapses sibling spellings (`unittest.TestCase`
+    /// vs `unittest.case.TestCase`) and renamed re-exports to a single key
+    /// by construction, so the query is an O(1) lookup with no scan.
     pub(crate) external_base_children: FxHashMap<(File, (u32, u32)), Vec<usize>>,
 }
 
@@ -1046,15 +1045,22 @@ pub(crate) struct ClassHierarchyIndices {
 ///   graph idxs. Drives intra-project BFS for both project and
 ///   external seeds (once the first hop lands a project class).
 /// * `external_base_children` — external base class decl `(File,
-///   name_range)` (a base whose `ClassLiteral` lives outside the project,
+///   name_range)` (a base whose definition lives outside the project,
 ///   e.g. `unittest.TestCase` in typeshed) → direct subclass graph idxs.
 ///   Lets the external-seed query recover the first project hop from
 ///   cached payloads instead of re-parsing every file.
 ///
-/// Each base in a payload is already the `(File, name_range)` key of the
-/// canonical `ClassLiteral` ty resolved it to (store side, in
-/// `build_class_bases`). Dispatch is therefore a single hashmap probe per
-/// base — no fqn chasing, no external-boundary re-resolution:
+/// Each base in a payload is a lightweight
+/// [`ClassBaseSpec`](crate::file_payload::ClassBaseSpec) — a
+/// `LocalClass(range)` for a same-file class or a `ModuleMember{module,
+/// name}` symbolic reference — deliberately *not* resolved at store time
+/// so the per-file payload stays salsa-invalidation-local (see
+/// `build_class_bases`). Assembly resolves each spec here, through
+/// [`crate::helpers::resolve_base_spec`], to the `(File, name_range)` key
+/// of the class's name token; `resolve_base_spec` chases `ModuleMember`
+/// rows via [`crate::helpers::resolve_member_def`] (ty's module resolver +
+/// re-export / assignment-alias following). Dispatch is then a single
+/// hashmap probe per resolved base:
 ///
 /// * the key hits `class_by_selection` → it's a project class; record a
 ///   `children_by_node` edge to that parent (every value in the map is a
@@ -1062,11 +1068,11 @@ pub(crate) struct ClassHierarchyIndices {
 /// * the key misses → it's an external base; record the child under
 ///   `external_base_children` keyed by that same `(File, name_range)`.
 ///
-/// Because store and query both derive the key from the class's
-/// `ClassLiteral`, every spelling of one base (direct, aliased,
-/// re-exported, sibling-module) collapses to the same key by
-/// construction — the query side ([`crate::helpers::locate_class_seed`])
-/// lands on the identical key.
+/// Because assembly and the query side both funnel `ModuleMember` rows
+/// through the same `resolve_member_def`, every spelling of one base
+/// (direct, aliased, re-exported, sibling-module) collapses to the same
+/// `(File, name_range)` key by construction — the query side
+/// ([`crate::helpers::locate_class_seed`]) lands on the identical key.
 fn build_class_hierarchy_indices(
     db: &ProjectDatabase,
     project_files: &[File],
@@ -1082,7 +1088,12 @@ fn build_class_hierarchy_indices(
             let Some(&child_idx) = class_by_selection.get(&(file, *cls_rk)) else {
                 continue;
             };
-            for &(base_file, base_rk) in bases {
+            for base in bases {
+                let Some((base_file, base_range)) = resolve_base_spec(db, base, file, file, 0)
+                else {
+                    continue;
+                };
+                let base_rk = range_key(base_range);
                 match class_by_selection.get(&(base_file, base_rk)) {
                     Some(&parent_idx) => by_node.entry(parent_idx).or_default().push(child_idx),
                     None => external_base_children
@@ -1720,9 +1731,10 @@ impl ProjectContext {
 
         // The plugin pass can still reload individual files on demand:
         // subclass resolution's `locate_class_seed` resolves an external base
-        // through ty (`SemanticModel` + `inferred_type`), which loads the
-        // target module's `parsed_module` to infer its members' types,
-        // repopulating those files' salsa `parsed_module` slots. Clear them
+        // through ty (`resolve_member_def` → the module resolver + use-def
+        // chain), which loads the target module's `parsed_module` to look up
+        // the member's binding, repopulating those files' salsa
+        // `parsed_module` slots. Clear them
         // again so the post-build resident set stays at the lean
         // post-populate level instead of creeping back up — the same memory
         // win `build_project_graph`'s populate phase secures.
@@ -3334,8 +3346,8 @@ fn find_classes_defining_method_indices_core(
 /// project seed walks the cached ``children_by_node`` index directly; an
 /// external seed reads its direct project subclasses from the cached
 /// ``external_base_children`` index (no re-parse — re-export / alias
-/// chains resolve to the same `ClassLiteral` through ty, so they're
-/// already folded into that index). See
+/// chains resolve to the same decl through `resolve_member_def`, so
+/// they're already folded into that index). See
 /// ``FrozenView::find_subclasses_indices`` for the fast/slow-path
 /// rationale.
 fn find_subclasses_indices_core(
@@ -3364,17 +3376,18 @@ fn find_subclasses_indices_core(
     // project subclasses are cached in `external_base_children` (folded
     // from the per-file `class_bases` payloads — no re-parse). A base bound
     // through one or more project re-exports or module-level aliases
-    // resolves to the same external `ClassLiteral` directly (ty follows the
-    // alias), so those subclasses land in `external_base_children` too.
+    // resolves to the same external decl through `resolve_member_def`
+    // (which follows re-export and alias chains), so those subclasses land
+    // in `external_base_children` too.
     //
     // Sibling fold by construction: the same external class can be spelled
     // several ways (`unittest.TestCase` vs `unittest.case.TestCase`), but
-    // the store side ran every observed base through ty's type system,
-    // keying by the canonical `ClassLiteral`'s `(file, range)`.
-    // `locate_class_seed` resolved this query's input through the same
-    // mechanism, so `(seed_file, rk)` is that same key: sibling spellings
-    // and renamed re-exports already collapsed into one entry. A single
-    // O(1) lookup, no scan.
+    // assemble ran every observed base through `resolve_member_def`, keying
+    // by the resolved decl's `(file, name-range)`. `locate_class_seed`
+    // resolved this query's input through the same resolver, so
+    // `(seed_file, rk)` is that same key: sibling spellings and renamed
+    // re-exports already collapsed into one entry. A single O(1) lookup,
+    // no scan.
     let direct = outputs
         .external_base_children
         .get(&(seed_file, rk))

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -35,8 +35,8 @@ use crate::file_payload::{file_to_edges, file_to_nodes, FileEdges, NodeKind, Nod
 use crate::file_ref_edges::{file_to_ref_edges, FileRefEdges};
 use crate::graph::{intern_kind, DeclIndex, NativeGraph, SymbolNode};
 use crate::helpers::{
-    file_path_string, is_dunder_name, locate_class_seed, locate_external_class_seed, rel_path,
-    CallArgs, MODULE_ALIAS_MARKER, NODE_FLAG_ENTRYPOINT,
+    file_path_string, is_dunder_name, locate_class_seed, rel_path, CallArgs, MODULE_ALIAS_MARKER,
+    NODE_FLAG_ENTRYPOINT,
 };
 use crate::ingest::emit_visitor_warning;
 use crate::progress::{
@@ -112,8 +112,9 @@ pub(crate) struct BuildOutputs {
     pub(crate) class_by_selection: FxHashMap<(File, (u32, u32)), usize>,
     /// Inverse of `class_by_selection`: `class node idx -> (file, name
     /// TextRange)`. Lets `locate_class_seed` recover a project class's
-    /// name range for ty `Type` lookups (`class_def_at` + `inferred_type`)
-    /// without re-parsing the file to re-find the def by line.
+    /// name-range seed directly — the same `(file, range)` key
+    /// `class_by_selection` is built on — without re-parsing the file to
+    /// re-find the def by line.
     pub(crate) class_selection_by_idx: FxHashMap<usize, (File, TextRange)>,
     /// `file -> module node idx`. Lets `find_main_blocks` reach the
     /// file's module node without a linear scan over `builder.nodes`.
@@ -161,22 +162,23 @@ pub(crate) struct BuildOutputs {
     /// into the project from the cached ``external_base_children`` index;
     /// once a project class is found, transitive walks use this map.
     pub(crate) children_by_node: FxHashMap<usize, Vec<usize>>,
-    /// Resolved *external* base class (a base not present in
-    /// `decl_by_fqname`, e.g. ``unittest.TestCase``) -> direct subclass
-    /// class graph idxs. Derived in the same `class_bases` fan-in as
-    /// `children_by_node`, but keyed by the external class's resolved decl
-    /// ``(File, name_range)`` rather than a project node idx.
+    /// Resolved *external* base class (a base whose `ClassLiteral` lives
+    /// outside the project, e.g. ``unittest.TestCase`` in typeshed) ->
+    /// direct subclass class graph idxs. Derived in the same `class_bases`
+    /// fan-in as `children_by_node`, but keyed by the external class's
+    /// resolved decl ``(File, name_range)`` rather than a project node idx.
     ///
-    /// The key is produced by `locate_external_class_seed` — the same
-    /// resolver the external-seed branch of `find_subclasses_indices_core`
-    /// runs on its query input. Funneling both the observed bases and the
-    /// query through one normalization collapses sibling spellings
-    /// (`unittest.TestCase` vs `unittest.case.TestCase`) and renamed
-    /// re-exports to a single key by construction, so the query is an O(1)
-    /// lookup with no scan. Re-export / alias chains through project
-    /// modules are folded in statically by `chase_base_fqn` first, so a
-    /// subclass reached only through a re-export is keyed here under the
-    /// terminal external class's decl.
+    /// The key is the canonical `ClassLiteral`'s `focus_range`, produced by
+    /// [`crate::helpers::class_literal_seed`] — the same resolver the
+    /// external-seed branch of `find_subclasses_indices_core` runs on its
+    /// query input (via `locate_class_seed`). Funneling both the observed
+    /// bases and the query through ty's type system collapses sibling
+    /// spellings (`unittest.TestCase` vs `unittest.case.TestCase`) and
+    /// renamed re-exports to a single key by construction, so the query is
+    /// an O(1) lookup with no scan. A base reached through a project
+    /// re-export or module-level alias resolves to the same `ClassLiteral`
+    /// directly — ty follows the alias — so no separate chase step is
+    /// needed.
     pub(crate) external_base_children: FxHashMap<(File, (u32, u32)), Vec<usize>>,
 }
 
@@ -386,7 +388,7 @@ pub(crate) fn build_project_graph(
                             // through assembly and the project-wide plugin
                             // pass — that's the memory win. Assembly, fqname,
                             // and the class hierarchy read only the cached
-                            // payloads (`name_bindings`, `external_base_children`,
+                            // payloads (`class_bases`, `external_base_children`,
                             // `children_by_node`), never the AST, so the
                             // all-ASTs-resident peak never forms. Subclass
                             // resolution can still pull an individual file's AST
@@ -443,7 +445,6 @@ pub(crate) fn build_project_graph(
     let module_nodes_by_file = assembled.module_nodes_by_file;
     let class_by_selection = assembled.class_by_selection;
     let decl_by_name_range = assembled.decl_by_name_range;
-    let ref_to_global = assembled.ref_to_global;
 
     counters.start_phase(PHASE_FQNAME, Some(builder.nodes.len()));
     let t4 = std::time::Instant::now();
@@ -460,14 +461,7 @@ pub(crate) fn build_project_graph(
     let ClassHierarchyIndices {
         children_by_node,
         external_base_children,
-    } = build_class_hierarchy_indices(
-        db,
-        &project_files,
-        &class_by_selection,
-        &ref_to_global,
-        &decl_by_fqname,
-        &builder.nodes,
-    );
+    } = build_class_hierarchy_indices(db, &project_files, &class_by_selection);
     let t_hierarchy_elapsed = t_hierarchy.elapsed();
     if timing {
         eprintln!(
@@ -543,15 +537,12 @@ fn current_rss_mb() -> usize {
 /// pieces of `BuildOutputs` that the assembly pass computes from the
 /// salsa-tracked per-file payloads; the driver adds `project_files`,
 /// `path_to_file`, and the fqname indices.
-struct AssembledGraph<'db> {
+struct AssembledGraph {
     builder: GraphBuilder,
     global_index: DeclIndex,
     module_nodes_by_file: FxHashMap<File, usize>,
     class_by_selection: FxHashMap<(File, (u32, u32)), usize>,
     decl_by_name_range: FxHashMap<(File, (u32, u32)), usize>,
-    /// PROTOTYPE: kept around so the class-hierarchy builder can map
-    /// `NodeRef -> global idx`.
-    ref_to_global: FxHashMap<NodeRef<'db>, usize>,
 }
 
 /// Serial pass that converts the salsa-tracked per-file payloads
@@ -589,7 +580,7 @@ fn assemble_graph<'db>(
     peer_pyi_to_py: &FxHashMap<File, File>,
     per_file_plugin_ids: &[crate::native_plugins::PerFilePluginId],
     counters: &Arc<ProgressCounters>,
-) -> PyResult<AssembledGraph<'db>> {
+) -> PyResult<AssembledGraph> {
     // Pre-count total nodes across project_files. file_to_nodes is
     // salsa-memoized from the parallel populate phase, so this is a
     // ~ns probe per file. Use the exact count to size the hashmaps
@@ -902,7 +893,6 @@ fn assemble_graph<'db>(
         module_nodes_by_file,
         class_by_selection,
         decl_by_name_range,
-        ref_to_global,
     })
 }
 
@@ -1056,79 +1046,35 @@ pub(crate) struct ClassHierarchyIndices {
 ///   graph idxs. Drives intra-project BFS for both project and
 ///   external seeds (once the first hop lands a project class).
 /// * `external_base_children` — external base class decl `(File,
-///   name_range)` (a base not present in `decl_by_fqname`, e.g.
-///   `unittest.TestCase`, resolved through `locate_external_class_seed`)
-///   → direct subclass graph idxs. Lets the external-seed query recover
-///   the first project hop from cached payloads instead of re-parsing
-///   every file, and — because store and query funnel through the same
-///   resolver — collapses sibling spellings to one key.
+///   name_range)` (a base whose `ClassLiteral` lives outside the project,
+///   e.g. `unittest.TestCase` in typeshed) → direct subclass graph idxs.
+///   Lets the external-seed query recover the first project hop from
+///   cached payloads instead of re-parsing every file.
 ///
-/// A base that hops across files (re-export, star-import, module-level
-/// alias) is chased to its terminal class on demand: each hop loads the
-/// next module's (salsa-cached) `name_bindings`, so the cross-file chain
-/// is never materialized in bulk. A `{module_fqn} -> File` map (one entry
-/// per file) lets the chaser find each hop's module. See
-/// [`chase_base_fqn`].
+/// Each base in a payload is already the `(File, name_range)` key of the
+/// canonical `ClassLiteral` ty resolved it to (store side, in
+/// `build_class_bases`). Dispatch is therefore a single hashmap probe per
+/// base — no fqn chasing, no external-boundary re-resolution:
 ///
-/// Resolution rules per `ResolvedBase` variant:
+/// * the key hits `class_by_selection` → it's a project class; record a
+///   `children_by_node` edge to that parent (every value in the map is a
+///   class node, so no kind check is needed).
+/// * the key misses → it's an external base; record the child under
+///   `external_base_children` keyed by that same `(File, name_range)`.
 ///
-/// * `LocalSameFileClass(local_idx)` — translate via the file's
-///   `refs[local_idx]` + `ref_to_global` to a parent class graph idx
-///   and emit a `children_by_node` entry.
-/// * `ImportedFqn(fqn)` / `Attribute { module_fqn, attr_name }` — chase
-///   the (composed) fqn through the alias chain to its terminal, then:
-///   a project class hit emits `children_by_node` entries; a terminal
-///   absent from `decl_by_fqname` (an external base, possibly reached
-///   through a project re-export) is resolved one more hop — through the
-///   external boundary via `locate_external_class_seed` — and emits an
-///   `external_base_children` entry keyed by the resolved decl `(File,
-///   name_range)`. See [`register_chased_base`].
-/// * `Unresolvable` — dropped.
-fn build_class_hierarchy_indices<'db>(
-    db: &'db ProjectDatabase,
+/// Because store and query both derive the key from the class's
+/// `ClassLiteral`, every spelling of one base (direct, aliased,
+/// re-exported, sibling-module) collapses to the same key by
+/// construction — the query side ([`crate::helpers::locate_class_seed`])
+/// lands on the identical key.
+fn build_class_hierarchy_indices(
+    db: &ProjectDatabase,
     project_files: &[File],
     class_by_selection: &FxHashMap<(File, (u32, u32)), usize>,
-    ref_to_global: &FxHashMap<NodeRef<'db>, usize>,
-    decl_by_fqname: &FxHashMap<String, Vec<usize>>,
-    nodes: &[GraphNode],
 ) -> ClassHierarchyIndices {
-    use crate::file_payload::ResolvedBase;
     let mut by_node: FxHashMap<usize, Vec<usize>> = FxHashMap::default();
     let mut external_base_children: FxHashMap<(File, (u32, u32)), Vec<usize>> =
         FxHashMap::default();
-
-    // The cross-file half of the uniform binder ladder chases a base
-    // through re-export / alias hops to its terminal class. Rather than
-    // eagerly folding *every* file's `name_bindings` into a project-wide
-    // `{module_fqn}.{name} -> next_fqn` chain — O(total project imports),
-    // nearly all of which is never chased — resolve on demand: a base is
-    // walked one hop at a time, loading the *next* module's (salsa-cached)
-    // `name_bindings` only when the chase reaches it (see
-    // [`chase_base_fqn`]). The only index that must exist up front is a
-    // `{module_fqn} -> File` map so the chaser can find the module owning
-    // the next hop; that's one entry per file, far cheaper than the dense
-    // chain. Per-starting-fqn memoization (`chase_memo`) collapses the
-    // shared suffix every subclass of one re-exported base would re-walk.
-    let mut module_to_file: FxHashMap<String, File> = FxHashMap::default();
-    for &file in project_files {
-        let payload = file_to_nodes(db, file);
-        module_to_file.insert(payload.nodes[0].fqname.clone(), file);
-    }
-    let mut chase_memo: FxHashMap<String, String> = FxHashMap::default();
-
-    // An external terminal is resolved one hop further — through the
-    // external boundary, via `locate_external_class_seed` — so it's keyed
-    // by the class's real decl `(file, range)` rather than its (possibly
-    // sibling-spelled) fqn. ty's module resolver needs an anchor file; any
-    // project file works. Results are memoized per terminal fqn so a base
-    // repeated across files resolves once.
-    let anchor = project_files.first().copied();
-    let mut ext_seed_memo: ExtSeedMemo = FxHashMap::default();
-    let mut chase_ctx = ChaseCtx {
-        db,
-        anchor,
-        ext_seed_memo: &mut ext_seed_memo,
-    };
 
     for &file in project_files {
         let payload = file_to_nodes(db, file);
@@ -1136,59 +1082,13 @@ fn build_class_hierarchy_indices<'db>(
             let Some(&child_idx) = class_by_selection.get(&(file, *cls_rk)) else {
                 continue;
             };
-            for base in bases {
-                match base {
-                    ResolvedBase::LocalSameFileClass(local_idx) => {
-                        let r = payload.refs[*local_idx as usize];
-                        if let Some(&parent_idx) = ref_to_global.get(&r) {
-                            if nodes[parent_idx].kind == "class" {
-                                by_node.entry(parent_idx).or_default().push(child_idx);
-                            }
-                        }
-                    }
-                    ResolvedBase::ImportedFqn(fqn) => {
-                        let terminal = chase_base_fqn(
-                            fqn,
-                            &module_to_file,
-                            db,
-                            decl_by_fqname,
-                            nodes,
-                            &mut chase_memo,
-                        );
-                        register_chased_base(
-                            &terminal,
-                            child_idx,
-                            &mut chase_ctx,
-                            decl_by_fqname,
-                            nodes,
-                            &mut by_node,
-                            &mut external_base_children,
-                        );
-                    }
-                    ResolvedBase::Attribute {
-                        module_fqn,
-                        attr_name,
-                    } => {
-                        let composed = format!("{module_fqn}.{attr_name}");
-                        let terminal = chase_base_fqn(
-                            &composed,
-                            &module_to_file,
-                            db,
-                            decl_by_fqname,
-                            nodes,
-                            &mut chase_memo,
-                        );
-                        register_chased_base(
-                            &terminal,
-                            child_idx,
-                            &mut chase_ctx,
-                            decl_by_fqname,
-                            nodes,
-                            &mut by_node,
-                            &mut external_base_children,
-                        );
-                    }
-                    ResolvedBase::Unresolvable => {}
+            for &(base_file, base_rk) in bases {
+                match class_by_selection.get(&(base_file, base_rk)) {
+                    Some(&parent_idx) => by_node.entry(parent_idx).or_default().push(child_idx),
+                    None => external_base_children
+                        .entry((base_file, base_rk))
+                        .or_default()
+                        .push(child_idx),
                 }
             }
         }
@@ -1205,133 +1105,6 @@ fn build_class_hierarchy_indices<'db>(
     ClassHierarchyIndices {
         children_by_node: by_node,
         external_base_children,
-    }
-}
-
-/// Follow a base-class fqn through the project-wide re-export / alias
-/// chain to its terminal fqn, resolving each hop on demand instead of
-/// from a pre-built chain. Stops at the first fqn that names a live
-/// project class — so a re-exported project base resolves to the class
-/// itself, not the intermediate import node — or at a fqn that isn't a
-/// project re-export (an external base, or an unresolvable leaf).
-///
-/// Each hop splits the current fqn at its last dot into `{module}.{name}`,
-/// finds the module's file via `module_to_file`, and reads that file's
-/// (salsa-cached) `name_bindings` for `name` — the same `{module_fqn}.{name}
-/// -> next` edge the old eager fold materialized, computed lazily. A
-/// `LocalClass`/absent binding (or a non-project module) ends the chase.
-/// `seen` guards re-export cycles; `memo` caches each starting fqn's
-/// terminal so a base shared across many subclasses resolves once.
-fn chase_base_fqn(
-    start: &str,
-    module_to_file: &FxHashMap<String, File>,
-    db: &ProjectDatabase,
-    decl_by_fqname: &FxHashMap<String, Vec<usize>>,
-    nodes: &[GraphNode],
-    memo: &mut FxHashMap<String, String>,
-) -> String {
-    use crate::file_payload::NameBinding;
-    if let Some(terminal) = memo.get(start) {
-        return terminal.clone();
-    }
-    let mut cur = start.to_string();
-    let mut seen: FxHashSet<String> = FxHashSet::default();
-    let terminal = loop {
-        // A fqn that already names a live project class is the terminal:
-        // don't chase past it through a same-name re-export shadow.
-        if decl_by_fqname
-            .get(cur.as_str())
-            .is_some_and(|idxs| idxs.iter().any(|&i| nodes[i].kind == "class"))
-        {
-            break cur;
-        }
-        // Resolve the next hop as an owned fqn, releasing every borrow of
-        // `cur` before it's reassigned below.
-        let next: Option<String> = match cur.rsplit_once('.') {
-            Some((module, name)) => match module_to_file.get(module) {
-                Some(&file) => match file_to_nodes(db, file).name_bindings.get(name) {
-                    None | Some(NameBinding::LocalClass(_)) => None,
-                    Some(NameBinding::Import(fqn)) => Some(fqn.clone()),
-                    Some(NameBinding::StarImport(m)) => Some(format!("{m}.{name}")),
-                    Some(NameBinding::ModuleAlias(other)) => Some(format!("{module}.{other}")),
-                },
-                None => None,
-            },
-            None => None,
-        };
-        match next {
-            Some(n) if seen.insert(cur.clone()) => cur = n,
-            _ => break cur,
-        }
-    };
-    memo.insert(start.to_string(), terminal.clone());
-    terminal
-}
-
-/// Memo for `register_chased_base`'s external-boundary resolution:
-/// terminal fqn → resolved class decl `(file, range)` (or `None` when ty
-/// can't resolve it). Keyed by spelling, so a base repeated across files
-/// resolves once; sibling spellings of one class hold distinct entries
-/// that resolve to the same value.
-type ExtSeedMemo = FxHashMap<String, Option<(File, (u32, u32))>>;
-
-/// Carries the external-boundary resolver context for
-/// [`register_chased_base`]'s external arm: the db + anchor file
-/// `locate_external_class_seed` needs, plus a per-terminal-fqn memo so a
-/// base repeated across files resolves once. Bundled into one struct to
-/// keep `register_chased_base` at the clippy arg-count limit.
-struct ChaseCtx<'a> {
-    db: &'a ProjectDatabase,
-    anchor: Option<File>,
-    ext_seed_memo: &'a mut ExtSeedMemo,
-}
-
-/// Fold a chased terminal base fqn into the project-wide subclass
-/// indices. A project class hit emits `children_by_node` entries; a
-/// terminal absent from `decl_by_fqname` is an external base — resolved
-/// one hop further through the external boundary
-/// ([`locate_external_class_seed`]) and keyed into `external_base_children`
-/// by its real decl `(file, range)`, so sibling spellings of the same
-/// class share a key and the subclass query needs no scan. An external
-/// base ty can't resolve (and a project decl that exists but isn't a
-/// class) is dropped — its subclass set is empty either way, and the
-/// query would resolve to nothing too.
-fn register_chased_base(
-    terminal: &str,
-    child_idx: usize,
-    ctx: &mut ChaseCtx,
-    decl_by_fqname: &FxHashMap<String, Vec<usize>>,
-    nodes: &[GraphNode],
-    by_node: &mut FxHashMap<usize, Vec<usize>>,
-    external_base_children: &mut FxHashMap<(File, (u32, u32)), Vec<usize>>,
-) {
-    match decl_by_fqname.get(terminal) {
-        Some(idxs) => {
-            for &parent_idx in idxs {
-                if nodes[parent_idx].kind == "class" {
-                    by_node.entry(parent_idx).or_default().push(child_idx);
-                }
-            }
-        }
-        None => {
-            let Some(anchor) = ctx.anchor else {
-                return;
-            };
-            let db = ctx.db;
-            let seed = *ctx
-                .ext_seed_memo
-                .entry(terminal.to_string())
-                .or_insert_with(|| {
-                    locate_external_class_seed(db, anchor, terminal)
-                        .map(|(f, r)| (f, (r.start().to_u32(), r.end().to_u32())))
-                });
-            if let Some(key) = seed {
-                external_base_children
-                    .entry(key)
-                    .or_default()
-                    .push(child_idx);
-            }
-        }
     }
 }
 
@@ -1946,13 +1719,13 @@ impl ProjectContext {
         plugin_result?;
 
         // The plugin pass can still reload individual files on demand:
-        // subclass resolution's `locate_class_seed` / `follow_class_through_module`
-        // chase calls `parsed_module(..).load()` to relocate a class seed (and
-        // follow its re-export chain) when the base resolves to a file rather
-        // than a cached decl, repopulating those files' salsa `parsed_module`
-        // slots. Clear them again so the post-build resident set stays at the
-        // lean post-populate level instead of creeping back up — the same
-        // memory win `build_project_graph`'s populate phase secures.
+        // subclass resolution's `locate_class_seed` resolves an external base
+        // through ty (`SemanticModel` + `inferred_type`), which loads the
+        // target module's `parsed_module` to infer its members' types,
+        // repopulating those files' salsa `parsed_module` slots. Clear them
+        // again so the post-build resident set stays at the lean
+        // post-populate level instead of creeping back up — the same memory
+        // win `build_project_graph`'s populate phase secures.
         {
             let this = slf.borrow(py);
             let outputs_ref = this.outputs.read();
@@ -3561,8 +3334,8 @@ fn find_classes_defining_method_indices_core(
 /// project seed walks the cached ``children_by_node`` index directly; an
 /// external seed reads its direct project subclasses from the cached
 /// ``external_base_children`` index (no re-parse — re-export / alias
-/// chains, including relative re-exports, are resolved statically into
-/// that index by ``chase_base_fqn``). See
+/// chains resolve to the same `ClassLiteral` through ty, so they're
+/// already folded into that index). See
 /// ``FrozenView::find_subclasses_indices`` for the fast/slow-path
 /// rationale.
 fn find_subclasses_indices_core(
@@ -3589,20 +3362,19 @@ fn find_subclasses_indices_core(
     let children_by_node = &outputs.children_by_node;
     // External seed: the class lives outside the project. Its direct
     // project subclasses are cached in `external_base_children` (folded
-    // from the per-file `class_bases` payloads — no re-parse). Re-export /
-    // alias chains that bind the external class through one or more
-    // project modules — including relative re-exports — are resolved
-    // statically by `chase_base_fqn` at assemble time, so they too land in
-    // `external_base_children`.
+    // from the per-file `class_bases` payloads — no re-parse). A base bound
+    // through one or more project re-exports or module-level aliases
+    // resolves to the same external `ClassLiteral` directly (ty follows the
+    // alias), so those subclasses land in `external_base_children` too.
     //
     // Sibling fold by construction: the same external class can be spelled
     // several ways (`unittest.TestCase` vs `unittest.case.TestCase`), but
-    // the store side ran every observed base through
-    // `locate_external_class_seed`, keying by the class's real decl
-    // `(file, range)`. `locate_class_seed` resolved this query's input
-    // through the same boundary, so `(seed_file, rk)` is that same key:
-    // sibling spellings and renamed re-exports already collapsed into one
-    // entry. A single O(1) lookup, no scan.
+    // the store side ran every observed base through ty's type system,
+    // keying by the canonical `ClassLiteral`'s `(file, range)`.
+    // `locate_class_seed` resolved this query's input through the same
+    // mechanism, so `(seed_file, rk)` is that same key: sibling spellings
+    // and renamed re-exports already collapsed into one entry. A single
+    // O(1) lookup, no scan.
     let direct = outputs
         .external_base_children
         .get(&(seed_file, rk))

--- a/tests/test_plugins/test_unittest.py
+++ b/tests/test_plugins/test_unittest.py
@@ -312,7 +312,7 @@ def test_unittest_plugin_marks_three_level_subclass_chain(build_plugin_graph, re
 
 def test_unittest_plugin_marks_subclass_via_module_alias(build_plugin_graph, reachable_fqnames):
     """A module-level alias of an imported ``TestCase`` (``Base = TestCase``)
-    resolves statically through the uniform binder ladder."""
+    resolves statically through ty's use-def chain."""
     graph = build_plugin_graph(
         {
             "pkg/__init__.py": "",
@@ -334,10 +334,9 @@ def test_unittest_plugin_marks_subclass_via_relative_reexport(
     build_plugin_graph, reachable_fqnames
 ):
     """A ``TestCase`` re-exported through a *relative* import
-    (``from .bases import TestCase``) resolves statically: the binder ladder
-    reads ``im.level`` and resolves the dotted prefix against the importing
-    file's package, so the cross-file chase reaches the external seed with no
-    ``find_references`` walk."""
+    (``from .bases import TestCase``) resolves statically: the shared member
+    resolver follows the re-export through ty's module resolver to the external
+    seed, with no ``find_references`` walk."""
     graph = build_plugin_graph(
         {
             "pkg/__init__.py": "",
@@ -356,8 +355,9 @@ def test_unittest_plugin_marks_subclass_via_relative_reexport(
 
 def test_unittest_plugin_marks_subclass_via_attribute_alias(build_plugin_graph, reachable_fqnames):
     """A module-level alias whose RHS is an *attribute* on an imported module
-    (``Base = unittest.TestCase``) binds through the uniform binder ladder to
-    the absolute fqn, so ``class MyThings(Base)`` resolves its base."""
+    (``Base = unittest.TestCase``) decomposes to its absolute ``module``/``name``
+    reference (resolved through ty's module resolver), so ``class MyThings(Base)``
+    resolves its base."""
     graph = build_plugin_graph(
         {
             "pkg/__init__.py": "",


### PR DESCRIPTION
## Summary

Class-base resolution (the input to the subclass index that powers
`unittest`, `init_subclass`, and the dispatch-app plugins) drove itself
through a hand-rolled "binder ladder": every file captured a module-level
name-binding table, each base was classified into one of four binding
kinds, and assemble chased those bindings cross-file through a
re-export/alias chain to each base's terminal class — with a separate
bespoke module-walking resolver for external bases. That machinery
re-implemented name binding and module resolution that ty already owns.

This PR lifts the whole thing onto ty's type system:

- **Store side** (`build_class_bases`): each base expression's
  `inferred_type`, when it names a statically-known class, yields that
  class's canonical `ClassLiteral`, keyed by its definition's
  `focus_range` — `(file, name-range)`, the exact key the assemble pass
  already writes into `class_by_selection`.
- **Assemble side** (`build_class_hierarchy_indices`): a 2-way hashmap
  probe per base — hit = project parent, miss = external base — with no
  fqn chase and no external-boundary re-resolution.
- **Query side** (`locate_class_seed`): funnels through the same
  `class_literal_seed`, so a subclass query lands on the identical key.

Because ty follows imports, aliases, and re-exports while inferring the
type, every spelling of one base (direct, aliased, star-imported,
sibling-module, absolute or relative re-export) collapses to a single key
by construction. Net **~500-line deletion**: the binder ladder, the
cross-file chase (`chase_base_fqn`/`register_chased_base`), the
external-seed module walk (`follow_class_through_module`/
`locate_external_class_seed`), and the `name_bindings` payload all go away.

Behavior is parity-preserving — no user-visible change; the `[Unreleased]`
CHANGELOG entry that described the binder-ladder mechanism is updated to
describe ty-based resolution (its behavioral and memory claims are
unchanged).

## Test plan

- [x] `cargo build -p dead-cst-runtime` + `cargo clippy -p dead-cst-runtime --all-targets` — clean
- [x] `cargo test --no-default-features --locked -p dead-cst-runtime` — 129 passed
- [x] `uv run --with maturin maturin develop --uv`
- [x] `uv run pytest` — full suite green at the same baseline (695 passed, 3 skipped, 5 deselected)
- [x] `uv run pytest tests/test_plugins/test_unittest.py` — 18 passed, including the attribute-alias and sibling-module-spelling tripwires (every cross-file base shape collapses to the single ty mechanism)
- [x] `uv run prek run --all-files` — all hooks pass