### PR TITLE
Convert pytest off synthetic seeds; add provisional test/fixture flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,6 +291,14 @@ two versions.
   `NodeFlags.ENTRYPOINT` on that decl instead of minting a `{marker}:{fqname}`
   synthetic seed plus an edge. The `PluginOps`/`FileOps` `keep_alive` op
   dropped its `marker: String` parameter (`plugin_api` epoch 2 → 3).
+- **`mock_patch` no longer mints `<patch-target>:` synthetic relay nodes.** A
+  recognized patch reference (`unittest.mock.patch` / `mock.patch`,
+  `mocker.patch`, `monkeypatch.setattr` / `.delattr`) now keeps each resolved
+  target alive with a direct `owner -> target` edge from the enclosing call
+  site, instead of routing every owner through a shared `<patch-target>:<fqname>`
+  relay node. An unresolved fqname keeps nothing alive (the previous empty-target
+  introspection record is dropped, matching the other relay eliminations). No
+  `plugin_api` epoch or `FORMAT_VERSION` bump — `add_edge` already exists.
 - **Graph node indices are now deterministic across runs.** ty's `files()`
   set has no stable iteration order, so the global index assigned to each node
   (and therefore the order of `Analysis.dead()` / `reachable()` results and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,19 @@ two versions.
   with no live `TestCase` now dies with its (unreachable) module, matching the
   module-dunder model — previously the per-module seed kept it alive
   unconditionally.
+- **`pytest` plugin no longer mints `<pytest:tests>:` / `<pytest:conftest>:` /
+  `<pytest:fixtures>:` synthetic seeds.** Each kind is now flagged directly on
+  the decl via `PluginOps::flag_decl`: `test_*` functions / `Test*` classes
+  (genuine test roots) carry the existing `test/testcase` flag, while every
+  `@pytest.fixture` function and every top-level `conftest.py` decl carry a new
+  provisional `test/fixture` flag (`seed: true, default_on: true`) — a
+  conservative keepalive that flips to non-seeding once fixture / conftest usage
+  is traced precisely as edges. Both flags are default-on seeds, so the alive
+  set is unchanged; the `test → fixture` / `class → fixture` parameter-name
+  edges are still emitted on top. `kept_alive_by_flags_only(test/fixture)` now
+  isolates the fixture-kept-alive blast radius, and the CLI `--query test_only`
+  subtracts both flags. Conftest decls moved from `test/testcase` to
+  `test/fixture` (they are support code, not collected tests).
 - **Resolved site-packages imports are now real `kind="external"` graph
   nodes.** A site-packages import (`[external dist] requests`) mints a real
   external node carrying the resolved site-packages path, replacing the old

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -355,8 +355,8 @@ class NativePlugin:
         ``unittest.mock.patch`` / ``mock.patch``, pytest-mock's
         ``mocker.patch``, and pytest's ``monkeypatch.setattr`` /
         ``monkeypatch.delattr`` to its target decl (and module), wiring a
-        synthetic ``<patch-target>:<fqname>`` keep-alive node from each call
-        site to the resolved targets.
+        direct keep-alive edge from each enclosing call site to every
+        resolved target. An unresolved fqname keeps nothing alive.
         """
         ...
 

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -375,12 +375,13 @@ class NativePlugin:
 
     @staticmethod
     def pytest() -> NativePlugin:
-        """Native pytest plugin. Seeds every top-level decl in ``conftest.py``
-        (``<pytest:conftest>:<module>``), every ``test_*`` function / ``Test*``
-        class in ``test_*.py`` / ``*_test.py`` (``<pytest:tests>:<module>``),
-        and every ``@pytest.fixture`` function (``<pytest:fixtures>:<module>``)
-        as ``TESTCASE`` entrypoints. On top of the seed it wires
-        ``test → fixture`` / ``class → fixture`` edges by parameter-name
+        """Native pytest plugin. Flags every ``test_*`` function / ``Test*``
+        class in ``test_*.py`` / ``*_test.py`` with the ``test/testcase`` node
+        flag, and flags every ``@pytest.fixture`` function plus every
+        top-level ``conftest.py`` decl with the provisional ``test/fixture``
+        node flag (a conservative keepalive pending precise fixture/conftest
+        usage modeling). Both are default-on seed flags. On top of the flags it
+        wires ``test → fixture`` / ``class → fixture`` edges by parameter-name
         matching (honoring the ``name=`` kwarg alias), so the dependency graph
         is queryable. Unmatched parameter names (pytest builtins, plugin
         fixtures) are silently ignored.

--- a/python/dead_cst/cli.py
+++ b/python/dead_cst/cli.py
@@ -220,8 +220,9 @@ def _select_dead(view: GraphView, query: Query) -> list[SymbolNode]:
         return [n for n in view.nodes() if n not in reachable]
     if query is Query.test_only:
         testcase = view.node_flag("test/testcase") or 0
+        fixture = view.node_flag("test/fixture") or 0
         full = set(view.reachable(seed_flags=seed_mask))
-        without_tests = set(view.reachable(seed_flags=seed_mask & ~testcase))
+        without_tests = set(view.reachable(seed_flags=seed_mask & ~(testcase | fixture)))
         return list(full - without_tests)
     raise typer.BadParameter(f"unknown --query value: {query!r}")
 

--- a/runtime/src/native_plugins.rs
+++ b/runtime/src/native_plugins.rs
@@ -3262,8 +3262,6 @@ impl plugin_api::ExternalPlugin for ClickPluginImpl {
 // test file targets a decl in another), hence project-wide.
 // ---------------------------------------------------------------------------
 
-const PATCH_TARGET_PREFIX: &str = "<patch-target>:";
-
 pub(crate) struct MockPatchPluginImpl;
 
 impl plugin_api::ExternalPlugin for MockPatchPluginImpl {
@@ -3314,27 +3312,20 @@ impl plugin_api::ExternalPlugin for MockPatchPluginImpl {
         }
 
         // Resolve targets per fqname (decls + the module node if the fqname is
-        // itself a module). One synthetic `<patch-target>:<fqname>` per fqname,
-        // emitted unconditionally — an empty target set still records the
-        // patch site for introspection, matching the Python plugin.
+        // itself a module) and wire a direct `owner -> target` keep-alive edge
+        // for each patch site. An unresolved fqname has no targets and emits no
+        // edge — there is nothing to keep alive.
         for fqname in order {
             let owners = &owners_by_fqname[&fqname];
             let mut target_idxs = ctx.find_declarations(&fqname);
             if let Some(mod_idx) = ctx.find_module(&fqname) {
                 target_idxs.push(mod_idx);
             }
-            let owner_path = ctx
-                .node_paths(&[owners[0]])
-                .into_iter()
-                .next()
-                .unwrap_or_default();
-            ops.add_synthetic_node(
-                format!("{PATCH_TARGET_PREFIX}{fqname}"),
-                owner_path,
-                0,
-                target_idxs,
-                owners.clone(),
-            );
+            for &owner_idx in owners {
+                for &target_idx in &target_idxs {
+                    ops.add_edge(owner_idx, target_idx, 0);
+                }
+            }
         }
         Ok(())
     }

--- a/runtime/src/native_plugins.rs
+++ b/runtime/src/native_plugins.rs
@@ -3985,10 +3985,6 @@ impl plugin_api::ExternalPlugin for ProjectScriptsPluginImpl {
 // tests anywhere), hence project-wide.
 // ---------------------------------------------------------------------------
 
-const PYTEST_CONFTEST_PREFIX: &str = "<pytest:conftest>:";
-const PYTEST_TESTS_PREFIX: &str = "<pytest:tests>:";
-const PYTEST_FIXTURES_PREFIX: &str = "<pytest:fixtures>:";
-
 fn is_test_filename(name: &str) -> bool {
     (name.starts_with("test_") && name.ends_with(".py")) || name.ends_with("_test.py")
 }
@@ -4002,58 +3998,42 @@ fn is_test_decl(kind: &str, fqname: &str) -> bool {
 /// The shared `test/testcase` node-flag spec declared by both the pytest and
 /// unittest plugins. Identical from both, so the registry collapses it to a
 /// single bit (idempotent registration); `seed + default_on` puts it in the
-/// default keepalive mask whenever a test plugin is registered.
+/// default keepalive mask whenever a test plugin is registered. Scoped to
+/// *genuine* test roots (things a framework collects and runs) — the
+/// conservatively-kept pytest support code (fixtures, conftest) rides the
+/// separate [`fixture_flag_spec`] instead.
 fn testcase_flag_spec() -> plugin_api::FlagSpec {
     plugin_api::FlagSpec {
         name: "test/testcase".to_string(),
         seed: true,
         default_on: true,
-        description: "Symbol kept alive because a test framework (pytest / unittest) \
-                      discovers it as a test, fixture, or lifecycle hook."
+        description: "Symbol a test framework collects and runs directly: a pytest \
+                      `test_*` function / `Test*` class, or a `unittest.TestCase` \
+                      subclass."
             .to_string(),
     }
 }
 
-/// Emit a seed node stamped with `flags` keeping `target_idxs` alive (no-op
-/// when empty). `flags` is the resolved `test/testcase` bit (see
-/// [`testcase_flag_spec`]).
-fn mark_seed(
-    ops: &mut plugin_api::PluginOps,
-    fqname: String,
-    path: String,
-    flags: u32,
-    target_idxs: Vec<usize>,
-) {
-    if target_idxs.is_empty() {
-        return;
+/// The pytest plugin's provisional `test/fixture` node-flag spec, stamped on
+/// symbols kept alive *conservatively* — every `@pytest.fixture` and every
+/// `conftest.py` decl — because their real usage (autouse / usefixtures /
+/// indirect parametrization, conftest auto-loading) is not modeled as edges
+/// yet. `seed + default_on` preserves today's keep-everything behavior; it is
+/// kept distinct from [`testcase_flag_spec`] so the conservative blast radius
+/// is measurable (`kept_alive_by_flags_only`) and can be flipped to
+/// `seed: false` in isolation once that usage is traced precisely. Declared by
+/// pytest only.
+fn fixture_flag_spec() -> plugin_api::FlagSpec {
+    plugin_api::FlagSpec {
+        name: "test/fixture".to_string(),
+        seed: true,
+        default_on: true,
+        description: "Conservatively kept alive by the pytest plugin (a @pytest.fixture \
+                      or a conftest.py decl) pending precise fixture/conftest-usage \
+                      modeling; provisional, flips to non-seeding once that usage is \
+                      traced as edges."
+            .to_string(),
     }
-    ops.add_synthetic_node(fqname, path, flags, target_idxs, Vec::new());
-}
-
-/// `{ path: module_fqname }` for every path resolving to a project module.
-fn module_fqnames_for(
-    ctx: &plugin_api::PluginCtx<'_>,
-    paths: &[String],
-) -> FxHashMap<String, String> {
-    if paths.is_empty() {
-        return FxHashMap::default();
-    }
-    let module_idxs = ctx.modules_for_paths(paths);
-    let present: Vec<(String, usize)> = paths
-        .iter()
-        .cloned()
-        .zip(module_idxs)
-        .filter_map(|(p, m)| m.map(|i| (p, i)))
-        .collect();
-    if present.is_empty() {
-        return FxHashMap::default();
-    }
-    let attrs = ctx.nodes_at(&present.iter().map(|(_, i)| *i).collect::<Vec<_>>());
-    present
-        .into_iter()
-        .zip(attrs)
-        .map(|((path, _), attr)| (path, attr.fqname))
-        .collect()
 }
 
 pub(crate) struct PytestPluginImpl;
@@ -4064,7 +4044,7 @@ impl plugin_api::ExternalPlugin for PytestPluginImpl {
     }
 
     fn declare_node_flags(&self) -> Vec<plugin_api::FlagSpec> {
-        vec![testcase_flag_spec()]
+        vec![testcase_flag_spec(), fixture_flag_spec()]
     }
 
     fn run(
@@ -4072,10 +4052,13 @@ impl plugin_api::ExternalPlugin for PytestPluginImpl {
         ctx: &plugin_api::PluginCtx<'_>,
         ops: &mut plugin_api::PluginOps,
     ) -> Result<(), plugin_api::PluginError> {
-        // The bit the host allocated for our declared `test/testcase` flag.
+        // The bits the host allocated for our declared flags.
         let testcase_flag = ctx
             .node_flag("test/testcase")
             .expect("test/testcase is declared in declare_node_flags");
+        let fixture_flag = ctx
+            .node_flag("test/fixture")
+            .expect("test/fixture is declared in declare_node_flags");
         // Every top-level function / class / variable decl + its path.
         let idxs = ctx.nodes_matching(&plugin_api::NodeFilter {
             kinds: &["function", "class", "variable"],
@@ -4090,39 +4073,34 @@ impl plugin_api::ExternalPlugin for PytestPluginImpl {
         }
         let paths = ctx.node_paths(&idxs);
 
-        // Bucket conftest decls; collect test-file candidates (idx + path).
-        let mut conftest_by_path: FxHashMap<String, Vec<usize>> = FxHashMap::default();
-        let mut conftest_order: Vec<String> = Vec::new();
+        // Flag every conftest.py decl `test/fixture`; collect test-file
+        // candidates for the `test/testcase` pass below. `fixture_flagged`
+        // dedups against the `@pytest.fixture` pass so a fixture defined in a
+        // conftest is flagged exactly once.
+        let mut fixture_flagged: FxHashSet<usize> = FxHashSet::default();
         let mut cand_idxs: Vec<usize> = Vec::new();
-        let mut cand_paths: Vec<String> = Vec::new();
         for (idx, path) in idxs.iter().zip(paths.iter()) {
             let filename = path_basename(path);
             if filename == "conftest.py" {
-                if !conftest_by_path.contains_key(path) {
-                    conftest_order.push(path.clone());
+                if fixture_flagged.insert(*idx) {
+                    ops.flag_decl(*idx, fixture_flag);
                 }
-                conftest_by_path.entry(path.clone()).or_default().push(*idx);
             } else if is_test_filename(filename) {
                 cand_idxs.push(*idx);
-                cand_paths.push(path.clone());
             }
         }
 
-        // Filter test candidates by `_is_test_decl`; track function/class kinds.
-        let mut tests_by_path: FxHashMap<String, Vec<usize>> = FxHashMap::default();
-        let mut tests_order: Vec<String> = Vec::new();
+        // Flag genuine test decls `test/testcase`; track function/class kinds
+        // for the fixture-parameter edges below.
         let mut test_function_idxs: Vec<usize> = Vec::new();
         let mut test_class_idxs: Vec<usize> = Vec::new();
         if !cand_idxs.is_empty() {
             let attrs = ctx.nodes_at(&cand_idxs);
-            for ((idx, path), attr) in cand_idxs.iter().zip(cand_paths.iter()).zip(attrs.iter()) {
+            for (idx, attr) in cand_idxs.iter().zip(attrs.iter()) {
                 if !is_test_decl(&attr.kind, &attr.fqname) {
                     continue;
                 }
-                if !tests_by_path.contains_key(path) {
-                    tests_order.push(path.clone());
-                }
-                tests_by_path.entry(path.clone()).or_default().push(*idx);
+                ops.flag_decl(*idx, testcase_flag);
                 if attr.kind == "function" {
                     test_function_idxs.push(*idx);
                 } else if attr.kind == "class" {
@@ -4131,69 +4109,20 @@ impl plugin_api::ExternalPlugin for PytestPluginImpl {
             }
         }
 
-        // Module fqnames for the paths we'll seed (conftest + filtered tests).
-        let mut seed_paths: Vec<String> = conftest_order.clone();
-        for p in &tests_order {
-            if !conftest_by_path.contains_key(p) {
-                seed_paths.push(p.clone());
-            }
-        }
-        let seed_module_fqnames = module_fqnames_for(ctx, &seed_paths);
-        for path in &conftest_order {
-            if let Some(module_fqname) = seed_module_fqnames.get(path) {
-                mark_seed(
-                    ops,
-                    format!("{PYTEST_CONFTEST_PREFIX}{module_fqname}"),
-                    path.clone(),
-                    testcase_flag,
-                    conftest_by_path[path].clone(),
-                );
-            }
-        }
-        for path in &tests_order {
-            if let Some(module_fqname) = seed_module_fqnames.get(path) {
-                mark_seed(
-                    ops,
-                    format!("{PYTEST_TESTS_PREFIX}{module_fqname}"),
-                    path.clone(),
-                    testcase_flag,
-                    tests_by_path[path].clone(),
-                );
-            }
-        }
-
         // `@pytest.fixture`-decorated decls (args extracted for the `name=`
-        // alias).
+        // alias). Each is conservatively flagged `test/fixture` — the rule
+        // that catches autouse / usefixtures / indirect without modeling them.
         let fixture_refs: Vec<(usize, CallArgs)> =
             ctx.decorated_decls_with_args(&["pytest"], &["fixture"]);
         if fixture_refs.is_empty() {
             return Ok(());
         }
+        for (idx, _) in &fixture_refs {
+            if fixture_flagged.insert(*idx) {
+                ops.flag_decl(*idx, fixture_flag);
+            }
+        }
         let fixture_idxs_all: Vec<usize> = fixture_refs.iter().map(|(idx, _)| *idx).collect();
-
-        // Per-file fixture seed (every `@pytest.fixture` stays alive — the
-        // conservative rule that catches autouse / usefixtures / indirect).
-        let fixture_paths = ctx.node_paths(&fixture_idxs_all);
-        let mut fixtures_by_path: FxHashMap<String, Vec<usize>> = FxHashMap::default();
-        let mut fixtures_path_order: Vec<String> = Vec::new();
-        for (idx, path) in fixture_idxs_all.iter().zip(fixture_paths.iter()) {
-            if !fixtures_by_path.contains_key(path) {
-                fixtures_path_order.push(path.clone());
-            }
-            fixtures_by_path.entry(path.clone()).or_default().push(*idx);
-        }
-        let fixture_module_fqnames = module_fqnames_for(ctx, &fixtures_path_order);
-        for path in &fixtures_path_order {
-            if let Some(module_fqname) = fixture_module_fqnames.get(path) {
-                mark_seed(
-                    ops,
-                    format!("{PYTEST_FIXTURES_PREFIX}{module_fqname}"),
-                    path.clone(),
-                    testcase_flag,
-                    fixtures_by_path[path].clone(),
-                );
-            }
-        }
 
         // Parameter-name edges. Skip when no test signature to inspect.
         if test_function_idxs.is_empty() && test_class_idxs.is_empty() {

--- a/tests/test_plugins/test_mock_patch.py
+++ b/tests/test_plugins/test_mock_patch.py
@@ -6,8 +6,6 @@ import pytest
 
 from dead_cst import _native as native
 
-PATCH_TARGET_PREFIX = "<patch-target>:"
-
 # Each entry is a ``tests/test_lib.py`` body that should keep
 # ``pkg.lib.helper`` alive via a string-fqname patch reference. The id
 # names the recognized form so failures point at the specific shape.
@@ -265,8 +263,7 @@ def test_only_marks_target_when_test_alive(build_plugin_graph, reachable_fqnames
     """A patch reference inside a dead decl doesn't promote anything.
 
     No entrypoint reaches ``isolated_helper``, so the synthesized
-    ``isolated_helper -> <patch-target>:pkg.lib.helper`` edge never
-    fires.
+    ``isolated_helper -> pkg.lib.helper`` keep-alive edge never fires.
     """
     graph = build_plugin_graph(
         {
@@ -285,12 +282,10 @@ def test_only_marks_target_when_test_alive(build_plugin_graph, reachable_fqnames
     assert "pkg.lib.helper" not in reachable_fqnames(graph)
 
 
-def test_monkeypatch_setattr_object_form_not_treated_as_fqname(
-    build_plugin_graph, reachable_fqnames
-):
+def test_monkeypatch_setattr_object_form_not_treated_as_fqname(build_plugin_graph):
     """``monkeypatch.setattr(obj, "attr", value)`` has 3 positional args
     and is the object form -- the ``"attr"`` string must not be treated
-    as a fqname reference."""
+    as a fqname reference, so no ``test -> helper`` patch edge is wired."""
     graph = build_plugin_graph(
         {
             "pkg/__init__.py": "",
@@ -302,15 +297,43 @@ def test_monkeypatch_setattr_object_form_not_treated_as_fqname(
             def test_helper(monkeypatch):
                 # 3 positional args: object form, "helper" is just an
                 # attribute name on the pkg.lib module object, not an
-                # fqname string. The reference to ``pkg.lib`` is what
-                # keeps the module alive (and ``helper`` with it).
+                # fqname string.
                 monkeypatch.setattr(pkg.lib, "helper", lambda: 2)
             """,
         },
         [native.NativePlugin.mock_patch(), native.NativePlugin.pytest()],
     )
-    synthetics = {n.fqname for n in graph.nodes() if n.kind == "synthetic"}
-    assert f"{PATCH_TARGET_PREFIX}helper" not in synthetics
+    nodes = graph.nodes()
+    by_fqname = {n.fqname: i for i, n in enumerate(nodes)}
+    test_idx = by_fqname["tests.test_lib.test_helper"]
+    helper_idx = by_fqname["pkg.lib.helper"]
+    assert (test_idx, helper_idx, 0) not in [(s, d, f) for (s, d, f) in graph.edges()]
+
+
+def test_mock_patch_emits_direct_owner_to_target_edge(build_plugin_graph):
+    """The keep-alive is a direct ``owner -> target`` edge, not a synthetic
+    relay node. Verify the edge is in the graph and no patch-target synthetic
+    remains."""
+    graph = build_plugin_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/lib.py": "def helper(): return 1",
+            "tests/__init__.py": "",
+            "tests/test_lib.py": """
+            from unittest.mock import patch
+
+            @patch("pkg.lib.helper")
+            def test_helper(_): pass
+            """,
+        },
+        [native.NativePlugin.mock_patch(), native.NativePlugin.pytest()],
+    )
+    nodes = graph.nodes()
+    by_fqname = {n.fqname: i for i, n in enumerate(nodes)}
+    owner_idx = by_fqname["tests.test_lib.test_helper"]
+    target_idx = by_fqname["pkg.lib.helper"]
+    assert (owner_idx, target_idx, 0) in [(s, d, f) for (s, d, f) in graph.edges()]
+    assert not any(n.kind == "synthetic" and "patch-target" in n.fqname for n in nodes)
 
 
 def test_monkeypatch_setitem_not_recognized(build_plugin_graph, reachable_fqnames):

--- a/tests/test_plugins/test_pytest.py
+++ b/tests/test_plugins/test_pytest.py
@@ -82,10 +82,9 @@ def test_pytest_plugin_marks_decorated_fixtures_outside_conftest(
     build_plugin_graph, reachable_fqnames
 ):
     """Every ``@pytest.fixture``-decorated function is unconditionally
-    alive via the synthetic ``<pytest:fixtures>:<module>`` seed,
-    regardless of whether any test parameter mentions it. The
-    parameter-name edges are *additive* — they make the dependency
-    queryable without changing the alive set."""
+    alive via the ``test/fixture`` flag, regardless of whether any test
+    parameter mentions it. The parameter-name edges are *additive* —
+    they make the dependency queryable without changing the alive set."""
     graph = build_plugin_graph(
         {
             "tests/__init__.py": "",
@@ -272,7 +271,7 @@ def test_pytest_plugin_fixture_name_kwarg_alias(build_plugin_graph):
     alias, not its function name. The ``test → fixture`` edge must
     resolve through the alias — verify the edge is present in the
     graph. (Reachability of the fixture itself is guaranteed by the
-    unconditional fixture seed, so we check the edge directly.)"""
+    ``test/fixture`` flag, so we check the edge directly.)"""
     graph = build_plugin_graph(
         {
             "tests/__init__.py": "",
@@ -300,10 +299,11 @@ def test_pytest_plugin_fixture_name_kwarg_alias(build_plugin_graph):
 
 
 def test_pytest_plugin_conftest_fixture_unused_stays_alive(build_plugin_graph, reachable_fqnames):
-    """Fixtures defined in a ``conftest.py`` are still seeded alive via
-    the conftest-seeds-everything rule (they're often referenced by
-    tests we don't model precisely). The test → fixture edge is
-    *additive* — it pulls non-conftest fixtures alive when used."""
+    """Fixtures defined in a ``conftest.py`` are still kept alive via the
+    ``test/fixture`` flag (conftest decls are flagged wholesale — they're
+    often referenced by tests we don't model precisely). The test →
+    fixture edge is *additive* — it pulls non-conftest fixtures alive
+    when used."""
     graph = build_plugin_graph(
         {
             "tests/__init__.py": "",
@@ -348,21 +348,79 @@ def test_pytest_plugin_loads_via_cli_loader():
     assert plugin.name == "PytestPlugin"
 
 
-def test_pytest_plugin_tags_seeds_as_testcase(build_plugin_graph):
+def test_pytest_plugin_flag_split_testcase_vs_fixture(build_plugin_graph):
+    """Genuine tests carry ``test/testcase``; fixtures and conftest decls
+    carry the provisional ``test/fixture`` flag instead. The two are
+    distinct bits and never overlap on a node."""
     graph = build_plugin_graph(
         {
             "tests/__init__.py": "",
-            "tests/test_things.py": "def test_one(): pass",
+            "tests/test_things.py": """
+            import pytest
+
+            def test_one(): pass
+
+            @pytest.fixture
+            def local_fixture(): return 1
+            """,
             "tests/conftest.py": """
             import pytest
 
             @pytest.fixture
             def my_fixture(): return 1
+
+            def pytest_configure(config): pass
             """,
         },
         [native.NativePlugin.pytest()],
     )
     testcase = graph.node_flag("test/testcase")
-    assert testcase is not None, "pytest plugin should register the test/testcase flag"
-    seeds = [n for n in graph.nodes() if n.flags & testcase]
-    assert seeds, "expected pytest plugin to seed at least one test/testcase node"
+    fixture = graph.node_flag("test/fixture")
+    assert testcase is not None, "pytest plugin should register test/testcase"
+    assert fixture is not None, "pytest plugin should register test/fixture"
+    assert testcase != fixture, "the two flags must be distinct bits"
+
+    by_fqname = {n.fqname: n for n in graph.nodes()}
+
+    # Genuine test → testcase only.
+    test_one = by_fqname["tests.test_things.test_one"]
+    assert test_one.flags & testcase
+    assert not test_one.flags & fixture
+
+    # Fixtures (in a test module or a conftest) → fixture only.
+    for fq in ("tests.test_things.local_fixture", "tests.conftest.my_fixture"):
+        node = by_fqname[fq]
+        assert node.flags & fixture, f"{fq} should carry test/fixture"
+        assert not node.flags & testcase, f"{fq} should not carry test/testcase"
+
+    # Non-fixture conftest decls → fixture (conftest is flagged wholesale).
+    configure = by_fqname["tests.conftest.pytest_configure"]
+    assert configure.flags & fixture
+    assert not configure.flags & testcase
+
+
+def test_pytest_plugin_fixture_flag_is_measurable(build_plugin_graph):
+    """Dropping the ``test/fixture`` bit from the seed mask removes exactly
+    the fixture-kept-alive set — the blast-radius query the provisional
+    flag exists to support."""
+    graph = build_plugin_graph(
+        {
+            "tests/__init__.py": "",
+            "tests/conftest.py": """
+            import pytest
+
+            @pytest.fixture
+            def only_fixture(): return 1
+            """,
+        },
+        [native.NativePlugin.pytest()],
+    )
+    fixture = graph.node_flag("test/fixture")
+    assert fixture is not None
+    seed = graph.default_seed_mask()
+    assert seed & fixture, "test/fixture is a default-on seed"
+
+    with_fixture = {n.fqname for n in graph.reachable(seed_flags=seed)}
+    without_fixture = {n.fqname for n in graph.reachable(seed_flags=seed & ~fixture)}
+    assert "tests.conftest.only_fixture" in with_fixture
+    assert "tests.conftest.only_fixture" not in without_fixture


### PR DESCRIPTION
## Summary

Stacked on #282 (base branch `flag-decl-op-unittest-conversion`). Continues the synthetic-seed-elimination effort: after unittest (#282), this converts the **pytest** plugin off its three synthetic seed nodes.

- pytest no longer mints `<pytest:tests>:` / `<pytest:conftest>:` / `<pytest:fixtures>:` seed nodes. Each kind is now stamped directly on the decl via `PluginOps::flag_decl`:
  - `test_*` functions / `Test*` classes (genuine collected roots) keep the existing **`test/testcase`** flag.
  - every `@pytest.fixture` function and every top-level `conftest.py` decl get a new **provisional `test/fixture`** flag (`seed: true, default_on: true`).
- The flag split keeps the alive set identical (both are default-on seeds) but makes the conservative fixture/conftest keepalive **separately measurable** (`kept_alive_by_flags_only(test/fixture)`) and lets it flip to `seed: false` in isolation once fixture/conftest usage is modeled precisely as edges.
- Conftest decls moved from `test/testcase` to `test/fixture` — they are support code, not collected tests.
- The `test → fixture` / `class → fixture` parameter-name edges are unchanged; the CLI `--query test_only` now subtracts both flags.
- Deleted the now-dead `mark_seed` / `module_fqnames_for` helpers and the three prefix consts.

No `PLUGIN_API_EPOCH` / `FORMAT_VERSION` bump — adding a built-in flag rides the existing registry serialization from #280.

## Test plan

- [x] `cargo build` + `cargo clippy --all-targets --locked -- -D warnings` (workspace)
- [x] `cargo test --no-default-features --locked -p dead-cst-runtime` → 136 passed
- [x] `maturin develop` + `uv run pytest` → 701 passed, 3 skipped
- [x] `cargo fmt --check` clean; `prek run --all-files` hooks pass
- [x] New tests: `test_pytest_plugin_flag_split_testcase_vs_fixture` (testcase/fixture never overlap), `test_pytest_plugin_fixture_flag_is_measurable` (blast-radius via seed-mask subtraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)