### PR TITLE
Convert dispatch-app plugins off synthetic seed nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,7 +194,7 @@ two versions.
   `PluginOps::add_synthetic_node` now takes a source
   `path` (empty for a placeless marker) so a project-wide synthetic node can
   be attributed to a file. On the Python side, `NativePlugin.dispatch_app(name,
-  marker_prefix, app_classes, registration_decorators, seed_as_entrypoint)`
+  app_classes, registration_decorators, seed_as_entrypoint)`
   exposes the generic engine behind `flask()` … `celery()`, so a custom
   framework can be wired without a bespoke plugin (the celery `@shared_task`
   fan-out stays internal to `celery()`).
@@ -299,6 +299,18 @@ two versions.
   relay node. An unresolved fqname keeps nothing alive (the previous empty-target
   introspection record is dropped, matching the other relay eliminations). No
   `plugin_api` epoch or `FORMAT_VERSION` bump — `add_edge` already exists.
+- **Dispatch-app plugins no longer mint `<{framework}-app>:` synthetic seeds.**
+  The shared dispatch engine behind `flask()`, `fastapi()`, `typer()`,
+  `cyclopts()`, `slack_bolt()`, `fastmcp()`, `celery()`, and the generic
+  `dispatch_app()` factory previously seeded each discovered app instance (and
+  each factory function returning one) with a `<{framework}-app>:<fqname>`
+  synthetic node, and celery fanned out appless `@shared_task` callables through
+  one `<celery-shared>:` seed per file. Each is now kept alive by setting
+  `NodeFlags.ENTRYPOINT` directly on the decl via `PluginOps::keep_alive`; the
+  handler-wiring edges (`app -> @app.route` &c.) are unchanged. The
+  `dispatch_app()` factory dropped its now-purposeless `marker_prefix` parameter
+  (it only named the removed synthetic nodes). No `plugin_api` epoch or
+  `FORMAT_VERSION` bump — `keep_alive` already exists.
 - **Graph node indices are now deterministic across runs.** ty's `files()`
   set has no stable iteration order, so the global index assigned to each node
   (and therefore the order of `Analysis.dead()` / `reachable()` results and the

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -311,7 +311,6 @@ class NativePlugin:
     @staticmethod
     def dispatch_app(
         name: str,
-        marker_prefix: str,
         app_classes: Sequence[str],
         registration_decorators: Sequence[str],
         seed_as_entrypoint: bool,
@@ -319,9 +318,8 @@ class NativePlugin:
         """Build a dispatch-app plugin for a framework ``dead-cst`` doesn't
         bundle — the generalized form behind :meth:`flask` … :meth:`celery`.
 
-        ``name`` labels the plugin in progress logs; ``marker_prefix``
-        namespaces the synthetic entrypoint / factory nodes it mints.
-        ``app_classes`` are dotted fqnames of the application classes (e.g.
+        ``name`` labels the plugin in progress logs. ``app_classes`` are
+        dotted fqnames of the application classes (e.g.
         ``["myframework.App"]``) whose instances — and transitive subclasses —
         anchor handler wiring; ``registration_decorators`` are the bare method
         names a handler is decorated with on such an instance

--- a/runtime/src/native_plugins.rs
+++ b/runtime/src/native_plugins.rs
@@ -927,8 +927,7 @@ impl NativePlugin {
     /// Build a dispatch-app plugin from a caller-supplied config — the
     /// generalized form behind :meth:`flask` … :meth:`celery`, for a
     /// framework `dead-cst` doesn't bundle. `name` labels the plugin in
-    /// progress logs; `marker_prefix` namespaces the synthetic entrypoint /
-    /// factory nodes it mints. `app_classes` are dotted fqnames of the
+    /// progress logs. `app_classes` are dotted fqnames of the
     /// application classes (e.g. `["myframework.App"]`) whose instances —
     /// and transitive subclasses — anchor handler wiring;
     /// `registration_decorators` are the bare method names a handler is
@@ -943,7 +942,6 @@ impl NativePlugin {
     #[staticmethod]
     fn dispatch_app(
         name: String,
-        marker_prefix: String,
         app_classes: Vec<String>,
         registration_decorators: Vec<String>,
         seed_as_entrypoint: bool,
@@ -951,7 +949,6 @@ impl NativePlugin {
         Self::from_dispatch_config(
             name,
             DispatchAppConfig {
-                marker_prefix,
                 app_classes,
                 registration_decorators,
                 seed_as_entrypoint,
@@ -2692,12 +2689,11 @@ impl plugin_api::ExternalPlugin for UnittestPluginImpl {
 /// Celery-style appless `@shared_task` fan-out layered on top of the standard
 /// dispatch policy. Mirrors `CeleryPlugin.policy`'s `super().policy(...)` then
 /// shared-task pass: every top-level function decorated with one of `names`
-/// (imported from `module`) is kept alive via one `<marker_prefix><basename>`
-/// entrypoint per file. `None` for non-celery configs.
+/// (imported from `module`) is kept alive directly. `None` for non-celery
+/// configs.
 struct SharedTaskFanout {
     module: String,
     names: Vec<String>,
-    marker_prefix: String,
 }
 
 /// Pure-data description of a dispatch-app framework — the Rust twin of the
@@ -2706,7 +2702,6 @@ struct SharedTaskFanout {
 /// below; the Python `NativePlugin.dispatch_app(...)` factory builds one from
 /// caller-supplied values (owned, so the config need not be `'static`).
 pub(crate) struct DispatchAppConfig {
-    marker_prefix: String,
     app_classes: Vec<String>,
     registration_decorators: Vec<String>,
     seed_as_entrypoint: bool,
@@ -2874,7 +2869,6 @@ impl plugin_api::ExternalPlugin for DispatchAppPluginImpl {
         // --- Phase 2: resolve paths/fqnames + assemble ops. All index
         // gathering happened above; bulk-fetch the node attrs the emission
         // loops need (parallel to their index vecs), then emit through `ops`.
-        let app_prefix = format!("<{}-app>:", cfg.marker_prefix);
 
         // vars_by_file: (path, simple var name) -> first var idx wins.
         let mut vars_by_file: FxHashMap<(String, String), usize> = FxHashMap::default();
@@ -2897,13 +2891,7 @@ impl plugin_api::ExternalPlugin for DispatchAppPluginImpl {
                 .or_default()
                 .push(var_idx);
             if cfg.seed_as_entrypoint {
-                ops.add_synthetic_node(
-                    format!("{app_prefix}{}", node.fqname),
-                    node.path.clone(),
-                    NodeFlags::ENTRYPOINT,
-                    vec![var_idx],
-                    Vec::new(),
-                );
+                ops.keep_alive(var_idx);
             }
         }
 
@@ -2944,40 +2932,15 @@ impl plugin_api::ExternalPlugin for DispatchAppPluginImpl {
                     continue;
                 }
                 classified.insert(key);
-                let node = ctx
-                    .node(var_idx)
-                    .expect("var index from frozen scan is in range");
-                ops.add_synthetic_node(
-                    format!("{app_prefix}{}", node.fqname),
-                    node.path.clone(),
-                    NodeFlags::ENTRYPOINT,
-                    vec![var_idx],
-                    Vec::new(),
-                );
+                ops.keep_alive(var_idx);
             }
         }
 
