### PR TITLE
Add a FlagSpec registry for node and edge flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,26 @@ two versions.
   modules, ML-generated ASTs, large nested literal dicts) that stack-overflow at
   the default — the size is virtual address space, so a large value costs no
   resident memory unless actually used.
+- **Extensible node/edge flag registry (`FlagSpec`).** Flags are no longer a
+  fixed catalog of compile-time bits. Every flag — engine built-ins included —
+  is now described by a `FlagSpec` (`name` as `owner/name`, `seed`, `default_on`,
+  `description`) and lives in one of two registries (a 32-bit node space, an
+  8-bit edge space). The engine registers its `engine/…` flags with explicit
+  masks (so hot-path reads still constant-fold); a native plugin contributes its
+  own through the new `ExternalPlugin::declare_node_flags()` /
+  `declare_edge_flags()` hooks and reads the host-assigned bit back at run time
+  with `PluginCtx::node_flag(name) -> Option<u32>` / `edge_flag(name) ->
+  Option<u8>`. Plugin bits are allocated above the engine masks in registration
+  order (deterministic); the `engine/` namespace is reserved (a plugin using it
+  fails the materialize); declaring the same spec from two plugins is idempotent
+  and shares one bit (this is how the built-in `pytest` and `unittest` plugins
+  now share a `test/testcase` flag), while a conflicting re-declaration or
+  exhausting the bit width fails loudly. Both registries are **serialized into
+  the `.dcg` graph file** so an external reader can decode any bit by name;
+  `native.ProjectContext` / a loaded graph expose `node_flag_registry()`,
+  `edge_flag_registry()`, `default_seed_mask()`, `node_flag(name)`, and
+  `edge_flag(name)`, and `GraphMetadata` carries both tables. (`PLUGIN_API_EPOCH`
+  bumped 1→2; `FORMAT_VERSION` bumped 1→2 — old graph files are rejected.)
 
 ### Changed
 
@@ -336,9 +356,37 @@ two versions.
   / `pathlib.PurePosixPath.match` (componentwise, from the right, case-sensitive
   — same match set). Behaviour is identical, but no built-in plugin re-acquires
   the GIL inside the GIL-free `rayon` fan-out anymore.
+- **Edge flags narrowed to `u8`** (node flags stay `u32`). `EdgeFlags` and every
+  edge-flag carrier across the runtime are now 8-bit; Python still sees edge-tuple
+  flags and node `.flags` as plain `int`, so the change is transparent across the
+  FFI boundary (the bincode layout change rides the `FORMAT_VERSION` 2 bump).
+- **The default keepalive mask is now registry-derived.** Reachability defaults
+  to `ctx.default_seed_mask()` — the OR of every registered flag that is `seed &&
+  default_on` — instead of the hand-maintained `KEEPALIVE_DEFAULT` constant. A
+  consequence: `test/testcase` is in the default mask **iff** a test plugin
+  (`pytest` / `unittest`) is registered, which is exactly the right behaviour.
+- **Overload status is now internal build-time metadata.** The `OVERLOAD` node
+  flag is replaced by an internal `is_overload` field on the build-time node
+  payload; it is no longer a reachability flag, is not serialized into the graph
+  file, and is not Python-visible. Overload behaviour is unchanged (the
+  `impl → stub` anchor edges are still emitted and cross-module imports still
+  resolve to the implementation, not a stub).
 
 ### Removed
 
+- **`NodeFlags` roster surgery (breaking).** `NodeFlags.SHADOWED` and
+  `NodeFlags.EXPORTED` (both dead — no set/read site) are deleted;
+  `NodeFlags.OVERLOAD` and `NodeFlags.TESTCASE` are removed from the public flag
+  surface. Overload status became internal build-time metadata (see Changed),
+  and `TESTCASE` became the registered `test/testcase` plugin flag — resolve it
+  with `ctx.node_flag("test/testcase")` (returns `None` when no test plugin is
+  registered). A new `NodeFlags.DEAD_BRANCH` (engine metadata for decls in a
+  statically-dead region; not a seed) is added. The surviving roster is `NONE`,
+  `ENTRYPOINT`, `NOQA`, `NOTEBOOK`, `DEAD_BRANCH`, `STAR_REEXPORT`.
+- **`dead_cst.graph.KEEPALIVE_DEFAULT` (breaking).** The hand-maintained
+  keepalive constant is gone; callers default `seed_flags` to the registry-derived
+  `default_seed_mask()` instead (available on `Analysis`, `native.ProjectContext`,
+  and a loaded graph). `Analysis` also gains a `node_flag(name)` passthrough.
 - `ProjectContext.find_comment_patterns(pattern)` (the regex-over-comments
   query) and its `_native.pyi` stub. It had no in-tree callers and was the last
   graph query that re-parsed files on demand after the build; removing it drops

--- a/NATIVE_PLUGINS.md
+++ b/NATIVE_PLUGINS.md
@@ -188,6 +188,65 @@ read a keyword via `CallArgs::str_value(name)`.
 Endpoint indices are bounds-checked by the host at apply time — a dangling
 index is rejected cleanly rather than minting an unconnected node.
 
+### Declaring flags
+
+Node and edge flags are described by a single `FlagSpec` vocabulary (re-exported
+from `plugin_api`) and live in two separate registries — a 32-bit node space and
+an 8-bit edge space. The engine registers its built-ins first (`engine/…`);
+plugins contribute their own through two optional `ExternalPlugin` hooks:
+
+```rust
+use dead_cst_runtime::native_plugins::plugin_api::FlagSpec;
+
+impl ExternalPlugin for MyPlugin {
+    fn name(&self) -> &str { "MyPlugin" }
+
+    fn declare_node_flags(&self) -> Vec<FlagSpec> {
+        vec![FlagSpec {
+            name: "acme/handler".to_string(),   // owner/name; "engine/" is reserved
+            seed: true,         // contributes to the default reachability seed mask…
+            default_on: true,   // …when also default_on
+            description: "Kept alive because acme's router registers it.".to_string(),
+        }]
+    }
+
+    fn run(&self, ctx: &PluginCtx<'_>, ops: &mut PluginOps) -> Result<(), PluginError> {
+        let handler = ctx
+            .node_flag("acme/handler")
+            .expect("declared in declare_node_flags");
+        // …stamp `handler` on synthetic seeds via `ops.add_synthetic_node(..)`.
+        Ok(())
+    }
+}
+```
+
+`FlagSpec` carries **no bit value**. The host allocates each plugin flag a bit
+**above the engine masks, in plugin registration order** — so two builds with
+the same plugin set produce identical bits. Read the assigned bit back at `run`
+time with `ctx.node_flag(name) -> Option<u32>` / `ctx.edge_flag(name) ->
+Option<u8>` (`None` if no plugin declared it). `declare_edge_flags` is the
+edge-space twin; edge flags share the 8-bit width and `seed`/`default_on` are
+node-reachability concepts (recorded but unused for edges today).
+
+Registration rules — all enforced once, under the GIL, before the parallel run:
+
+- **`engine/` is protected.** A plugin declaring an `engine/…` flag fails the
+  whole materialize.
+- **Idempotent on an identical spec.** Two plugins declaring the *same*
+  `owner/name` with the same `seed`/`default_on`/`description` collapse to one
+  shared bit — this is exactly how the built-in `pytest` and `unittest` plugins
+  both declare `test/testcase` and share it. A re-declaration with a
+  *conflicting* spec (same name, different fields) fails loudly.
+- **Width is capped.** Exhausting the node width (bit 31) or edge width (bit 7)
+  fails with a clear error naming the flag and the cap.
+
+Both registries are serialized into the `.dcg` graph file (`FORMAT_VERSION` 2),
+so an external reader can decode any bit — engine or plugin — back to its name.
+The Python layer derives its default keepalive mask from the registry
+(`ctx.default_seed_mask()`, the OR of every `seed && default_on` bit) rather than
+a hand-maintained constant, so a plugin's seed flag is kept alive by default iff
+that plugin is registered.
+
 ### Per-file plugins (optional, salsa-cached)
 
 By default an `ExternalPlugin` is **project-wide**: its `run(ctx, ops)` is
@@ -246,6 +305,14 @@ function of its `file` — it may read only what `PluginFileCtx` exposes and mus
 not consult project-wide state, other files, globals, the clock, or the
 filesystem, and it may only reference nodes *in this file*. An impure
 `run_on_file` would serve stale ops after an unrelated edit.
+
+This is also why a per-file plugin **cannot** look flags up through the registry
+(`ctx.node_flag` / `ctx.edge_flag` exist only on the project-wide `PluginCtx`):
+the flag registry is derived from the *whole* plugin set, which isn't a file
+input, so reading it from `run_on_file` would serve stale bits after a
+plugin-set change. Per-file plugins emit the built-in engine flag constants
+(`plugin_api::FLAG_*`) instead; declaring custom flags is a project-wide-plugin
+capability today.
 
 Each plugin `cdylib` also exports a **manifest** — a self-contained
 `#[repr(C)]` table listing the plugins it provides and the ABI fingerprint it

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -41,48 +41,32 @@ class NodeFlags:
     """
 
     NONE: int
-    SHADOWED: int
-    """Decl rebound by a later assignment in the same file. Kept in
-    the graph (with its parent-module edge) but excluded from the
-    cross-module lookup so consumers of an exported name route to the
-    live binding."""
 
     ENTRYPOINT: int
     """Explicit entrypoint — plugin-emitted seeds, the CLI's ``-e`` flag,
-    ``[project.scripts]`` targets, factory-app synthetics, etc. One of
-    the keepalive bits ORed into ``KEEPALIVE_DEFAULT`` on the Python
-    side, so reachability seeds from ``ENTRYPOINT``-flagged nodes by
-    default."""
-
-    OVERLOAD: int
-    """``typing.overload`` stub (or any same-name decl anchored to a
-    matching impl). Excluded from the lookup trie like ``SHADOWED``;
-    kept alive by an explicit ``impl -> overload`` edge."""
-
-    TESTCASE: int
-    """Pytest / unittest test discoveries. One of the keepalive bits in
-    ``KEEPALIVE_DEFAULT``, so tests are alive by default. The
-    ``kept_alive_by_flags_only(TESTCASE)`` blast-radius query isolates
-    "what's only alive because of tests" by computing the diff against
-    ``reachable(seed_flags=KEEPALIVE_DEFAULT & ~TESTCASE)``."""
+    ``[project.scripts]`` targets, factory-app synthetics, etc. A seed
+    flag (registered ``engine/entrypoint``), so reachability seeds from
+    ``ENTRYPOINT``-flagged nodes by default."""
 
     NOQA: int
     """Import alias preserved by a user noqa directive (bare
     ``# noqa``, ``# noqa: F401``, multi-rule ``# noqa: E501, F401``, or
-    the file-level ``# ruff: noqa`` / ``# flake8: noqa``). One of the
-    keepalive bits in ``KEEPALIVE_DEFAULT``."""
+    the file-level ``# ruff: noqa`` / ``# flake8: noqa``). A seed flag
+    (registered ``engine/noqa``)."""
 
     NOTEBOOK: int
     """Every node sourced from a Jupyter ``.ipynb`` file. Cells run
     top-to-bottom rather than being imported, so the bit alone keeps
-    the node alive (no ``ENTRYPOINT`` overlay needed — ``NOTEBOOK`` is
-    in ``KEEPALIVE_DEFAULT``). The codemod also reads the bit to skip
-    notebook nodes (it can't rewrite the cell JSON envelope)."""
+    the node alive — a seed flag (registered ``engine/notebook``). The
+    codemod also reads the bit to skip notebook nodes (it can't rewrite
+    the cell JSON envelope)."""
 
-    EXPORTED: int
-    """Every node sourced from a file under the package's ``exported``
-    glob. Used by the cross-package merge to filter to entries the
-    owning package opts into exposing."""
+    DEAD_BRANCH: int
+    """Decl that sits in a statically-dead region (the body of
+    ``if False:``, the else of ``if True:``, code after an
+    unconditional ``return`` / ``raise``, …) — the node-level companion
+    to ``EdgeFlags.DEAD_BRANCH``. Metadata only (not a seed); registered
+    ``engine/dead_branch``."""
 
     STAR_REEXPORT: int
     """Per-name import decl synthesized from ``from X import *`` — one
@@ -1073,6 +1057,43 @@ class ProjectContext:
         """Live edges as ``(src_idx, dst_idx, flags)`` triples."""
         ...
 
+    # ----- Flag registries ----------------------------------------------
+    #
+    # The engine seeds both registries with its built-in flags at
+    # construction; plugins extend the node / edge registries during
+    # :meth:`materialize`. The getters decode bits by name and feed the
+    # registry-derived keepalive seed the Python layer uses.
+
+    def node_flag_registry(self) -> list[tuple[str, int, bool, bool, str]]:
+        """Every registered node flag as
+        ``(name, bit, seed, default_on, description)`` tuples, sorted by
+        bit. Includes the engine built-ins plus any flag a registered
+        plugin declared via ``declare_node_flags``."""
+        ...
+
+    def edge_flag_registry(self) -> list[tuple[str, int, bool, bool, str]]:
+        """Every registered edge flag, same tuple shape as
+        :meth:`node_flag_registry`."""
+        ...
+
+    def default_seed_mask(self) -> int:
+        """OR of every node-flag bit whose flag both seeds reachability
+        and is on by default — the registry-derived replacement for the
+        old ``KEEPALIVE_DEFAULT`` constant. The default ``seed_flags`` for
+        :class:`dead_cst.Analysis` reachability queries."""
+        ...
+
+    def node_flag(self, name: str) -> int | None:
+        """Resolve a node-flag bit by its registered ``owner/name`` (e.g.
+        ``"engine/entrypoint"``, ``"test/testcase"``), or ``None`` when no
+        flag with that name is registered."""
+        ...
+
+    def edge_flag(self, name: str) -> int | None:
+        """Resolve an edge-flag bit by its registered ``owner/name``, or
+        ``None`` when no flag with that name is registered."""
+        ...
+
 # ---------- Node-attribute rows ------------------------------------------
 
 class NodeAttrs:
@@ -1101,9 +1122,12 @@ class GraphMetadata:
 
     ``created_at`` is unix-epoch seconds at write time. ``user_meta``
     is the list of ``(key, value)`` pairs the writer passed (from
-    ``dead-cst build --meta key=value``). The counts mirror the
-    graph stamped into the file and double as a sanity check against
-    the deserialized payload.
+    ``dead-cst build --meta key=value``). ``node_flag_registry`` /
+    ``edge_flag_registry`` carry the flag tables stamped into the file
+    (``(name, bit, seed, default_on, description)`` tuples) so a reader
+    can decode flag bits by name. The counts mirror the graph stamped
+    into the file and double as a sanity check against the deserialized
+    payload.
     """
 
     format_version: int
@@ -1113,6 +1137,8 @@ class GraphMetadata:
     file_count: int
     line_count: int
     user_meta: list[tuple[str, str]]
+    node_flag_registry: list[tuple[str, int, bool, bool, str]]
+    edge_flag_registry: list[tuple[str, int, bool, bool, str]]
 
 class ProgressHandle:
     """Borrow-free view over the build-progress atomic counters.
@@ -1137,11 +1163,16 @@ def write_graph(
     nodes: list[SymbolNode],
     edges: list[tuple[int, int, int]],
     meta: list[tuple[str, str]],
+    node_flag_registry: list[tuple[str, int, bool, bool, str]],
+    edge_flag_registry: list[tuple[str, int, bool, bool, str]],
 ) -> None:
     """Persist ``nodes`` + ``edges`` to ``path`` as a bincode-encoded
     graph file. ``meta`` is the user-supplied list of ``(key, value)``
     pairs (from ``--meta`` on the CLI); they are stored verbatim in
-    the file's metadata block.
+    the file's metadata block. ``node_flag_registry`` /
+    ``edge_flag_registry`` are the flag tables
+    (``(name, bit, seed, default_on, description)`` tuples) so a reader
+    can decode flag bits by name.
     """
     ...
 

--- a/python/dead_cst/analyze.py
+++ b/python/dead_cst/analyze.py
@@ -5,7 +5,7 @@ import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Sequence, TypedDict
 
-from .graph import KEEPALIVE_DEFAULT, EdgeFlags
+from .graph import EdgeFlags
 
 if TYPE_CHECKING:
     from dead_cst import _native as native
@@ -663,20 +663,25 @@ class Analysis:
             if poller is not None:
                 poller.stop()
 
