### PR TITLE
Make graph node indices deterministic via sorted-file offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,13 @@ two versions.
 
 ### Changed
 
+- **Graph node indices are now deterministic across runs.** ty's `files()`
+  set has no stable iteration order, so the global index assigned to each node
+  (and therefore the order of `Analysis.dead()` / `reachable()` results and the
+  CLI's reports) could vary run-to-run. The build now sorts files into
+  canonical path order and assigns each node a position-derived index
+  (`offset[file] + local_index`) — the per-file offsets come from prefix-summing
+  node counts captured during the parallel fan-out — so output is reproducible.
 - **`from X import *` now mints a node per re-exported name.** Previously a
   star import collapsed to a single `<mod>.*<source>` statement node. It now
   also mints one `NodeFlags.STAR_REEXPORT` per-name `kind="import"` node for

--- a/runtime/src/builder.rs
+++ b/runtime/src/builder.rs
@@ -197,12 +197,13 @@ impl GraphBuilder {
     /// assembly pass owns the index, so this writes `nodes[idx]`
     /// directly and records the key. Payload nodes are
     /// position-distinct (`CLAUDE.md` principle 3), so no two ever
-    /// share a [`NodeKey`]; the debug assertion guards that invariant.
-    /// Requires the region to be pre-sized via
-    /// [`prefill_payload_region`].
+    /// share a [`NodeKey`]; an assertion — kept on in release too,
+    /// since a collision would silently overwrite a node and corrupt
+    /// the index map — guards that invariant. Requires the region to
+    /// be pre-sized via [`prefill_payload_region`].
     pub(crate) fn place_node(&mut self, idx: usize, node: GraphNode) {
         let prev = self.node_index.insert(node.key(), idx);
-        debug_assert!(
+        assert!(
             prev.is_none(),
             "payload node key collision at index {idx}: assembly must mint each NodeKey once"
         );

--- a/runtime/src/builder.rs
+++ b/runtime/src/builder.rs
@@ -41,6 +41,11 @@ pub(crate) struct NodeKey {
 /// only for the nodes a Python caller actually surfaces (`nodes()`,
 /// `nodes_at()`, the descendants / ancestors / reachable snapshots).
 /// Internal queries read the fields here directly with no borrow.
+///
+/// `Default` yields an empty placeholder used by
+/// [`GraphBuilder::prefill_payload_region`]; every slot it creates is
+/// overwritten by [`GraphBuilder::place_node`] before the graph is read.
+#[derive(Default)]
 pub(crate) struct GraphNode {
     pub(crate) fqname: String,
     pub(crate) kind: &'static str,
@@ -168,6 +173,40 @@ impl GraphBuilder {
         self.forward_adj.push(Vec::new());
         self.reverse_adj.push(Vec::new());
         idx
+    }
+
+    /// Pre-size the payload region to `total_nodes` so the
+    /// offset-driven assembly pass can write each file's nodes at a
+    /// precomputed global index (`offset[file] + local_idx`) via
+    /// [`place_node`] instead of relying on serial append order.
+    /// `nodes` is filled with `GraphNode::default()` placeholders that
+    /// `place_node` overwrites exactly once each — the per-file
+    /// offsets partition `[0, total_nodes)`, so no placeholder
+    /// survives into the finished graph. Synthetic nodes minted later
+    /// via [`intern_node`] append past this region (index
+    /// `total_nodes` onward).
+    pub(crate) fn prefill_payload_region(&mut self, total_nodes: usize) {
+        self.nodes.resize_with(total_nodes, GraphNode::default);
+        self.forward_adj.resize_with(total_nodes, Vec::new);
+        self.reverse_adj.resize_with(total_nodes, Vec::new);
+        self.node_index.reserve(total_nodes);
+    }
+
+    /// Place a payload node at its precomputed global index. Unlike
+    /// [`intern_node`] (append + dedup-by-key), the offset-driven
+    /// assembly pass owns the index, so this writes `nodes[idx]`
+    /// directly and records the key. Payload nodes are
+    /// position-distinct (`CLAUDE.md` principle 3), so no two ever
+    /// share a [`NodeKey`]; the debug assertion guards that invariant.
+    /// Requires the region to be pre-sized via
+    /// [`prefill_payload_region`].
+    pub(crate) fn place_node(&mut self, idx: usize, node: GraphNode) {
+        let prev = self.node_index.insert(node.key(), idx);
+        debug_assert!(
+            prev.is_none(),
+            "payload node key collision at index {idx}: assembly must mint each NodeKey once"
+        );
+        self.nodes[idx] = node;
     }
 
     /// Get (or mint) the deduplicated synthetic node with the given

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -857,12 +857,23 @@ fn assemble_graph<'db>(
                 }
             }
         }
-        for r in external_keys {
-            if let NodeRef::External(key) = r {
-                let fqname = key.fqname(db).clone();
-                let idx = builder.intern_synthetic(fqname);
-                ref_to_global.insert(r, idx);
-            }
+        // Mint the synthetic External nodes in a deterministic order.
+        // `external_keys` is an FxHashSet whose iteration order tracks
+        // the salsa id layout and so varies run-to-run; minting in that
+        // order would hand the synthetics run-dependent graph indices.
+        // Sort by fqname — the dedup identity `intern_synthetic` keys on
+        // — so each External lands at the same index every run.
+        let mut externals: Vec<(String, NodeRef<'db>)> = external_keys
+            .into_iter()
+            .filter_map(|r| match r {
+                NodeRef::External(key) => Some((key.fqname(db).clone(), r)),
+                _ => None,
+            })
+            .collect();
+        externals.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        for (fqname, r) in externals {
+            let idx = builder.intern_synthetic(fqname);
+            ref_to_global.insert(r, idx);
         }
 
         // 2c: parallel translation. `ref_to_global` is owned + read-
@@ -913,7 +924,13 @@ fn assemble_graph<'db>(
         );
     }
 
-    // Pass 3: peer .pyi/.py reachability edges.
+    // Pass 3: peer .pyi/.py reachability edges. Collect every peer
+    // edge first, then sort + dedup before inserting: the source maps
+    // (`peer_pyi_to_py` and each file's `exports_by_name`) are
+    // FxHashMaps whose iteration order isn't stable run-to-run, so
+    // inserting as we walk them would give the adjacency lists a
+    // run-dependent order. Sorting the collected triples pins it.
+    let mut peer_triples: Vec<(usize, usize, u32)> = Vec::new();
     for (&pyi_file, &py_twin) in peer_pyi_to_py {
         let pyi_payload = file_to_nodes(db, pyi_file);
         let py_payload = file_to_nodes(db, py_twin);
@@ -931,11 +948,14 @@ fn assemble_graph<'db>(
                     let Some(&py_idx) = ref_to_global.get(&py_ref) else {
                         continue;
                     };
-                    builder.add_edge(pyi_idx, py_idx, 0);
+                    peer_triples.push((pyi_idx, py_idx, 0));
                 }
             }
         }
     }
