### PR TITLE
Key NodeRef::Def by an owned DeclKey, not Definition<'db>

### DIFF
--- a/runtime/src/file_payload.rs
+++ b/runtime/src/file_payload.rs
@@ -37,7 +37,7 @@ use ty_python_core::place::{PlaceExprRef, ScopedPlaceId};
 use ty_python_core::scope::FileScopeId;
 use ty_python_core::semantic_index;
 
-use crate::graph::NodeFlags;
+use crate::graph::{DeclKey, NodeFlags};
 use crate::helpers::{
     classify_base, collect_all_imports_local, file_default_flags, file_path_string,
     iter_top_level_classes, module_fqname_for_file, position, range_key, scan_noqa_directives,
@@ -51,18 +51,41 @@ use crate::ingest::{decl_kind_str, file_package_name, from_module_string};
 /// `NodeRef` to its final `u32` graph index after all per-file
 /// payloads are collected.
 ///
-/// `NodeRef::Def` covers every binding ty enumerates as a `Definition`.
+/// `NodeRef::Def` covers every binding ty enumerates as a `Definition`,
+/// keyed by an owned [`DeclKey`] (`(File, ScopedPlaceId, name_range)`)
+/// rather than the `Definition<'db>` itself. The triple is the same
+/// cross-file identity the assembly pass interns into `global_index`,
+/// and — unlike `Definition` — it carries no `semantic_index` lifetime,
+/// so storing it lets salsa evict the per-file `SemanticIndex` once the
+/// payloads are built. `def_key` mints it from a `Definition`.
 /// `NodeRef::Module` covers the synthetic `kind="module"` node per
 /// file — `File` is itself a salsa input ingredient, so its handle is
-/// stable and `Hash + Eq + Copy` just like `Definition`.
+/// stable and `Hash + Eq + Copy`.
 /// `NodeRef::External` covers the synthetic `[external] X` /
 /// `[stdlib] X` / `[unresolved] X` nodes via a globally-interned
 /// `ExternalKey` — same fqname produces the same key, dedup is free.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
 pub(crate) enum NodeRef<'db> {
-    Def(Definition<'db>),
+    Def(DeclKey),
     Module(File),
     External(ExternalKey<'db>),
+}
+
+/// Mint the owned [`DeclKey`] for a global-scope `Definition`: the
+/// `(file, bound place, name target_range)` triple. Deterministic in
+/// `def`, so a construction site and a later lookup that pass the same
+/// `Definition` agree by construction — which is what lets
+/// `ref_to_local` and `global_index` use the key interchangeably.
+pub(crate) fn def_key<'db>(
+    db: &'db dyn ProjectDb,
+    def: Definition<'db>,
+    parsed: &ruff_db::parsed::ParsedModuleRef,
+) -> DeclKey {
+    (
+        def.file(db),
+        def.place(db),
+        range_key(def.kind(db).target_range(parsed)),
+    )
 }
 
 /// Globally-interned synthetic external node identity. Same `fqname`
@@ -304,7 +327,7 @@ pub(crate) enum ClassBaseSpec {
 pub(crate) fn ref_to_node<'db>(db: &'db dyn ProjectDb, r: NodeRef<'db>) -> NodeData {
     match r {
         NodeRef::Def(d) => {
-            let file = d.file(db);
+            let file = d.0;
             let payload = file_to_nodes(db, file);
             let idx = *payload
                 .ref_to_local
@@ -547,10 +570,13 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
             imports: import_spec.clone(),
             name_range: (target_range.start().to_u32(), target_range.end().to_u32()),
         };
+        // Same triple `def_key` would mint, reusing the `place_id` /
+        // `target_range` already computed above.
+        let key = NodeRef::Def((file, place_id, range_key(target_range)));
         let local_idx = nodes.len() as u32;
         nodes.push(node);
-        refs.push(NodeRef::Def(def));
-        ref_to_local.insert(NodeRef::Def(def), local_idx);
+        refs.push(key);
+        ref_to_local.insert(key, local_idx);
 
         // Star-reexport tracking: mirror `ingest_decls`'s logic — a
         // later non-star binding for the same name clears the star
@@ -633,7 +659,7 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
             if def.file(db) != file || def.file_scope(db) != global {
                 continue;
             }
-            if let Some(&local_idx) = ref_to_local.get(&NodeRef::Def(def)) {
+            if let Some(&local_idx) = ref_to_local.get(&NodeRef::Def(def_key(db, def, &parsed))) {
                 if nodes[local_idx as usize].flags & NodeFlags::OVERLOAD != 0 {
                     continue;
                 }
@@ -915,7 +941,7 @@ pub(crate) fn file_to_edges<'db>(db: &'db dyn ProjectDb, file: File) -> FileEdge
         if def.file(db) != file || def.file_scope(db) != global {
             continue;
         }
-        let alias_ref = NodeRef::Def(def);
+        let alias_ref = NodeRef::Def(def_key(db, def, &parsed));
         // Skip Definitions that file_to_nodes didn't mint (non-symbol
         // places, unsupported kinds). Keeps the edge set internally
         // consistent with the node set.

--- a/runtime/src/file_ref_edges.rs
+++ b/runtime/src/file_ref_edges.rs
@@ -49,7 +49,7 @@ use ty_python_core::{semantic_index, SemanticIndex};
 use ty_python_semantic::SemanticModel;
 
 use crate::file_payload::{
-    file_to_nodes, import_payload_for_pure as import_payload_for, ExternalKey, FileNodes,
+    def_key, file_to_nodes, import_payload_for_pure as import_payload_for, ExternalKey, FileNodes,
     ImportPayload, NodeData, NodeKind, NodeRef,
 };
 
@@ -121,7 +121,7 @@ pub(crate) fn file_to_ref_edges<'db>(db: &'db dyn ProjectDb, file: File) -> File
         if def.file(db) != file || def.file_scope(db) != global {
             continue;
         }
-        let owner_ref = NodeRef::Def(def);
+        let owner_ref = NodeRef::Def(def_key(db, def, &parsed));
         if !self_nodes.ref_to_local.contains_key(&owner_ref) {
             continue;
         }
@@ -336,7 +336,7 @@ impl<'a, 'db> RefWalker<'a, 'db> {
                 if self.range_in_tc_block(def.full_range(db, self.parsed).range()) {
                     resolved_in_tc = true;
                 }
-                let candidate = NodeRef::Def(def);
+                let candidate = NodeRef::Def(def_key(self.db, def, self.parsed));
                 if self.self_nodes.ref_to_local.contains_key(&candidate) {
                     results.push(Resolution::Alias(candidate));
                     continue;
@@ -389,7 +389,7 @@ impl<'a, 'db> RefWalker<'a, 'db> {
                         if def.file(db) != self.file {
                             continue;
                         }
-                        let candidate = NodeRef::Def(def);
+                        let candidate = NodeRef::Def(def_key(self.db, def, self.parsed));
                         let Some(&idx) = self.self_nodes.ref_to_local.get(&candidate) else {
                             continue;
                         };
@@ -423,7 +423,7 @@ impl<'a, 'db> RefWalker<'a, 'db> {
                 if def.file(db) != self.file {
                     continue;
                 }
-                let candidate = NodeRef::Def(def);
+                let candidate = NodeRef::Def(def_key(self.db, def, self.parsed));
                 if self.self_nodes.ref_to_local.contains_key(&candidate) {
                     results.push(Resolution::Alias(candidate));
                 }
@@ -737,7 +737,7 @@ impl<'a, 'db> RefWalker<'a, 'db> {
             if def.file(self.model.db()) != self.file {
                 continue;
             }
-            let candidate = NodeRef::Def(def);
+            let candidate = NodeRef::Def(def_key(self.db, def, self.parsed));
             if self.self_nodes.ref_to_local.contains_key(&candidate) {
                 return Some(candidate);
             }

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -668,9 +668,10 @@ fn assemble_graph<'db>(
                     module_nodes_by_file.insert(file, global_idx);
                 }
                 NodeRef::Def(d) => {
-                    let place_id = d.place(db);
+                    // `d` is already the `(file, place_id, name_range)`
+                    // triple `global_index` keys on.
+                    global_index.insert(d, global_idx);
                     let rk = node_data.name_range;
-                    global_index.insert((file, place_id, rk), global_idx);
                     if matches!(node_data.kind, NodeKind::Class) {
                         class_by_selection.insert((file, rk), global_idx);
                     }


### PR DESCRIPTION
## Summary

The per-file graph-node identity `NodeRef::Def` stored a `Definition<'db>` — a
salsa tracked-struct handle that pins the per-file `SemanticIndex` for as long as
any payload holds it. This swaps it for the owned `DeclKey = (File, ScopedPlaceId,
name_range)` triple the assembly pass already interns into `global_index`, minted
from a `Definition` by a new `def_key` helper at each construction site.

- The triple is deterministic in the `Definition`, so a construction site and a
  later lookup that pass the same `Definition` agree by construction — which is
  what lets `ref_to_local` and `global_index` use the key interchangeably.
- It carries no `semantic_index` lifetime: once the salsa-tracked payloads
  (`FileNodes`/`FileEdges`/`FileRefEdges`) are built, nothing stored holds a
  `Definition`. `NodeRef` keeps its `'db` (now sourced only from the interned
  `External` arm) and stays `Copy`.
- Pure internal refactor — identical graph, identical public API, no behavior
  change.

### Why (and what's deferred)

This is the **structural precondition** for evicting the per-file semantic index
to cut the memory peak. It does **not** itself reduce memory: a `Definition` is a
~4-byte salsa id and `DeclKey` is a wider owned triple, so the per-file payloads
grow slightly, and salsa does not auto-evict `semantic_index` (same reason #274
needed an explicit `ParsedModule::clear`).

The actual win — an explicit `semantic_index` eviction after the build phase that
needs it, plus an end-to-end RSS measurement — lands in a **follow-up PR**.
Note: `DEAD_CST_DUMP_HEAP` / `salsa_memory_dump()` currently enumerates only the
`ty_project` ingredients (`Program`, `Project`, `FileRoot`, `project_dist_lookup`,
…) and **not** `semantic_index`/`use_def_map`/`Definition`, so the follow-up will
measure peak RSS end-to-end rather than that ingredient directly.

## Test plan

- [x] `cargo build -p dead-cst-runtime` + `cargo clippy --all-targets`
- [x] `cargo fmt --check`
- [x] `cargo test --no-default-features --locked -p dead-cst-runtime` (129 passed)
- [x] `maturin develop --uv` + `uv run pytest` (695 passed, 3 skipped)
- [x] `uv run prek run --all-files` (all Python hooks pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)