-    def reachable(self, *, seed_flags: int = KEEPALIVE_DEFAULT) -> set[int]:
+    def reachable(self, *, seed_flags: int | None = None) -> set[int]:
         """Positional indices of every decl reachable from any seed in
         ``seed_flags``. Pair with :meth:`native.ProjectContext.nodes_at`
         / :meth:`native.ProjectContext.node_attrs` to materialise the
         underlying ``SymbolNode``\\ s or batched attribute snapshots
-        on demand.
+        on demand. ``seed_flags`` defaults to the registry-derived
+        :meth:`native.ProjectContext.default_seed_mask`.
         """
         ctx = self.materialize_all()
+        if seed_flags is None:
+            seed_flags = ctx.default_seed_mask()
         return set(ctx.reachable_indices(seed_flags=seed_flags))
 
-    def dead(self, *, seed_flags: int = KEEPALIVE_DEFAULT) -> Iterator[int]:
+    def dead(self, *, seed_flags: int | None = None) -> Iterator[int]:
         """Yield positional indices of every decl that no seed in
         ``seed_flags`` reaches. Skips ``module`` and ``synthetic``
         nodes (markers/anchors, not "dead" in the actionable sense).
+        ``seed_flags`` defaults to the registry-derived
+        :meth:`native.ProjectContext.default_seed_mask`.
         """
         ctx = self.materialize_all()
         return _iter_dead_indices(ctx, self.reachable(seed_flags=seed_flags))
@@ -697,24 +702,38 @@ class Analysis:
         ctx = self.materialize_all()
         return list(ctx.ancestors_indices(decl_idx, skip_flags=skip_flags))
 
-    def kept_alive_by_dead_branches(self, *, seed_flags: int = KEEPALIVE_DEFAULT) -> set[int]:
-        """Indices reachable only via ``EdgeFlags.DEAD_BRANCH`` edges."""
+    def kept_alive_by_dead_branches(self, *, seed_flags: int | None = None) -> set[int]:
+        """Indices reachable only via ``EdgeFlags.DEAD_BRANCH`` edges.
+        ``seed_flags`` defaults to the registry-derived
+        :meth:`native.ProjectContext.default_seed_mask`."""
         ctx = self.materialize_all()
+        if seed_flags is None:
+            seed_flags = ctx.default_seed_mask()
         full = set(ctx.reachable_indices(seed_flags=seed_flags))
         strict = set(ctx.reachable_indices(seed_flags=seed_flags, skip_flags=EdgeFlags.DEAD_BRANCH))
         return full - strict
 
-    def kept_alive_by_flags_only(
-        self, flags: int, *, seed_flags: int = KEEPALIVE_DEFAULT
-    ) -> set[int]:
+    def kept_alive_by_flags_only(self, flags: int, *, seed_flags: int | None = None) -> set[int]:
         """Blast radius of dropping every seed whose flags carry any
         bit in ``flags`` — the diff between
         ``reachable_indices(seed_flags)`` and
-        ``reachable_indices(seed_flags & ~flags)``."""
+        ``reachable_indices(seed_flags & ~flags)``. ``seed_flags``
+        defaults to the registry-derived
+        :meth:`native.ProjectContext.default_seed_mask`."""
         ctx = self.materialize_all()
+        if seed_flags is None:
+            seed_flags = ctx.default_seed_mask()
         full = set(ctx.reachable_indices(seed_flags=seed_flags))
         without = set(ctx.reachable_indices(seed_flags=seed_flags & ~flags))
         return full - without
+
+    def node_flag(self, name: str) -> int | None:
+        """Resolve a node-flag bit by its registered ``owner/name`` (e.g.
+        ``"engine/entrypoint"``, ``"test/testcase"``), or ``None`` if no
+        flag with that name is registered. The available names depend on
+        the registered plugin set — a flag a plugin declares only exists
+        once that plugin is registered."""
+        return self.materialize_all().node_flag(name)
 
 
 __all__ = [

--- a/python/dead_cst/cli.py
+++ b/python/dead_cst/cli.py
@@ -37,10 +37,8 @@ from dead_cst import _native as native
 from .analyze import Analysis
 from .codemod import generate_patch
 from .graph import (
-    KEEPALIVE_DEFAULT,
     GraphMetadata,
     LoadedGraph,
-    NodeFlags,
     SymbolNode,
     read_graph,
     write_graph,
@@ -217,12 +215,14 @@ def _load_or_build(
 
 
 def _select_dead(view: GraphView, query: Query) -> list[SymbolNode]:
+    seed_mask = view.default_seed_mask()
     if query is Query.dead:
-        reachable = set(view.reachable(seed_flags=KEEPALIVE_DEFAULT))
+        reachable = set(view.reachable(seed_flags=seed_mask))
         return [n for n in view.nodes() if n not in reachable]
     if query is Query.test_only:
-        full = set(view.reachable(seed_flags=KEEPALIVE_DEFAULT))
-        without_tests = set(view.reachable(seed_flags=KEEPALIVE_DEFAULT & ~NodeFlags.TESTCASE))
+        testcase = view.node_flag("test/testcase") or 0
+        full = set(view.reachable(seed_flags=seed_mask))
+        without_tests = set(view.reachable(seed_flags=seed_mask & ~testcase))
         return list(full - without_tests)
     raise typer.BadParameter(f"unknown --query value: {query!r}")
 

--- a/python/dead_cst/graph.py
+++ b/python/dead_cst/graph.py
@@ -3,8 +3,8 @@
 :class:`SymbolNode` is what every node in the project graph is.
 :class:`Import` captures a cross-file reference (the dotted module
 name plus optional decl). :class:`NodeFlags` and :class:`EdgeFlags`
-mark structural attributes (``SHADOWED`` decls, ``DEAD_BRANCH`` edges,
-explicit ``ENTRYPOINT``\\s).
+mark structural attributes (``NOQA``-pinned imports, ``DEAD_BRANCH``
+edges, explicit ``ENTRYPOINT``\\s).
 
 All four are re-exported straight from the rust extension
 (:mod:`dead_cst._native`) — there is no parallel Python copy anymore.
@@ -34,24 +34,19 @@ from dead_cst._native import (
 if TYPE_CHECKING:
     from dead_cst import _native as native
 
-#: Default seed mask for reachability queries. ORs together every
-#: :class:`NodeFlags` bit that semantically "keeps a node alive":
-#:
-#: * :data:`NodeFlags.ENTRYPOINT` — explicit entrypoints (plugin-emitted
-#:   seeds, ``-e`` CLI flag, ``[project.scripts]`` targets, ...).
-#: * :data:`NodeFlags.TESTCASE` — pytest / unittest discoveries.
-#: * :data:`NodeFlags.NOQA` — imports pinned by a ``# noqa: F401``
-#:   directive.
-#: * :data:`NodeFlags.NOTEBOOK` — notebook cells (run top-to-bottom,
-#:   never imported, always alive).
-#:
-#: :meth:`Analysis.reachable` / :meth:`Analysis.dead` default to this
-#: mask. Pass a subset to scope the question — e.g.
-#: ``reachable(seed_flags=NodeFlags.ENTRYPOINT)`` asks "what would be
-#: alive if the test suite, ``noqa`` pins, and notebooks didn't exist."
-KEEPALIVE_DEFAULT: int = (
-    NodeFlags.ENTRYPOINT | NodeFlags.TESTCASE | NodeFlags.NOQA | NodeFlags.NOTEBOOK
-)
+#: A flag-registry entry: ``(name, bit, seed, default_on, description)``.
+FlagEntry = tuple[str, int, bool, bool, str]
+
+
+def _seed_mask_from_registry(registry: Sequence[FlagEntry]) -> int:
+    """OR of every node-flag bit whose flag both seeds reachability and is
+    on by default — the registry-derived replacement for the old
+    hand-maintained ``KEEPALIVE_DEFAULT`` constant."""
+    mask = 0
+    for _name, bit, seed, default_on, _description in registry:
+        if seed and default_on:
+            mask |= bit
+    return mask
 
 
 class LoadedGraph:
@@ -65,12 +60,22 @@ class LoadedGraph:
     walk here keeps the ``ProjectContext`` off the critical path.
     """
 
-    __slots__ = ("_nodes", "_edges", "_out", "_index")
+    __slots__ = (
+        "_nodes",
+        "_edges",
+        "_out",
+        "_index",
+        "_node_flag_registry",
+        "_edge_flag_registry",
+        "_default_seed_mask",
+    )
 
     def __init__(
         self,
         nodes: Sequence[SymbolNode],
         edges: Sequence[tuple[int, int, int]],
+        node_flag_registry: Sequence[FlagEntry] = (),
+        edge_flag_registry: Sequence[FlagEntry] = (),
     ) -> None:
         self._nodes: list[SymbolNode] = list(nodes)
         self._edges: list[tuple[int, int, int]] = list(edges)
@@ -79,6 +84,9 @@ class LoadedGraph:
         for src, dst, flags in self._edges:
             out[src].append((dst, flags))
         self._out: list[list[tuple[int, int]]] = out
+        self._node_flag_registry: list[FlagEntry] = list(node_flag_registry)
+        self._edge_flag_registry: list[FlagEntry] = list(edge_flag_registry)
+        self._default_seed_mask: int = _seed_mask_from_registry(self._node_flag_registry)
 
     def nodes(self) -> list[SymbolNode]:
         return list(self._nodes)
@@ -86,18 +94,46 @@ class LoadedGraph:
     def edges(self) -> list[tuple[int, int, int]]:
         return list(self._edges)
 
+    def node_flag_registry(self) -> list[FlagEntry]:
+        """The node-flag registry loaded from the graph file, so a
+        loaded-then-rewritten graph preserves it. Empty for a graph
+        written before format version 2."""
+        return list(self._node_flag_registry)
+
+    def edge_flag_registry(self) -> list[FlagEntry]:
+        """The edge-flag registry loaded from the graph file."""
+        return list(self._edge_flag_registry)
+
+    def default_seed_mask(self) -> int:
+        """Registry-derived default keepalive mask (see
+        :func:`_seed_mask_from_registry`)."""
+        return self._default_seed_mask
+
+    def node_flag(self, name: str) -> int | None:
+        """Resolve a node-flag bit by its registered ``owner/name`` from
+        the loaded registry, mirroring
+        :meth:`native.ProjectContext.node_flag`. ``None`` if no flag with
+        that name is recorded in the file."""
+        for entry_name, bit, *_rest in self._node_flag_registry:
+            if entry_name == name:
+                return bit
+        return None
+
     def reachable(
         self,
         *,
-        seed_flags: int = KEEPALIVE_DEFAULT,
+        seed_flags: int | None = None,
         skip_flags: int = 0,
     ) -> list[SymbolNode]:
         """Forward closure from every node whose ``flags & seed_flags``.
 
         Mirrors :meth:`native.ProjectContext.reachable` — same seed
         semantics, same ``skip_flags`` masking on edges — implemented
-        as a Python BFS over the loaded adjacency list.
+        as a Python BFS over the loaded adjacency list. ``seed_flags``
+        defaults to the registry-derived :meth:`default_seed_mask`.
         """
+        if seed_flags is None:
+            seed_flags = self._default_seed_mask
         seeds = [i for i, n in enumerate(self._nodes) if n.flags & seed_flags]
         visited: set[int] = set()
         stack: list[int] = list(seeds)
@@ -131,6 +167,17 @@ def _edge_iterable(obj: object) -> list[tuple[int, int, int]]:
     return list(edges_fn())
 
 
