### PR TITLE
Mint a per-name node for each `from X import *` re-export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,19 @@ two versions.
 
 ### Changed
 
+- **`from X import *` now mints a node per re-exported name.** Previously a
+  star import collapsed to a single `<mod>.*<source>` statement node. It now
+  also mints one `NodeFlags.STAR_REEXPORT` per-name `kind="import"` node for
+  each name `X` exports (`mod.g`, `mod.h`, …), each keyed on ty's per-name
+  `StarImport` definition so a use of a star-bound name resolves *straight to
+  its own node* rather than to the shared statement node. Every per-name node
+  edges to the kept statement node, which retains the single upstream-module
+  edge and stays the unit the codemod removes; cross-module `from X import g`
+  still chases the star chain to the real upstream decl. The codemod skips
+  `STAR_REEXPORT` nodes — they share the `*` token's source range and have no
+  removable span of their own — so a dead star import is handled exactly as
+  before. This grows the graph but lets shadowed/duplicate star re-exports and
+  per-name reachability be expressed precisely.
 - **Per-file parsed ASTs are freed mid-build to cut the memory peak.** The
   project-wide plugin queries that used to re-walk each file's AST (parameters,
   class-defining-method, decorators, constructions, factories, and the

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -85,9 +85,14 @@ class NodeFlags:
     owning package opts into exposing."""
 
     STAR_REEXPORT: int
-    """Import decl synthesized from ``from X import *`` — one per name
-    the star statement brought in. Set so the cross-module trie can
-    distinguish "real" import aliases from per-name star fan-out."""
+    """Per-name import decl synthesized from ``from X import *`` — one
+    node per name the star statement brought in, keyed on ty's
+    per-name ``StarImport`` definition so uses resolve straight to it.
+    Each edges to the kept ``<mod>.*<src>`` statement node (which
+    carries the single upstream-module edge and stays the unit the
+    codemod removes). The codemod skips ``STAR_REEXPORT`` nodes
+    themselves: they share the ``*`` statement's source range and have
+    no removable span of their own."""
 
 class EdgeFlags:
     """Bit values stamped into the third slot of each

