### PR TITLE
Key NodeData and NodeKey on the salsa File, not a path String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -479,6 +479,12 @@ two versions.
 
 ### Removed
 
+- **`ProjectContext.descendants(root)` / `ancestors(decl)` (breaking,
+  native API).** The two `SymbolNode`-keyed traversal methods are removed
+  in favor of the index-keyed `descendants_indices(root_idx)` /
+  `ancestors_indices(decl_idx)` already used by `Analysis`. Callers that hold
+  a `SymbolNode` resolve its index via `ctx.nodes().index(node)` first. The
+  internal `node_key_of` / `lookup_idx` helpers go with them.
 - **`add_synthetic_node` plugin op and the `kind="synthetic"` node kind
   (breaking, plugin API).** `PluginOps::add_synthetic_node` /
   `FileOps::add_synthetic_node` — and the `PreparedOp::Node` /

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -522,8 +522,8 @@ class ProjectContext:
     :meth:`materialize`. Each plugin's rust impl runs against this same
     instance, emitting graph mutations the apply pass folds into the
     in-progress graph; an impl may call any of the ``find_*`` /
-    ``decls_*`` / ``descendants`` / ``ancestors`` / ``reachable``
-    queries below.
+    ``decls_*`` / ``descendants_indices`` / ``ancestors_indices`` /
+    ``reachable`` queries below.
 
     Queries answer against the live in-progress graph (so an op
     emitted earlier in the same plugin is visible to later queries).
@@ -800,38 +800,27 @@ class ProjectContext:
 
     # ----- Traversal -----------------------------------------------------
 
-    def descendants(self, root: SymbolNode, *, skip_flags: int = 0) -> list[SymbolNode]:
-        """Forward closure: every node reachable from ``root`` by
-        following graph edges.
+    def descendants_indices(self, root_idx: int, *, skip_flags: int = 0) -> list[int]:
+        """Forward closure: every node reachable from ``root_idx`` by
+        following graph edges. Takes a positional index into
+        :meth:`nodes` and returns descendant indices.
 
         ``skip_flags`` filters out edges whose flag mask intersects —
         pass ``EdgeFlags.DEAD_BRANCH`` to compute strict reachability
-        excluding dead branches.
-        """
-        ...
-
-    def descendants_indices(self, root_idx: int, *, skip_flags: int = 0) -> list[int]:
-        """Idx-keyed variant of :meth:`descendants`. Takes a positional
-        index into :meth:`nodes` and returns descendant indices rather
-        than allocating ``SymbolNode`` clones. Raises
-        :class:`IndexError` when ``root_idx`` is out of range.
-        """
-        ...
-
-    def ancestors(self, decl: SymbolNode, *, skip_flags: int = 0) -> list[SymbolNode]:
-        """Reverse closure: every node that can reach ``decl`` by
-        following graph edges.
-
-        Used for predecessor-chain walks and blast-radius scoping.
-        ``skip_flags`` works the same as in :meth:`descendants`.
+        excluding dead branches. Raises :class:`IndexError` when
+        ``root_idx`` is out of range.
         """
         ...
 
     def ancestors_indices(self, decl_idx: int, *, skip_flags: int = 0) -> list[int]:
-        """Idx-keyed variant of :meth:`ancestors`. Takes a positional
-        index into :meth:`nodes` and returns ancestor indices rather
-        than allocating ``SymbolNode`` clones. Raises
-        :class:`IndexError` when ``decl_idx`` is out of range.
+        """Reverse closure: every node that can reach ``decl_idx`` by
+        following graph edges. Takes a positional index into
+        :meth:`nodes` and returns ancestor indices. Used for
+        predecessor-chain walks and blast-radius scoping.
+
+        ``skip_flags`` works the same as in
+        :meth:`descendants_indices`. Raises :class:`IndexError` when
+        ``decl_idx`` is out of range.
         """
         ...
 

--- a/runtime/src/builder.rs
+++ b/runtime/src/builder.rs
@@ -5,7 +5,7 @@
 
 use std::sync::OnceLock;
 
-use pyo3::exceptions::{PyIndexError, PyRuntimeError, PyValueError};
+use pyo3::exceptions::{PyIndexError, PyRuntimeError};
 use pyo3::prelude::*;
 use ruff_db::files::File;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -18,13 +18,15 @@ use crate::project::ProjectContext;
 /// Positional identity for a node.
 ///
 /// Per `CLAUDE.md` principle 3, `flags` is deliberately *not* part of
