### PR TITLE
Drop the nested `from X import *` fan-out for non-runnable input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,12 @@ two versions.
 
 ### Changed
 
+- **Nested `from X import *` is no longer fanned out.** A `from X import *`
+  inside a function or class body is a `SyntaxError` ("import * only allowed at
+  module level"), so it cannot occur in runnable Python. The engine previously
+  expanded such a statement to an edge per public export of the target module;
+  it now skips it (contributing no edges). Module-level star imports — the only
+  valid form — are unaffected.
 - **Module-level dunder / `__future__` keep-alive moved into the engine.**
   Module-scope dunders (`__all__`, `__version__`, PEP 562
   `__getattr__` / `__dir__`, …) and `__future__` imports are now kept alive by

--- a/runtime/src/file_ref_edges.rs
+++ b/runtime/src/file_ref_edges.rs
@@ -513,12 +513,12 @@ impl<'a, 'db> RefWalker<'a, 'db> {
         self.current_flags = 0;
     }
 
-    /// `from X import …` inside a function/class body. Resolves the
+    /// `from X import name` inside a function/class body. Resolves the
     /// from-clause through ty (so relative imports get level dots
-    /// converted to absolute), then walks each alias. `*` fans out to
-    /// every non-underscore export in the upstream via
-    /// [`emit_nested_star`]. Mirrors today's
-    /// `RefCollector::emit_nested_import_from` (lines 2071–2096).
+    /// converted to absolute), then walks each alias and emits the
+    /// upstream edges. A nested `from X import *` is a SyntaxError
+    /// ("import * only allowed at module level") so it cannot occur in
+    /// runnable Python — it is skipped rather than fanned out.
     fn emit_nested_import_from(&mut self, stmt: &ruff_python_ast::StmtImportFrom) {
         let module_str = from_module_string(self.model.db(), self.file, stmt);
         if module_str.is_empty() {
@@ -527,11 +527,9 @@ impl<'a, 'db> RefWalker<'a, 'db> {
         self.current_flags = self.flags_for_range(stmt.range);
         for alias in &stmt.names {
             let name = alias.name.id.as_str();
+            // `from X import *` here would be a module-level-only
+            // SyntaxError; skip it (no fan-out for non-runnable code).
             if name == "*" {
-                let Some(module_name) = ModuleName::new(&module_str) else {
-                    continue;
-                };
-                self.emit_nested_star(&module_name);
                 continue;
             }
             let bound_name = match &alias.asname {
@@ -546,28 +544,6 @@ impl<'a, 'db> RefWalker<'a, 'db> {
             self.emit_upstream(&spec, bound_name, &[]);
         }
         self.current_flags = 0;
-    }
-
-    /// Fan a nested `from X import *` out to every non-underscore
-    /// export in the upstream module. Mirrors today's
-    /// `RefCollector::emit_nested_star` (lines 2109–2129).
-    fn emit_nested_star(&mut self, module_name: &ModuleName) {
-        let Some(module) = resolve_module(self.db, self.file, module_name) else {
-            return;
-        };
-        let Some(target_file) = module.file(self.db) else {
-            return;
-        };
-        self.emit_edge(NodeRef::Module(target_file));
-        let target_nodes = file_to_nodes(self.db, target_file);
-        for (name, locals) in &target_nodes.exports_by_name {
-            if name.starts_with('_') {
-                continue;
-            }
-            for &local_idx in locals {
-                self.emit_edge(target_nodes.refs[local_idx as usize]);
-            }
-        }
     }
 
     /// Walk an annotation expression, marking the recursion so any

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -283,17 +283,16 @@ IMPORT_BASE_EDGES = frozenset(
             id="nested-try-except-cst.Import",
         ),
         pytest.param(
-            # Nested star import fans out to every name `p.functions`
-            # exports, attributed to the enclosing function. No alias
-            # node is minted.
+            # `from X import *` nested in a function body is a SyntaxError
+            # ("import * only allowed at module level"), so it cannot occur
+            # in runnable Python. We deliberately do not fan it out: the
+            # nested star contributes no edges, leaving only the enclosing
+            # function's parent-module edge (`f()` resolves to nothing).
             "def a():\n    from p.functions import *\n    f()\n",
             {
-                "p.x.a -> p.functions",
-                "p.x.a -> p.functions.f",
-                "p.x.a -> p.functions.g",
                 "p.x.a -> p.x",
             },
-            id="nested-star-import",
+            id="nested-star-import-is-skipped",
         ),
         pytest.param(
             "from .functions import f\ndef a(): f()",


### PR DESCRIPTION
## Summary

- `RefWalker::emit_nested_star` only ever fired for a `from X import *`
  statement found **inside a function or class body**. That form is a hard
  `SyntaxError` in CPython ("import * only allowed at module level"), so it
  cannot occur in runnable Python — the visitor reached it only because ruff
  surfaces the violation as a *semantic-syntax diagnostic* while still
  producing an AST node.
- Remove `emit_nested_star` and the star branch in `emit_nested_import_from`;
  a nested `from X import *` is now skipped (contributes no edges) instead of
  being fanned out to every public export of the target module.
- Valid nested imports (`import x`, `from x import y` in a def/class body) and
  module-level star imports — the only valid star form — are untouched.

The only behavior change is to non-compilable input, so the alive set for any
real (parseable-and-runnable) project is unchanged.

## Test plan

- [x] `cargo test --no-default-features --locked -p dead-cst-runtime` — green
- [x] `uv run pytest` — 700 passed, 3 skipped, 5 deselected
- [x] `uv run prek run --all-files` — ruff, ruff-format, ty, cargo fmt, clippy all pass
- [x] `tests/test_imports.py` nested-star param retargeted to assert the skip
  (only the enclosing function's parent-module edge `p.x.a -> p.x` remains) and
  renamed `nested-star-import-is-skipped`

🤖 Generated with [Claude Code](https://claude.com/claude-code)