### PR TITLE
Convert main_block/server_config/project_scripts off synthetic seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,6 +311,16 @@ two versions.
   `dispatch_app()` factory dropped its now-purposeless `marker_prefix` parameter
   (it only named the removed synthetic nodes). No `plugin_api` epoch or
   `FORMAT_VERSION` bump — `keep_alive` already exists.
+- **`main_block`, `server_config`, and `project_scripts` no longer mint
+  `<__main__>:` / `<server-config>:` / `<project.scripts>:` synthetic seeds.**
+  `main_block()` stamped a `<__main__>:<module>` node pointing at the module and
+  every decl inside the `if __name__ == "__main__":` guard; `server_config()`
+  stamped a `<server-config>:<module>` node over a config file's whole top-level
+  surface; `project_scripts()` stamped one `<project.scripts>:<name>` node per
+  `[project.scripts]` entry. Each target is now kept alive by setting
+  `NodeFlags.ENTRYPOINT` directly on the decl via `keep_alive` — same
+  reachability, no orphan seed node. No `plugin_api` epoch or `FORMAT_VERSION`
+  bump — `keep_alive` already exists.
 - **Graph node indices are now deterministic across runs.** ty's `files()`
   set has no stable iteration order, so the global index assigned to each node
   (and therefore the order of `Analysis.dead()` / `reachable()` results and the

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -210,10 +210,10 @@ class NativePlugin:
 
     @staticmethod
     def main_block() -> NativePlugin:
-        """``MainBlockPlugin``. Marks every file with a top-level
-        ``if __name__ == "__main__":`` block as an entrypoint and wires
-        edges to the containing module + every top-level decl inside the
-        block. Implemented as a per-file (salsa-cached) plugin.
+        """``MainBlockPlugin``. For every file with a top-level
+        ``if __name__ == "__main__":`` block, keeps the containing module
+        node and every top-level decl inside the block alive as entrypoints.
+        Implemented as a per-file (salsa-cached) plugin.
         """
         ...
 
@@ -234,7 +234,7 @@ class NativePlugin:
         ``filenames`` defaults to the conventional Gunicorn/Hypercorn set;
         pass a custom sequence to match other server-config basenames.
         Per-file (salsa-cached): a file matches purely on its own basename,
-        so an unchanged file's marker is reused across ``re_materialize``.
+        so an unchanged file's ops are reused across ``re_materialize``.
         Identical filename sets intern to one cache key.
         """
         ...
@@ -390,10 +390,10 @@ class NativePlugin:
     def project_scripts(pyproject_path: str | None = None) -> NativePlugin:
         """Native ``[project.scripts]`` plugin. Reads ``pyproject.toml`` (from
         ``pyproject_path`` if given, else ``<project_root>/pyproject.toml``)
-        and, for each ``name = "pkg.mod:func"`` entry, wires a synthetic
-        ``<project.scripts>:<name>`` entrypoint to the resolved ``pkg.mod.func``
-        decl (falling back to the ``pkg.mod`` module node). A missing file or
-        unresolved target is skipped silently.
+        and, for each ``name = "pkg.mod:func"`` entry, keeps the resolved
+        ``pkg.mod.func`` decl alive as an entrypoint (falling back to the
+        ``pkg.mod`` module node). A missing file or unresolved target is
+        skipped silently.
         """
         ...
 

--- a/runtime/src/native_plugins.rs
+++ b/runtime/src/native_plugins.rs
@@ -1110,14 +1110,11 @@ pub(crate) fn _builtin_native_plugin(name: &str) -> Option<NativePlugin> {
 }
 
 // ---------------------------------------------------------------------------
-// MainBlockPlugin — first per-file impl. Equivalent to
-// ``dead_cst.plugins.main_block.MainBlockPlugin``: emit one synthetic
-// ``<__main__>:<module_fqname>`` entrypoint per file with a top-level
-// ``if __name__ == "__main__":`` block, with edges to the containing
-// module and to every top-level decl inside the block.
+// MainBlockPlugin — first per-file impl. For every file with a top-level
+// ``if __name__ == "__main__":`` block, keep the module node alive plus
+// every top-level decl whose source span falls inside the block (via
+// ``keep_alive``, which stamps ENTRYPOINT directly on each target).
 // ---------------------------------------------------------------------------
-
-const MAIN_BLOCK_PREFIX: &str = "<__main__>:";
 
 /// Test-only counter: number of times [`MainBlockPluginImpl::run_on_file`]
 /// actually executed (i.e. salsa cache *misses* for the per-file
@@ -1150,21 +1147,15 @@ impl plugin_api::PerFilePlugin for MainBlockPluginImpl {
             return;
         };
         let (block_start_line, block_end_line) = file.line_span(block_range);
-        // Local indices of every top-level decl whose source span falls
-        // inside the ``if __name__`` block. Skip index 0 (the module
-        // node) — it's added explicitly below as the first edge.
-        let mut edges_to_local_idx: Vec<u32> = vec![file.module_local_idx()];
+        // Keep the module node alive, plus every top-level decl whose source
+        // span falls inside the ``if __name__`` block. Skip index 0 (the
+        // module node) — it's kept alive explicitly first.
+        ops.keep_alive(file.module_local_idx());
         for node in file.nodes().iter().skip(1) {
             if node.start_line >= block_start_line && node.end_line <= block_end_line {
-                edges_to_local_idx.push(node.local_idx);
+                ops.keep_alive(node.local_idx);
             }
         }
-        ops.add_synthetic_node(
-            format!("{MAIN_BLOCK_PREFIX}{}", file.module_fqname()),
-            NodeFlags::ENTRYPOINT,
-            edges_to_local_idx,
-            Vec::new(),
-        );
     }
 }
 