-/// the key: two nodes for the same `(fqname, kind, path, position)` are
-/// the same node regardless of which path computed their flags.
+/// the key: two nodes for the same `(fqname, kind, file, position)` are
+/// the same node regardless of which path computed their flags. `file`
+/// is a `Copy` salsa id (one per path), so it discriminates exactly as
+/// the old path string did without the per-node `String` clone.
 #[derive(Hash, Eq, PartialEq, Clone)]
 pub(crate) struct NodeKey {
     pub(crate) fqname: String,
     pub(crate) kind: &'static str,
-    pub(crate) path: String,
+    pub(crate) file: File,
     pub(crate) start_line: usize,
     pub(crate) start_column: usize,
     pub(crate) end_line: usize,
@@ -63,14 +65,15 @@ pub(crate) struct GraphNode {
 }
 
 impl GraphNode {
-    /// Positional identity for the intern table. Mirrors
-    /// [`node_key_of`] (which projects a `SymbolNode`) but reads the
-    /// pure-rust fields directly.
-    pub(crate) fn key(&self) -> NodeKey {
+    /// Positional identity for the intern table. The `file` is supplied
+    /// by the caller (it owns the `File` at mint — the assembly loop and
+    /// [`GraphBuilder::intern_external`]) so [`GraphNode`] need not carry
+    /// one and can stay `Default`-constructible for the prefill region.
+    pub(crate) fn key(&self, file: File) -> NodeKey {
         NodeKey {
             fqname: self.fqname.clone(),
             kind: self.kind,
-            path: self.path.clone(),
+            file,
             start_line: self.start_line,
             start_column: self.start_column,
             end_line: self.end_line,
@@ -167,8 +170,8 @@ impl GraphBuilder {
         }
     }
 
-    pub(crate) fn intern_node(&mut self, node: GraphNode) -> usize {
-        let key = node.key();
+    pub(crate) fn intern_node(&mut self, node: GraphNode, file: File) -> usize {
+        let key = node.key(file);
         if let Some(&idx) = self.node_index.get(&key) {
             return idx;
         }
@@ -206,8 +209,8 @@ impl GraphBuilder {
     /// since a collision would silently overwrite a node and corrupt
     /// the index map — guards that invariant. Requires the region to
     /// be pre-sized via [`prefill_payload_region`].
-    pub(crate) fn place_node(&mut self, idx: usize, node: GraphNode) {
-        let prev = self.node_index.insert(node.key(), idx);
+    pub(crate) fn place_node(&mut self, idx: usize, node: GraphNode, file: File) {
+        let prev = self.node_index.insert(node.key(file), idx);
         assert!(
             prev.is_none(),
             "payload node key collision at index {idx}: assembly must mint each NodeKey once"
@@ -216,20 +219,21 @@ impl GraphBuilder {
     }
 
     /// Get (or mint) the deduplicated `kind="external"` node for a
-    /// non-first-party import target the project doesn't own —
-    /// ``[external dist] X`` covers third-party site-packages,
-    /// ``[external file] X`` a resolved-but-out-of-tree file, and
-    /// ``[unresolved] X`` a genuinely-missing top-level name. The
-    /// resolved target's `path` (empty for ``[unresolved]``, which has
-    /// no file) is carried so callers can exclude these nodes by path;
-    /// position is the (0, 0) sentinel. Deduped by fqname project-wide;
-    /// the first `path` seen for a given fqname wins, so several
-    /// submodules of one dist collapse to a single node.
-    pub(crate) fn intern_external(&mut self, fqname: String, path: String) -> usize {
+    /// resolved non-first-party import target the project doesn't own —
+    /// ``[external dist] X`` covers third-party site-packages and
+    /// ``[external file] X`` a resolved-but-out-of-tree file. (Genuinely
+    /// unresolved imports never reach here: they keep their alias node,
+    /// flagged `NodeFlags::UNRESOLVED`.) The resolved target's `path` is
+    /// carried so callers can exclude these nodes by path, and its
+    /// `file` keys the [`NodeKey`]; position is the (0, 0) sentinel.
+    /// Deduped by fqname project-wide; the first `path`/`file` seen for a
+    /// given fqname wins, so several submodules of one dist collapse to a
+    /// single node.
+    pub(crate) fn intern_external(&mut self, fqname: String, path: String, file: File) -> usize {
         if let Some(&idx) = self.external_nodes.get(&fqname) {
             return idx;
         }
-        let idx = self.intern_node(positionless_node(fqname.clone(), "external", path, 0));
+        let idx = self.intern_node(positionless_node(fqname.clone(), "external", path, 0), file);
         self.external_nodes.insert(fqname, idx);
         idx
     }
@@ -274,21 +278,6 @@ pub(crate) fn not_materialized(op: &str) -> PyErr {
         "ProjectContext.{op}() called outside an active materialize() — \
          did you call it from a plugin's run() method?"
     ))
-}
-
-/// Project a `SymbolNode` onto the `NodeKey` used for intern-table
-/// identity. Clones the two `String` fields (`fqname`, `path`); the
-/// rest are `Copy`.
-pub(crate) fn node_key_of(node: &SymbolNode) -> NodeKey {
-    NodeKey {
-        fqname: node.fqname.clone(),
-        kind: node.kind,
-        path: node.path.clone(),
-        start_line: node.start_line,
-        start_column: node.start_column,
-        end_line: node.end_line,
-        end_column: node.end_column,
-    }
 }
 
 /// Direction passed to :func:`bfs` — forward follows ``src -> dst``
@@ -465,22 +454,6 @@ fn check_idx_in_range(len: usize, idx: usize, op: &str, side: &str) -> PyResult<
     Ok(())
 }
 
-/// Resolve a `SymbolNode` reference to its builder-side index for an
-/// edge endpoint. Surfaces a precise `ValueError` (with `side`) when
-/// the node was never interned in this context.
-pub(crate) fn lookup_idx(builder: &GraphBuilder, node: &SymbolNode, side: &str) -> PyResult<usize> {
-    builder
-        .node_index
-        .get(&node_key_of(node))
-        .copied()
-        .ok_or_else(|| {
-            PyValueError::new_err(format!(
-                "add_edge: {side} node {:?} is not interned in this ProjectContext",
-                node.fqname
-            ))
-        })
-}
-
 #[cfg(test)]
 mod tests {
     //! Pure-rust tests for the graph-building primitives.
@@ -489,89 +462,13 @@ mod tests {
     //! pyo3-init / a GIL; those paths are exercised by the python suite
     //! end-to-end. Here we cover the data-only pieces:
     //!
-    //! * `NodeKey` equality / hashing (flags excluded from identity).
-    //! * `node_key_of` projection.
     //! * `positionless_node` field defaults.
     //! * `bfs` traversal — direction switch + `skip_flags` filtering.
+    //!
+    //! `NodeKey` identity (positional, flags-excluded) is keyed on a
+    //! salsa `File`, which needs a db to construct, so it's covered by
+    //! the Python suite's shadowing / cross-file tests rather than here.
     use super::*;
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
-    /// Build a bare `SymbolNode` for projection tests. Avoids pyo3
-    /// because the helper doesn't need to be reachable from Python.
-    fn raw_symbol(
-        fqname: &str,
-        kind: &'static str,
-        path: &str,
-        start_line: usize,
-        flags: u32,
-    ) -> SymbolNode {
-        SymbolNode {
-            fqname: fqname.to_string(),
-            kind,
-            path: path.to_string(),
-            start_line,
-            start_column: 0,
-            end_line: start_line,
-            end_column: 0,
-            flags,
-            imports: None,
-            cached_hash: OnceLock::new(),
-        }
-    }
-
-    fn hash_of(key: &NodeKey) -> u64 {
-        let mut h = DefaultHasher::new();
-        key.hash(&mut h);
-        h.finish()
-    }
-
-    // -- node_key_of / NodeKey -------------------------------------------
-
-    #[test]
-    fn node_key_of_projects_identity_fields() {
-        let n = raw_symbol("pkg.mod.f", "function", "pkg/mod.py", 12, 0);
-        let key = node_key_of(&n);
-        assert_eq!(key.fqname, "pkg.mod.f");
-        assert_eq!(key.kind, "function");
-        assert_eq!(key.path, "pkg/mod.py");
-        assert_eq!(key.start_line, 12);
-        assert_eq!(key.end_line, 12);
-    }
-
-    #[test]
-    fn node_key_excludes_flags_from_identity() {
-        // Principle 3 from CLAUDE.md: two nodes for the same
-        // (fqname, kind, path, position) are the same node regardless
-        // of which path computed their flags.
-        let a = node_key_of(&raw_symbol("m.f", "function", "m.py", 1, 0));
-        let b = node_key_of(&raw_symbol("m.f", "function", "m.py", 1, 7));
-        assert!(a == b);
-        assert_eq!(hash_of(&a), hash_of(&b));
-    }
-
-    #[test]
-    fn node_key_distinguishes_by_position() {
-        // Two `def f` at different lines must be distinct nodes
-        // (shadowing semantics).
-        let a = node_key_of(&raw_symbol("m.f", "function", "m.py", 1, 0));
-        let b = node_key_of(&raw_symbol("m.f", "function", "m.py", 9, 0));
-        assert!(a != b);
-    }
-
-    #[test]
-    fn node_key_distinguishes_by_kind() {
-        let a = node_key_of(&raw_symbol("m.X", "class", "m.py", 1, 0));
-        let b = node_key_of(&raw_symbol("m.X", "variable", "m.py", 1, 0));
-        assert!(a != b);
-    }
-
-    #[test]
-    fn node_key_distinguishes_by_path() {
-        let a = node_key_of(&raw_symbol("X", "class", "a/m.py", 1, 0));
-        let b = node_key_of(&raw_symbol("X", "class", "b/m.py", 1, 0));
-        assert!(a != b);
-    }
 
     // -- positionless_node ------------------------------------------------
 

--- a/runtime/src/file_payload.rs
+++ b/runtime/src/file_payload.rs
@@ -40,8 +40,8 @@ use ty_python_core::semantic_index;
 use crate::graph::{DeclKey, NodeFlags};
 use crate::helpers::{
     classify_base, collect_all_imports_local, detect_dead_ranges, file_default_flags,
-    file_path_string, iter_top_level_classes, module_fqname_for_file, position, range_key,
-    scan_noqa_directives, NODE_FLAGS_NOQA_PIN,
+    iter_top_level_classes, module_fqname_for_file, position, range_key, scan_noqa_directives,
+    NODE_FLAGS_NOQA_PIN,
 };
 use crate::ingest::{decl_kind_str, file_package_name, from_module_string};
 
@@ -108,17 +108,18 @@ pub(crate) fn def_key<'db>(
 /// * `[external file] X` — a site-packages file with no owning dist;
 ///   `X` is the top-level module name.
 ///
-/// `path` is the resolved target file's site-packages path so the
-/// assembled `kind="external"` node can be excluded by path (codemod,
-/// scoping). Several keys may share an fqname with different paths —
-/// e.g. two submodules of one dist; assembly dedups by fqname and keeps
-/// the first path. Stdlib targets and genuinely-unresolved imports mint
-/// no `ExternalKey`: stdlib stays silent, and an unresolved import's
-/// alias node carries `NodeFlags::UNRESOLVED`.
+/// `file` is the resolved target's site-packages `File`, carried so the
+/// assembled `kind="external"` node can re-derive its path (for codemod
+/// / scoping exclusion) without re-resolving. Several keys may share an
+/// fqname with different files — e.g. two submodules of one dist;
+/// assembly dedups by fqname and keeps the first (path-sorted) file.
+/// Stdlib targets and genuinely-unresolved imports mint no `ExternalKey`:
+/// stdlib stays silent, and an unresolved import's alias node carries
+/// `NodeFlags::UNRESOLVED`.
 #[salsa::interned(debug)]
 pub(crate) struct ExternalKey<'db> {
     pub(crate) fqname: String,
-    pub(crate) path: String,
+    pub(crate) file: File,
 }
 
 // Salsa tracks the interned heap separately; report 0 from GetSize.
@@ -173,7 +174,10 @@ pub(crate) fn external_fqname_for(
 pub(crate) struct NodeData {
     pub(crate) fqname: String,
     pub(crate) kind: NodeKind,
-    pub(crate) path: String,
+    /// The file this node belongs to. Every node in a `file_to_nodes`
+    /// payload shares it; the assembly pass re-derives the path string
+    /// from it (one allocation per file instead of one per node).
+    pub(crate) file: File,
     pub(crate) start_line: usize,
     pub(crate) start_column: usize,
     pub(crate) end_line: usize,
@@ -249,8 +253,8 @@ pub(crate) struct ImportPayload {
 
 /// Salsa-tracked output of [`file_to_nodes`]. Parallel arrays plus a
 /// reverse lookup map make every per-file node addressable in O(1)
-/// either by index (assembly pass) or by `NodeRef` identity
-/// (cross-file edge resolution via [`ref_to_node`]).
+/// either by index (assembly pass) or by `NodeRef` identity via
+/// `ref_to_local` (cross-file edge resolution).
 ///
 /// Indexing convention: `nodes[0]` is the synthetic `kind="module"`
 /// node for the file; `nodes[1..]` are global-scope definitions in
@@ -329,61 +333,6 @@ pub(crate) enum ClassBaseSpec {
     ModuleMember { module: String, name: String },
 }
 
-/// Resolve a `NodeRef` to its `NodeData` payload.
-///
-/// Thin accessor (not salsa-tracked — see PR discussion): one
-/// `file_to_nodes` lookup (memoized, ~ns) plus one HashMap probe.
-/// Keeps the public identity model (callers traffic in `NodeRef`,
-/// fetch `NodeData` on demand) without paying the ~200–400MB of
-/// salsa ingredient overhead a `#[salsa::tracked] ref_to_node` would
-/// cost at 4M-node scale.
-///
-/// Panics if the `NodeRef` doesn't belong to the project (file not
-/// in the project, or `Def(d)` whose `d.file(db)` doesn't enumerate
-/// `d` at module scope). Both indicate a contract violation upstream;
-/// surface the bug loudly.
-#[allow(dead_code)]
-pub(crate) fn ref_to_node<'db>(db: &'db dyn ProjectDb, r: NodeRef<'db>) -> NodeData {
-    match r {
-        NodeRef::Def(d) => {
-            let file = d.0;
-            let payload = file_to_nodes(db, file);
-            let idx = *payload
-                .ref_to_local
-                .get(&r)
-                .expect("NodeRef::Def does not belong to its claimed file's payload")
-                as usize;
-            payload.nodes[idx].clone()
-        }
-        NodeRef::Module(f) => {
-            let payload = file_to_nodes(db, f);
-            payload.nodes[0].clone()
-        }
-        NodeRef::StarStmt(file, _) => {
-            let payload = file_to_nodes(db, file);
-            let idx = *payload
-                .ref_to_local
-                .get(&r)
-                .expect("NodeRef::StarStmt does not belong to its claimed file's payload")
-                as usize;
-            payload.nodes[idx].clone()
-        }
-        NodeRef::External(k) => NodeData {
-            fqname: k.fqname(db).clone(),
-            kind: NodeKind::External,
-            path: k.path(db).clone(),
-            start_line: 0,
-            start_column: 0,
-            end_line: 0,
-            end_column: 0,
-            flags: 0,
-            is_overload: false,
-            imports: None,
-            name_range: (0, 0),
-        },
-    }
-}
-
 /// Modules whose `.overload` attribute marks a function decl as a stub.
 const OVERLOAD_MODULES: &[&str] = &["typing", "typing_extensions"];
 
@@ -445,7 +394,6 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
     let parsed = parsed_module(db, file).load(db);
     let source = source_text(db, file);
     let line_index = line_index(db, file);
-    let path_str = file_path_string(db, file);
     let module_fqname = module_fqname_for_file(db, file);
     let default_flags = file_default_flags(db, file);
     let (file_pinned_by_noqa, per_line_noqa_pins) =
@@ -463,7 +411,7 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
     nodes.push(NodeData {
         fqname: module_fqname.clone(),
         kind: NodeKind::Module,
-        path: path_str.clone(),
+        file,
         start_line: msl,
         start_column: msc,
         end_line: mel,
@@ -604,7 +552,7 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         let node = NodeData {
             fqname: format!("{module_fqname}.{local_name}"),
             kind: node_kind,
-            path: path_str.clone(),
+            file,
             start_line: sl,
             start_column: sc,
             end_line: el,
@@ -641,7 +589,7 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
                     let star_node = NodeData {
                         fqname: star_fqname,
                         kind: NodeKind::Import,
-                        path: path_str.clone(),
+                        file,
                         start_line: sl,
                         start_column: sc,
                         end_line: el,
@@ -1156,13 +1104,13 @@ pub(crate) fn file_to_edges<'db>(db: &'db dyn ProjectDb, file: File) -> FileEdge
         }
         // Non-first-party (site-packages) → External node keyed on the
         // PEP 503 dist name (or top-level module name) with the resolved
-        // file's path.
+        // target file (its path is re-derived at assembly).
         if target_module
             .search_path(db)
             .is_some_and(|sp| !sp.is_first_party() && sp.is_site_packages())
         {
             let fqname = external_fqname_for(db, target_file, top_level);
-            let key = ExternalKey::new(db, fqname, file_path_string(db, target_file));
+            let key = ExternalKey::new(db, fqname, target_file);
             edges.insert((alias_ref, NodeRef::External(key), 0));
             continue;
         }

--- a/runtime/src/file_ref_edges.rs
+++ b/runtime/src/file_ref_edges.rs
@@ -69,8 +69,8 @@ enum Resolution<'db> {
     },
 }
 use crate::helpers::{
-    detect_dead_ranges, detect_type_checking_ranges, file_path_string, is_dunder_name,
-    EDGE_FLAG_DEAD_BRANCH, EDGE_FLAG_DYNAMIC_IMPORT,
+    detect_dead_ranges, detect_type_checking_ranges, is_dunder_name, EDGE_FLAG_DEAD_BRANCH,
+    EDGE_FLAG_DYNAMIC_IMPORT,
 };
 use crate::ingest::{
     collapse_attribute_chain, detect_dynamic_call, file_package_name, from_module_string,
@@ -271,7 +271,7 @@ impl<'a, 'db> RefWalker<'a, 'db> {
     /// the resolved upstream path: `[external dist] X` / `[external file] X`
     /// for site-packages (via `external_fqname_for`'s PEP 503 lookup).
     fn emit_external_node(&mut self, fqname: String, target_file: File) {
-        let key = ExternalKey::new(self.db, fqname, file_path_string(self.db, target_file));
+        let key = ExternalKey::new(self.db, fqname, target_file);
         self.emit_edge(NodeRef::External(key));
     }
 

--- a/runtime/src/native_plugins.rs
+++ b/runtime/src/native_plugins.rs
@@ -58,8 +58,8 @@ use crate::file_payload::{file_to_nodes, NodeData, NodeKind};
 use crate::flag_registry::FlagRegistry;
 use crate::graph::EdgeFlags;
 use crate::helpers::{
-    collect_modules_imports_local, decorators_match_imports, matched_call_target_any,
-    top_level_assign_to_name, ArgValue, CallArgs, FactoryCallFinder,
+    collect_modules_imports_local, decorators_match_imports, file_path_string,
+    matched_call_target_any, top_level_assign_to_name, ArgValue, CallArgs, FactoryCallFinder,
 };
 use crate::ingest::file_package_name;
 use crate::project::FrozenView;
@@ -274,6 +274,13 @@ impl<'db> FileContext<'db> {
     /// The file's module fqname (``nodes()[0].fqname``).
     pub(crate) fn module_fqname(&self) -> &'db str {
         &file_to_nodes(self.db, self.file).nodes[0].fqname
+    }
+
+    /// This file's source path, re-derived from its [`File`]. Every node
+    /// in the file shares it, so [`PluginFileCtx`] computes it once per
+    /// call and lends it to [`file_node_view`].
+    pub(crate) fn path(&self) -> String {
+        file_path_string(self.db, self.file)
     }
 
     /// Local index of the module node (always 0 — kept as a
@@ -2050,12 +2057,16 @@ pub mod plugin_api {
     /// Project the crate-internal per-file `NodeData` onto the curated,
     /// owned [`FileNodeView`]. Shared by [`PluginFileCtx::node`] and
     /// [`PluginFileCtx::nodes`] so the two stay in lockstep.
-    fn file_node_view(local_idx: u32, node: &crate::file_payload::NodeData) -> FileNodeView {
+    fn file_node_view(
+        local_idx: u32,
+        node: &crate::file_payload::NodeData,
+        path: &str,
+    ) -> FileNodeView {
         FileNodeView {
             local_idx,
             fqname: node.fqname.clone(),
             kind: node.kind.as_static_str().to_string(),
-            path: node.path.clone(),
+            path: path.to_string(),
             start_line: node.start_line,
             end_line: node.end_line,
             flags: node.flags,
@@ -2099,17 +2110,18 @@ pub mod plugin_api {
         /// Resolve a file-local index to an owned [`FileNodeView`].
         pub fn node(&self, local_idx: u32) -> Option<FileNodeView> {
             let node = self.inner.nodes().get(local_idx as usize)?;
-            Some(file_node_view(local_idx, node))
+            Some(file_node_view(local_idx, node, &self.inner.path()))
         }
 
         /// Every node in this file as a [`FileNodeView`], in file-local
         /// index order.
         pub fn nodes(&self) -> Vec<FileNodeView> {
+            let path = self.inner.path();
             self.inner
                 .nodes()
                 .iter()
                 .enumerate()
-                .map(|(i, node)| file_node_view(i as u32, node))
+                .map(|(i, node)| file_node_view(i as u32, node, &path))
                 .collect()
         }
 

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -25,8 +25,7 @@ use ty_project::{Db as ProjectDb, ProjectDatabase, ProjectMetadata};
 use ty_python_core::program::UseDefaultStrategy;
 
 use crate::builder::{
-    apply_prepared_batch, bfs, lookup_idx, not_materialized, Direction, GraphBuilder, GraphNode,
-    PreparedOp,
+    apply_prepared_batch, bfs, not_materialized, Direction, GraphBuilder, GraphNode, PreparedOp,
 };
 use crate::file_extraction::{
     file_extraction, imports_local_from_facts, match_callee_chain, match_callee_descriptor,
@@ -716,7 +715,10 @@ fn assemble_graph<'db>(
             let node = GraphNode {
                 fqname: node_data.fqname.clone(),
                 kind: intern_kind(node_data.kind.as_static_str())?,
-                path: node_data.path.clone(),
+                // Every node in this file's payload shares the file, so
+                // its path is `path_str` (computed once above) — re-derived
+                // here instead of stored per `NodeData`.
+                path: path_str.clone(),
                 start_line: node_data.start_line,
                 start_column: node_data.start_column,
                 end_line: node_data.end_line,
@@ -726,7 +728,7 @@ fn assemble_graph<'db>(
                 imports: node_data.imports.clone(),
             };
             let global_idx = base + local_idx;
-            builder.place_node(global_idx, node);
+            builder.place_node(global_idx, node, file);
             ref_to_global.insert(node_ref, global_idx);
             local_to_global.insert((file, local_idx as u32), global_idx);
 
@@ -841,16 +843,19 @@ fn assemble_graph<'db>(
     // Sort by (fqname, path) — `intern_external` dedups on fqname, so
     // the first path after the sort wins deterministically, and every
     // External lands at the same index every run.
-    let mut externals: Vec<(String, String, NodeRef<'db>)> = external_keys
+    let mut externals: Vec<(String, String, File, NodeRef<'db>)> = external_keys
         .into_iter()
         .filter_map(|r| match r {
-            NodeRef::External(key) => Some((key.fqname(db).clone(), key.path(db).clone(), r)),
+            NodeRef::External(key) => {
+                let file = key.file(db);
+                Some((key.fqname(db).clone(), file_path_string(db, file), file, r))
+            }
             _ => None,
         })
         .collect();
     externals.sort_unstable_by(|a, b| (&a.0, &a.1).cmp(&(&b.0, &b.1)));
-    for (fqname, path, r) in externals {
-        let idx = builder.intern_external(fqname, path);
+    for (fqname, path, file, r) in externals {
+        let idx = builder.intern_external(fqname, path, file);
         ref_to_global.insert(r, idx);
     }
 
@@ -2231,29 +2236,13 @@ impl ProjectContext {
         Ok(decls_matching_name_indices_in(&outputs, &regex))
     }
 
-    /// Forward closure: every node reachable from ``root`` by following
-    /// graph edges. ``skip_flags`` filters out edges whose flag mask
-    /// matches (pass ``EdgeFlags.DEAD_BRANCH.value`` to compute strict
-    /// reachability excluding dead branches).
-    #[pyo3(signature = (root, *, skip_flags = 0))]
-    pub(crate) fn descendants(
-        &self,
-        py: Python<'_>,
-        root: &SymbolNode,
-        skip_flags: u8,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.materialized("descendants")?;
-        let root_idx = lookup_idx(&outputs.builder, root, "root")?;
-        bfs(&outputs.builder, [root_idx], Direction::Forward, skip_flags)
-            .into_iter()
-            .map(|i| outputs.builder.nodes[i].to_symbol(py))
-            .collect()
-    }
-
-    /// Idx-keyed variant of :meth:`descendants`. Takes a positional
-    /// index into ``ctx.nodes()`` and returns descendant indices
-    /// rather than allocating ``Py<SymbolNode>`` clones. Raises
-    /// :class:`IndexError` when ``root_idx`` is out of range.
+    /// Forward closure: every node reachable from ``root_idx`` by
+    /// following graph edges. Takes a positional index into
+    /// ``ctx.nodes()`` and returns descendant indices. ``skip_flags``
+    /// filters out edges whose flag mask matches (pass
+    /// ``EdgeFlags.DEAD_BRANCH.value`` for strict reachability excluding
+    /// dead branches). Raises :class:`IndexError` when ``root_idx`` is
+    /// out of range.
     #[pyo3(signature = (root_idx, *, skip_flags = 0))]
     pub(crate) fn descendants_indices(
         &self,
@@ -2274,27 +2263,12 @@ impl ProjectContext {
         )
     }
 
-    /// Reverse closure: every node that can reach ``decl`` by following
-    /// graph edges. Used for ``why-alive`` and blast-radius scoping.
-    #[pyo3(signature = (decl, *, skip_flags = 0))]
-    pub(crate) fn ancestors(
-        &self,
-        py: Python<'_>,
-        decl: &SymbolNode,
-        skip_flags: u8,
-    ) -> PyResult<Vec<Py<SymbolNode>>> {
-        let outputs = self.materialized("ancestors")?;
-        let idx = lookup_idx(&outputs.builder, decl, "decl")?;
-        bfs(&outputs.builder, [idx], Direction::Reverse, skip_flags)
-            .into_iter()
-            .map(|i| outputs.builder.nodes[i].to_symbol(py))
-            .collect()
-    }
-
-    /// Idx-keyed variant of :meth:`ancestors`. Takes a positional
-    /// index into ``ctx.nodes()`` and returns ancestor indices rather
-    /// than allocating ``Py<SymbolNode>`` clones. Raises
-    /// :class:`IndexError` when ``decl_idx`` is out of range.
+    /// Reverse closure: every node that can reach ``decl_idx`` by
+    /// following graph edges. Takes a positional index into
+    /// ``ctx.nodes()`` and returns ancestor indices. Used for
+    /// ``why-alive`` and blast-radius scoping. ``skip_flags`` works the
+    /// same as in :meth:`descendants_indices`. Raises :class:`IndexError`
+    /// when ``decl_idx`` is out of range.
     #[pyo3(signature = (decl_idx, *, skip_flags = 0))]
     pub(crate) fn ancestors_indices(
         &self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,15 +210,32 @@ def assert_dynamic_import_edges():
 def successors_of():
     """Return the one-hop successors of ``node`` in ``ctx`` (test-only).
 
-    Production code uses :meth:`ProjectContext.descendants` for the
-    transitive closure; the one-hop accessor lives here because only
-    tests reach for it.
+    The transitive closure lives in :func:`descendants_of`; this one-hop
+    accessor stays here because only tests reach for it.
     """
 
     def _of(ctx: "native.ProjectContext", node) -> list:
         nodes = ctx.nodes()
         idx = nodes.index(node)
         return [nodes[v] for u, v, _ in ctx.edges() if u == idx]
+
+    return _of
+
+
+@pytest.fixture
+def descendants_of():
+    """Return the transitive forward closure of ``node`` in ``ctx`` as
+    ``SymbolNode``s (test-only).
+
+    The native surface is index-keyed (``descendants_indices``); this
+    fixture maps the seed node to its index, runs the closure, and maps
+    the result back to nodes so tests can assert on ``SymbolNode``s.
+    """
+
+    def _of(ctx: "native.ProjectContext", node, *, skip_flags: int = 0) -> list:
+        nodes = ctx.nodes()
+        idx = nodes.index(node)
+        return [nodes[i] for i in ctx.descendants_indices(idx, skip_flags=skip_flags)]
 
     return _of
 

--- a/tests/test_canonical_fqname.py
+++ b/tests/test_canonical_fqname.py
@@ -35,7 +35,7 @@ def _module_fqnames(graph) -> dict[str, str]:
 
 
 def test_pep660_finder_install_resolves_via_project_root(
-    tmp_path, write_files, make_workspace_venv
+    tmp_path, write_files, make_workspace_venv, descendants_of
 ):
     """Reproduces #222: a venv whose ``.pth`` is a PEP 660 finder stub
     (no flat path entries) must not break first-party resolution. We
@@ -71,7 +71,7 @@ def test_pep660_finder_install_resolves_via_project_root(
     job_router_alias = next(n for n in graph.nodes() if n.fqname == "myapp.main.job_router")
     router_var = next(n for n in graph.nodes() if n.fqname == "myapp.routes.job.router")
     # The alias's descendant set should reach the upstream var.
-    assert router_var in graph.descendants(job_router_alias)
+    assert router_var in descendants_of(graph, job_router_alias)
 
 
 def test_monorepo_pth_beats_project_root_in_fqname(tmp_path, write_files, make_workspace_venv):

--- a/tests/test_codemod.py
+++ b/tests/test_codemod.py
@@ -94,12 +94,13 @@ def build_unreachable_nodes(tmp_path, make_analysis):
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(_normalise(src))
         ctx = make_analysis().materialize_all()
-        seeds = [n for n in ctx.nodes() if n.fqname in entrypoints]
-        reachable: set = set()
-        for seed in seeds:
-            reachable.update(ctx.descendants(seed))
-            reachable.add(seed)
-        return [n for n in ctx.nodes() if n not in reachable]
+        nodes = ctx.nodes()
+        seed_idxs = [i for i, n in enumerate(nodes) if n.fqname in entrypoints]
+        reachable: set[int] = set()
+        for idx in seed_idxs:
+            reachable.update(ctx.descendants_indices(idx))
+            reachable.add(idx)
+        return [n for i, n in enumerate(nodes) if i not in reachable]
 
     return _build
 

--- a/tests/test_overloads_and_pyi.py
+++ b/tests/test_overloads_and_pyi.py
@@ -72,9 +72,10 @@ def test_dead_overloads_are_removed_with_impl(tmp_path, make_analysis):
         )
     )
     graph = make_analysis().materialize_all()
-    keep = next(n for n in graph.nodes() if n.fqname == "mod.keep")
-    reachable = set(graph.descendants(keep)) | {keep}
-    unreachable = [n for n in graph.nodes() if n not in reachable]
+    nodes = graph.nodes()
+    keep_idx = next(i for i, n in enumerate(nodes) if n.fqname == "mod.keep")
+    reachable = set(graph.descendants_indices(keep_idx)) | {keep_idx}
+    unreachable = [n for i, n in enumerate(nodes) if i not in reachable]
     remove_code(unreachable, tmp_path)
 
     rewritten = (tmp_path / "mod.py").read_text()
@@ -110,7 +111,7 @@ def test_live_overloads_survive_codemod(tmp_path, make_analysis):
     assert rewritten.count("@overload") == 2
 
 
-def test_overload_decorator_forms_recognised(build_decl_graph):
+def test_overload_decorator_forms_recognised(build_decl_graph, descendants_of):
     """Both `@overload` (from-import / aliased) and the `@typing.overload`
     attribute form (plain `import typing`) are recognised as overload stubs.
     Overload status is internal (not Python-visible); the observable proxy is
@@ -144,14 +145,14 @@ def test_overload_decorator_forms_recognised(build_decl_graph):
     f_nodes = [n for n in graph.nodes() if n.fqname == "mod.f" and n.kind == "function"]
     by_line = {n.start_line: n for n in f_nodes}
     assert set(by_line) == {5, 7, 8}, f"unexpected lines: {sorted(by_line)}"
-    descendants = set(graph.descendants(by_line[8]))
+    descendants = set(descendants_of(graph, by_line[8]))
     assert by_line[5] in descendants, "@ovl (aliased) stub should anchor to the impl"
     assert by_line[7] in descendants, (
         "@typing.overload (attribute form) stub should anchor to the impl"
     )
 
 
-def test_impl_to_overload_anchor_edges(build_decl_graph):
+def test_impl_to_overload_anchor_edges(build_decl_graph, descendants_of):
     """Each in-file `@overload` stub gets an explicit `impl -> stub` edge,
     visible in `descendants(impl)`."""
     graph = build_decl_graph(
@@ -183,7 +184,7 @@ def test_impl_to_overload_anchor_edges(build_decl_graph):
         if n.fqname == "mod.f" and n.kind == "function" and n.start_line in (4, 6)
     ]
     assert len(stubs) == 2
-    descendants = set(graph.descendants(impl))
+    descendants = set(descendants_of(graph, impl))
     assert all(s in descendants for s in stubs), (
         "Each overload stub should be a descendant of the impl via the anchor edge"
     )


### PR DESCRIPTION
## Summary

- **`NodeData` / `NodeKey` now store a salsa `File`, not a path `String`.**
  The per-node path was just the file's path repeated on every node. We store
  the `File` instead and re-derive the path string once per file at graph
  assembly (one allocation per file rather than one per node). `File` <-> path
  is a bijection, so keying `NodeKey` on the `File` discriminates identically to
  keying on the path. `ExternalKey` likewise carries the `File` it already held
  at its mint site. `GraphNode` keeps its `String` path (read across the query
  layer); the `File` is threaded into interning (`intern_node` / `place_node` /
  `intern_external` / `GraphNode::key(file)`) rather than stored on the node, so
  `GraphNode` stays `Default`-compatible.
- **Removed the `SymbolNode`-keyed `ProjectContext.descendants(root)` /
  `ancestors(decl)` pyclass methods** (and the internal `node_key_of` /
  `lookup_idx` helpers) in favor of the index-keyed `descendants_indices` /
  `ancestors_indices` the `Analysis` layer already uses. Tests resolve a node to
  its index first via a new `descendants_of` conftest fixture.
- Deleted the now-dead `ref_to_node` path. Net -155 lines.

## Test plan

- [x] `cargo build -p dead-cst-runtime` + `cargo clippy --all-targets` clean
- [x] `cargo test --no-default-features --locked -p dead-cst-runtime` (129 pass)
- [x] `maturin develop` + `uv run pytest` (700 passed, 3 skipped)
- [x] `uv run prek run --all-files` (ruff, ty, cargo fmt, cargo clippy) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)