+    peer_triples.sort_unstable();
+    peer_triples.dedup();
+    builder.extend_edges(peer_triples);
 
     // Pass 4: per-file native plugin fold. Replay each per-file
     // plugin's salsa-cached `FileLocalOp`s (warmed in the parallel

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -3,6 +3,7 @@
 //! Salsa-backed analysis context that the rest of the crate operates on.
 
 use std::str::FromStr;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use parking_lot::lock_api::RawRwLockRecursive;
@@ -259,7 +260,14 @@ pub(crate) fn build_project_graph(
 
     counters.start_phase(PHASE_ENUM, None);
     let t0 = std::time::Instant::now();
-    let project_files: Vec<File> = (&db.project().files(db)).into_iter().collect();
+    let mut project_files: Vec<File> = (&db.project().files(db)).into_iter().collect();
+    // Canonical, deterministic file order. ty's `files()` set has no
+    // stable iteration order, so without this the global node indices
+    // assigned in assembly (and everything keyed on them) would vary
+    // run-to-run. Paths are unique per `File`, so sorting on the path
+    // string is a total order; `sort_by_cached_key` computes each
+    // (allocating) path string exactly once.
+    project_files.sort_by_cached_key(|&f| file_path_string(db, f));
     counters.set_enum_total(project_files.len());
     let mut path_to_file: FxHashMap<String, File> =
         FxHashMap::with_capacity_and_hasher(project_files.len(), Default::default());
@@ -318,6 +326,15 @@ pub(crate) fn build_project_graph(
     // classification) hits a warm salsa cache instead of paying
     // the ~100ms walk inline.
     let t_populate = std::time::Instant::now();
+    // Per-file node counts, captured during the fan-out: each worker
+    // records its file's node total at the file's (sorted) position.
+    // Prefix-summed into per-file global-index offsets below, so the
+    // assembly pass assigns each node a deterministic index
+    // (`offset[file] + local_idx`) instead of a serial running
+    // counter — the seam for a future parallel assembly.
+    let node_counts: Vec<AtomicUsize> = (0..project_files.len())
+        .map(|_| AtomicUsize::new(0))
+        .collect();
     {
         // Per-file work-stealing on rayon: pre-clone N salsa
         // snapshots into a bounded MPMC channel; each task pulls a
@@ -348,6 +365,7 @@ pub(crate) fn build_project_graph(
         // commit message for the hazard.
         let dist_db: ProjectDatabase = db.clone();
         let files_ref: &[File] = &project_files;
+        let counts_ref: &[AtomicUsize] = &node_counts;
         let per_file_ids_ref: &[crate::native_plugins::PerFilePluginId] = per_file_plugin_ids;
         let counters_ref = Arc::clone(counters);
         let run_populate = move || {
@@ -356,14 +374,21 @@ pub(crate) fn build_project_graph(
                 let _ = crate::file_payload::project_dist_lookup(local_db);
             });
             rayon::scope(|s| {
-                for &file in files_ref {
+                for (file_idx, &file) in files_ref.iter().enumerate() {
                     let db_tx = db_tx.clone();
                     let db_rx = db_rx.clone();
                     let counters_inner = Arc::clone(&counters_ref);
                     s.spawn(move |_| {
                         let local_db = db_rx.recv().expect("snapshot available");
                         local_db.attach(|local_db| {
-                            let _ = file_to_nodes(local_db, file);
+                            // Record this file's node count for the offset
+                            // prefix-sum. `nodes` and `refs` are parallel
+                            // arrays, so `nodes.len()` is exactly what the
+                            // assembly mint loop iterates for this file.
+                            counts_ref[file_idx].store(
+                                file_to_nodes(local_db, file).nodes.len(),
+                                Ordering::Relaxed,
+                            );
                             let _ = file_to_edges(local_db, file);
                             let _ = file_to_ref_edges(local_db, file);
                             // Owned per-file facts for the project-wide
@@ -419,6 +444,18 @@ pub(crate) fn build_project_graph(
     progress.imports.finish_and_clear();
     progress.references.finish_and_clear();
 
+    // Exclusive prefix-sum the per-file node counts into per-file
+    // global-index offsets: file `i`'s nodes occupy global indices
+    // `[offset[i], offset[i] + count[i])`. The running total after the
+    // last file is the exact graph node population, which sizes the
+    // builder's payload region.
+    let mut node_offsets: Vec<usize> = Vec::with_capacity(node_counts.len());
+    let mut total_nodes: usize = 0;
+    for count in &node_counts {
+        node_offsets.push(total_nodes);
+        total_nodes += count.load(Ordering::Relaxed);
+    }
+
     counters.start_phase(PHASE_ASSEMBLE, Some(project_files.len()));
 
     // Serial assembly pass: walk files in deterministic order,
@@ -432,6 +469,8 @@ pub(crate) fn build_project_graph(
         py,
         db,
         &project_files,
+        &node_offsets,
+        total_nodes,
         &peer_pyi_to_py,
         per_file_plugin_ids,
         counters,
@@ -572,31 +611,32 @@ struct AssembledGraph {
 /// Warnings buffered in each `FileRefEdges.warnings` are flushed to
 /// the `dead_cst._visitor` Python logger at the end — once per
 /// warning, on the main thread, with the GIL we already hold.
+#[allow(clippy::too_many_arguments)]
 fn assemble_graph<'db>(
     py: Python<'_>,
     db: &'db ProjectDatabase,
     project_files: &[File],
+    node_offsets: &[usize],
+    total_nodes: usize,
     peer_pyi_to_py: &FxHashMap<File, File>,
     per_file_plugin_ids: &[crate::native_plugins::PerFilePluginId],
     counters: &Arc<ProgressCounters>,
 ) -> PyResult<AssembledGraph> {
-    // Pre-count total nodes across project_files. file_to_nodes is
-    // salsa-memoized from the parallel populate phase, so this is a
-    // ~ns probe per file. Use the exact count to size the hashmaps
-    // that grow one-per-node (ref_to_global, global_index,
-    // decl_by_name_range) and skip rehashing entirely. The Vec-backed
-    // builder fields get pre-allocated too.
-    let mut total_nodes: usize = 0;
-    let mut total_decls: usize = 0;
-    for &file in project_files {
-        let nodes_len = file_to_nodes(db, file).nodes.len();
-        total_nodes += nodes_len;
-        // Index 0 of every file's nodes is the synthetic module node;
-        // everything else is a decl. So decls = nodes - 1 per file.
-        total_decls += nodes_len.saturating_sub(1);
-    }
+    // `total_nodes` and `node_offsets` come from the fan-out's per-file
+    // node-count prefix sum (see the populate phase). The exact total
+    // sizes the hashmaps that grow one-per-node (ref_to_global,
+    // global_index, decl_by_name_range) and skip rehashing entirely.
+    // Every file's index 0 is its synthetic module node and everything
+    // else is a decl, so `decls = nodes - 1` per file — an upper bound
+    // (star-statement nodes aren't decls either) that's fine for
+    // capacity reservation.
+    let total_decls = total_nodes.saturating_sub(project_files.len());
 
     let mut builder = GraphBuilder::with_capacity(total_nodes);
+    // Pre-size the payload region so Pass 1 can place each node at its
+    // offset-derived global index instead of appending. The offsets
+    // partition [0, total_nodes), so every slot is written exactly once.
+    builder.prefill_payload_region(total_nodes);
     let mut global_index: DeclIndex =
         FxHashMap::with_capacity_and_hasher(total_decls, Default::default());
     let mut module_nodes_by_file: FxHashMap<File, usize> =
@@ -615,8 +655,11 @@ fn assemble_graph<'db>(
     let mut all_warnings: Vec<String> = Vec::new();
 
     // Pass 1: node mint.
-    for &file in project_files {
+    for (file_pos, &file) in project_files.iter().enumerate() {
         let payload = file_to_nodes(db, file);
+        // This file's nodes occupy the contiguous global-index block
+        // starting at `base`; each local ref lands at `base + local_idx`.
+        let base = node_offsets[file_pos];
 
         // Stub-only ENTRYPOINT context: if this is a .pyi without a
         // .py twin, every decl needs ENTRYPOINT. If it has a twin,
@@ -659,7 +702,8 @@ fn assemble_graph<'db>(
                 flags,
                 imports: node_data.imports.clone(),
             };
-            let global_idx = builder.intern_node(node);
+            let global_idx = base + local_idx;
+            builder.place_node(global_idx, node);
             ref_to_global.insert(node_ref, global_idx);
             local_to_global.insert((file, local_idx as u32), global_idx);
 

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -373,56 +373,77 @@ pub(crate) fn build_project_graph(
             dist_db.attach(|local_db| {
                 let _ = crate::file_payload::project_dist_lookup(local_db);
             });
+            // Stride the spawn order with a block transpose so the tasks
+            // in flight at any instant come from different packages. The
+            // path sort clusters a package's files contiguously, so a
+            // naive in-order fan-out runs sibling files concurrently and
+            // they contend on the shared upstream salsa queries a package
+            // resolves into (its `__init__`, common imports). Walking
+            // `lane * cols + col` column-major over a `lanes x cols` grid
+            // decorrelates neighbours: consecutive spawns sit `cols` apart
+            // in sorted order, i.e. in different packages. This only
+            // permutes processing order; each task still records its count
+            // at its true sorted `file_idx`, so offsets stay deterministic.
+            let lanes = num_workers.max(1);
+            let cols = files_ref.len().div_ceil(lanes);
             rayon::scope(|s| {
-                for (file_idx, &file) in files_ref.iter().enumerate() {
-                    let db_tx = db_tx.clone();
-                    let db_rx = db_rx.clone();
-                    let counters_inner = Arc::clone(&counters_ref);
-                    s.spawn(move |_| {
-                        let local_db = db_rx.recv().expect("snapshot available");
-                        local_db.attach(|local_db| {
-                            // Record this file's node count for the offset
-                            // prefix-sum. `nodes` and `refs` are parallel
-                            // arrays, so `nodes.len()` is exactly what the
-                            // assembly mint loop iterates for this file.
-                            counts_ref[file_idx].store(
-                                file_to_nodes(local_db, file).nodes.len(),
-                                Ordering::Relaxed,
-                            );
-                            let _ = file_to_edges(local_db, file);
-                            let _ = file_to_ref_edges(local_db, file);
-                            // Owned per-file facts for the project-wide
-                            // plugin queries. Warmed here, while the AST
-                            // is live, so the queries below run as cache
-                            // reads.
-                            let _ = file_extraction(local_db, file);
-                            // Per-file native plugins: warm the salsa-cached
-                            // `per_file_plugin_ops(file, id)` query on this
-                            // worker so the serial assembly fold below is a
-                            // pure cache read. `run_on_file` is GIL-free and
-                            // touches only this file, so it composes with the
-                            // GIL-released fan-out.
-                            for &id in per_file_ids_ref {
-                                let _ =
-                                    crate::native_plugins::per_file_plugin_ops(local_db, file, id);
-                            }
-                            // Every per-file AST consumer for this file has
-                            // now run and memoized its result, so drop the
-                            // parsed AST rather than let it sit resident
-                            // through assembly and the project-wide plugin
-                            // pass — that's the memory win. Assembly, fqname,
-                            // and the class hierarchy read only the cached
-                            // payloads (`class_bases`, `external_base_children`,
-                            // `children_by_node`), never the AST, so the
-                            // all-ASTs-resident peak never forms. Subclass
-                            // resolution can still pull an individual file's AST
-                            // back on demand to relocate a class seed; that rare
-                            // reload is re-cleared right after the plugin pass.
-                            parsed_module(local_db, file).clear();
+                for col in 0..cols {
+                    for lane in 0..lanes {
+                        let file_idx = lane * cols + col;
+                        if file_idx >= files_ref.len() {
+                            continue;
+                        }
+                        let file = files_ref[file_idx];
+                        let db_tx = db_tx.clone();
+                        let db_rx = db_rx.clone();
+                        let counters_inner = Arc::clone(&counters_ref);
+                        s.spawn(move |_| {
+                            let local_db = db_rx.recv().expect("snapshot available");
+                            local_db.attach(|local_db| {
+                                // Record this file's node count for the offset
+                                // prefix-sum. `nodes` and `refs` are parallel
+                                // arrays, so `nodes.len()` is exactly what the
+                                // assembly mint loop iterates for this file.
+                                counts_ref[file_idx].store(
+                                    file_to_nodes(local_db, file).nodes.len(),
+                                    Ordering::Relaxed,
+                                );
+                                let _ = file_to_edges(local_db, file);
+                                let _ = file_to_ref_edges(local_db, file);
+                                // Owned per-file facts for the project-wide
+                                // plugin queries. Warmed here, while the AST
+                                // is live, so the queries below run as cache
+                                // reads.
+                                let _ = file_extraction(local_db, file);
+                                // Per-file native plugins: warm the salsa-cached
+                                // `per_file_plugin_ops(file, id)` query on this
+                                // worker so the serial assembly fold below is a
+                                // pure cache read. `run_on_file` is GIL-free and
+                                // touches only this file, so it composes with the
+                                // GIL-released fan-out.
+                                for &id in per_file_ids_ref {
+                                    let _ = crate::native_plugins::per_file_plugin_ops(
+                                        local_db, file, id,
+                                    );
+                                }
+                                // Every per-file AST consumer for this file has
+                                // now run and memoized its result, so drop the
+                                // parsed AST rather than let it sit resident
+                                // through assembly and the project-wide plugin
+                                // pass — that's the memory win. Assembly, fqname,
+                                // and the class hierarchy read only the cached
+                                // payloads (`class_bases`, `external_base_children`,
+                                // `children_by_node`), never the AST, so the
+                                // all-ASTs-resident peak never forms. Subclass
+                                // resolution can still pull an individual file's AST
+                                // back on demand to relocate a class seed; that rare
+                                // reload is re-cleared right after the plugin pass.
+                                parsed_module(local_db, file).clear();
+                            });
+                            db_tx.send(local_db).expect("channel open");
+                            counters_inner.populate_inc();
                         });
-                        db_tx.send(local_db).expect("channel open");
-                        counters_inner.populate_inc();
-                    });
+                    }
                 }
             });
         };

--- a/tests/prototype/test_native_graph.py
+++ b/tests/prototype/test_native_graph.py
@@ -267,6 +267,35 @@ def test_node_indices_follow_sorted_file_order(project_factory):
     assert first_seen == sorted(first_seen)
 
 
+def test_external_synthetic_nodes_minted_in_fqname_order(project_factory):
+    """Synthetic external nodes (the `[unresolved] X` endpoints for
+    non-first-party imports) are minted in fqname order, so their graph
+    indices are deterministic. Assembly collects the external endpoints
+    into an FxHashSet whose iteration order tracks salsa ids and varies
+    run-to-run; it sorts by fqname before minting to pin the indices.
+    Without that sort these indices would follow hash order."""
+    # Import several unresolved top-level modules whose names are *not*
+    # in sorted order, so hash order and fqname order diverge.
+    proj, _ = project_factory(
+        {
+            "mod.py": (
+                "import qux_zzz\n"
+                "import abc_aaa\n"
+                "import mno_mmm\n"
+                "import def_ddd\n"
+                "import ghi_ggg\n"
+                "import jkl_jjj\n"
+            ),
+        }
+    )
+    g = proj.build()
+    externals = [n.fqname for n in g.nodes if n.fqname.startswith("[unresolved] ")]
+    assert len(externals) == 6
+    # Listed in graph-index order, the external fqnames come out sorted —
+    # i.e. they were minted in fqname order, which pins their indices.
+    assert externals == sorted(externals)
+
+
 # ---------------------------------------------------------------------------
 # Shadowed declarations (Principle 3 — first-class graph nodes)
 # ---------------------------------------------------------------------------

--- a/tests/prototype/test_native_graph.py
+++ b/tests/prototype/test_native_graph.py
@@ -237,6 +237,37 @@ def test_submodule_edges_to_parent(project_factory):
 
 
 # ---------------------------------------------------------------------------
+# Deterministic node indices
+# ---------------------------------------------------------------------------
+
+
+def test_node_indices_follow_sorted_file_order(project_factory):
+    """Global node indices are a pure function of (sorted file position,
+    local index): each file's nodes occupy one contiguous index run, and
+    the runs ascend by file path. ty's `files()` set has no stable
+    iteration order, so the build sorts files first — without that, these
+    indices (and everything keyed on them) would vary run-to-run."""
+    proj, _ = project_factory(
+        {
+            "z.py": "def z(): pass\n",
+            "a.py": "def a(): pass\n",
+            "pkg/__init__.py": "",
+            "pkg/m.py": "def m(): pass\n",
+        }
+    )
+    g = proj.build()
+    # Per-file nodes carry the file's path; synthetics (none here) carry "".
+    paths = [n.path for n in g.nodes if n.path]
+    first_seen = list(dict.fromkeys(paths))
+    # Each file is one contiguous run of indices (offset placement, no
+    # interleaving): the number of run-starts equals the distinct count.
+    run_starts = sum(1 for i, p in enumerate(paths) if i == 0 or paths[i - 1] != p)
+    assert run_starts == len(first_seen)
+    # The runs ascend by path — the deterministic, sorted order.
+    assert first_seen == sorted(first_seen)
+
+
+# ---------------------------------------------------------------------------
 # Shadowed declarations (Principle 3 — first-class graph nodes)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- ty's `files()` set has no stable iteration order, and assembly assigned each node's global index from the serial append order over that set — so node indices (and the order of `Analysis.dead()` / `reachable()` results and the CLI's reports) could vary run-to-run for an unchanged codebase.
- Sort `project_files` into canonical path order, capture each file's node count in the parallel fan-out (at its sorted position), prefix-sum those counts into per-file global offsets, and place each node at `offset[file] + local_idx` via a new `GraphBuilder::place_node` into a `prefill_payload_region`-sized builder — replacing the running `intern_node` append counter. The total node count / `decls` estimate come from the same prefix sum, retiring the serial pre-count probe.
- The index is now a pure function of (sorted file position, local index) rather than an incidental consequence of walk order: **structural determinism**, and the seam for parallelizing the mint loop next (each file's worker can compute its own indices with no shared counter). `intern_node` still backs synthetic / plugin nodes, which append past the payload region.

## Test plan

- [x] `cargo build -p dead-cst-runtime` + `cargo clippy -p dead-cst-runtime --all-targets` clean
- [x] `cargo test --no-default-features --locked -p dead-cst-runtime` — 129 pass
- [x] `cargo fmt --check` clean
- [x] `maturin develop --uv` + `uv run pytest` — 696 pass / 3 skip / 5 deselected
- [x] New `test_node_indices_follow_sorted_file_order` pins the guarantee: each file's nodes form one contiguous index run, and the runs ascend by path
- [x] `uv run prek run --all-files` — ruff, ruff-format, ty, and all other hooks pass (the local `cargo-fmt` hook fails only on a `cargo`-not-on-PATH env quirk; `cargo fmt --check` passes directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)