+def _flag_registry(obj: object, attr: str) -> list[FlagEntry]:
+    """Read a ``node_flag_registry`` / ``edge_flag_registry`` table off a
+    duck-typed graph. Both :class:`native.ProjectContext` and
+    :class:`LoadedGraph` expose them as methods; a graph without them
+    (e.g. a third-party duck type) serializes an empty table."""
+    fn = getattr(obj, attr, None)
+    if fn is None:
+        return []
+    return [tuple(entry) for entry in fn()]
+
+
 def write_graph(
     path: Path | str,
     graph: native.ProjectContext | LoadedGraph,
@@ -149,7 +196,11 @@ def write_graph(
     """
     nodes = _node_iterable(graph)
     edges = _edge_iterable(graph)
-    _native_mod.write_graph(str(path), nodes, edges, list(meta))
+    node_flag_registry = _flag_registry(graph, "node_flag_registry")
+    edge_flag_registry = _flag_registry(graph, "edge_flag_registry")
+    _native_mod.write_graph(
+        str(path), nodes, edges, list(meta), node_flag_registry, edge_flag_registry
+    )
 
 
 def read_graph(path: Path | str) -> tuple[LoadedGraph, GraphMetadata]:
@@ -161,11 +212,18 @@ def read_graph(path: Path | str) -> tuple[LoadedGraph, GraphMetadata]:
     in-place migrations.
     """
     native_graph, metadata = _native_mod.read_graph(str(path))
-    return LoadedGraph(list(native_graph.nodes), list(native_graph.edges)), metadata
+    return (
+        LoadedGraph(
+            list(native_graph.nodes),
+            list(native_graph.edges),
+            list(metadata.node_flag_registry),
+            list(metadata.edge_flag_registry),
+        ),
+        metadata,
+    )
 
 
 __all__ = [
-    "KEEPALIVE_DEFAULT",
     "EdgeFlags",
     "GraphMetadata",
     "Import",

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -7,7 +7,11 @@ use std::process::Command;
 /// so a plugin built against the old API is rejected at load, distinct from a
 /// plain version bump. Folded into the ABI fingerprint below and re-exported as
 /// `native_plugins::plugin_api::PLUGIN_API_EPOCH`.
-const PLUGIN_API_EPOCH: u32 = 1;
+///
+/// 1 → 2: added `ExternalPlugin::declare_node_flags` / `declare_edge_flags`,
+/// `PluginCtx::node_flag` / `edge_flag`, the re-exported `FlagSpec`, and
+/// narrowed edge `flags` from `u32` to `u8`.
+const PLUGIN_API_EPOCH: u32 = 2;
 
 /// Compose the ABI fingerprint that gates external native-plugin loading.
 /// It changes whenever anything that could break the dylib ABI changes:

--- a/runtime/src/builder.rs
+++ b/runtime/src/builder.rs
@@ -55,6 +55,10 @@ pub(crate) struct GraphNode {
     pub(crate) end_line: usize,
     pub(crate) end_column: usize,
     pub(crate) flags: u32,
+    /// `@overload` stub marker carried from [`NodeData`]. Build-time only —
+    /// drives the fqname-trie exclusion in `build_fqname_indices`; never
+    /// reaches `SymbolNode`, the dcg file, or Python.
+    pub(crate) is_overload: bool,
     pub(crate) imports: Option<ImportPayload>,
 }
 
@@ -109,13 +113,13 @@ impl GraphNode {
 pub(crate) struct GraphBuilder {
     pub(crate) nodes: Vec<GraphNode>,
     pub(crate) node_index: FxHashMap<NodeKey, usize>,
-    pub(crate) edges: Vec<(usize, usize, u32)>,
-    pub(crate) edge_set: FxHashSet<(usize, usize, u32)>,
+    pub(crate) edges: Vec<(usize, usize, u8)>,
+    pub(crate) edge_set: FxHashSet<(usize, usize, u8)>,
     /// Per-node forward / reverse adjacency lists kept in sync with
     /// ``edges``. ``bfs`` reads these so traversals are O(deg(i)) per
     /// pop instead of O(|edges|).
-    pub(crate) forward_adj: Vec<Vec<(usize, u32)>>,
-    pub(crate) reverse_adj: Vec<Vec<(usize, u32)>>,
+    pub(crate) forward_adj: Vec<Vec<(usize, u8)>>,
+    pub(crate) reverse_adj: Vec<Vec<(usize, u8)>>,
     /// `{ pyi_file -> py_twin_file }` for peer ``.pyi`` files whose
     /// ``.py`` twin is also in the project. Both files get ingested
     /// independently (the rust path differs from libcst here — we
@@ -231,7 +235,7 @@ impl GraphBuilder {
         idx
     }
 
-    pub(crate) fn add_edge(&mut self, src: usize, dst: usize, flags: u32) {
+    pub(crate) fn add_edge(&mut self, src: usize, dst: usize, flags: u8) {
         let triple = (src, dst, flags);
         if self.edge_set.insert(triple) {
             self.edges.push(triple);
@@ -249,7 +253,7 @@ impl GraphBuilder {
     /// with looping `add_edge`, the win is amortising the per-edge
     /// branch / hash overhead and pre-reserving capacity on `edges`
     /// and the per-node adjacency vectors.
-    pub(crate) fn extend_edges(&mut self, triples: Vec<(usize, usize, u32)>) {
+    pub(crate) fn extend_edges(&mut self, triples: Vec<(usize, usize, u8)>) {
         if triples.is_empty() {
             return;
         }
@@ -303,7 +307,7 @@ pub(crate) fn bfs(
     builder: &GraphBuilder,
     seeds: impl IntoIterator<Item = usize>,
     direction: Direction,
-    skip_flags: u32,
+    skip_flags: u8,
 ) -> FxHashSet<usize> {
     let mut visited: FxHashSet<usize> = FxHashSet::default();
     let mut stack: Vec<usize> = seeds.into_iter().collect();
@@ -346,6 +350,7 @@ pub(crate) fn synthetic_node(
         end_line: 0,
         end_column: 0,
         flags,
+        is_overload: false,
         imports: None,
     }
 }
@@ -360,7 +365,7 @@ pub(crate) enum PreparedOp {
     Edge {
         src_idx: usize,
         dst_idx: usize,
-        flags: u32,
+        flags: u8,
     },
     Entrypoint {
         decl_idx: usize,
@@ -688,7 +693,7 @@ mod tests {
     /// Append a forward+reverse adjacency entry. The plain `Vec::push`
     /// path is enough because `bfs` only reads `forward_adj` /
     /// `reverse_adj` — it never inspects `edges` / `edge_set` / `nodes`.
-    fn add_edge_manual(b: &mut GraphBuilder, src: usize, dst: usize, flags: u32) {
+    fn add_edge_manual(b: &mut GraphBuilder, src: usize, dst: usize, flags: u8) {
         b.forward_adj[src].push((dst, flags));
         b.reverse_adj[dst].push((src, flags));
     }

--- a/runtime/src/file_payload.rs
+++ b/runtime/src/file_payload.rs
@@ -39,9 +39,9 @@ use ty_python_core::semantic_index;
 
 use crate::graph::{DeclKey, NodeFlags};
 use crate::helpers::{
-    classify_base, collect_all_imports_local, file_default_flags, file_path_string,
-    iter_top_level_classes, module_fqname_for_file, position, range_key, scan_noqa_directives,
-    NODE_FLAGS_NOQA_PIN,
+    classify_base, collect_all_imports_local, detect_dead_ranges, file_default_flags,
+    file_path_string, iter_top_level_classes, module_fqname_for_file, position, range_key,
+    scan_noqa_directives, NODE_FLAGS_NOQA_PIN,
 };
 use crate::ingest::{decl_kind_str, file_package_name, from_module_string};
 
@@ -173,6 +173,11 @@ pub(crate) struct NodeData {
     pub(crate) end_line: usize,
     pub(crate) end_column: usize,
     pub(crate) flags: u32,
+    /// Whether this decl is an `@overload` stub. Build-time only: drives the
+    /// `impl → stub` anchor-edge pass and the export-binding / fqname-trie
+    /// exclusions, then is dropped — overload status is neither serialized nor
+    /// Python-visible (a loaded graph behaves correctly off the anchor edges).
+    pub(crate) is_overload: bool,
     pub(crate) imports: Option<ImportPayload>,
     /// Byte range of the bound *name* (ty's `DefinitionKind::target_range`),
     /// stashed so the assembly pass can rebuild its `(File, place_id,
@@ -275,8 +280,8 @@ pub(crate) struct ImportPayload {
 ///   in-file `@typing.overload` groups. The assembly pass emits one
 ///   `impl → stub` edge per pair so reachability propagates from a
 ///   live impl to its stubs (and a dead impl drags its stubs along
-///   for the codemod). Stubs are also flagged `NodeFlags::OVERLOAD`
-///   in `nodes` and excluded from `exports_by_name` so cross-module
+///   for the codemod). Stubs also carry `NodeData::is_overload`
+///   in `nodes` and are excluded from `exports_by_name` so cross-module
 ///   `from mod import f` resolves to the impl only.
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct FileNodes<'db> {
@@ -366,6 +371,7 @@ pub(crate) fn ref_to_node<'db>(db: &'db dyn ProjectDb, r: NodeRef<'db>) -> NodeD
             end_line: 0,
             end_column: 0,
             flags: 0,
+            is_overload: false,
             imports: None,
             name_range: (0, 0),
         },
@@ -457,6 +463,7 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         end_line: mel,
         end_column: mec,
         flags: default_flags,
+        is_overload: false,
         imports: None,
         name_range: (0, 0),
     });
@@ -497,6 +504,13 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
             }
         }
     }
+
+    // Statically-dead statement ranges (`if False:` bodies, post-`return`
+    // suites, …). A decl whose name sits inside one is stamped
+    // `NodeFlags::DEAD_BRANCH` — the node-level companion to the edge flag
+    // of the same name. Metadata only (not a seed); recorded for the
+    // explorer / blast-radius queries.
+    let dead_ranges = detect_dead_ranges(&parsed);
 
     for (_def_id, state, _used) in use_def_map.all_definitions_with_usage() {
         let DefinitionState::Defined(def) = state else {
@@ -558,19 +572,23 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         if import_noqa_pin {
             flags |= NODE_FLAGS_NOQA_PIN;
         }
-        // `@typing.overload`-decorated function defs: flag now so the
+        // `@typing.overload`-decorated function defs: record now so the
         // post-pass can partition same-name groups into impl / stubs.
         // The set is keyed on the function's name TextRange, which is
         // exactly what `DefinitionKind::Function::target_range` returns.
-        if matches!(node_kind, NodeKind::Function) && overload_decorated.contains(&target_range) {
-            flags |= NodeFlags::OVERLOAD;
-        }
+        let is_overload =
+            matches!(node_kind, NodeKind::Function) && overload_decorated.contains(&target_range);
         // Per-name implicit star bindings: flag so the codemod skips
         // them. They share the `*` token's range and can't be removed
         // individually; the `*<src>` statement node (minted below, no
         // `STAR_REEXPORT` flag) stays the removable unit.
         if is_star {
             flags |= NodeFlags::STAR_REEXPORT;
+        }
+        // Decl sitting in a statically-dead region — node-level companion
+        // to `EdgeFlags::DEAD_BRANCH`.
+        if dead_ranges.iter().any(|r| r.contains_range(target_range)) {
+            flags |= NodeFlags::DEAD_BRANCH;
         }
         // Stub-only ENTRYPOINT flagging is deferred to the assembly
         // pass; it needs the project-wide peer-stub map and the .py
@@ -586,6 +604,7 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
             end_line: el,
             end_column: ec,
             flags,
+            is_overload,
             imports: import_spec.clone(),
             name_range: (target_range.start().to_u32(), target_range.end().to_u32()),
         };
@@ -622,6 +641,7 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
                         end_line: el,
                         end_column: ec,
                         flags: star_flags,
+                        is_overload: false,
                         imports: import_spec.clone(),
                         name_range: (target_range.start().to_u32(), target_range.end().to_u32()),
                     };
@@ -654,9 +674,9 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
     // non-overload impl, pair each stub with the *last* non-overload
     // decl (CPython's runtime semantics — the impl is the final one).
     // Stubs that aren't anchored to an impl (e.g. a .pyi stub file
-    // where every `def f` is `@overload`) keep their OVERLOAD flag
-    // but emit no anchor; reachability falls back to the
-    // module-anchor edge.
+    // where every `def f` is `@overload`) stay `is_overload` but
+    // emit no anchor; reachability falls back to the module-anchor
+    // edge.
     let mut overload_anchors: Vec<(u32, u32)> = Vec::new();
     let mut by_name: FxHashMap<String, Vec<u32>> = FxHashMap::default();
     for (i, node) in nodes.iter().enumerate() {
@@ -680,12 +700,12 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         let Some(&impl_idx) = group
             .iter()
             .rev()
-            .find(|&&i| nodes[i as usize].flags & NodeFlags::OVERLOAD == 0)
+            .find(|&&i| !nodes[i as usize].is_overload)
         else {
             continue;
         };
         for &i in group {
-            if nodes[i as usize].flags & NodeFlags::OVERLOAD != 0 {
+            if nodes[i as usize].is_overload {
                 overload_anchors.push((impl_idx, i));
             }
         }
@@ -716,7 +736,7 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
                 continue;
             }
             if let Some(&local_idx) = ref_to_local.get(&NodeRef::Def(def_key(db, def, &parsed))) {
-                if nodes[local_idx as usize].flags & NodeFlags::OVERLOAD != 0 {
+                if nodes[local_idx as usize].is_overload {
                     continue;
                 }
                 live.push(local_idx);
@@ -896,7 +916,7 @@ pub(crate) fn import_payload_for_pure<'db>(
 /// payloads are collected.
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct FileEdges<'db> {
-    pub(crate) edges: FxHashSet<(NodeRef<'db>, NodeRef<'db>, u32)>,
+    pub(crate) edges: FxHashSet<(NodeRef<'db>, NodeRef<'db>, u8)>,
 }
 
 /// Per-file edge emission. Salsa-tracked so the per-file walk
@@ -944,7 +964,7 @@ pub(crate) struct FileEdges<'db> {
 pub(crate) fn file_to_edges<'db>(db: &'db dyn ProjectDb, file: File) -> FileEdges<'db> {
     let self_nodes = file_to_nodes(db, file);
     let module_ref = NodeRef::Module(file);
-    let mut edges: FxHashSet<(NodeRef<'db>, NodeRef<'db>, u32)> = FxHashSet::default();
+    let mut edges: FxHashSet<(NodeRef<'db>, NodeRef<'db>, u8)> = FxHashSet::default();
 
     // 1. Decl → module anchor edges. Every per-file def points at the
     //    module node so reachability seeded from the module covers all
@@ -956,7 +976,7 @@ pub(crate) fn file_to_edges<'db>(db: &'db dyn ProjectDb, file: File) -> FileEdge
     // 1a. `impl → stub` anchor edges for in-file `@typing.overload`
     //     groups. Lets reachability propagate from a live impl to its
     //     stubs and lets the codemod drop a dead impl's stubs in the
-    //     same pass. (`NodeFlags::OVERLOAD` on the stub additionally
+    //     same pass. (`NodeData::is_overload` on the stub additionally
     //     excludes it from cross-module `from mod import f` lookups.)
     for &(impl_local, stub_local) in self_nodes.overload_anchors.iter() {
         let impl_ref = self_nodes.refs[impl_local as usize];

--- a/runtime/src/file_ref_edges.rs
+++ b/runtime/src/file_ref_edges.rs
@@ -91,7 +91,7 @@ use crate::ingest::{
 /// GIL-free so workers run inside `py.allow_threads` cleanly.
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct FileRefEdges<'db> {
-    pub(crate) edges: FxHashSet<(NodeRef<'db>, NodeRef<'db>, u32)>,
+    pub(crate) edges: FxHashSet<(NodeRef<'db>, NodeRef<'db>, u8)>,
     pub(crate) warnings: Vec<String>,
 }
 
@@ -101,7 +101,7 @@ pub(crate) struct FileRefEdges<'db> {
 #[salsa::tracked(returns(ref), heap_size = ruff_memory_usage::heap_size)]
 pub(crate) fn file_to_ref_edges<'db>(db: &'db dyn ProjectDb, file: File) -> FileRefEdges<'db> {
     let self_nodes = file_to_nodes(db, file);
-    let mut edges: FxHashSet<(NodeRef<'db>, NodeRef<'db>, u32)> = FxHashSet::default();
+    let mut edges: FxHashSet<(NodeRef<'db>, NodeRef<'db>, u8)> = FxHashSet::default();
     let mut warnings: Vec<String> = Vec::new();
 
     let parsed = parsed_module(db, file).load(db);
@@ -204,7 +204,7 @@ struct RefWalker<'a, 'db> {
     /// `TYPE_CHECKING` as `True`); `find_local_bindings` recovers it
     /// from the scope-wide reachable bindings.
     tc_ranges: &'a [TextRange],
-    edges: &'a mut FxHashSet<(NodeRef<'db>, NodeRef<'db>, u32)>,
+    edges: &'a mut FxHashSet<(NodeRef<'db>, NodeRef<'db>, u8)>,
     /// Per-file warnings buffer. Workers push pure-rust strings; the
     /// driver flushes them to Python logging from the main thread.
     warnings: &'a mut Vec<String>,
@@ -225,7 +225,7 @@ struct RefWalker<'a, 'db> {
     /// (set by `emit_name_use` / nested-import handlers from
     /// `flags_for_range` on the reference's source position;
     /// reset to 0 after the reference completes).
-    current_flags: u32,
+    current_flags: u8,
 }
 
 impl<'a, 'db> RefWalker<'a, 'db> {
@@ -237,7 +237,7 @@ impl<'a, 'db> RefWalker<'a, 'db> {
 
     /// Returns `EDGE_FLAG_DEAD_BRANCH` if `range` is contained in any
     /// statically-dead region recorded for this file, else `0`.
-    fn flags_for_range(&self, range: TextRange) -> u32 {
+    fn flags_for_range(&self, range: TextRange) -> u8 {
         if self.dead_ranges.iter().any(|r| r.contains_range(range)) {
             EDGE_FLAG_DEAD_BRANCH
         } else {

--- a/runtime/src/flag_registry.rs
+++ b/runtime/src/flag_registry.rs
@@ -1,0 +1,271 @@
+//! Node- and edge-flag registries: one [`FlagSpec`] mechanism with two
+//! registration paths.
+//!
+//! Every flag — engine built-ins included — is described by a [`FlagSpec`].
+//! The engine registers first via [`FlagRegistry::register_engine`] with an
+//! **explicit mask** (the `graph.rs` const, so hot-path `flags & CONST` reads
+//! still constant-fold). Plugins register via
+//! [`FlagRegistry::register_plugin`] **without** a mask; the host allocates
+//! the next free bit **above the last engine mask**, in plugin registration
+//! order — a pure function of that order, hence deterministic.
+//!
+//! [`FlagSpec`] is the only author-facing type (re-exported from
+//! `plugin_api`); it is pyo3-free. [`FlagRegistry`] is host-internal and
+//! never crosses the plugin airlock — plugins read a resolved bit through
+//! `PluginCtx::node_flag` / `edge_flag`, which hand back a plain `Option`.
+
+use rustc_hash::FxHashMap;
+
+use crate::graph::{BUILTIN_EDGE_FLAGS, BUILTIN_NODE_FLAGS};
+use crate::native_plugins::plugin_api::PluginError;
+
+/// Declarative description of one flag. Carries no bit value: engine flags
+/// pass their mask separately to [`FlagRegistry::register_engine`], and
+/// plugin flags are assigned a bit by the host.
+///
+/// `name` is `owner/name` namespaced; the `engine/` owner is reserved for
+/// built-ins. `seed` marks a flag that seeds reachability; `default_on`
+/// (only meaningful with `seed`) puts it in the default keepalive mask.
+#[derive(Debug, Clone)]
+pub struct FlagSpec {
+    pub name: String,
+    pub seed: bool,
+    pub default_on: bool,
+    pub description: String,
+}
+
+/// A name↔bit registry over a fixed bit width (32 for node flags, 8 for edge
+/// flags). Seeded with the engine built-ins, then frozen after the plugin
+/// declaration pass and lent read-only into the parallel plugin run.
+pub(crate) struct FlagRegistry {
+    width_bits: u32,
+    by_name: FxHashMap<String, u64>,
+    /// `(bit, spec)` in registration order (engine ascending, then plugins
+    /// ascending — already bit-sorted, but [`entries`](Self::entries) sorts
+    /// defensively).
+    specs: Vec<(u64, FlagSpec)>,
+    /// Lowest bit a plugin flag may take: one above the highest engine mask,
+    /// advanced as plugin flags are allocated.
+    next_plugin_bit: u64,
+}
+
+impl FlagRegistry {
+    fn new(width_bits: u32) -> Self {
+        Self {
+            width_bits,
+            by_name: FxHashMap::default(),
+            specs: Vec::new(),
+            next_plugin_bit: 0,
+        }
+    }
+
+    /// A node-flag registry (`u32`) seeded with the engine node built-ins.
+    pub(crate) fn with_node_builtins() -> Self {
+        Self::seeded(32, BUILTIN_NODE_FLAGS)
+    }
+
+    /// An edge-flag registry (`u8`) seeded with the engine edge built-ins.
+    pub(crate) fn with_edge_builtins() -> Self {
+        Self::seeded(8, BUILTIN_EDGE_FLAGS)
+    }
+
+    fn seeded(width_bits: u32, builtins: &[(u64, &str, bool, bool, &str)]) -> Self {
+        let mut reg = Self::new(width_bits);
+        for &(mask, name, seed, default_on, description) in builtins {
+            reg.register_engine(
+                mask,
+                FlagSpec {
+                    name: name.to_string(),
+                    seed,
+                    default_on,
+                    description: description.to_string(),
+                },
+            )
+            .expect("built-in flag table must be self-consistent");
+        }
+        reg
+    }
+
+    /// Register an engine flag with its explicit (constant-folded) mask.
+    /// Crate-internal; the engine owns the `engine/` namespace.
+    pub(crate) fn register_engine(&mut self, mask: u64, spec: FlagSpec) -> Result<(), PluginError> {
+        debug_assert!(
+            mask.is_power_of_two() && mask < (1u64 << self.width_bits),
+            "engine flag {:?} mask {mask:#x} must be a single in-range bit",
+            spec.name,
+        );
+        if self.by_name.contains_key(&spec.name) {
+            return Err(PluginError::value(format!(
+                "duplicate engine flag {:?}",
+                spec.name
+            )));
+        }
+        self.by_name.insert(spec.name.clone(), mask);
+        self.specs.push((mask, spec));
+        let next = mask << 1;
+        if next > self.next_plugin_bit {
+            self.next_plugin_bit = next;
+        }
+        Ok(())
+    }
+
+    /// Register a plugin flag, allocating the next free bit above the last
+    /// engine mask. Idempotent on an identical spec (so a flag two plugins
+    /// share — e.g. `test/testcase` — collapses to one bit); a conflicting
+    /// re-registration or an `engine/`-prefixed name fails loudly, as does
+    /// exhausting the bit width.
+    pub(crate) fn register_plugin(&mut self, spec: FlagSpec) -> Result<u64, PluginError> {
+        if spec.name.starts_with("engine/") {
+            return Err(PluginError::value(format!(
+                "plugin flag {:?}: the 'engine/' namespace is reserved for built-in flags",
+                spec.name
+            )));
+        }
+        if let Some(&bit) = self.by_name.get(&spec.name) {
+            let existing = &self
+                .specs
+                .iter()
+                .find(|(b, _)| *b == bit)
+                .expect("by_name bit must have a spec")
+                .1;
+            if existing.seed != spec.seed
+                || existing.default_on != spec.default_on
+                || existing.description != spec.description
+            {
+                return Err(PluginError::value(format!(
+                    "flag {:?} re-registered with a conflicting spec",
+                    spec.name
+                )));
+            }
+            return Ok(bit);
+        }
+        let bit = self.next_plugin_bit;
+        if bit == 0 || bit >= (1u64 << self.width_bits) {
+            return Err(PluginError::value(format!(
+                "flag registry exhausted: no free bit for {:?} within {} bits",
+                spec.name, self.width_bits
+            )));
+        }
+        self.by_name.insert(spec.name.clone(), bit);
+        self.specs.push((bit, spec));
+        self.next_plugin_bit <<= 1;
+        Ok(bit)
+    }
+
+    /// The bit for `name`, if registered.
+    pub(crate) fn get(&self, name: &str) -> Option<u64> {
+        self.by_name.get(name).copied()
+    }
+
+    /// All `(bit, spec)` entries, sorted by bit — for serialization and the
+    /// `ProjectContext` getters.
+    pub(crate) fn entries(&self) -> Vec<(u64, FlagSpec)> {
+        let mut out = self.specs.clone();
+        out.sort_by_key(|(bit, _)| *bit);
+        out
+    }
+
+    /// OR of every bit whose flag both seeds reachability and is on by
+    /// default — the default keepalive mask the Python layer consumes.
+    pub(crate) fn default_seed_mask(&self) -> u64 {
+        self.specs
+            .iter()
+            .filter(|(_, s)| s.seed && s.default_on)
+            .map(|(bit, _)| *bit)
+            .fold(0, |acc, bit| acc | bit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(name: &str, seed: bool, default_on: bool) -> FlagSpec {
+        FlagSpec {
+            name: name.to_string(),
+            seed,
+            default_on,
+            description: String::new(),
+        }
+    }
+
+    #[test]
+    fn node_builtins_seed_engine_bits() {
+        let reg = FlagRegistry::with_node_builtins();
+        assert_eq!(reg.get("engine/entrypoint"), Some(2));
+        assert_eq!(reg.get("engine/star_reexport"), Some(128));
+        // entries are bit-sorted and all engine-namespaced.
+        let entries = reg.entries();
+        assert!(entries.windows(2).all(|w| w[0].0 < w[1].0));
+        assert!(entries.iter().all(|(_, s)| s.name.starts_with("engine/")));
+    }
+
+    #[test]
+    fn plugins_allocate_above_last_engine_mask() {
+        let mut reg = FlagRegistry::with_node_builtins();
+        // Highest engine node mask is 128, so the first plugin bit is 256.
+        assert_eq!(
+            reg.register_plugin(spec("acme/a", false, false)).unwrap(),
+            256
+        );
+        assert_eq!(
+            reg.register_plugin(spec("acme/b", false, false)).unwrap(),
+            512
+        );
+    }
+
+    #[test]
+    fn shared_flag_registration_is_idempotent() {
+        let mut reg = FlagRegistry::with_node_builtins();
+        let first = reg
+            .register_plugin(spec("test/testcase", true, true))
+            .unwrap();
+        let again = reg
+            .register_plugin(spec("test/testcase", true, true))
+            .unwrap();
+        assert_eq!(first, again);
+    }
+
+    #[test]
+    fn conflicting_reregistration_fails() {
+        let mut reg = FlagRegistry::with_node_builtins();
+        reg.register_plugin(spec("test/testcase", true, true))
+            .unwrap();
+        assert!(reg
+            .register_plugin(spec("test/testcase", false, false))
+            .is_err());
+    }
+
+    #[test]
+    fn engine_prefix_is_reserved_for_plugins() {
+        let mut reg = FlagRegistry::with_node_builtins();
+        assert!(reg
+            .register_plugin(spec("engine/sneaky", false, false))
+            .is_err());
+    }
+
+    #[test]
+    fn edge_width_exhaustion_is_loud() {
+        // Edge registry is u8: engine masks 1 and 2, plugins from bit 4.
+        // Free plugin bits are 4,8,16,32,64,128 (six), then exhaustion.
+        let mut reg = FlagRegistry::with_edge_builtins();
+        for i in 0..6 {
+            reg.register_plugin(spec(&format!("acme/e{i}"), false, false))
+                .expect("six plugin edge bits should fit in u8");
+        }
+        assert!(reg
+            .register_plugin(spec("acme/overflow", false, false))
+            .is_err());
+    }
+
+    #[test]
+    fn default_seed_mask_ors_seed_and_default_on() {
+        let mut reg = FlagRegistry::with_node_builtins();
+        // engine/entrypoint|noqa|notebook are seed+default_on (2|16|32 = 50);
+        // star_reexport/dead_branch are not.
+        assert_eq!(reg.default_seed_mask(), 2 | 16 | 32);
+        reg.register_plugin(spec("test/testcase", true, true))
+            .unwrap();
+        assert_eq!(reg.default_seed_mask(), 2 | 16 | 32 | 256);
+    }
+}

--- a/runtime/src/graph.rs
+++ b/runtime/src/graph.rs
@@ -229,7 +229,7 @@ impl SymbolNode {
 #[pyclass(get_all, frozen)]
 pub(crate) struct NativeGraph {
     pub(crate) nodes: Vec<Py<SymbolNode>>,
-    pub(crate) edges: Vec<(usize, usize, u32)>,
+    pub(crate) edges: Vec<(usize, usize, u8)>,
 }
 
 #[pymethods]
@@ -268,55 +268,81 @@ pub(crate) struct NodeFlags;
 impl NodeFlags {
     #[classattr]
     pub(crate) const NONE: u32 = 0;
-    /// Decl rebound by a later assignment in the same file. Kept in the
-    /// graph (with its parent-module edge) but excluded from the
-    /// cross-module lookup so consumers of an exported name route to
-    /// the live binding.
-    #[classattr]
-    pub(crate) const SHADOWED: u32 = 1;
-    /// Explicit entrypoint — plugin-emitted seeds, the CLI's `-e`
-    /// flag, `[project.scripts]` targets, factory-app synthetics, etc.
-    /// One of the keepalive bits ORed into `KEEPALIVE_DEFAULT` on the
-    /// Python side, so reachability seeds from `ENTRYPOINT`-flagged
-    /// nodes by default.
+    /// Explicit entrypoint — plugin-emitted seeds, the CLI's `-e` flag,
+    /// `[project.scripts]` targets, factory-app synthetics, etc. A `seed`
+    /// flag (registered `engine/entrypoint`), so reachability seeds from
+    /// `ENTRYPOINT`-flagged nodes by default.
     #[classattr]
     pub(crate) const ENTRYPOINT: u32 = 2;
-    /// `typing.overload` stub (or any same-name decl whose lifetime is
-    /// anchored to a matching impl). Excluded from the lookup trie like
-    /// `SHADOWED`; kept alive by an explicit `impl -> overload` edge.
-    #[classattr]
-    pub(crate) const OVERLOAD: u32 = 4;
-    /// Pytest / unittest test discoveries. One of the keepalive bits in
-    /// `KEEPALIVE_DEFAULT`, so tests are alive by default. The
-    /// `kept_alive_by_flags_only(TESTCASE)` blast-radius query isolates
-    /// "what's only alive because of tests" by computing the diff
-    /// against `reachable(seed_flags=KEEPALIVE_DEFAULT & ~TESTCASE)`.
-    #[classattr]
-    pub(crate) const TESTCASE: u32 = 8;
     /// Import alias preserved by a user noqa directive (bare `# noqa`,
-    /// `# noqa: F401`, multi-rule `# noqa: E501, F401`, or the
-    /// file-level `# ruff: noqa` / `# flake8: noqa`). One of the
-    /// keepalive bits in `KEEPALIVE_DEFAULT`.
+    /// `# noqa: F401`, multi-rule `# noqa: E501, F401`, or the file-level
+    /// `# ruff: noqa` / `# flake8: noqa`). A `seed` flag (registered
+    /// `engine/noqa`).
     #[classattr]
     pub(crate) const NOQA: u32 = 16;
     /// Every node sourced from a Jupyter `.ipynb` file. Cells run
-    /// top-to-bottom rather than being imported, so the bit alone keeps
-    /// the node alive (no `ENTRYPOINT` overlay needed — `NOTEBOOK` is in
-    /// `KEEPALIVE_DEFAULT`). The codemod also reads the bit to skip
-    /// notebook nodes (it can't rewrite the cell JSON envelope).
+    /// top-to-bottom rather than being imported, so the bit alone keeps the
+    /// node alive. A `seed` flag (registered `engine/notebook`). The codemod
+    /// also reads the bit to skip notebook nodes (it can't rewrite the cell
+    /// JSON envelope).
     #[classattr]
     pub(crate) const NOTEBOOK: u32 = 32;
-    /// Every node sourced from a file under the package's `exported`
-    /// glob. Used by the cross-package merge to filter to entries the
-    /// owning package opts into exposing.
+    /// Decl that sits in a statically-dead region (the body of `if False:`,
+    /// the else of `if True:`, code after an unconditional `return` /
+    /// `raise`, …) — the node-level companion to [`EdgeFlags::DEAD_BRANCH`].
+    /// Metadata only (not a seed); registered `engine/dead_branch`.
     #[classattr]
-    pub(crate) const EXPORTED: u32 = 64;
-    /// Import decl synthesized from `from X import *` — one per name
-    /// the star statement brought in. Set so the cross-module trie can
+    pub(crate) const DEAD_BRANCH: u32 = 64;
+    /// Import decl synthesized from `from X import *` — one per name the
+    /// star statement brought in. Set so the cross-module trie can
     /// distinguish "real" import aliases from per-name star fan-out.
+    /// Registered `engine/star_reexport` (not a seed).
     #[classattr]
     pub(crate) const STAR_REEXPORT: u32 = 128;
 }
+
+/// Engine node flags, seeded into the node `FlagRegistry` before any plugin
+/// registers. Tuple = `(mask, owner/name, seed, default_on, description)`;
+/// the masks are the [`NodeFlags`] consts so hot-path `flags & CONST` reads
+/// still constant-fold. Single source of truth for the engine roster — the
+/// distinct-bits test iterates it.
+pub(crate) const BUILTIN_NODE_FLAGS: &[(u64, &str, bool, bool, &str)] = &[
+    (
+        NodeFlags::ENTRYPOINT as u64,
+        "engine/entrypoint",
+        true,
+        true,
+        "Explicit reachability entrypoint.",
+    ),
+    (
+        NodeFlags::NOQA as u64,
+        "engine/noqa",
+        true,
+        true,
+        "Import alias pinned by a noqa directive.",
+    ),
+    (
+        NodeFlags::NOTEBOOK as u64,
+        "engine/notebook",
+        true,
+        true,
+        "Node sourced from a Jupyter notebook cell.",
+    ),
+    (
+        NodeFlags::DEAD_BRANCH as u64,
+        "engine/dead_branch",
+        false,
+        false,
+        "Decl in a statically-dead region.",
+    ),
+    (
+        NodeFlags::STAR_REEXPORT as u64,
+        "engine/star_reexport",
+        false,
+        false,
+        "Per-name binding synthesized from a star import.",
+    ),
+];
 
 /// Bit values stamped into the third tuple slot of each `NativeGraph`
 /// edge. Mirrors `dead_cst.graph.EdgeFlags`.
@@ -326,7 +352,7 @@ pub(crate) struct EdgeFlags;
 #[pymethods]
 impl EdgeFlags {
     #[classattr]
-    pub(crate) const NONE: u32 = 0;
+    pub(crate) const NONE: u8 = 0;
     /// Reference originated inside a statically-dead region (the body of
     /// `if False:`, the else of `if True:`, after an unconditional
     /// `return` / `raise` / `break` / `continue`, …). Metadata only —
@@ -334,14 +360,34 @@ impl EdgeFlags {
     /// `descendants(..., skip_flags=EdgeFlags.DEAD_BRANCH)` to compute
     /// the kept-alive-only-by-dead-branches set.
     #[classattr]
-    pub(crate) const DEAD_BRANCH: u32 = 1;
+    pub(crate) const DEAD_BRANCH: u8 = 1;
     /// Edge emitted from a runtime-import call (`__import__('X')` /
     /// `importlib.import_module('X')`). Lets plugins read which edges
     /// the visitor produced from dynamic-import shapes and choose to
     /// fan out / specialize.
     #[classattr]
-    pub(crate) const DYNAMIC_IMPORT: u32 = 2;
+    pub(crate) const DYNAMIC_IMPORT: u8 = 2;
 }
+
+/// Engine edge flags, seeded into the edge `FlagRegistry` before any plugin
+/// registers. Same tuple shape as [`BUILTIN_NODE_FLAGS`]; `seed` / `default_on`
+/// are node-reachability concepts, recorded-but-unused for edges in v1.
+pub(crate) const BUILTIN_EDGE_FLAGS: &[(u64, &str, bool, bool, &str)] = &[
+    (
+        EdgeFlags::DEAD_BRANCH as u64,
+        "engine/dead_branch",
+        false,
+        false,
+        "Edge originating in a statically-dead region.",
+    ),
+    (
+        EdgeFlags::DYNAMIC_IMPORT as u64,
+        "engine/dynamic_import",
+        false,
+        false,
+        "Edge from a runtime-import call.",
+    ),
+];
 
 #[cfg(test)]
 mod tests {
@@ -380,26 +426,16 @@ mod tests {
 
     #[test]
     fn node_flags_constants_are_distinct_bits() {
-        // Each flag should be a single distinct bit (or zero for NONE).
-        let flags = [
-            NodeFlags::SHADOWED,
-            NodeFlags::ENTRYPOINT,
-            NodeFlags::OVERLOAD,
-            NodeFlags::TESTCASE,
-            NodeFlags::NOQA,
-            NodeFlags::NOTEBOOK,
-            NodeFlags::EXPORTED,
-            NodeFlags::STAR_REEXPORT,
-        ];
+        // The engine roster table is authoritative: every mask is a single
+        // distinct bit, all in u32 range.
         assert_eq!(NodeFlags::NONE, 0);
-        for &f in &flags {
-            // Single-bit invariant.
-            assert!(f.is_power_of_two(), "flag {f} is not a single bit");
-        }
-        // All distinct.
         let mut seen = std::collections::HashSet::new();
-        for &f in &flags {
-            assert!(seen.insert(f), "duplicate flag value {f}");
+        for &(mask, name, ..) in BUILTIN_NODE_FLAGS {
+            assert!(
+                mask.is_power_of_two() && mask < (1u64 << 32),
+                "node flag {name:?} mask {mask:#x} is not a single in-range bit",
+            );
+            assert!(seen.insert(mask), "duplicate node flag mask {mask:#x}");
         }
     }
 
@@ -408,14 +444,21 @@ mod tests {
         let combo = NodeFlags::ENTRYPOINT | NodeFlags::NOQA;
         assert!(combo & NodeFlags::ENTRYPOINT != 0);
         assert!(combo & NodeFlags::NOQA != 0);
-        assert!(combo & NodeFlags::TESTCASE == 0);
+        assert!(combo & NodeFlags::STAR_REEXPORT == 0);
     }
 
     #[test]
-    fn edge_flags_are_distinct_bits() {
+    fn edge_flags_constants_are_distinct_bits() {
+        // Mirror of the node-flag table check over the edge roster (u8).
         assert_eq!(EdgeFlags::NONE, 0);
-        assert!(EdgeFlags::DEAD_BRANCH.is_power_of_two());
-        assert!(EdgeFlags::DYNAMIC_IMPORT.is_power_of_two());
+        let mut seen = std::collections::HashSet::new();
+        for &(mask, name, ..) in BUILTIN_EDGE_FLAGS {
+            assert!(
+                mask.is_power_of_two() && mask < (1u64 << 8),
+                "edge flag {name:?} mask {mask:#x} is not a single in-range bit",
+            );
+            assert!(seen.insert(mask), "duplicate edge flag mask {mask:#x}");
+        }
         assert_ne!(EdgeFlags::DEAD_BRANCH, EdgeFlags::DYNAMIC_IMPORT);
     }
 }

--- a/runtime/src/helpers.rs
+++ b/runtime/src/helpers.rs
@@ -896,8 +896,8 @@ pub(crate) const NODE_FLAGS_NOQA_PIN: u32 = NodeFlags::NOQA;
 /// `NodeFlags::ENTRYPOINT` (which would force every reader to chase the
 /// `pyclass` macro to decide whether it's a runtime lookup or a const).
 pub(crate) const NODE_FLAG_ENTRYPOINT: u32 = NodeFlags::ENTRYPOINT;
-pub(crate) const EDGE_FLAG_DEAD_BRANCH: u32 = EdgeFlags::DEAD_BRANCH;
-pub(crate) const EDGE_FLAG_DYNAMIC_IMPORT: u32 = EdgeFlags::DYNAMIC_IMPORT;
+pub(crate) const EDGE_FLAG_DEAD_BRANCH: u8 = EdgeFlags::DEAD_BRANCH;
+pub(crate) const EDGE_FLAG_DYNAMIC_IMPORT: u8 = EdgeFlags::DYNAMIC_IMPORT;
 
 /// Collect the source ranges of every statically-dead statement in
 /// `parsed` — bodies of `if False` / `else` of `if True` / `while False`

--- a/runtime/src/io.rs
+++ b/runtime/src/io.rs
@@ -8,11 +8,13 @@
 //! body        : bincode(GraphFile)
 //! ```
 //!
-//! The body holds the project-wide node + edge lists and a small
+//! The body holds the project-wide node + edge lists, a small
 //! [`GraphMetadata`] block (creation timestamp, counts, user-supplied
-//! `--meta key=value` pairs). The format intentionally captures only
-//! the graph — plugins must rebuild on load — so the file stays small
-//! and the rust ↔ Python round-trip is one allocation per node.
+//! `--meta key=value` pairs), and the node + edge flag registries (so a
+//! reader can decode a flag bit to its `owner/name`). The format
+//! intentionally captures only the graph — plugins must rebuild on load
+//! — so the file stays small and the rust ↔ Python round-trip is one
+//! allocation per node.
 
 use std::fs::File as StdFile;
 use std::io::{BufReader, BufWriter, Read, Write};
@@ -30,14 +32,62 @@ pub(crate) const MAGIC: &[u8; 8] = b"DEADCSTG";
 
 /// On-disk format version. Bumped on any breaking layout change to
 /// [`GraphFileBody`]; the loader rejects mismatched values outright
-/// (graphs are cheap to rebuild — no migration logic).
-pub(crate) const FORMAT_VERSION: u32 = 1;
+/// (graphs are cheap to rebuild — no migration logic). Bumped 1 → 2
+/// when the flag registries were added to the body and edge flags
+/// narrowed to `u8`.
+pub(crate) const FORMAT_VERSION: u32 = 2;
 
 #[derive(Serialize, Deserialize)]
 struct GraphFileBody {
     metadata: GraphMetadataRecord,
     nodes: Vec<NodeRecord>,
-    edges: Vec<(u32, u32, u32)>,
+    edges: Vec<(u32, u32, u8)>,
+    /// Node-flag registry (engine built-ins + plugin declarations) so a
+    /// reader can decode a node's flag bits to `owner/name`. Top-level
+    /// (structural), not user metadata.
+    node_flag_registry: Vec<FlagRecord>,
+    /// Edge-flag registry — the edge-space twin of [`Self::node_flag_registry`].
+    edge_flag_registry: Vec<FlagRecord>,
+}
+
+/// One serialized flag-registry entry: a `owner/name` flag and the bit it
+/// occupies, plus its reachability semantics. `bit` is stored as `u64` for
+/// headroom against a future width widen; the runtime narrows it to `u32`
+/// (node) / `u8` (edge) on read.
+#[derive(Serialize, Deserialize, Clone)]
+struct FlagRecord {
+    name: String,
+    bit: u64,
+    seed: bool,
+    default_on: bool,
+    description: String,
+}
+
+/// Python-facing flag-registry entry tuple: `(name, bit, seed, default_on,
+/// description)`. The shape `GraphMetadata` exposes and `write_graph` accepts,
+/// so a loaded graph can be re-written without reshaping.
+type FlagTuple = (String, u64, bool, bool, String);
+
+impl FlagRecord {
+    fn from_tuple((name, bit, seed, default_on, description): FlagTuple) -> Self {
+        Self {
+            name,
+            bit,
+            seed,
+            default_on,
+            description,
+        }
+    }
+
+    fn into_tuple(self) -> FlagTuple {
+        (
+            self.name,
+            self.bit,
+            self.seed,
+            self.default_on,
+            self.description,
+        )
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -87,13 +137,20 @@ pub(crate) struct GraphMetadata {
     pub(crate) file_count: u64,
     pub(crate) line_count: u64,
     pub(crate) user_meta: Vec<(String, String)>,
+    /// Node-flag registry entries `(name, bit, seed, default_on, description)`,
+    /// bit-sorted. Lets a Python reader decode a node's flags by name and a
+    /// re-write preserve the registry.
+    pub(crate) node_flag_registry: Vec<FlagTuple>,
+    /// Edge-flag registry entries — the edge-space twin of
+    /// [`Self::node_flag_registry`].
+    pub(crate) edge_flag_registry: Vec<FlagTuple>,
 }
 
 #[pymethods]
 impl GraphMetadata {
     fn __repr__(&self) -> String {
         format!(
-            "GraphMetadata(format_version={}, created_at={}, nodes={}, edges={}, files={}, lines={}, user_meta={} entries)",
+            "GraphMetadata(format_version={}, created_at={}, nodes={}, edges={}, files={}, lines={}, user_meta={} entries, node_flags={}, edge_flags={})",
             self.format_version,
             self.created_at,
             self.node_count,
@@ -101,6 +158,8 @@ impl GraphMetadata {
             self.file_count,
             self.line_count,
             self.user_meta.len(),
+            self.node_flag_registry.len(),
+            self.edge_flag_registry.len(),
         )
     }
 }
@@ -133,14 +192,19 @@ where
 /// `nodes` / `edges` are the same payload `NativeGraph` exposes —
 /// passed as plain Python objects so callers don't need to keep the
 /// `NativeGraph` instance around. `meta` is the user-supplied list of
-/// `(key, value)` pairs from `--meta`.
+/// `(key, value)` pairs from `--meta`. `node_flag_registry` /
+/// `edge_flag_registry` are the `(name, bit, seed, default_on,
+/// description)` tuples from `ProjectContext.{node,edge}_flag_registry`,
+/// persisted so a reader can decode flag bits by name.
 #[pyfunction]
-#[pyo3(signature = (path, nodes, edges, meta))]
+#[pyo3(signature = (path, nodes, edges, meta, node_flag_registry, edge_flag_registry))]
 pub(crate) fn write_graph(
     path: String,
     nodes: Vec<Py<SymbolNode>>,
-    edges: Vec<(u32, u32, u32)>,
+    edges: Vec<(u32, u32, u8)>,
     meta: Vec<(String, String)>,
+    node_flag_registry: Vec<FlagTuple>,
+    edge_flag_registry: Vec<FlagTuple>,
     py: Python<'_>,
 ) -> PyResult<()> {
     let mut node_records: Vec<NodeRecord> = Vec::with_capacity(nodes.len());
@@ -189,6 +253,14 @@ pub(crate) fn write_graph(
         },
         nodes: node_records,
         edges,
+        node_flag_registry: node_flag_registry
+            .into_iter()
+            .map(FlagRecord::from_tuple)
+            .collect(),
+        edge_flag_registry: edge_flag_registry
+            .into_iter()
+            .map(FlagRecord::from_tuple)
+            .collect(),
     };
 
     let file = StdFile::create(&path)
@@ -252,6 +324,8 @@ pub(crate) fn read_graph(
         metadata,
         nodes,
         edges,
+        node_flag_registry,
+        edge_flag_registry,
     } = body;
 
     let mut node_objs: Vec<Py<SymbolNode>> = Vec::with_capacity(nodes.len());
@@ -298,6 +372,14 @@ pub(crate) fn read_graph(
         file_count: metadata.file_count,
         line_count: metadata.line_count,
         user_meta: metadata.user_meta,
+        node_flag_registry: node_flag_registry
+            .into_iter()
+            .map(FlagRecord::into_tuple)
+            .collect(),
+        edge_flag_registry: edge_flag_registry
+            .into_iter()
+            .map(FlagRecord::into_tuple)
+            .collect(),
     };
     Ok((Py::new(py, graph)?, Py::new(py, meta)?))
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -29,6 +29,7 @@ mod builder;
 mod file_extraction;
 mod file_payload;
 mod file_ref_edges;
+mod flag_registry;
 mod graph;
 mod helpers;
 mod ingest;

--- a/runtime/src/native_plugins.rs
+++ b/runtime/src/native_plugins.rs
@@ -55,6 +55,7 @@ use ty_project::Db as ProjectDb;
 
 use crate::builder::PreparedOp;
 use crate::file_payload::{file_to_nodes, NodeData, NodeKind};
+use crate::flag_registry::FlagRegistry;
 use crate::graph::{EdgeFlags, NodeFlags};
 use crate::helpers::{
     collect_modules_imports_local, decorators_match_imports, is_dunder_name,
@@ -150,9 +151,15 @@ impl PluginJob {
 pub(crate) fn extract_plugin_jobs(
     py: Python<'_>,
     plugins: &[PyObject],
-) -> PyResult<(Vec<PluginJob>, Vec<String>)> {
+) -> PyResult<(Vec<PluginJob>, Vec<String>, FlagRegistry, FlagRegistry)> {
     let mut jobs = Vec::with_capacity(plugins.len());
     let mut names = Vec::with_capacity(plugins.len());
+    // Seed both registries with the engine built-ins, then fold in each
+    // plugin's declared flags in registration order (so bit allocation is a
+    // pure function of plugin order). A conflicting / reserved / overflowing
+    // declaration surfaces here, on the GIL thread, before the parallel run.
+    let mut node_reg = FlagRegistry::with_node_builtins();
+    let mut edge_reg = FlagRegistry::with_edge_builtins();
     for plugin in plugins {
         let bound = plugin.bind(py);
         let native = match bound.downcast::<NativePlugin>() {
@@ -166,6 +173,16 @@ pub(crate) fn extract_plugin_jobs(
             }
         };
         let native_ref = native.borrow();
+        // Any plugin carrying an `ExternalPlugin` (project-wide or
+        // per-file-capable) may declare flags; pure per-file built-ins don't.
+        if let NativePluginKind::External { plugin, .. } = &native_ref.kind {
+            for spec in plugin.declare_node_flags() {
+                node_reg.register_plugin(spec)?;
+            }
+            for spec in plugin.declare_edge_flags() {
+                edge_reg.register_plugin(spec)?;
+            }
+        }
         let (job, name) = match &native_ref.kind {
             NativePluginKind::External {
                 plugin,
@@ -183,7 +200,7 @@ pub(crate) fn extract_plugin_jobs(
         jobs.push(job);
         names.push(name);
     }
-    Ok((jobs, names))
+    Ok((jobs, names, node_reg, edge_reg))
 }
 
 // ---------------------------------------------------------------------------
@@ -231,7 +248,7 @@ pub(crate) enum FileLocalOp {
     Edge {
         src_local_idx: u32,
         dst_local_idx: u32,
-        flags: u32,
+        flags: u8,
     },
     /// Keep a node in this file alive via a synthetic entrypoint marker
     /// (`PreparedOp::Entrypoint` shape). ``decl_local_idx`` is a file-local
@@ -1212,6 +1229,12 @@ pub mod plugin_api {
     // values via [`CallArgs::get`] / [`CallArgs::str_value`].
     pub use crate::helpers::{ArgValue, CallArgs};
 
+    // Flag declaration vocabulary. A plugin returns these from
+    // [`ExternalPlugin::declare_node_flags`] / [`declare_edge_flags`]; the host
+    // allocates each a bit and the plugin reads it back via
+    // [`PluginCtx::node_flag`] / [`edge_flag`]. Pyo3-free.
+    pub use crate::flag_registry::FlagSpec;
+
     /// `NodeFlags::ENTRYPOINT` re-exported for plugin authors: set it on a
     /// node minted via [`PluginOps::add_synthetic_node`] /
     /// [`FileOps::add_synthetic_node`] to make that node a reachability seed.
@@ -1222,13 +1245,13 @@ pub mod plugin_api {
     /// [`PluginOps::add_edge`] / [`FileOps::add_edge`]: mark a plugin-added
     /// edge as originating in a statically-dead region. Metadata only — the
     /// edge still participates in default reachability.
-    pub const FLAG_DEAD_BRANCH: u32 = EdgeFlags::DEAD_BRANCH;
+    pub const FLAG_DEAD_BRANCH: u8 = EdgeFlags::DEAD_BRANCH;
 
     /// `EdgeFlags::DYNAMIC_IMPORT` re-exported for the `flags` argument of
     /// [`PluginOps::add_edge`] / [`FileOps::add_edge`]: mark a plugin-added
     /// edge as a runtime-import (`__import__` / `importlib.import_module`)
     /// fan-out, the same bit the visitor stamps on dynamic-import edges.
-    pub const FLAG_DYNAMIC_IMPORT: u32 = EdgeFlags::DYNAMIC_IMPORT;
+    pub const FLAG_DYNAMIC_IMPORT: u8 = EdgeFlags::DYNAMIC_IMPORT;
 
     /// Epoch of this curated `plugin_api` surface — the author-facing contract
     /// version, baked into the [ABI fingerprint](super::PLUGIN_ABI_FINGERPRINT)
@@ -1357,6 +1380,25 @@ pub mod plugin_api {
         /// output (that would break the salsa cache); use it for project-wide
         /// `run` setup only.
         fn prepare(&self, _project_root: &str) {}
+
+        /// Node flags this plugin contributes to the registry. Each returned
+        /// [`FlagSpec`] is assigned a bit by the host (above the engine flags,
+        /// in registration order) before [`run`](Self::run); read the bit back
+        /// with [`PluginCtx::node_flag`]. Declaring the same `owner/name` spec
+        /// from two plugins is idempotent (they share one bit); a conflicting
+        /// re-declaration, an `engine/`-prefixed name, or exhausting the 32-bit
+        /// node width fails the whole materialize. Default none.
+        fn declare_node_flags(&self) -> Vec<FlagSpec> {
+            Vec::new()
+        }
+
+        /// Edge flags this plugin contributes to the registry — the edge-space
+        /// twin of [`declare_node_flags`](Self::declare_node_flags), read back
+        /// with [`PluginCtx::edge_flag`]. Edge flags share an 8-bit width.
+        /// Default none.
+        fn declare_edge_flags(&self) -> Vec<FlagSpec> {
+            Vec::new()
+        }
     }
 
     /// Per-file capability for an [`ExternalPlugin`]. Invoked once per
@@ -1432,7 +1474,7 @@ pub mod plugin_api {
         /// Destination node index.
         pub dst: usize,
         /// `EdgeFlags` bitset.
-        pub flags: u32,
+        pub flags: u8,
     }
 
     /// Conjunctive filter for [`PluginCtx::nodes_matching`] — a node must
@@ -1923,6 +1965,23 @@ pub mod plugin_api {
         pub fn project_root(&self) -> &str {
             self.inner.project_root()
         }
+
+        // --- flag registry --------------------------------------------------
+
+        /// The bit a node flag named `name` (`owner/name`) was assigned, or
+        /// `None` if no plugin/engine declared it. A plugin reads its own
+        /// declared flag this way: the host allocated the bit from
+        /// [`ExternalPlugin::declare_node_flags`] before `run`, so a plugin
+        /// that declared `name` can `.expect()` the lookup.
+        pub fn node_flag(&self, name: &str) -> Option<u32> {
+            self.inner.node_flags.get(name).map(|bit| bit as u32)
+        }
+
+        /// The bit an edge flag named `name` was assigned (edge-space twin of
+        /// [`Self::node_flag`]), or `None` if undeclared.
+        pub fn edge_flag(&self, name: &str) -> Option<u8> {
+            self.inner.edge_flags.get(name).map(|bit| bit as u8)
+        }
     }
 
     /// Op sink for external plugins. Wraps the internal `PreparedOp` vec so
@@ -1953,7 +2012,7 @@ pub mod plugin_api {
         /// existing nodes, stamped with `flags` (`0` for a plain edge, or
         /// one of [`FLAG_DEAD_BRANCH`] / [`FLAG_DYNAMIC_IMPORT`]). Emits a
         /// [`PreparedOp::Edge`].
-        pub fn add_edge(&mut self, src_idx: usize, dst_idx: usize, flags: u32) {
+        pub fn add_edge(&mut self, src_idx: usize, dst_idx: usize, flags: u8) {
             self.sink.push(PreparedOp::Edge {
                 src_idx,
                 dst_idx,
@@ -2211,7 +2270,7 @@ pub mod plugin_api {
         /// [`FLAG_DEAD_BRANCH`] / [`FLAG_DYNAMIC_IMPORT`]). Both endpoints
         /// are positions in [`PluginFileCtx::nodes`]; an edge with an
         /// unresolvable endpoint is dropped at apply time.
-        pub fn add_edge(&mut self, src_local_idx: u32, dst_local_idx: u32, flags: u32) {
+        pub fn add_edge(&mut self, src_local_idx: u32, dst_local_idx: u32, flags: u8) {
             self.sink.push(FileLocalOp::Edge {
                 src_local_idx,
                 dst_local_idx,
@@ -2586,6 +2645,10 @@ impl plugin_api::ExternalPlugin for UnittestPluginImpl {
         "UnittestPlugin"
     }
 
+    fn declare_node_flags(&self) -> Vec<plugin_api::FlagSpec> {
+        vec![testcase_flag_spec()]
+    }
+
     fn run(
         &self,
         ctx: &plugin_api::PluginCtx<'_>,
@@ -2595,6 +2658,10 @@ impl plugin_api::ExternalPlugin for UnittestPluginImpl {
         if !ctx.has_imports_of("unittest") {
             return Ok(());
         }
+        // The bit the host allocated for our declared `test/testcase` flag.
+        let testcase_flag = ctx
+            .node_flag("test/testcase")
+            .expect("test/testcase is declared in declare_node_flags");
         let import_idxs = ctx.imports_of("unittest");
         let importer_paths: std::collections::HashSet<String> =
             ctx.node_paths(&import_idxs).into_iter().collect();
@@ -2651,7 +2718,7 @@ impl plugin_api::ExternalPlugin for UnittestPluginImpl {
             ops.add_synthetic_node(
                 format!("{UNITTEST_PREFIX}{}", attr.fqname),
                 path.clone(),
-                NodeFlags::TESTCASE,
+                testcase_flag,
                 decls_by_path[path].clone(),
                 Vec::new(),
             );
@@ -4002,17 +4069,35 @@ fn is_test_decl(kind: &str, fqname: &str) -> bool {
         || (kind == "class" && simple.starts_with("Test"))
 }
 
-/// Emit a `TESTCASE` seed node keeping `target_idxs` alive (no-op when empty).
+/// The shared `test/testcase` node-flag spec declared by both the pytest and
+/// unittest plugins. Identical from both, so the registry collapses it to a
+/// single bit (idempotent registration); `seed + default_on` puts it in the
+/// default keepalive mask whenever a test plugin is registered.
+fn testcase_flag_spec() -> plugin_api::FlagSpec {
+    plugin_api::FlagSpec {
+        name: "test/testcase".to_string(),
+        seed: true,
+        default_on: true,
+        description: "Symbol kept alive because a test framework (pytest / unittest) \
+                      discovers it as a test, fixture, or lifecycle hook."
+            .to_string(),
+    }
+}
+
+/// Emit a seed node stamped with `flags` keeping `target_idxs` alive (no-op
+/// when empty). `flags` is the resolved `test/testcase` bit (see
+/// [`testcase_flag_spec`]).
 fn mark_seed(
     ops: &mut plugin_api::PluginOps,
     fqname: String,
     path: String,
+    flags: u32,
     target_idxs: Vec<usize>,
 ) {
     if target_idxs.is_empty() {
         return;
     }
-    ops.add_synthetic_node(fqname, path, NodeFlags::TESTCASE, target_idxs, Vec::new());
+    ops.add_synthetic_node(fqname, path, flags, target_idxs, Vec::new());
 }
 
 /// `{ path: module_fqname }` for every path resolving to a project module.
@@ -4048,11 +4133,19 @@ impl plugin_api::ExternalPlugin for PytestPluginImpl {
         "PytestPlugin"
     }
 
+    fn declare_node_flags(&self) -> Vec<plugin_api::FlagSpec> {
+        vec![testcase_flag_spec()]
+    }
+
     fn run(
         &self,
         ctx: &plugin_api::PluginCtx<'_>,
         ops: &mut plugin_api::PluginOps,
     ) -> Result<(), plugin_api::PluginError> {
+        // The bit the host allocated for our declared `test/testcase` flag.
+        let testcase_flag = ctx
+            .node_flag("test/testcase")
+            .expect("test/testcase is declared in declare_node_flags");
         // Every top-level function / class / variable decl + its path.
         let idxs = ctx.nodes_matching(&plugin_api::NodeFilter {
             kinds: &["function", "class", "variable"],
@@ -4122,6 +4215,7 @@ impl plugin_api::ExternalPlugin for PytestPluginImpl {
                     ops,
                     format!("{PYTEST_CONFTEST_PREFIX}{module_fqname}"),
                     path.clone(),
+                    testcase_flag,
                     conftest_by_path[path].clone(),
                 );
             }
@@ -4132,6 +4226,7 @@ impl plugin_api::ExternalPlugin for PytestPluginImpl {
                     ops,
                     format!("{PYTEST_TESTS_PREFIX}{module_fqname}"),
                     path.clone(),
+                    testcase_flag,
                     tests_by_path[path].clone(),
                 );
             }
@@ -4164,6 +4259,7 @@ impl plugin_api::ExternalPlugin for PytestPluginImpl {
                     ops,
                     format!("{PYTEST_FIXTURES_PREFIX}{module_fqname}"),
                     path.clone(),
+                    testcase_flag,
                     fixtures_by_path[path].clone(),
                 );
             }

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -34,6 +34,7 @@ use crate::file_extraction::{
 };
 use crate::file_payload::{file_to_edges, file_to_nodes, FileEdges, NodeKind, NodeRef};
 use crate::file_ref_edges::{file_to_ref_edges, FileRefEdges};
+use crate::flag_registry::FlagRegistry;
 use crate::graph::{intern_kind, DeclIndex, NativeGraph, SymbolNode};
 use crate::helpers::{
     file_path_string, is_dunder_name, locate_class_seed, range_key, rel_path, resolve_base_spec,
@@ -721,6 +722,7 @@ fn assemble_graph<'db>(
                 end_line: node_data.end_line,
                 end_column: node_data.end_column,
                 flags,
+                is_overload: node_data.is_overload,
                 imports: node_data.imports.clone(),
             };
             let global_idx = base + local_idx;
@@ -775,7 +777,7 @@ fn assemble_graph<'db>(
     //       the parallel phase only has to read `ref_to_global`.
     //   2c. `Python::allow_threads` + `par_iter().flat_map(...)` to
     //       translate every `(NodeRef, NodeRef, flags)` triple into
-    //       `(usize, usize, u32)` via two `ref_to_global` probes.
+    //       `(usize, usize, u8)` via two `ref_to_global` probes.
     //       Drops endpoints whose owning file wasn't enumerated.
     //
     // After the parallel phase, sort + dedup the triple list and
@@ -884,7 +886,7 @@ fn assemble_graph<'db>(
         let ref_to_global_ref = &ref_to_global;
         let edge_payloads_ref = &edge_payloads;
         let ref_edge_payloads_ref = &ref_edge_payloads;
-        let mut triples: Vec<(usize, usize, u32)> = py.allow_threads(|| {
+        let mut triples: Vec<(usize, usize, u8)> = py.allow_threads(|| {
             use rayon::prelude::*;
             let from_edges = edge_payloads_ref.par_iter().flat_map_iter(|payload| {
                 payload.edges.iter().filter_map(|&(src, dst, flags)| {
@@ -900,7 +902,7 @@ fn assemble_graph<'db>(
                     Some((src_idx, dst_idx, flags))
                 })
             });
-            let mut t: Vec<(usize, usize, u32)> = from_edges.chain(from_refs).collect();
+            let mut t: Vec<(usize, usize, u8)> = from_edges.chain(from_refs).collect();
             t.par_sort_unstable();
             t.dedup();
             t
@@ -930,7 +932,7 @@ fn assemble_graph<'db>(
     // FxHashMaps whose iteration order isn't stable run-to-run, so
     // inserting as we walk them would give the adjacency lists a
     // run-dependent order. Sorting the collected triples pins it.
-    let mut peer_triples: Vec<(usize, usize, u32)> = Vec::new();
+    let mut peer_triples: Vec<(usize, usize, u8)> = Vec::new();
     for (&pyi_file, &py_twin) in peer_pyi_to_py {
         let pyi_payload = file_to_nodes(db, pyi_file);
         let py_payload = file_to_nodes(db, py_twin);
@@ -1265,12 +1267,12 @@ pub(crate) fn build_fqname_indices(
     let mut children_by_parent: FxHashMap<String, Vec<usize>> = FxHashMap::default();
     for (idx, node) in builder.nodes.iter().enumerate() {
         counters.fqname_inc();
-        // `OVERLOAD`-flagged decls (the `@typing.overload`-decorated
-        // stubs of an in-file overload group) are excluded from the
-        // fqname trie so cross-module `from mod import f` resolves to
-        // the impl only. Reachability still anchors them via the
-        // explicit `impl → stub` edge emitted in `file_to_edges`.
-        if node.flags & crate::graph::NodeFlags::OVERLOAD != 0 {
+        // `@typing.overload`-decorated stubs of an in-file overload group
+        // are excluded from the fqname trie so cross-module `from mod
+        // import f` resolves to the impl only. Reachability still anchors
+        // them via the explicit `impl → stub` edge emitted in
+        // `file_to_edges`.
+        if node.is_overload {
             continue;
         }
         let mut index_child = false;
@@ -1514,6 +1516,16 @@ pub(crate) struct ProjectContext {
     /// deeply-nested generated code (protobuf modules, long
     /// star-reexport chains) that overflow the default.
     pub(crate) stack_size: Option<usize>,
+    /// Node-flag registry: engine built-ins plus every flag the registered
+    /// plugins declared. Seeded with `with_node_builtins()` at construction
+    /// (so a never-materialized ctx still decodes the engine flags) and
+    /// overwritten by `materialize` with the post-declaration registry. Read
+    /// by the `node_flag` / `default_seed_mask` / `node_flag_registry`
+    /// getters and serialized into the graph file.
+    pub(crate) node_flag_registry: FlagRegistry,
+    /// Edge-flag registry — the edge-space twin of
+    /// [`Self::node_flag_registry`] (`u8`-width).
+    pub(crate) edge_flag_registry: FlagRegistry,
 }
 
 #[pymethods]
@@ -1549,6 +1561,8 @@ impl ProjectContext {
             show_progress,
             stack_size: None,
             progress: Arc::new(ProgressCounters::new()),
+            node_flag_registry: FlagRegistry::with_node_builtins(),
+            edge_flag_registry: FlagRegistry::with_edge_builtins(),
         })
     }
 
@@ -1556,6 +1570,43 @@ impl ProjectContext {
     #[getter]
     pub(crate) fn project_root(&self) -> &str {
         &self.root
+    }
+
+    /// Node-flag registry entries `(name, bit, seed, default_on, description)`,
+    /// bit-sorted: engine built-ins plus every flag the registered plugins
+    /// declared (populated by :meth:`materialize`; engine-only before then).
+    /// Threaded into :func:`write_graph` so the graph file records the table.
+    /// A method (not a getter) to match the duck-typed `nodes()` / `edges()`
+    /// the `write_graph` wrapper calls.
+    pub(crate) fn node_flag_registry(&self) -> Vec<(String, u64, bool, bool, String)> {
+        flag_registry_tuples(&self.node_flag_registry)
+    }
+
+    /// Edge-flag registry entries — the edge-space twin of
+    /// :meth:`node_flag_registry`.
+    pub(crate) fn edge_flag_registry(&self) -> Vec<(String, u64, bool, bool, String)> {
+        flag_registry_tuples(&self.edge_flag_registry)
+    }
+
+    /// Default reachability seed mask: the OR of every node-flag bit whose
+    /// flag both seeds reachability and is on by default (e.g.
+    /// ``engine/entrypoint``, and ``test/testcase`` when a test plugin is
+    /// registered). The Python layer uses it as the default ``seed_flags``.
+    pub(crate) fn default_seed_mask(&self) -> u32 {
+        self.node_flag_registry.default_seed_mask() as u32
+    }
+
+    /// The bit a node flag named ``name`` (``owner/name``) occupies, or
+    /// ``None`` if undeclared. Engine flags resolve even before materialize;
+    /// plugin flags resolve after.
+    pub(crate) fn node_flag(&self, name: &str) -> Option<u32> {
+        self.node_flag_registry.get(name).map(|bit| bit as u32)
+    }
+
+    /// The bit an edge flag named ``name`` occupies (edge-space twin of
+    /// :meth:`node_flag`), or ``None`` if undeclared.
+    pub(crate) fn edge_flag(&self, name: &str) -> Option<u8> {
+        self.edge_flag_registry.get(name).map(|bit| bit as u8)
     }
 
     /// Override the rayon worker stack size (bytes) used by the
@@ -1722,7 +1773,7 @@ impl ProjectContext {
         // ops fold into the graph in one end-of-pass apply, in
         // registration order — the same frozen-graph contract the old
         // Python ``ThreadPoolExecutor`` driver honoured.
-        let (jobs, plugin_names) =
+        let (jobs, plugin_names, node_reg, edge_reg) =
             match crate::native_plugins::extract_plugin_jobs(py, &slf.borrow(py).plugins) {
                 Ok(extracted) => extracted,
                 Err(e) => {
@@ -1759,6 +1810,13 @@ impl ProjectContext {
             let root_ref: &str = &root;
             let jobs_ref = &jobs;
             let results_ref = &results;
+            // Lend the frozen registries into each worker's `FrozenView`.
+            // `&FlagRegistry` is `Send` (the registry is `Sync`), so the refs
+            // ride the `allow_threads` boundary the way `root_ref` does; the
+            // owned registries stay on this stack and move into the pyclass
+            // after the pass.
+            let node_reg_ref = &node_reg;
+            let edge_reg_ref = &edge_reg;
             // ``base_db`` + ``outputs_lock`` move *into* the closure: a
             // ``&ProjectDatabase`` is ``!Send`` (salsa's ``ZalsaLocal`` is
             // ``!Sync``), so — like every GIL-free per-file scan here — we
@@ -1776,7 +1834,13 @@ impl ProjectContext {
                             let db_t = base_db.clone();
                             s.spawn(move |_| {
                                 counters_ref.plugin_started(idx);
-                                let view = FrozenView::new(db_t, outputs_ref, root_ref);
+                                let view = FrozenView::new(
+                                    db_t,
+                                    outputs_ref,
+                                    root_ref,
+                                    node_reg_ref,
+                                    edge_reg_ref,
+                                );
                                 let mut sink: Vec<PreparedOp> = Vec::new();
                                 let res = job.run(&view, &mut sink).map(|()| sink);
                                 results_ref.lock().unwrap().push((idx, res));
@@ -1821,6 +1885,17 @@ impl ProjectContext {
         counters.finish_phase(PHASE_PLUGINS);
         counters.mark_finished();
         plugin_result?;
+
+        // Persist the post-declaration registries on the pyclass so the
+        // `node_flag` / `default_seed_mask` / `*_flag_registry` getters and
+        // the graph-file writer see the plugin-allocated bits. The parallel
+        // pass's borrows have ended (the `allow_threads` block above returned),
+        // so the owned registries are free to move in.
+        {
+            let mut this = slf.borrow_mut(py);
+            this.node_flag_registry = node_reg;
+            this.edge_flag_registry = edge_reg;
+        }
 
         // The plugin pass can still reload individual files on demand:
         // subclass resolution's `locate_class_seed` resolves an external base
@@ -2246,7 +2321,7 @@ impl ProjectContext {
         &self,
         py: Python<'_>,
         root: &SymbolNode,
-        skip_flags: u32,
+        skip_flags: u8,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
         let outputs = self.materialized("descendants")?;
         let root_idx = lookup_idx(&outputs.builder, root, "root")?;
@@ -2264,7 +2339,7 @@ impl ProjectContext {
     pub(crate) fn descendants_indices(
         &self,
         root_idx: usize,
-        skip_flags: u32,
+        skip_flags: u8,
     ) -> PyResult<Vec<usize>> {
         let outputs = self.materialized("descendants_indices")?;
         let len = outputs.builder.nodes.len();
@@ -2287,7 +2362,7 @@ impl ProjectContext {
         &self,
         py: Python<'_>,
         decl: &SymbolNode,
-        skip_flags: u32,
+        skip_flags: u8,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
         let outputs = self.materialized("ancestors")?;
         let idx = lookup_idx(&outputs.builder, decl, "decl")?;
@@ -2305,7 +2380,7 @@ impl ProjectContext {
     pub(crate) fn ancestors_indices(
         &self,
         decl_idx: usize,
-        skip_flags: u32,
+        skip_flags: u8,
     ) -> PyResult<Vec<usize>> {
         let outputs = self.materialized("ancestors_indices")?;
         let len = outputs.builder.nodes.len();
@@ -2329,7 +2404,7 @@ impl ProjectContext {
     pub(crate) fn direct_predecessors_idx(
         &self,
         idx: usize,
-        skip_flags: u32,
+        skip_flags: u8,
     ) -> PyResult<Vec<usize>> {
         let outputs = self.materialized("direct_predecessors_idx")?;
         let len = outputs.builder.nodes.len();
@@ -2349,7 +2424,7 @@ impl ProjectContext {
     pub(crate) fn reachable(
         &self,
         py: Python<'_>,
-        skip_flags: u32,
+        skip_flags: u8,
         seed_flags: u32,
     ) -> PyResult<Vec<Py<SymbolNode>>> {
         let outputs = self.materialized("reachable")?;
@@ -2382,7 +2457,7 @@ impl ProjectContext {
 /// Shared one-hop reverse-adjacency walk used by
 /// :meth:`ProjectContext::direct_predecessors` and
 /// :meth:`direct_predecessors_idx`.
-fn direct_predecessors_idxs_in(outputs: &BuildOutputs, idx: usize, skip_flags: u32) -> Vec<usize> {
+fn direct_predecessors_idxs_in(outputs: &BuildOutputs, idx: usize, skip_flags: u8) -> Vec<usize> {
     let mut seen: FxHashSet<usize> = FxHashSet::default();
     let mut out: Vec<usize> = Vec::new();
     for &(src, flags) in &outputs.builder.reverse_adj[idx] {
@@ -3539,6 +3614,16 @@ fn find_subclasses_of_idx_in(outputs: &BuildOutputs, class_idx: usize) -> Option
 // subclass walk clones it once (it resolves the seed serially first).
 // ============================================================
 
+/// Flatten a [`FlagRegistry`] into the bit-sorted `(name, bit, seed,
+/// default_on, description)` tuples the Python getters and `write_graph`
+/// consume.
+fn flag_registry_tuples(reg: &FlagRegistry) -> Vec<(String, u64, bool, bool, String)> {
+    reg.entries()
+        .into_iter()
+        .map(|(bit, spec)| (spec.name, bit, spec.seed, spec.default_on, spec.description))
+        .collect()
+}
+
 /// Read-only, owned-db snapshot of a materialized project, handed to a
 /// project-wide native plugin's `run`. `Send` but `!Sync`: each
 /// fan-out task owns its view; views are never shared across threads.
@@ -3546,11 +3631,30 @@ pub(crate) struct FrozenView<'a> {
     pub(crate) db: ProjectDatabase,
     pub(crate) outputs: &'a BuildOutputs,
     pub(crate) root: &'a str,
+    /// Frozen node/edge flag registries (engine built-ins + plugin
+    /// declarations), lent read-only for the parallel plugin pass so a
+    /// plugin can resolve a declared flag name to its bit via
+    /// [`crate::native_plugins::plugin_api::PluginCtx::node_flag`] /
+    /// `edge_flag`.
+    pub(crate) node_flags: &'a FlagRegistry,
+    pub(crate) edge_flags: &'a FlagRegistry,
 }
 
 impl<'a> FrozenView<'a> {
-    pub(crate) fn new(db: ProjectDatabase, outputs: &'a BuildOutputs, root: &'a str) -> Self {
-        Self { db, outputs, root }
+    pub(crate) fn new(
+        db: ProjectDatabase,
+        outputs: &'a BuildOutputs,
+        root: &'a str,
+        node_flags: &'a FlagRegistry,
+        edge_flags: &'a FlagRegistry,
+    ) -> Self {
+        Self {
+            db,
+            outputs,
+            root,
+            node_flags,
+            edge_flags,
+        }
     }
 
     // --- data accessors -------------------------------------------------
@@ -3688,7 +3792,7 @@ impl<'a> FrozenView<'a> {
     pub(crate) fn descendants_indices(
         &self,
         root_idx: usize,
-        skip_flags: u32,
+        skip_flags: u8,
     ) -> Option<Vec<usize>> {
         if root_idx >= self.outputs.builder.nodes.len() {
             return None;
@@ -3705,7 +3809,7 @@ impl<'a> FrozenView<'a> {
         )
     }
 
-    pub(crate) fn ancestors_indices(&self, decl_idx: usize, skip_flags: u32) -> Option<Vec<usize>> {
+    pub(crate) fn ancestors_indices(&self, decl_idx: usize, skip_flags: u8) -> Option<Vec<usize>> {
         if decl_idx >= self.outputs.builder.nodes.len() {
             return None;
         }
@@ -3721,11 +3825,7 @@ impl<'a> FrozenView<'a> {
         )
     }
 
-    pub(crate) fn direct_predecessors_idx(
-        &self,
-        idx: usize,
-        skip_flags: u32,
-    ) -> Option<Vec<usize>> {
+    pub(crate) fn direct_predecessors_idx(&self, idx: usize, skip_flags: u8) -> Option<Vec<usize>> {
         if idx >= self.outputs.builder.nodes.len() {
             return None;
         }
@@ -3941,7 +4041,7 @@ impl ProjectContext {
     }
 
     /// Live edges as `(src_idx, dst_idx, flags)` triples.
-    pub(crate) fn edges(&self) -> PyResult<Vec<(usize, usize, u32)>> {
+    pub(crate) fn edges(&self) -> PyResult<Vec<(usize, usize, u8)>> {
         Ok(self.materialized("edges")?.builder.edges.clone())
     }
 
@@ -3957,7 +4057,7 @@ impl ProjectContext {
     #[pyo3(signature = (*, skip_flags = 0, seed_flags = NODE_FLAG_ENTRYPOINT))]
     pub(crate) fn reachable_indices(
         &self,
-        skip_flags: u32,
+        skip_flags: u8,
         seed_flags: u32,
     ) -> PyResult<Vec<usize>> {
         let outputs = self.materialized("reachable_indices")?;

--- a/tests/e2e/test_flux0.py
+++ b/tests/e2e/test_flux0.py
@@ -22,7 +22,6 @@ import pytest
 from typer.testing import CliRunner
 
 from dead_cst import Analysis, _native as native
-from dead_cst.graph import KEEPALIVE_DEFAULT
 from dead_cst.cli import app
 
 pytestmark = pytest.mark.e2e
@@ -126,7 +125,7 @@ def test_flux0_cli_cmds_dead_without_dynamic_seed(flux0_cli_src):
     so with only ``main_block`` the cmds modules are correctly dead."""
     base = Path(flux0_cli_src)
     graph = Analysis(base, plugins=[native.NativePlugin.main_block()]).materialize_all()
-    reachable = graph.reachable(seed_flags=KEEPALIVE_DEFAULT)
+    reachable = graph.reachable(seed_flags=graph.default_seed_mask())
 
     cmds_agents = _module_node(graph, "flux0_cli.cmds.agents")
     assert cmds_agents is not None, "cmds.agents module should be in the graph"

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -1723,8 +1723,8 @@ def test_notebook_decls_carry_notebook_flag(write_notebook, build_decl_graph):
 
     ``NOTEBOOK`` does two jobs:
 
-    * It's a keepalive bit in :data:`KEEPALIVE_DEFAULT` so cells stay
-      alive (notebooks are executed top-to-bottom, not imported).
+    * It's a seed flag (``engine/notebook``) in the default seed mask so
+      cells stay alive (notebooks are executed top-to-bottom, not imported).
     * It tells the codemod to skip these nodes — it can't rewrite cell
       JSON envelopes safely.
     """

--- a/tests/test_eclipsed_modules.py
+++ b/tests/test_eclipsed_modules.py
@@ -12,7 +12,6 @@ synthetics) keep working -- but consumer imports never see its decls.
 from __future__ import annotations
 
 from dead_cst import _native as native
-from dead_cst.graph import KEEPALIVE_DEFAULT
 
 
 def test_package_wins_trie_slot_for_cross_module_imports(
@@ -34,7 +33,7 @@ def test_package_wins_trie_slot_for_cross_module_imports(
     assert len(targets) == 1
     assert targets[0].path.endswith("/__init__.py")
 
-    reachable = set(graph.reachable(seed_flags=KEEPALIVE_DEFAULT))
+    reachable = set(graph.reachable(seed_flags=graph.default_seed_mask()))
     package_x = next(
         n for n in graph.nodes() if n.fqname == "pkg.foo.x" and n.path.endswith("/__init__.py")
     )
@@ -55,7 +54,7 @@ def test_eclipsed_file_keeps_main_block_entrypoint(tmp_path, write_files, make_a
     )
     analysis = make_analysis(plugins=[native.NativePlugin.main_block()])
     graph = analysis.materialize_all()
-    reachable = set(graph.reachable(seed_flags=KEEPALIVE_DEFAULT))
+    reachable = set(graph.reachable(seed_flags=graph.default_seed_mask()))
 
     helper = next(n for n in graph.nodes() if n.fqname == "pkg.foo.helper")
     eclipsed_module = next(

--- a/tests/test_kept_alive_by_noqa.py
+++ b/tests/test_kept_alive_by_noqa.py
@@ -2,24 +2,23 @@
 
 Imports preserved by a ruff/pyflakes ``# noqa[: ...F401...]`` (per-line)
 or a file-level ``# ruff: noqa`` / ``# flake8: noqa`` are stamped with
-:data:`NodeFlags.NOQA` -- one of the keepalive bits in
-:data:`KEEPALIVE_DEFAULT`, so reachability seeds from them by default.
-The flag-taking blast-radius query returns modules and decls currently
-kept alive only because of those pinned imports.
+:data:`NodeFlags.NOQA` -- a seed flag (registered ``engine/noqa``), so
+reachability seeds from them by default. The flag-taking blast-radius
+query returns modules and decls currently kept alive only because of
+those pinned imports.
 """
 
 from __future__ import annotations
 
 from dead_cst import NodeFlags
-from dead_cst.graph import KEEPALIVE_DEFAULT
 
 
 def find_reachable_excluding_noqa(graph):
-    return set(graph.reachable(seed_flags=KEEPALIVE_DEFAULT & ~NodeFlags.NOQA))
+    return set(graph.reachable(seed_flags=graph.default_seed_mask() & ~NodeFlags.NOQA))
 
 
 def find_kept_alive_by_noqa_only(graph):
-    full = set(graph.reachable(seed_flags=KEEPALIVE_DEFAULT))
+    full = set(graph.reachable(seed_flags=graph.default_seed_mask()))
     return full - find_reachable_excluding_noqa(graph)
 
 
@@ -38,7 +37,7 @@ def test_noqa_pin_keeps_module_alive_only_via_noqa(make_analysis, write_files):
     )
     graph = make_analysis().materialize_all()
     side = next(n for n in graph.nodes() if n.fqname == "pkg.side_effect")
-    assert side in set(graph.reachable(seed_flags=KEEPALIVE_DEFAULT))
+    assert side in set(graph.reachable(seed_flags=graph.default_seed_mask()))
     assert side not in find_reachable_excluding_noqa(graph)
     assert side in find_kept_alive_by_noqa_only(graph)
 
@@ -108,9 +107,10 @@ def test_excluding_multiple_flags_in_one_pass(make_analysis, write_files):
 
     graph = make_analysis(plugins=[native.NativePlugin.pytest()]).materialize_all()
     side = next(n for n in graph.nodes() if n.fqname == "pkg.side_effect")
-    assert side in set(graph.reachable(seed_flags=KEEPALIVE_DEFAULT))
+    assert side in set(graph.reachable(seed_flags=graph.default_seed_mask()))
+    testcase = graph.node_flag("test/testcase") or 0
     excluded = set(
-        graph.reachable(seed_flags=KEEPALIVE_DEFAULT & ~(NodeFlags.TESTCASE | NodeFlags.NOQA))
+        graph.reachable(seed_flags=graph.default_seed_mask() & ~(testcase | NodeFlags.NOQA))
     )
     assert side not in excluded
 

--- a/tests/test_kept_alive_by_tests.py
+++ b/tests/test_kept_alive_by_tests.py
@@ -1,25 +1,26 @@
-"""End-to-end tests for :data:`NodeFlags.TESTCASE` and ``kept_alive_by_flags_only(NodeFlags.TESTCASE)``.
+"""End-to-end tests for the ``test/testcase`` plugin flag and
+``kept_alive_by_flags_only(test/testcase)``.
 
-Test plugins (pytest, unittest) stamp their synthetic seed nodes with
-``ENTRYPOINT | TESTCASE``. Default reachability treats those seeds the
-same as any other entrypoint; the flag-taking blast-radius query
+Test plugins (pytest, unittest) declare and stamp their synthetic seed
+nodes with the registered ``test/testcase`` flag (resolved by name via
+``node_flag("test/testcase")``). Default reachability treats those seeds
+the same as any other entrypoint; the flag-taking blast-radius query
 returns production code currently kept alive only because tests still
 touch it.
 """
 
 from __future__ import annotations
 
-from dead_cst import NodeFlags
 from dead_cst import _native as native
-from dead_cst.graph import KEEPALIVE_DEFAULT
 
 
 def find_reachable_excluding_tests(graph):
-    return set(graph.reachable(seed_flags=KEEPALIVE_DEFAULT & ~NodeFlags.TESTCASE))
+    testcase = graph.node_flag("test/testcase") or 0
+    return set(graph.reachable(seed_flags=graph.default_seed_mask() & ~testcase))
 
 
 def find_kept_alive_by_tests_only(graph):
-    full = set(graph.reachable(seed_flags=KEEPALIVE_DEFAULT))
+    full = set(graph.reachable(seed_flags=graph.default_seed_mask()))
     return full - find_reachable_excluding_tests(graph)
 
 
@@ -42,7 +43,7 @@ def test_test_only_helper_is_kept_alive_by_tests(make_analysis, write_files):
     )
     graph = make_analysis(plugins=[native.NativePlugin.pytest()]).materialize_all()
     helper = next(n for n in graph.nodes() if n.fqname == "pkg.lib.helper")
-    assert helper in set(graph.reachable(seed_flags=KEEPALIVE_DEFAULT))
+    assert helper in set(graph.reachable(seed_flags=graph.default_seed_mask()))
     assert helper not in find_reachable_excluding_tests(graph)
     assert helper in find_kept_alive_by_tests_only(graph)
 
@@ -92,7 +93,7 @@ def test_unittest_kept_alive_by_tests(make_analysis, write_files):
     )
     graph = make_analysis(plugins=[native.NativePlugin.unittest()]).materialize_all()
     helper = next(n for n in graph.nodes() if n.fqname == "pkg.lib.helper")
-    assert helper in set(graph.reachable(seed_flags=KEEPALIVE_DEFAULT))
+    assert helper in set(graph.reachable(seed_flags=graph.default_seed_mask()))
     assert helper in find_kept_alive_by_tests_only(graph)
 
 
@@ -110,7 +111,7 @@ def test_analysis_method_returns_strict_diff(make_analysis, write_files):
         }
     )
     analysis = make_analysis(plugins=[native.NativePlugin.pytest()])
-    blast = analysis.kept_alive_by_flags_only(NodeFlags.TESTCASE)
+    blast = analysis.kept_alive_by_flags_only(analysis.node_flag("test/testcase"))
     ctx = analysis.materialize_all()
     fqnames = {a.fqname for a in ctx.node_attrs(list(blast))}
     assert "pkg.lib.helper" in fqnames

--- a/tests/test_noqa_pinning.py
+++ b/tests/test_noqa_pinning.py
@@ -1,7 +1,7 @@
 """Imports flagged with a ruff/pyflakes ``# noqa`` directive that silences
-F401 are pinned alive (flagged with :data:`NodeFlags.NOQA`, which is one
-of the keepalive bits in :data:`KEEPALIVE_DEFAULT`), matching the
-semantics ruff itself uses for the unused-import rule.
+F401 are pinned alive (flagged with :data:`NodeFlags.NOQA`, a seed flag in
+the default seed mask), matching the semantics ruff itself uses for the
+unused-import rule.
 
 Both per-line directives (``# noqa``, ``# noqa: F401``, multi-rule
 ``# noqa: E501, F401``, case-insensitive ``noqa`` keyword) and file-level

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 
 from dead_cst.codemod import generate_patch
-from dead_cst.graph import KEEPALIVE_DEFAULT, NodeFlags
+from dead_cst.graph import NodeFlags
 
 
 def test_every_notebook_node_carries_notebook_flag(write_notebook, make_analysis):
@@ -18,10 +18,11 @@ def test_every_notebook_node_carries_notebook_flag(write_notebook, make_analysis
     ctx = make_analysis().materialize_all()
     notebook_nodes = [n for n in ctx.nodes() if n.flags & NodeFlags.NOTEBOOK]
     assert notebook_nodes
-    # ``NOTEBOOK`` alone is enough — it's a keepalive bit in
-    # ``KEEPALIVE_DEFAULT``, so the BFS seeds from these nodes by default
-    # without needing an explicit ``ENTRYPOINT`` overlay.
-    assert any(n.flags & KEEPALIVE_DEFAULT for n in notebook_nodes), (
+    # ``NOTEBOOK`` alone is enough — it's a seed flag, so the BFS seeds
+    # from these nodes by default (it's in the registry-derived
+    # ``default_seed_mask``) without needing an explicit ``ENTRYPOINT``
+    # overlay.
+    assert any(n.flags & ctx.default_seed_mask() for n in notebook_nodes), (
         "notebook nodes should be keepalive seeds"
     )
 
@@ -30,7 +31,7 @@ def test_notebook_keeps_referenced_py_code_alive(write_notebook, write_files, ma
     write_files({"lib.py": "def used(): return 1\ndef unused(): return 2\n"})
     write_notebook("use.ipynb", ["from lib import used\nused()\n"])
     ctx = make_analysis().materialize_all()
-    reachable = set(ctx.reachable(seed_flags=KEEPALIVE_DEFAULT))
+    reachable = set(ctx.reachable(seed_flags=ctx.default_seed_mask()))
     used = next(n for n in ctx.nodes() if n.fqname == "lib.used")
     unused = next(n for n in ctx.nodes() if n.fqname == "lib.unused")
     assert used in reachable

--- a/tests/test_overloads_and_pyi.py
+++ b/tests/test_overloads_and_pyi.py
@@ -6,9 +6,7 @@ from __future__ import annotations
 import textwrap
 
 
-from dead_cst import NodeFlags
 from dead_cst import _native as native
-from dead_cst.graph import KEEPALIVE_DEFAULT
 from dead_cst.codemod import remove_code
 
 
@@ -46,8 +44,11 @@ def test_overloads_are_excluded_from_cross_module_lookup(tmp_path, make_analysis
         if s.fqname == "mod.f" and s.kind == "function"
     ]
     assert targets, "main.f should reach mod.f"
-    assert all(not (t.flags & NodeFlags.OVERLOAD) for t in targets), (
-        "Cross-module imports should resolve to the impl, not the overload"
+    # Overload status is internal (not Python-visible); the observable proxy
+    # is that resolution lands on the impl (line 5), never the overload stub
+    # (line 4).
+    assert {t.start_line for t in targets} == {5}, (
+        "Cross-module imports should resolve to the impl (line 5), not the overload (line 4)"
     )
 
 
@@ -100,7 +101,7 @@ def test_live_overloads_survive_codemod(tmp_path, make_analysis):
     )
     a = make_analysis(plugins=[native.NativePlugin.explicit([], ["mod.f"], [])])
     graph = a.materialize_all()
-    reachable = set(graph.reachable(seed_flags=KEEPALIVE_DEFAULT))
+    reachable = set(graph.reachable(seed_flags=graph.default_seed_mask()))
     unreachable = [n for n in graph.nodes() if n not in reachable]
     remove_code(unreachable, tmp_path)
 
@@ -109,10 +110,13 @@ def test_live_overloads_survive_codemod(tmp_path, make_analysis):
     assert rewritten.count("@overload") == 2
 
 
-def test_overload_stub_flag_set_on_stubs_only(build_decl_graph):
-    """`NodeFlags.OVERLOAD` is set on `@typing.overload`-decorated stubs and
-    not on the impl. Recognise both `@overload` (from-import / aliased) and
-    the `@typing.overload` attribute form (plain `import typing`)."""
+def test_overload_decorator_forms_recognised(build_decl_graph):
+    """Both `@overload` (from-import / aliased) and the `@typing.overload`
+    attribute form (plain `import typing`) are recognised as overload stubs.
+    Overload status is internal (not Python-visible); the observable proxy is
+    that each recognised stub gets an `impl -> stub` anchor edge, so both
+    stubs are descendants of the impl while the impl itself isn't anchored to
+    anything."""
     graph = build_decl_graph(
         {
             "mod.py": """
@@ -140,9 +144,11 @@ def test_overload_stub_flag_set_on_stubs_only(build_decl_graph):
     f_nodes = [n for n in graph.nodes() if n.fqname == "mod.f" and n.kind == "function"]
     by_line = {n.start_line: n for n in f_nodes}
     assert set(by_line) == {5, 7, 8}, f"unexpected lines: {sorted(by_line)}"
-    assert by_line[5].flags & NodeFlags.OVERLOAD
-    assert by_line[7].flags & NodeFlags.OVERLOAD
-    assert not (by_line[8].flags & NodeFlags.OVERLOAD)
+    descendants = set(graph.descendants(by_line[8]))
+    assert by_line[5] in descendants, "@ovl (aliased) stub should anchor to the impl"
+    assert by_line[7] in descendants, (
+        "@typing.overload (attribute form) stub should anchor to the impl"
+    )
 
 
 def test_impl_to_overload_anchor_edges(build_decl_graph):
@@ -186,7 +192,7 @@ def test_impl_to_overload_anchor_edges(build_decl_graph):
 def test_cross_module_import_reaches_impl_not_stubs(build_decl_graph):
     """`from mod import f` should produce exactly one decl edge per consumer
     use — to the impl, not the stubs (which are deliberately excluded from
-    the cross-module trie via `NodeFlags.OVERLOAD`)."""
+    the cross-module trie as overload stubs)."""
     graph = build_decl_graph(
         {
             "mod.py": """
@@ -212,7 +218,11 @@ def test_cross_module_import_reaches_impl_not_stubs(build_decl_graph):
         if nodes[u] == main_alias and nodes[v].fqname == "mod.f" and nodes[v].kind == "function"
     ]
     assert targets, "import alias should reach at least one mod.f decl"
-    assert all(not (t.flags & NodeFlags.OVERLOAD) for t in targets)
+    # Overload stubs (lines 4, 6) are excluded from the cross-module trie, so
+    # the only reachable decl is the impl (line 7).
+    assert {t.start_line for t in targets} == {7}, (
+        "import alias should reach only the impl (line 7), not the stubs (lines 4, 6)"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -232,7 +242,7 @@ def test_orphan_pyi_stub_uses_runtime_fqname(tmp_path, make_analysis, successors
 
     a = make_analysis(plugins=[native.NativePlugin.explicit([], ["main"], [])])
     graph = a.materialize_all()
-    reachable = set(graph.reachable(seed_flags=KEEPALIVE_DEFAULT))
+    reachable = set(graph.reachable(seed_flags=graph.default_seed_mask()))
 
     stub_compute = next(
         n for n in graph.nodes() if n.fqname == "mypkg._native.compute" and n.kind == "function"

--- a/tests/test_plugins/conftest.py
+++ b/tests/test_plugins/conftest.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 from dead_cst import Analysis
-from dead_cst.graph import KEEPALIVE_DEFAULT
 
 if TYPE_CHECKING:
     from dead_cst import _native as native
@@ -18,7 +17,7 @@ def reachable_fqnames():
     """``{fqname for n in ctx.reachable() if n.kind != "synthetic"}``."""
 
     def _reachable(ctx: "native.ProjectContext") -> set[str]:
-        reached = ctx.reachable(seed_flags=KEEPALIVE_DEFAULT)
+        reached = ctx.reachable(seed_flags=ctx.default_seed_mask())
         return {n.fqname for n in reached if n.kind != "synthetic"}
 
     return _reachable

--- a/tests/test_plugins/test_celery.py
+++ b/tests/test_plugins/test_celery.py
@@ -330,10 +330,10 @@ def test_celery_plugin_handles_factory_function(build_plugin_graph, reachable_fq
         },
         [native.NativePlugin.celery()],
     )
-    from dead_cst.graph import KEEPALIVE_DEFAULT
-
     reached = {
-        n.fqname for n in graph.reachable(seed_flags=KEEPALIVE_DEFAULT) if n.kind != "synthetic"
+        n.fqname
+        for n in graph.reachable(seed_flags=graph.default_seed_mask())
+        if n.kind != "synthetic"
     }
     assert "app.celery.app" in reached
     assert "app.celery.run" in reached

--- a/tests/test_plugins/test_flask.py
+++ b/tests/test_plugins/test_flask.py
@@ -485,10 +485,10 @@ def test_flask_plugin_handles_factory_function(build_plugin_graph, reachable_fqn
         },
         [native.NativePlugin.flask()],
     )
-    from dead_cst.graph import KEEPALIVE_DEFAULT
-
     reached = {
-        n.fqname for n in graph.reachable(seed_flags=KEEPALIVE_DEFAULT) if n.kind != "synthetic"
+        n.fqname
+        for n in graph.reachable(seed_flags=graph.default_seed_mask())
+        if n.kind != "synthetic"
     }
     assert "app.main.app" in reached
     assert "app.main.list_items" in reached

--- a/tests/test_plugins/test_pytest.py
+++ b/tests/test_plugins/test_pytest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dead_cst import _native as native
-from dead_cst.graph import NodeFlags
 
 
 def test_pytest_plugin_marks_test_functions(build_plugin_graph, reachable_fqnames):
@@ -363,5 +362,7 @@ def test_pytest_plugin_tags_seeds_as_testcase(build_plugin_graph):
         },
         [native.NativePlugin.pytest()],
     )
-    seeds = [n for n in graph.nodes() if n.flags & NodeFlags.TESTCASE]
-    assert seeds, "expected pytest plugin to seed at least one TESTCASE node"
+    testcase = graph.node_flag("test/testcase")
+    assert testcase is not None, "pytest plugin should register the test/testcase flag"
+    seeds = [n for n in graph.nodes() if n.flags & testcase]
+    assert seeds, "expected pytest plugin to seed at least one test/testcase node"

--- a/tests/test_plugins/test_server_config.py
+++ b/tests/test_plugins/test_server_config.py
@@ -171,20 +171,24 @@ def test_server_config_loads_via_cli_loader():
 
 def test_seeds_are_not_tagged_testcase(build_plugin_graph):
     # Server-config entrypoints are production code, not tests -- they
-    # should seed reachability but not get filtered by
-    # ``kept_alive_by_flags_only(NodeFlags.TESTCASE)``.
+    # should seed reachability but never carry the ``test/testcase`` flag
+    # (so ``kept_alive_by_flags_only(test/testcase)`` doesn't filter them).
+    # Register pytest alongside so the ``test/testcase`` flag is registered
+    # and there's a bit to check against.
     graph = build_plugin_graph(
         {
             "pkg/__init__.py": "",
             "gunicorn.conf.py": "workers = 4",
         },
-        [native.NativePlugin.server_config()],
+        [native.NativePlugin.server_config(), native.NativePlugin.pytest()],
     )
+    testcase = graph.node_flag("test/testcase")
+    assert testcase is not None, "pytest plugin should register the test/testcase flag"
     seeds = [n for n in graph.nodes() if n.flags & NodeFlags.ENTRYPOINT]
     server_seeds = [s for s in seeds if s.fqname.startswith("<server-config>:")]
     assert server_seeds
     for seed in server_seeds:
-        assert not (seed.flags & NodeFlags.TESTCASE), seed.fqname
+        assert not (seed.flags & testcase), seed.fqname
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plugins/test_unittest.py
+++ b/tests/test_plugins/test_unittest.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 
 from dead_cst import _native as native
-from dead_cst.graph import NodeFlags
 
 
 def test_unittest_plugin_marks_testcase_subclass(build_plugin_graph, reachable_fqnames):
@@ -231,8 +230,10 @@ def test_unittest_plugin_tags_seeds_as_testcase(build_plugin_graph):
         },
         [native.NativePlugin.unittest()],
     )
-    seeds = [n for n in graph.nodes() if n.flags & NodeFlags.TESTCASE]
-    assert seeds, "expected unittest plugin to seed at least one TESTCASE node"
+    testcase = graph.node_flag("test/testcase")
+    assert testcase is not None, "unittest plugin should register the test/testcase flag"
+    seeds = [n for n in graph.nodes() if n.flags & testcase]
+    assert seeds, "expected unittest plugin to seed at least one test/testcase node"
 
 
 def test_unittest_plugin_marks_subclass_via_local_mixin(build_plugin_graph, reachable_fqnames):

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -26,7 +26,6 @@ EXPECTED_PUBLIC_API: dict[str, list[str]] = {
         "EdgeFlags",
         "GraphMetadata",
         "Import",
-        "KEEPALIVE_DEFAULT",
         "LoadedGraph",
         "NodeFlags",
         "SymbolNode",


### PR DESCRIPTION
## Summary

- **One `FlagSpec` mechanism, two registration paths.** The engine registers its `engine/*` flags with explicit masks (so hot-path `flags & CONST` reads still constant-fold); plugins declare flags via the new `ExternalPlugin::declare_node_flags()` / `declare_edge_flags()` hooks, and the host allocates each a bit above the engine masks in registration order (deterministic). The `engine/` namespace is reserved, identical specs declared by two plugins share one bit (`pytest` and `unittest` now share `test/testcase`), and a conflicting re-declaration or exhausting the bit width fails loudly. Read the assigned bit back at run time with `PluginCtx::node_flag(name)` / `edge_flag(name)`.
- **Both registries are serialized into the `.dcg` graph file** (`FORMAT_VERSION` 1→2, old files rejected) so an external reader can decode any bit — engine or plugin — back to its name. `ProjectContext` / a loaded graph expose `node_flag_registry()`, `edge_flag_registry()`, `default_seed_mask()`, `node_flag()`, `edge_flag()`. Node flags stay `u32`; edge flags narrow to `u8`.
- **Roster surgery.** Drop the dead `SHADOWED` / `EXPORTED` flags; move `OVERLOAD` off the flag space into an internal build-time `is_overload` field on the node payload (not serialized, not Python-visible — overload behavior is unchanged); move `TESTCASE` to the shared `test/testcase` plugin flag; add an engine `dead_branch` node flag. The hand-maintained `KEEPALIVE_DEFAULT` constant is replaced by the registry-derived `default_seed_mask()` (OR of `seed && default_on` bits), so `test/testcase` is kept alive by default iff a test plugin is registered.
- `PLUGIN_API_EPOCH` bumped 1→2 (the curated `plugin_api` surface changed).

**Breaking (pre-1.0):** `NodeFlags.SHADOWED/OVERLOAD/TESTCASE/EXPORTED` and `dead_cst.graph.KEEPALIVE_DEFAULT` are removed; callers use the registry getters / `default_seed_mask()`, and overload status is now internal node metadata.

## Test plan

- [x] `cargo build -p dead-cst-runtime` + `cargo clippy --all-targets` clean
- [x] `cargo test --no-default-features --locked -p dead-cst-runtime` — 136 pass (registry round-trip, idempotence/determinism, loud failures, edge-`u8` split)
- [x] `maturin develop --uv` builds the extension
- [x] `uv run pytest` — 698 pass, 3 skipped, 5 e2e deselected (overload behavior, keepalive derivation, plugin/reachability/io suites)
- [x] `uv run prek run --all-files` — ruff, ruff-format, ty, cargo fmt, cargo clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)