-        // Celery `@shared_task` fan-out: one `<marker_prefix><basename>`
-        // entrypoint per file, keeping every appless task callable alive.
-        if let Some(st) = &cfg.shared_task {
-            let shared_paths = ctx.node_paths(&shared_idxs);
-            let mut by_path: FxHashMap<String, Vec<usize>> = FxHashMap::default();
-            let mut path_order: Vec<String> = Vec::new();
-            for (&decl_idx, path) in shared_idxs.iter().zip(shared_paths.iter()) {
-                if !by_path.contains_key(path) {
-                    path_order.push(path.clone());
-                }
-                by_path.entry(path.clone()).or_default().push(decl_idx);
-            }
-            for path in path_order {
-                let target_idxs = by_path.remove(&path).unwrap_or_default();
-                ops.add_synthetic_node(
-                    format!("{}{}", st.marker_prefix, path_basename(&path)),
-                    path.clone(),
-                    NodeFlags::ENTRYPOINT,
-                    target_idxs,
-                    Vec::new(),
-                );
+        // Celery `@shared_task` fan-out: keep every appless task callable
+        // alive directly (no per-file marker node).
+        if cfg.shared_task.is_some() {
+            for &decl_idx in &shared_idxs {
+                ops.keep_alive(decl_idx);
             }
         }
 
@@ -3000,7 +2963,6 @@ fn owned(items: &[&str]) -> Vec<String> {
 
 fn flask_config() -> DispatchAppConfig {
     DispatchAppConfig {
-        marker_prefix: "flask".to_string(),
         app_classes: owned(&["flask.Flask"]),
         registration_decorators: owned(&[
             "route",
@@ -3043,7 +3005,6 @@ fn flask_config() -> DispatchAppConfig {
 
 fn fastapi_config() -> DispatchAppConfig {
     DispatchAppConfig {
-        marker_prefix: "fastapi".to_string(),
         app_classes: owned(&["fastapi.FastAPI"]),
         registration_decorators: owned(&[
             "get",
@@ -3068,7 +3029,6 @@ fn fastapi_config() -> DispatchAppConfig {
 
 fn typer_config() -> DispatchAppConfig {
     DispatchAppConfig {
-        marker_prefix: "typer".to_string(),
         app_classes: owned(&["typer.Typer"]),
         registration_decorators: owned(&["command", "callback"]),
         seed_as_entrypoint: false,
@@ -3078,7 +3038,6 @@ fn typer_config() -> DispatchAppConfig {
 
 fn cyclopts_config() -> DispatchAppConfig {
     DispatchAppConfig {
-        marker_prefix: "cyclopts".to_string(),
         app_classes: owned(&["cyclopts.App"]),
         registration_decorators: owned(&["command", "default"]),
         seed_as_entrypoint: false,
@@ -3088,7 +3047,6 @@ fn cyclopts_config() -> DispatchAppConfig {
 
 fn slack_bolt_config() -> DispatchAppConfig {
     DispatchAppConfig {
-        marker_prefix: "slack-bolt".to_string(),
         app_classes: owned(&["slack_bolt.App", "slack_bolt.async_app.AsyncApp"]),
         registration_decorators: owned(&[
             "event", "message", "command", "action", "shortcut", "view", "options", "error",
@@ -3101,7 +3059,6 @@ fn slack_bolt_config() -> DispatchAppConfig {
 
 fn fastmcp_config() -> DispatchAppConfig {
     DispatchAppConfig {
-        marker_prefix: "fastmcp".to_string(),
         app_classes: owned(&["fastmcp.FastMCP", "mcp.server.fastmcp.FastMCP"]),
         registration_decorators: owned(&["tool", "resource", "prompt", "completion"]),
         seed_as_entrypoint: true,
@@ -3111,14 +3068,12 @@ fn fastmcp_config() -> DispatchAppConfig {
 
 fn celery_config() -> DispatchAppConfig {
     DispatchAppConfig {
-        marker_prefix: "celery".to_string(),
         app_classes: owned(&["celery.Celery"]),
         registration_decorators: owned(&["task"]),
         seed_as_entrypoint: true,
         shared_task: Some(SharedTaskFanout {
             module: "celery".to_string(),
             names: owned(&["shared_task"]),
-            marker_prefix: "<celery-shared>:".to_string(),
         }),
     }
 }

--- a/tests/test_plugins/test_celery.py
+++ b/tests/test_plugins/test_celery.py
@@ -373,7 +373,7 @@ def test_celery_plugin_factory_in_different_package(make_analysis, write_files, 
 def test_celery_plugin_factory_module_form_in_different_package(
     make_analysis, write_files, reachable_fqnames
 ):
-    """Factory uses ``import celery; celery.Celery()`` -- factory marker required.
+    """Factory uses ``import celery; celery.Celery()`` -- module-attribute form.
 
     See ``test_flask_plugin_factory_module_form_in_different_package``
     for the rationale; the external-edge classifier drops the

--- a/tests/test_plugins/test_dispatch_app.py
+++ b/tests/test_plugins/test_dispatch_app.py
@@ -37,7 +37,6 @@ _SOURCE = {
 def test_dispatch_app_threads_app_classes_and_decorators(build_plugin_graph, reachable_fqnames):
     plugin = native.NativePlugin.dispatch_app(
         name="myframework",
-        marker_prefix="myframework",
         app_classes=["flask.Flask"],
         registration_decorators=["route", "get"],
         seed_as_entrypoint=True,
@@ -60,7 +59,6 @@ def test_dispatch_app_seed_as_entrypoint_false_does_not_seed(build_plugin_graph,
     # not auto-seeded, so with no other entrypoint nothing comes alive.
     plugin = native.NativePlugin.dispatch_app(
         name="myframework",
-        marker_prefix="myframework",
         app_classes=["flask.Flask"],
         registration_decorators=["route", "get"],
         seed_as_entrypoint=False,

--- a/tests/test_plugins/test_fastapi.py
+++ b/tests/test_plugins/test_fastapi.py
@@ -414,8 +414,7 @@ def test_fastapi_plugin_factory_module_form_in_different_package(
 ):
     """Factory in dep package uses ``import fastapi; fastapi.FastAPI()``.
 
-    Without the factory-marker synthetic the cross-package walk has no
-    discriminator: the external-edge classifier drops the
+    In module-attribute form the external-edge classifier drops the
     ``decl='FastAPI'`` half of the access, so every reference to
     ``fastapi`` collapses to the same ``[external dist] fastapi``
     node regardless of which class is being constructed.
@@ -453,9 +452,9 @@ def test_fastapi_plugin_router_factory_in_different_package(
 ):
     """APIRouter factory in dep package, consumer wires it via include_router.
 
-    The factory-marker route shouldn't promote routers to entrypoints
-    on its own -- only a FastAPI app that ``include_router``s it keeps
-    the router alive.
+    A router factory shouldn't promote routers to entrypoints on its
+    own -- only a FastAPI app that ``include_router``s it keeps the
+    router alive.
     """
     write_files(
         {
@@ -495,10 +494,10 @@ def test_fastapi_plugin_orphan_router_factory_stays_dead_cross_package(
 ):
     """APIRouter factory in dep package that nobody ``include_router``s.
 
-    The factory marker carries the ``APIRouter`` kind, which finalize
-    explicitly leaves un-entrypointed -- so a downstream consumer that
-    only constructs the router (without registering it on a FastAPI
-    app) still gets flagged dead.
+    The factory walk only seeds factories returning the app class
+    (``FastAPI``); an ``APIRouter`` factory is never entrypointed on
+    its own -- so a downstream consumer that only constructs the router
+    (without registering it on a FastAPI app) still gets flagged dead.
     """
     write_files(
         {

--- a/tests/test_plugins/test_fastmcp.py
+++ b/tests/test_plugins/test_fastmcp.py
@@ -316,9 +316,9 @@ def test_fastmcp_plugin_factory_in_different_package(
     """Factory in dep package, consumer in dependent package.
 
     The classic uv-workspace layout: ``pkg_a`` owns the FastMCP factory
-    and ``pkg_b`` imports + calls it. Walking from the pending marker
-    in ``pkg_b`` must reach the ``FastMCP`` import inside ``pkg_a``'s
-    factory body.
+    and ``pkg_b`` imports + calls it. The factory walk must recognize
+    ``create_server`` (whose ``FastMCP`` return type is imported inside
+    ``pkg_a``'s factory body) and keep ``pkg_b``'s ``mcp`` alive.
     """
     write_files(
         {
@@ -353,8 +353,7 @@ def test_fastmcp_plugin_factory_module_form_in_different_package(
 ):
     """Factory in dep package uses ``import fastmcp; fastmcp.FastMCP()``.
 
-    Without the factory-marker synthetic the cross-package walk has no
-    discriminator: the external-edge classifier drops the
+    In module-attribute form the external-edge classifier drops the
     ``decl='FastMCP'`` half of the access, so every reference to
     ``fastmcp`` would collapse to the same ``[external dist] fastmcp``
     node.

--- a/tests/test_plugins/test_flask.py
+++ b/tests/test_plugins/test_flask.py
@@ -639,9 +639,9 @@ def test_flask_plugin_factory_module_form_in_different_package(
 ):
     """Factory in dep package uses ``import flask; flask.Flask()``.
 
-    Without the factory-marker synthetic the cross-package walk has no
-    discriminator -- the external-edge classifier drops the
-    ``decl='Flask'`` half of the access.
+    In module-attribute form the external-edge classifier drops the
+    ``decl='Flask'`` half of the access, so the plugin's own factory
+    detection -- not the import graph -- is what keeps ``app`` alive.
     """
     write_files(
         {
@@ -713,10 +713,10 @@ def test_flask_plugin_orphan_blueprint_factory_stays_dead_cross_package(
 ):
     """Blueprint factory in dep package that nobody ``register_blueprint``s.
 
-    The factory marker carries the ``Blueprint`` kind, which finalize
-    explicitly leaves un-entrypointed -- so a downstream consumer that
-    only constructs the blueprint (without registering it on a Flask
-    app) still gets flagged dead.
+    The factory walk only seeds factories returning the app class
+    (``Flask``); a ``Blueprint`` factory is never entrypointed on its
+    own -- so a downstream consumer that only constructs the blueprint
+    (without registering it on a Flask app) still gets flagged dead.
     """
     write_files(
         {


### PR DESCRIPTION
## Summary

Continues the synthetic-seed elimination: the shared dispatch engine behind `flask()`, `fastapi()`, `typer()`, `cyclopts()`, `slack_bolt()`, `fastmcp()`, `celery()`, and the generic `dispatch_app()` factory no longer mints `<{framework}-app>:` / `<celery-shared>:` synthetic ENTRYPOINT nodes.

- All three minting sites in `DispatchAppPluginImpl::run()` (direct `X = App()` constructions, the factory-returning-var walk, and the celery `@shared_task` fan-out) now call `PluginOps::keep_alive(idx)`, which stamps `ENTRYPOINT` directly on the target. Same reachability outcome, minus the orphan seed node. Handler-wiring edges (`app -> @app.route` &c.) are unchanged.
- `marker_prefix` only ever named those nodes, so it's dropped from `DispatchAppConfig`, `SharedTaskFanout`, the `dispatch_app()` factory (now **4-param** — a pre-1.0 breaking change, mirrored in `_native.pyi`), and all seven config builders.
- Stale `factory-marker` / `pending marker` docstrings in the framework tests are reworded. The `the <fw> synthetic` references are intentionally left — they point at the engine's still-present `[external dist] <fw>` node, not the removed seed.
- No `plugin_api` epoch or `FORMAT_VERSION` bump — `keep_alive` already exists.

## Test plan

- [x] `cargo build -p dead-cst-runtime`
- [x] `cargo clippy -p dead-cst-runtime --all-targets --locked -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo test --no-default-features --locked -p dead-cst-runtime` (136 passed)
- [x] `maturin develop` + `uv run pytest` (702 passed, 3 skipped dylib-plugin, 5 deselected e2e)
- [x] `uv run prek run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)