@@ -2487,8 +2478,6 @@ pub(crate) fn load_native_plugins(path: String) -> PyResult<Vec<NativePlugin>> {
 // (the harness already holds the GIL).
 // ---------------------------------------------------------------------------
 
-const SERVER_CONFIG_PREFIX: &str = "<server-config>:";
-
 /// Conventional filenames Gunicorn / Hypercorn load at startup. The default
 /// the [`NativePlugin::server_config`] factory supplies when no `filenames`
 /// are given; callers pass a custom set for other server-config basenames.
@@ -2558,9 +2547,9 @@ pub(crate) fn _reset_server_config_run_count() {
 /// Per-file body for `ServerConfigPlugin` (see
 /// [`ConfiguredPerFile::ServerConfig`], ported from
 /// `dead_cst.contrib.server_config.ServerConfigPlugin`): when a file's basename
-/// is one of `filenames`, mint a `<server-config>:` entrypoint keeping that
-/// file's whole top-level surface alive. File-local — the match and the targets
-/// are both functions of the single file.
+/// is one of `filenames`, keep that file's whole top-level surface alive (via
+/// `keep_alive`, stamping ENTRYPOINT on each node). File-local — the match and
+/// the targets are both functions of the single file.
 fn server_config_run_on_file(
     filenames: &[String],
     file: &plugin_api::PluginFileCtx<'_>,
@@ -2588,15 +2577,9 @@ fn server_config_run_on_file(
         })
         .map(|node| node.local_idx)
         .collect();
-    if targets.is_empty() {
-        return;
+    for local in targets {
+        ops.keep_alive(local);
     }
-    ops.add_synthetic_node(
-        format!("{SERVER_CONFIG_PREFIX}{}", file.module_fqname()),
-        NodeFlags::ENTRYPOINT,
-        targets,
-        Vec::new(),
-    );
 }
 
 /// Project-wide port of `dead_cst.contrib.unittest.UnittestPlugin`: keep
@@ -3842,8 +3825,6 @@ impl plugin_api::ExternalPlugin for ExplicitEntrypointPluginImpl {
 // crate; a missing file is a no-op.
 // ---------------------------------------------------------------------------
 
-const PROJECT_SCRIPTS_PREFIX: &str = "<project.scripts>:";
-
 pub(crate) struct ProjectScriptsPluginImpl {
     pyproject_path: Option<String>,
 }
@@ -3892,7 +3873,7 @@ impl plugin_api::ExternalPlugin for ProjectScriptsPluginImpl {
             })
             .unwrap_or_default();
 
-        for (script_name, target) in scripts {
+        for (_script_name, target) in scripts {
             let (module_part, decl_part) = match target.split_once(':') {
                 Some((m, d)) => (m, d),
                 None => (target.as_str(), ""),
@@ -3908,16 +3889,9 @@ impl plugin_api::ExternalPlugin for ProjectScriptsPluginImpl {
                     target_idxs.push(module_idx);
                 }
             }
-            if target_idxs.is_empty() {
-                continue;
+            for idx in target_idxs {
+                ops.keep_alive(idx);
             }
-            ops.add_synthetic_node(
-                format!("{PROJECT_SCRIPTS_PREFIX}{script_name}"),
-                pyproject.clone(),
-                NodeFlags::ENTRYPOINT,
-                target_idxs,
-                Vec::new(),
-            );
         }
         Ok(())
     }

--- a/tests/e2e/test_flux0.py
+++ b/tests/e2e/test_flux0.py
@@ -94,17 +94,18 @@ def _ancestor_fqnames(base: Path, target_fqname: str) -> list[str]:
 def test_why_alive_flux0_server_main(flux0_server_src):
     """Level 1: ``main`` is reached via the module's ``if __name__ ...`` block.
 
-    The native ``main_block`` plugin attaches a synthetic
-    ``<__main__>:<module>`` node as a predecessor of every top-level
-    call inside the guard.
+    The native ``main_block`` plugin stamps ``ENTRYPOINT`` on the module
+    node (and any decls inside the guard); ``main`` is then reached from
+    its module via the call inside the guard, so the module node is a
+    predecessor.
     """
     ancestors = _ancestor_fqnames(Path(flux0_server_src), "flux0_server.main.main")
-    assert any(a.startswith("<__main__>:flux0_server.main") for a in ancestors)
+    assert "flux0_server.main" in ancestors
 
 
 def test_why_alive_flux0_cli_main(flux0_cli_src):
     ancestors = _ancestor_fqnames(Path(flux0_cli_src), "flux0_cli.main.main")
-    assert any(a.startswith("<__main__>:flux0_cli.main") for a in ancestors)
+    assert "flux0_cli.main" in ancestors
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_eclipsed_modules.py
+++ b/tests/test_eclipsed_modules.py
@@ -5,8 +5,8 @@ directory whenever both shapes coexist, so the analyzer mirrors that
 precedence: the trie holds the ``__init__.py`` and any cross-module
 import of ``pkg.foo`` (or of a name re-exported from it) routes to the
 package alone. The eclipsed file is still parsed -- its nodes appear in
-the graph and observe-time entrypoints (``__main__``, plugin
-synthetics) keep working -- but consumer imports never see its decls.
+the graph and observe-time entrypoints (``__main__`` and other plugin
+keep-alives) keep working -- but consumer imports never see its decls.
 """
 
 from __future__ import annotations
@@ -63,13 +63,14 @@ def test_eclipsed_file_keeps_main_block_entrypoint(tmp_path, write_files, make_a
     package_module = next(
         n for n in graph.nodes() if n.fqname == "pkg.foo" and n.path.endswith("/__init__.py")
     )
-    main_synth = next(
-        n for n in graph.nodes() if n.kind == "synthetic" and n.fqname.endswith(":pkg.foo")
-    )
-
-    assert main_synth in reachable, "MainBlockPlugin synthetic must seed reachability"
-    assert helper in reachable, "decls in the eclipsed file are alive when the synth reaches them"
-    assert eclipsed_module in reachable, "eclipsed module node stays alive via the synth"
+    # The per-file main_block plugin stamps ENTRYPOINT on the eclipsed
+    # ``.py`` module node — not the eclipsing package ``__init__.py`` (both
+    # share the ``pkg.foo`` fqname) — so the eclipsed file's main block keeps
+    # its own decls alive.
+    assert eclipsed_module.flags & native.NodeFlags.ENTRYPOINT
+    assert not (package_module.flags & native.NodeFlags.ENTRYPOINT)
+    assert eclipsed_module in reachable, "eclipsed module node stays alive via keep_alive"
+    assert helper in reachable, "decls in the eclipsed file are alive when the module reaches them"
     # The package itself is unreached: nothing imports pkg.foo from outside.
     assert package_module not in reachable
 

--- a/tests/test_plugins/test_native_plugin.py
+++ b/tests/test_plugins/test_native_plugin.py
@@ -18,9 +18,10 @@ import pytest
 from dead_cst import _native as native
 
 
-def test_native_main_block_emits_entrypoint_marker(build_plugin_graph):
-    """The synthetic ``<__main__>:<module>`` marker still lands in the
-    graph — verify the node is interned and carries ``ENTRYPOINT``."""
+def test_native_main_block_marks_module_entrypoint(build_plugin_graph):
+    """The per-file main_block plugin stamps ``ENTRYPOINT`` directly on
+    the module node of a file with a top-level ``if __name__`` block (via
+    ``keep_alive``) — no separate synthetic marker node."""
     ctx = build_plugin_graph(
         {
             "pkg/__init__.py": "",
@@ -32,9 +33,9 @@ def test_native_main_block_emits_entrypoint_marker(build_plugin_graph):
         },
         [native.NativePlugin.main_block()],
     )
-    markers = [n for n in ctx.nodes() if n.fqname == "<__main__>:pkg.script"]
-    assert len(markers) == 1
-    assert markers[0].flags & native.NodeFlags.ENTRYPOINT
+    mods = [n for n in ctx.nodes() if n.fqname == "pkg.script"]
+    assert len(mods) == 1
+    assert mods[0].flags & native.NodeFlags.ENTRYPOINT
 
 
 def test_native_plugin_name_attribute():
@@ -74,15 +75,14 @@ def test_multiple_native_plugins_in_one_list(build_plugin_graph, reachable_fqnam
 
 
 def test_native_plugin_no_main_block_no_ops(build_plugin_graph):
-    """A project without any ``if __name__ == "__main__":`` block
-    produces no synthetic markers — same shape as the Python
-    equivalent's empty path."""
+    """A project without any ``if __name__ == "__main__":`` block leaves
+    every module un-entrypointed — the plugin emits no ``keep_alive``."""
     ctx = build_plugin_graph(
         {"pkg/__init__.py": "", "pkg/m.py": "def f(): pass\n"},
         [native.NativePlugin.main_block()],
     )
-    main_markers = [n for n in ctx.nodes() if n.fqname.startswith("<__main__>:")]
-    assert main_markers == []
+    entrypoints = [n for n in ctx.nodes() if n.flags & native.NodeFlags.ENTRYPOINT]
+    assert entrypoints == []
 
 
 def test_native_plugin_cannot_be_directly_instantiated():
@@ -112,7 +112,7 @@ def _write(path, src: str) -> None:
 
 def test_per_file_main_block_caches_unchanged_files(tmp_path):
     """Editing one file should re-run the per-file MainBlock plugin for
-    *only* that file on ``re_materialize`` — every other file's marker is
+    *only* that file on ``re_materialize`` — every other file's ops are
     served from the salsa cache."""
     from dead_cst import Analysis
 
@@ -172,15 +172,17 @@ def test_per_file_main_block_cache_invalidates_on_edit(tmp_path):
 
     analysis = Analysis(tmp_path, plugins=[native.NativePlugin.main_block()])
     ctx = analysis.materialize_all()
-    assert any(n.fqname == "<__main__>:pkg.a" for n in ctx.nodes())
+    mod = next(n for n in ctx.nodes() if n.fqname == "pkg.a")
+    assert mod.flags & native.NodeFlags.ENTRYPOINT
 
-    # Remove the main block entirely; the marker should disappear after
-    # re_materialize (cache miss on the edited file).
+    # Remove the main block entirely; the module should lose ENTRYPOINT
+    # after re_materialize (cache miss on the edited file).
     native._reset_main_block_run_count()
     _write(tmp_path / "pkg/a.py", "def main(): pass\n")
     ctx2 = analysis.re_materialize(analysis.materialize_all().detect_changes())
     assert native._main_block_run_count() >= 1  # a.py re-ran
-    assert not any(n.fqname == "<__main__>:pkg.a" for n in ctx2.nodes())
+    mod2 = next(n for n in ctx2.nodes() if n.fqname == "pkg.a")
+    assert not (mod2.flags & native.NodeFlags.ENTRYPOINT)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plugins/test_server_config.py
+++ b/tests/test_plugins/test_server_config.py
@@ -185,7 +185,7 @@ def test_seeds_are_not_tagged_testcase(build_plugin_graph):
     testcase = graph.node_flag("test/testcase")
     assert testcase is not None, "pytest plugin should register the test/testcase flag"
     seeds = [n for n in graph.nodes() if n.flags & NodeFlags.ENTRYPOINT]
-    server_seeds = [s for s in seeds if s.fqname.startswith("<server-config>:")]
+    server_seeds = [s for s in seeds if s.fqname.startswith("gunicorn.conf")]
     assert server_seeds
     for seed in server_seeds:
         assert not (seed.flags & testcase), seed.fqname
@@ -235,7 +235,8 @@ def test_per_file_server_config_cache_invalidates_on_edit(tmp_path):
 
     analysis = Analysis(tmp_path, plugins=[native.NativePlugin.server_config()])
     ctx = analysis.materialize_all()
-    assert any(n.fqname == "<server-config>:gunicorn.conf" for n in ctx.nodes())
+    mod = next(n for n in ctx.nodes() if n.fqname == "gunicorn.conf")
+    assert mod.flags & NodeFlags.ENTRYPOINT
 
     native._reset_server_config_run_count()
     _write(tmp_path / "gunicorn.conf.py", "workers = 4\nbind = '0.0.0.0:8000'\n")


### PR DESCRIPTION
## Summary

Continues the synthetic-seed-node elimination. These three plugins each
minted a synthetic `ENTRYPOINT` node pointing at their targets; replace
all three with direct `keep_alive(idx)` (which stamps
`NodeFlags.ENTRYPOINT` on the target itself) — same reachability, no
orphan seed node.

- **`main_block`** stamped a `<__main__>:<module>` node over the module +
  every decl inside the `if __name__ == "__main__":` guard → now
  `keep_alive` per target.
- **`server_config`** stamped a `<server-config>:<module>` node over a
  matched config file's whole top-level surface → now `keep_alive` per
  target.
- **`project_scripts`** stamped one `<project.scripts>:<name>` node per
  `[project.scripts]` entry → now `keep_alive` per resolved decl.

Drops the now-dead `MAIN_BLOCK_PREFIX` / `SERVER_CONFIG_PREFIX` /
`PROJECT_SCRIPTS_PREFIX` consts. Tests that asserted on the synthetic
node by name now assert `ENTRYPOINT` directly on the real decl; the
eclipsed-module test keeps its sharper invariant (the per-file
`keep_alive` lands on the eclipsed `.py` module node, not the eclipsing
package `__init__.py`). No `plugin_api` epoch or `FORMAT_VERSION` bump —
`keep_alive` already exists.

The two discordpy sites (`<discordpy-cog>:` / `<discordpy-extension>:`)
are intentionally left for a follow-up PR.

## Test plan

- [x] `cargo build -p dead-cst-runtime` + `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check` + `cargo test --no-default-features --locked -p dead-cst-runtime` (136 passed)
- [x] `maturin develop --uv` + `uv run pytest` (702 passed, 3 skipped, 5 deselected)
- [x] `uv run prek run --all-files` (ruff, ty, cargo fmt, cargo clippy all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)