### PR TITLE
Drop the previous BuildOutputs off-thread on re_materialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,11 @@ two versions.
 
 ### Changed
 
+- **`re_materialize` drops the previous graph off-thread.** When a rebuild
+  swaps in fresh `BuildOutputs`, the previous build's graph (nodes, edges,
+  adjacency, the fqname/base indices) is now deallocated on a detached thread
+  instead of inline under the GIL, so `re_materialize` returns without waiting
+  on the old graph's dealloc. Behavior is unchanged; only the drop is offloaded.
 - **Nested `from X import *` is no longer fanned out.** A `from X import *`
   inside a function or class body is a `SyntaxError` ("import * only allowed at
   module level"), so it cannot occur in runnable Python. The engine previously

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -1684,7 +1684,24 @@ impl ProjectContext {
                 return Err(e);
             }
         };
-        *slf.borrow(py).outputs.write() = Some(outputs);
+        // Swap in the freshly built outputs and offload the *previous*
+        // ``BuildOutputs`` to a detached thread for dropping. It's ``None``
+        // on the first build and ``Some`` on every ``re_materialize``; the
+        // old graph (nodes, edges, adjacency, the fqname/base indices) is a
+        // large web of allocations whose dealloc would otherwise run on this
+        // GIL-holding thread and stall the caller. The swap itself is a
+        // pointer move under the write lock; the drop happens after the lock
+        // is released. ``BuildOutputs`` is ``Send + 'static`` (it already
+        // rides the ``Arc<RwLock<…>>`` here and the rayon plugin scope below),
+        // so the move is sound. If the OS can't spawn the thread, the unrun
+        // closure is dropped and ``old`` deallocs inline — correct, just not
+        // offloaded.
+        let previous = slf.borrow(py).outputs.write().replace(outputs);
+        if let Some(old) = previous {
+            let _ = std::thread::Builder::new()
+                .name("dead-cst-drop-outputs".into())
+                .spawn(move || drop(old));
+        }
 
         // Project-wide plugin pass — fan out across a GIL-free
         // ``rayon`` scope, one task per plugin, mirroring the per-file


### PR DESCRIPTION
## Summary

- On `re_materialize`, `materialize` swaps fresh `BuildOutputs` into the
  context. The **previous** build's graph — nodes, edges, adjacency, the
  fqname/base indices — was previously deallocated **inline while holding the
  GIL**, stalling the caller on a large web of frees.
- Now the swap is a pointer move under the write lock, and the old graph is
  handed to a **detached thread** for dropping, so `re_materialize` returns
  without waiting on the dealloc.
- `None` on the first build (nothing to offload); `Some` on every
  `re_materialize`. `BuildOutputs` is `Send + 'static` (it already rides the
  `Arc<RwLock<…>>` here and the rayon plugin scope), so the move is sound. If
  the OS can't spawn the thread, the unrun closure is dropped and the old graph
  deallocs inline — correct, just not offloaded. Behavior is otherwise
  unchanged.

## Test plan

- [x] `cargo build -p dead-cst-runtime` + `cargo clippy --all-targets` clean
- [x] `cargo test --no-default-features --locked -p dead-cst-runtime` (129 pass)
- [x] `maturin develop` + `uv run pytest` (700 passed, 3 skipped), including the
  `re_materialize`-exercising incremental + plugin suites
- [x] `uv run prek run --all-files` (ruff, ty, cargo fmt, cargo clippy) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)