--- a/python/dead_cst/codemod.py
+++ b/python/dead_cst/codemod.py
@@ -99,6 +99,11 @@ def _select_files(
 
     ``NodeFlags.NOTEBOOK`` nodes are dropped: cell-aware writeback into
     the notebook JSON envelope is not implemented today.
+
+    ``NodeFlags.STAR_REEXPORT`` nodes are dropped: a per-name binding from
+    ``from mod import *`` has no source range of its own (it shares the
+    ``*`` token), so it can't be removed individually. The statement-level
+    ``mod.*<src>`` node -- unflagged -- stays the removable unit.
     """
     by_file: dict[Path, list[SymbolNode]] = {}
     deleted_modules: list[Path] = []
@@ -109,6 +114,8 @@ def _select_files(
         if not path.exists():
             continue
         if node.flags & NodeFlags.NOTEBOOK:
+            continue
+        if node.flags & NodeFlags.STAR_REEXPORT:
             continue
         match node.kind:
             case "function" | "class" | "variable" | "type_alias" | "import":

--- a/runtime/src/file_payload.rs
+++ b/runtime/src/file_payload.rs
@@ -69,6 +69,14 @@ pub(crate) enum NodeRef<'db> {
     Def(DeclKey),
     Module(File),
     External(ExternalKey<'db>),
+    /// The kept `*<module>` node for a `from <module> import *` statement.
+    /// Keyed on `(file, <star-token range>)` rather than a ty def: the
+    /// per-name `StarImport` defs back the individual `STAR_REEXPORT`
+    /// nodes now, so the statement-level node it folds into needs its own
+    /// identity. Carries the import payload + the module-level upstream
+    /// edge, and stays the unit the codemod removes when the whole star
+    /// import is unused.
+    StarStmt(File, (u32, u32)),
 }
 
 /// Mint the owned [`DeclKey`] for a global-scope `Definition`: the
@@ -340,6 +348,15 @@ pub(crate) fn ref_to_node<'db>(db: &'db dyn ProjectDb, r: NodeRef<'db>) -> NodeD
             let payload = file_to_nodes(db, f);
             payload.nodes[0].clone()
         }
+        NodeRef::StarStmt(file, _) => {
+            let payload = file_to_nodes(db, file);
+            let idx = *payload
+                .ref_to_local
+                .get(&r)
+                .expect("NodeRef::StarStmt does not belong to its claimed file's payload")
+                as usize;
+            payload.nodes[idx].clone()
+        }
         NodeRef::External(k) => NodeData {
             fqname: k.fqname(db).clone(),
             kind: NodeKind::Synthetic,
@@ -452,11 +469,11 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
     let use_def_map = index.use_def_map(global);
 
     // Star imports: ty mints one Definition per name brought in by
-    // `from X import *`, but every per-name def from the same statement
-    // shares the `*` token's range. Cache the synthesized `*<src>`
-    // local name so we don't re-format / re-resolve it N times for
-    // a star with N names. Identical names → identical NodeData →
-    // dedup happens naturally at assembly time.
+    // `from X import *`, each kept as its own `STAR_REEXPORT` node. Every
+    // per-name def from the same statement shares the `*` token's range,
+    // so this map (range → `*<src>` fqname) doubles as the "already
+    // minted the statement-level `*<src>` node?" guard — `insert`
+    // returning `None` means this is the first name of the statement.
     let mut star_local_name_cache: HashMap<TextRange, String> = HashMap::new();
 
     let mut star_reexports: FxHashMap<String, String> = FxHashMap::default();
@@ -504,16 +521,11 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         let per_name = symbol.name().as_str().to_string();
 
         let target_range = kind.target_range(&parsed);
-        let local_name = match kind {
-            DefinitionKind::StarImport(k) => star_local_name_cache
-                .entry(target_range)
-                .or_insert_with(|| {
-                    let src = from_module_string(db, file, k.import(&parsed));
-                    format!("*{src}")
-                })
-                .clone(),
-            _ => per_name.clone(),
-        };
+        let is_star = matches!(kind, DefinitionKind::StarImport(_));
+        // Per-name star bindings keep their real name now (one
+        // `STAR_REEXPORT` node per exported name); the statement-level
+        // `*<src>` node is minted separately, once, below.
+        let local_name = per_name.clone();
 
         let (mut sl, mut sc, el, ec) = position(&line_index, &source, target_range);
 
@@ -541,9 +553,9 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         };
 
         let mut flags: u32 = default_flags;
-        if matches!(node_kind, NodeKind::Import)
-            && (file_pinned_by_noqa || per_line_noqa_pins.contains(&sl))
-        {
+        let import_noqa_pin = matches!(node_kind, NodeKind::Import)
+            && (file_pinned_by_noqa || per_line_noqa_pins.contains(&sl));
+        if import_noqa_pin {
             flags |= NODE_FLAGS_NOQA_PIN;
         }
         // `@typing.overload`-decorated function defs: flag now so the
@@ -552,6 +564,13 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         // exactly what `DefinitionKind::Function::target_range` returns.
         if matches!(node_kind, NodeKind::Function) && overload_decorated.contains(&target_range) {
             flags |= NodeFlags::OVERLOAD;
+        }
+        // Per-name implicit star bindings: flag so the codemod skips
+        // them. They share the `*` token's range and can't be removed
+        // individually; the `*<src>` statement node (minted below, no
+        // `STAR_REEXPORT` flag) stays the removable unit.
+        if is_star {
+            flags |= NodeFlags::STAR_REEXPORT;
         }
         // Stub-only ENTRYPOINT flagging is deferred to the assembly
         // pass; it needs the project-wide peer-stub map and the .py
@@ -577,6 +596,43 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         nodes.push(node);
         refs.push(key);
         ref_to_local.insert(key, local_idx);
+
+        // Mint the statement-level `*<src>` node once per `from <src>
+        // import *` (keyed on the shared `*` token range). It carries the
+        // import payload + the module-level upstream edge, and stays the
+        // codemod's removable unit — so it gets the import flags but NOT
+        // `STAR_REEXPORT`. The per-name nodes above edge into it.
+        if is_star {
+            if let Some(spec) = &import_spec {
+                let star_fqname = format!("{module_fqname}.*{}", spec.module);
+                if star_local_name_cache
+                    .insert(target_range, star_fqname.clone())
+                    .is_none()
+                {
+                    let mut star_flags: u32 = default_flags;
+                    if import_noqa_pin {
+                        star_flags |= NODE_FLAGS_NOQA_PIN;
+                    }
+                    let star_node = NodeData {
+                        fqname: star_fqname,
+                        kind: NodeKind::Import,
+                        path: path_str.clone(),
+                        start_line: sl,
+                        start_column: sc,
+                        end_line: el,
+                        end_column: ec,
+                        flags: star_flags,
+                        imports: import_spec.clone(),
+                        name_range: (target_range.start().to_u32(), target_range.end().to_u32()),
+                    };
+                    let star_key = NodeRef::StarStmt(file, range_key(target_range));
+                    let star_idx = nodes.len() as u32;
+                    nodes.push(star_node);
+                    refs.push(star_key);
+                    ref_to_local.insert(star_key, star_idx);
+                }
+            }
+        }
 
         // Star-reexport tracking: mirror `ingest_decls`'s logic — a
         // later non-star binding for the same name clears the star
@@ -941,7 +997,7 @@ pub(crate) fn file_to_edges<'db>(db: &'db dyn ProjectDb, file: File) -> FileEdge
         if def.file(db) != file || def.file_scope(db) != global {
             continue;
         }
-        let alias_ref = NodeRef::Def(def_key(db, def, &parsed));
+        let mut alias_ref = NodeRef::Def(def_key(db, def, &parsed));
         // Skip Definitions that file_to_nodes didn't mint (non-symbol
         // places, unsupported kinds). Keeps the edge set internally
         // consistent with the node set.
@@ -984,17 +1040,20 @@ pub(crate) fn file_to_edges<'db>(db: &'db dyn ProjectDb, file: File) -> FileEdge
                 (target, None)
             }
             DefinitionKind::StarImport(k) => {
-                // `from X import *` — emit only the module-level
-                // edge (`alias → Module(X)`); no per-name decl
-                // fan-out. We collapse the per-name aliases to one
-                // node per statement (see file_to_nodes), and the
-                // existing pipeline matches this by returning
-                // Vec::new() in resolve_from_imported's StarImport
-                // branch. Uses of star-bound names still get
-                // resolved via walk_exports_chain on the consumer's
-                // from-import lookup; the chain walk takes care of
-                // them.
+                // `from X import *`. Each per-name `STAR_REEXPORT` node
+                // edges into the kept statement-level `*X` node, which in
+                // turn carries the module-level edge (`*X → Module(X)`).
+                // Rebind `alias_ref` to that `*X` node so the generic
+                // resolution below (stdlib / external / unresolved
+                // handling) emits the upstream edge from `*X`, not from
+                // the per-name node. Uses of star-bound names land on the
+                // per-name node (ty's use-def chain distinguishes them);
+                // `from <here> import name` lookups resolve per-name via
+                // walk_exports_chain.
                 let module = from_module_string(db, file, k.import(&parsed));
+                let star_ref = NodeRef::StarStmt(file, range_key(kind.target_range(&parsed)));
+                edges.insert((alias_ref, star_ref, 0));
+                alias_ref = star_ref;
                 (module, None)
             }
             _ => continue,

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -677,6 +677,13 @@ fn assemble_graph<'db>(
                     }
                     decl_by_name_range.insert((file, rk), global_idx);
                 }
+                NodeRef::StarStmt(_, _) => {
+                    // The kept `*<src>` star-statement node. Not a real
+                    // decl, so it contributes nothing to the decl indices
+                    // (`global_index` / `decl_by_name_range` /
+                    // `class_by_selection`); `ref_to_global` +
+                    // `local_to_global` above already wired it up.
+                }
                 NodeRef::External(_) => {
                     // External NodeRefs never appear in FileNodes.refs;
                     // they're only emitted as edge endpoints. This

--- a/tests/prototype/test_native_graph.py
+++ b/tests/prototype/test_native_graph.py
@@ -143,16 +143,16 @@ def test_aliased_import_binds_asname(project_factory):
     assert "pkg.mod.gee -> pkg.other.g" in _edges(g)
 
 
-def test_star_import_mints_one_node_per_statement(project_factory):
-    """`from X import *` mints exactly one `kind=import` node per
-    statement (named `<importing_module>.*<source>`), not one per
-    name `X` exports — ty already resolves uses of star-bound names
-    to their specific upstream definitions, so the per-name aliases
-    libcst minted as a workaround aren't needed here. The single
-    star node carries one outgoing edge to the upstream module; uses
-    of star-bound names emit `use → star_node` plus the standard
-    parallel `use → upstream_module` / `use → upstream_decl` edges
-    via Principle 2.
+def test_star_import_mints_per_name_nodes_plus_statement_node(project_factory):
+    """`from X import *` mints one `STAR_REEXPORT`-flagged per-name
+    `kind=import` node for each name `X` exports, plus the kept
+    statement node `<importing_module>.*<source>`. Each per-name node
+    edges to the statement node, which carries the single outgoing
+    edge to the upstream module. Because the per-name nodes are keyed
+    on ty's per-name `StarImport` definitions, uses of star-bound names
+    resolve straight to them (alongside the standard parallel
+    `use → upstream_module` / `use → upstream_decl` edges, Principle 2).
+    Underscored names `X` doesn't export are skipped.
     """
     proj, _ = project_factory(
         {
@@ -163,20 +163,28 @@ def test_star_import_mints_one_node_per_statement(project_factory):
     )
     g = proj.build()
     fqs = _fqnames(g)
-    # One star node per statement — the underscored-private decl
-    # didn't matter for node count, and per-name `pkg.mod.g` /
-    # `pkg.mod.h` aliases are gone.
+    # The kept statement node plus one per-name node per exported name;
+    # the underscored-private decl is not star-exported.
     assert "pkg.mod.*pkg.other" in fqs
-    assert "pkg.mod.g" not in fqs
-    assert "pkg.mod.h" not in fqs
+    assert "pkg.mod.g" in fqs
+    assert "pkg.mod.h" in fqs
+    assert "pkg.mod._private" not in fqs
+    per_name = {n.fqname for n in g.nodes if n.flags & NodeFlags.STAR_REEXPORT}
+    assert per_name == {"pkg.mod.g", "pkg.mod.h"}
+
     edges = _edges(g)
-    # Star alias's one outgoing edge: to the upstream module.
+    # Each per-name node edges to the statement node; the statement
+    # node carries the single upstream-module edge.
+    assert "pkg.mod.g -> pkg.mod.*pkg.other" in edges
+    assert "pkg.mod.h -> pkg.mod.*pkg.other" in edges
     assert "pkg.mod.*pkg.other -> pkg.other" in edges
-    # Use sites: alias edge through the star + parallel upstream
-    # (ty's resolution finds `g` / `h` in `pkg.other`).
-    assert "pkg.mod.use -> pkg.mod.*pkg.other" in edges
+    # Uses resolve to the per-name nodes, not through the statement
+    # node, plus the parallel upstream-decl edges via ty's resolution.
+    assert "pkg.mod.use -> pkg.mod.g" in edges
+    assert "pkg.mod.use -> pkg.mod.h" in edges
     assert "pkg.mod.use -> pkg.other.g" in edges
     assert "pkg.mod.use -> pkg.other.h" in edges
+    assert "pkg.mod.use -> pkg.mod.*pkg.other" not in edges
 
 
 def test_star_import_node_carries_star_spec(project_factory):

--- a/tests/test_codemod.py
+++ b/tests/test_codemod.py
@@ -21,6 +21,7 @@ from libcst.metadata import FullRepoManager, MetadataWrapper
 
 from dead_cst.codemod import RemoveDeadSymbols, generate_patch, remove_code
 from dead_cst._fqn import FixedFullyQualifiedNameProvider
+from dead_cst.graph import NodeFlags
 
 
 def _normalise(s: str) -> str:
@@ -814,3 +815,29 @@ def test_generate_patch_per_subgraph_slice_isolates_decls(build_unreachable_node
     assert "-def dead_one():" in patch
     # The slice excludes dead_two, so the downstream SCC pass owns it.
     assert "-def dead_two():" not in patch
+
+
+def test_codemod_skips_star_reexport_per_name_nodes(build_unreachable_nodes, tmp_path):
+    """Per-name ``STAR_REEXPORT`` nodes share the ``*`` token's source
+    range, so the codemod must skip them: on their own they yield an
+    empty patch, and feeding the whole dead set never rewrites the
+    ``from X import *`` line they fan out from."""
+    unreachable = build_unreachable_nodes(
+        {
+            "consumer.py": "from helpers import *\ndef main():\n    return 1\n",
+            "helpers.py": "def helper_a(): pass\ndef helper_b(): pass\n",
+        },
+        {"consumer.main"},
+    )
+    per_name = [n for n in unreachable if n.flags & NodeFlags.STAR_REEXPORT]
+    assert {n.fqname for n in per_name} == {"consumer.helper_a", "consumer.helper_b"}
+
+    # Skipped entirely -- no removable span of their own.
+    assert generate_patch(per_name, tmp_path) == ""
+
+    # The full dead set deletes the dead ``helpers`` module but leaves
+    # ``consumer.py`` byte-for-byte intact: the star statement is not
+    # individually removable and the per-name nodes are skipped.
+    patch = generate_patch(unreachable, tmp_path)
+    assert "b/consumer.py" not in patch
+    assert "from helpers import *" in (tmp_path / "consumer.py").read_text()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -10,6 +10,7 @@ import logging
 
 import pytest
 
+from dead_cst.graph import NodeFlags
 from dead_cst.plugins._core import EXTERNAL_PREFIXES, STDLIB_PREFIX, UNRESOLVED_PREFIX
 
 IMPORT_TEST_FILES = {
@@ -33,23 +34,6 @@ IMPORT_BASE_EDGES = frozenset(
         "p.functions.f -> p.functions",
         "p.functions.g -> p.functions",
         "p.x -> p",
-    }
-)
-
-# Edges from materializing ``from p.functions import *`` (or a synonym)
-# into ``p/x.py``: one synthetic re-export per name plus the
-# ``module -> synthetic -> target`` chain. Used by every star-shaped
-# test case in this file.
-STAR_REEXPORT_EDGES = frozenset(
-    {
-        "p.x -> p.x.f",
-        "p.x -> p.x.g",
-        "p.x.f -> p.functions",
-        "p.x.f -> p.functions.f",
-        "p.x.f -> p.x",
-        "p.x.g -> p.functions",
-        "p.x.g -> p.functions.g",
-        "p.x.g -> p.x",
     }
 )
 
@@ -427,23 +411,29 @@ STAR_REEXPORT_EDGES = frozenset(
             },
             id="import-package-then-dotted-access",
         ),
-        # libcst minted per-name synthetic aliases as a workaround for
-        # its inability to resolve uses *through* a star import; the
-        # rust backend leans on ty and mints one node per
-        # `from X import *` statement (named `<mod>.*<src>`) with a
-        # single outgoing edge to the upstream module. Use sites
-        # route through this node and emit the standard parallel
+        # `from X import *` mints one `STAR_REEXPORT`-flagged per-name
+        # node per name X exports (`p.x.f`, `p.x.g`) plus the kept
+        # `<mod>.*<src>` statement node (`p.x.*p.functions`). Each
+        # per-name node edges to the statement node; the statement node
+        # carries the single upstream-module edge. Because the per-name
+        # nodes are keyed on the same ty definition each use resolves
+        # to, a use site attributes straight to its per-name node
+        # (`p.x.a -> p.x.f`) and still emits the standard parallel
         # upstream module/decl edges via ty's name resolution
         # (Principle 2).
         pytest.param(
             "from p.functions import *\ndef a(): f()",
             {
-                "p.x.*p.functions -> p.x",
                 "p.x.*p.functions -> p.functions",
-                "p.x.a -> p.x",
-                "p.x.a -> p.x.*p.functions",
+                "p.x.*p.functions -> p.x",
                 "p.x.a -> p.functions",
                 "p.x.a -> p.functions.f",
+                "p.x.a -> p.x",
+                "p.x.a -> p.x.f",
+                "p.x.f -> p.x",
+                "p.x.f -> p.x.*p.functions",
+                "p.x.g -> p.x",
+                "p.x.g -> p.x.*p.functions",
             },
             id="star-import-fans-out-to-all-decls-rust",
         ),
@@ -697,14 +687,14 @@ def test_imports(build_decl_graph, assert_edges, src, expected_extra_edges):
         ),
         pytest.param(
             # ``from pkg import g`` resolves through the star node to
-            # ``pkg._internal.g``. The rust backend mints one
-            # ``*pkg._internal`` node per ``from pkg._internal import *``
-            # statement rather than a per-name ``pkg.g`` alias; ty
-            # resolves ``from pkg import g`` straight to
-            # ``pkg._internal.g``, so the consumer alias edges directly
-            # to the upstream decl. The absence of any
-            # ``consumer.g -> pkg.g`` edge from the set below codifies
-            # the "no per-name alias is minted" invariant.
+            # ``pkg._internal.g``. ``pkg`` mints a ``STAR_REEXPORT``
+            # per-name node ``pkg.g`` that edges to the kept
+            # ``*pkg._internal`` statement node, which carries the
+            # single upstream-module edge. The consumer's import alias
+            # chases the star chain to the *real* decl, so it edges to
+            # ``pkg._internal.g`` (not the intermediate ``pkg.g``); the
+            # module-level ``g()`` use emits the parallel reachability
+            # edge to the immediate binding ``pkg.g``.
             {
                 "pkg/__init__.py": "from pkg._internal import *\n",
                 "pkg/_internal.py": "def g(): pass\n",
@@ -713,7 +703,7 @@ def test_imports(build_decl_graph, assert_edges, src, expected_extra_edges):
             {
                 "consumer -> consumer.g",
                 "consumer -> pkg",
-                "consumer -> pkg.*pkg._internal",
+                "consumer -> pkg.g",
                 "consumer.g -> consumer",
                 "consumer.g -> pkg",
                 "consumer.g -> pkg._internal.g",
@@ -722,12 +712,17 @@ def test_imports(build_decl_graph, assert_edges, src, expected_extra_edges):
                 "pkg._internal -> pkg",
                 "pkg._internal -> pkg._internal",
                 "pkg._internal.g -> pkg._internal",
+                "pkg.g -> pkg",
+                "pkg.g -> pkg.*pkg._internal",
             },
             id="import-resolves-through-star-reexport",
         ),
         pytest.param(
             # ``from A import g`` follows the ``A -> B -> C`` star
-            # chain to ``C.g``.
+            # chain to ``C.g``. Each link mints its own ``STAR_REEXPORT``
+            # per-name ``g`` node (``A.g``, ``B.g``) edging to that
+            # link's kept statement node; the consumer alias still
+            # chases the chain to the terminal real decl ``C.g``.
             {
                 "A.py": "from B import *\n",
                 "B.py": "from C import *\n",
@@ -737,11 +732,15 @@ def test_imports(build_decl_graph, assert_edges, src, expected_extra_edges):
             {
                 "A.*B -> A",
                 "A.*B -> B",
+                "A.g -> A",
+                "A.g -> A.*B",
                 "B.*C -> B",
                 "B.*C -> C",
+                "B.g -> B",
+                "B.g -> B.*C",
                 "C.g -> C",
                 "consumer -> A",
-                "consumer -> A.*B",
+                "consumer -> A.g",
                 "consumer -> consumer.g",
                 "consumer.g -> A",
                 "consumer.g -> C.g",
@@ -752,7 +751,14 @@ def test_imports(build_decl_graph, assert_edges, src, expected_extra_edges):
         pytest.param(
             # Mutual ``from B import *`` / ``from A import *``
             # terminates without spinning; consumer's ``b`` still
-            # resolves to ``B.b``.
+            # resolves to ``B.b``. Each module re-exports both names, so
+            # within ``A`` the name ``a`` exists twice: the real
+            # ``def a`` and a ``STAR_REEXPORT`` per-name node (``a``
+            # round-tripped back through ``from B import *``). They
+            # share the fqname ``A.a`` but are distinct nodes keyed on
+            # different definitions, so the set shows both the real
+            # decl's anchor (``A.a -> A``) and the per-name node's
+            # statement edge (``A.a -> A.*B``); likewise for ``B.b``.
             {
                 "A.py": "from B import *\ndef a(): pass\n",
                 "B.py": "from A import *\ndef b(): pass\n",
@@ -762,9 +768,15 @@ def test_imports(build_decl_graph, assert_edges, src, expected_extra_edges):
                 "A.*B -> A",
                 "A.*B -> B",
                 "A.a -> A",
+                "A.a -> A.*B",
+                "A.b -> A",
+                "A.b -> A.*B",
                 "B.*A -> A",
                 "B.*A -> B",
+                "B.a -> B",
+                "B.a -> B.*A",
                 "B.b -> B",
+                "B.b -> B.*A",
                 "consumer.b -> A",
                 "consumer.b -> B.b",
                 "consumer.b -> consumer",
@@ -776,7 +788,11 @@ def test_imports(build_decl_graph, assert_edges, src, expected_extra_edges):
             # re-export of the same name. The absence of
             # ``consumer.g -> other.g`` from the set below codifies
             # that the consumer's ``g`` resolves to ``mod.g`` (not
-            # through the star re-export to ``other.g``).
+            # through the star re-export to ``other.g``). The shadowed
+            # ``STAR_REEXPORT`` per-name node still exists -- it shares
+            # the fqname ``mod.g`` with the real decl but is a distinct
+            # node, contributing the ``mod.g -> mod.*other`` statement
+            # edge.
             {
                 "other.py": "def g(): pass\n",
                 "mod.py": "from other import *\ndef g(): return 1\n",
@@ -792,6 +808,7 @@ def test_imports(build_decl_graph, assert_edges, src, expected_extra_edges):
                 "mod.*other -> mod",
                 "mod.*other -> other",
                 "mod.g -> mod",
+                "mod.g -> mod.*other",
                 "other.g -> other",
             },
             id="star-reexport-shadowed-by-real-decl",
@@ -1172,14 +1189,20 @@ def test_from_import_prefers_namespace_binding_over_submodule(build_decl_graph):
     assert ("p.q", "module") not in targets, targets
 
 
-def test_star_reexport_is_skipped_by_codemod_rust(build_decl_graph):
-    """The rust backend mints one node per ``from X import *`` named
-    ``<mod>.*<src>`` with ``kind="import"`` and an ``imports.star=True``
-    payload — the ``*`` prefix is the codemod's marker."""
+def test_star_reexport_mints_per_name_and_statement_nodes(build_decl_graph):
+    """``from X import *`` mints a per-name ``STAR_REEXPORT`` node for
+    each name X exports *and* the kept ``<mod>.*<src>`` statement node.
+
+    The statement node (``kind="import"``, ``imports.star=True``, the
+    ``*`` prefix as the codemod marker) is the removable unit and is
+    *not* ``STAR_REEXPORT``-flagged. The per-name nodes are flagged so
+    the codemod skips them -- they share the ``*`` token's source range
+    and have no removable span of their own.
+    """
     graph = build_decl_graph(
         {
             "pkg/__init__.py": "from pkg._internal import *\n",
-            "pkg/_internal.py": "def g(): pass\n",
+            "pkg/_internal.py": "def g(): pass\ndef h(): pass\n",
         }
     )
     star_nodes = [
@@ -1189,6 +1212,15 @@ def test_star_reexport_is_skipped_by_codemod_rust(build_decl_graph):
     assert star_nodes[0].imports is not None
     assert star_nodes[0].imports.star is True
     assert star_nodes[0].imports.module == "pkg._internal"
+    # The statement node is the removable unit, so it carries no
+    # STAR_REEXPORT flag.
+    assert not star_nodes[0].flags & NodeFlags.STAR_REEXPORT
+
+    # One STAR_REEXPORT-flagged per-name node per name _internal exports.
+    per_name = {
+        n.fqname for n in graph.nodes() if n.flags & NodeFlags.STAR_REEXPORT and n.kind == "import"
+    }
+    assert per_name == {"pkg.g", "pkg.h"}
 
 
 def test_cross_dep_submodule_import(tmp_path, make_analysis, assert_edges):


### PR DESCRIPTION
## Summary

`from X import *` previously collapsed to a single `<mod>.*<source>` statement node, which meant per-name reachability and shadowed/duplicate star re-exports couldn't be expressed. This change keeps that statement node **and** mints one `NodeFlags.STAR_REEXPORT` per-name `kind="import"` node for each name `X` exports.

- Per-name nodes are keyed on ty's per-name `StarImport` definition, so a use of a star-bound name resolves **straight to its own node** instead of the shared statement node (no use-resolution code change needed — the key already matches what ty resolves the use to).
- Each per-name node edges to the kept `<mod>.*<source>` statement node, which retains the single upstream-module edge and stays the unit the codemod removes. The statement node now rides on a dedicated `NodeRef::StarStmt(File, range)` key, since the per-name `StarImport` defs back the individual nodes.
- Cross-module `from X import g` still chases the star chain to the **real upstream decl** (`walk_exports_chain` is unchanged).
- The codemod **skips** `STAR_REEXPORT` nodes — they share the `*` token's source range and have no removable span of their own — so a dead star import is handled exactly as before (the statement node was never individually removable by `RemoveImportsVisitor`, and still isn't).

This grows the graph (one node per re-exported name) in exchange for precise per-name reachability, matching the existing principle that shadowed declarations are first-class graph nodes.

## Test plan

- [x] `cargo clippy -p dead-cst-runtime --all-targets` — clean
- [x] `cargo test --no-default-features --locked -p dead-cst-runtime` — 129 passed (incl. new `plugin_error_boundary` tests already present)
- [x] `cargo fmt --check` — clean
- [x] `uv run pytest` — 696 passed, 3 skipped
- [x] `uv run prek run --all-files` — ruff / ruff-format / ty pass
- [x] Updated 6 star-shaped edge tests + the prototype graph test to the per-name shape
- [x] Added `test_star_reexport_mints_per_name_and_statement_nodes` (presence + `STAR_REEXPORT` flag, statement node unflagged)
- [x] Added `test_codemod_skips_star_reexport_per_name_nodes` (per-name nodes yield an empty patch; `from X import *` line left intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)