### PR TITLE
Add a topic/fact channel for per-file native plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ two versions.
   name to a handle. Facts are an in-memory build-time side channel — not
   graph-mutating and not serialized into the graph file. The
   `ProjectContext.topic_registry()` / `facts_for_topic(name)` getters expose
-  the same data to Python. Bumps `PLUGIN_API_EPOCH` to 6.
+  the same data to Python. Bumps `PLUGIN_API_EPOCH` to 6. See
+  `examples/per_file_decorated/` for a worked per-file-emit → project-wide-read
+  round trip that also stamps a declared node flag.
 - **`plugin_api` epoch in the ABI fingerprint.** The native-plugin ABI
   fingerprint gains a dedicated `api<N>` segment
   (`native_plugins::plugin_api::PLUGIN_API_EPOCH`, bumped in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ two versions.
 
 ### Added
 
+- **Topic/fact channel for native plugins.** A per-file native plugin can
+  now hand structured facts up to its project-wide reader. A plugin declares
+  topics with `ExternalPlugin::declare_topics() -> Vec<TopicSpec>` (same
+  `engine/`-reserved, idempotent-on-identical-spec registration as the flag
+  registries), emits per-file facts with
+  `FileOps::emit_fact(topic_name, decl_local_idx, value)`, and reads them
+  project-wide through `PluginCtx::topic(name) -> Option<u32>` +
+  `facts_for_topic(handle) -> Vec<Fact>`. Each `Fact` carries the source file
+  path, an optional graph decl index (the file-local decl is translated to a
+  global index, or the fact is dropped if it can't resolve), and a `String`
+  value. Per-file plugins emit by topic *name* (salsa-stable) so the per-file
+  cache stays a pure function of the file; the project-wide side resolves the
+  name to a handle. Facts are an in-memory build-time side channel — not
+  graph-mutating and not serialized into the graph file. The
+  `ProjectContext.topic_registry()` / `facts_for_topic(name)` getters expose
+  the same data to Python. Bumps `PLUGIN_API_EPOCH` to 6.
 - **`plugin_api` epoch in the ABI fingerprint.** The native-plugin ABI
   fingerprint gains a dedicated `api<N>` segment
   (`native_plugins::plugin_api::PLUGIN_API_EPOCH`, bumped in

--- a/NATIVE_PLUGINS.md
+++ b/NATIVE_PLUGINS.md
@@ -393,6 +393,14 @@ example:
   the manifest. Start here.
 - **[`examples/per_file_main_block/`](examples/per_file_main_block/)** — the
   same behaviour as a **per-file** plugin (`per_file()` + `run_on_file`).
+- **[`examples/per_file_decorated/`](examples/per_file_decorated/)** — a
+  **two-plugin** cdylib wiring the per-file → project-wide channel end to end:
+  a per-file scanner emits a fact per Click-decorated command (via the
+  ready-made `decorated_decls` query), and a project-wide reader resolves the
+  shared topic, reads the facts, and stamps a declared `click/command` node
+  flag on each matched decl. The worked example for `declare_node_flags` /
+  `declare_topics` / `emit_fact` / `facts_for_topic` and for a manifest that
+  exports more than one plugin.
 
 ---
 

--- a/NATIVE_PLUGINS.md
+++ b/NATIVE_PLUGINS.md
@@ -310,6 +310,79 @@ plugin-set change. Per-file plugins emit the built-in engine flag constants
 (`plugin_api::FLAG_*`) instead; declaring custom flags is a project-wide-plugin
 capability today.
 
+### Topics: per-file facts → project-wide reader
+
+A per-file plugin can't see project-wide state — but it often discovers
+something one file at a time that its project-wide half needs to act on. The
+**topic/fact** channel carries that across: the per-file run *publishes facts*
+under a topic, and the project-wide `run` *reads them all back*.
+
+Declare topics the same way you declare flags, via `declare_topics`:
+
+```rust
+use dead_cst_runtime::native_plugins::plugin_api::TopicSpec;
+
+impl ExternalPlugin for MyPlugin {
+    fn name(&self) -> &str { "MyPlugin" }
+    fn per_file(&self) -> Option<&dyn PerFilePlugin> { Some(self) }
+
+    fn declare_topics(&self) -> Vec<TopicSpec> {
+        vec![TopicSpec {
+            name: "acme/handlers".to_string(),   // owner/name; "engine/" is reserved
+            description: "decls that look like request handlers".to_string(),
+        }]
+    }
+}
+
+impl PerFilePlugin for MyPlugin {
+    fn run_on_file(&self, file: &PluginFileCtx<'_>, ops: &mut FileOps) {
+        for n in file.nodes() {
+            if n.local_idx != 0 && n.fqname.ends_with("_handler") {
+                // emit by topic *name*, optionally pinned to a file-local decl
+                ops.emit_fact("acme/handlers", Some(n.local_idx), n.fqname.to_string());
+            }
+        }
+    }
+}
+```
+
+Then read them in the project-wide `run`:
+
+```rust
+fn run(&self, ctx: &PluginCtx<'_>, ops: &mut PluginOps) -> Result<(), PluginError> {
+    let handle = ctx.topic("acme/handlers").expect("declared in declare_topics");
+    for fact in ctx.facts_for_topic(handle) {
+        // fact: { path: String, decl_idx: Option<usize>, value: String }
+        if let Some(idx) = fact.decl_idx {
+            ops.keep_alive(idx);
+        }
+    }
+    Ok(())
+}
+```
+
+Key points:
+
+- **Facts are emitted by topic *name*, not handle.** Same reason a per-file
+  plugin can't resolve a flag bit: the registry handle is allocated from the
+  whole plugin set, which isn't a file input, so keying the salsa cache on it
+  would serve stale handles after a plugin-set change. The topic *name* is
+  salsa-stable, so the per-file output stays cacheable; the host resolves
+  name → handle on the project-wide side.
+- **`decl_local_idx` is optional and translated.** `Some(local)` pins the fact
+  to a position in `file.nodes()`, which the host maps to a **global** node
+  index at assemble time; a fact whose decl doesn't resolve is dropped (so a
+  `Some` `decl_idx` you read back always names a live node). `None` leaves the
+  fact file-scoped (`path` only).
+- **`engine/` is reserved and registration is idempotent**, exactly like flags:
+  two plugins declaring the same `owner/name` topic share one handle; a
+  conflicting re-declaration fails loudly.
+- **Facts don't mutate the graph and aren't serialized.** They're an in-memory
+  build-time side channel, queried on the live `ProjectContext`
+  (`ctx.facts_for_topic` in Rust; `ProjectContext.topic_registry()` /
+  `ProjectContext.facts_for_topic(name)` from Python). Nothing is written to the
+  `.dcg` file.
+
 Each plugin `cdylib` also exports a **manifest** — a self-contained
 `#[repr(C)]` table listing the plugins it provides and the ABI fingerprint it
 was built against. It's deliberately boring boilerplate; copy it from a worked

--- a/examples/main_block_plugin/src/lib.rs
+++ b/examples/main_block_plugin/src/lib.rs
@@ -15,12 +15,12 @@
 
 use std::ffi::c_void;
 
-use dead_cst_runtime::native_plugins::plugin_api::{ExternalPlugin, PluginCtx, PluginOps};
+use dead_cst_runtime::native_plugins::plugin_api::{
+    ExternalPlugin, PluginCtx, PluginError, PluginOps,
+};
 use dead_cst_runtime::native_plugins::{
     PluginDesc, PluginManifest, PLUGIN_ABI_FINGERPRINT, PLUGIN_MANIFEST_MAGIC,
 };
-
-const MARKER: &str = "<__main__>:external";
 
 struct MainBlockPlugin;
 
@@ -29,15 +29,16 @@ impl ExternalPlugin for MainBlockPlugin {
         "ExternalMainBlockPlugin"
     }
 
-    fn run(&self, ctx: &PluginCtx<'_>, ops: &mut PluginOps) {
+    fn run(&self, ctx: &PluginCtx<'_>, ops: &mut PluginOps) -> Result<(), PluginError> {
         for (module_idx, decl_indices) in ctx.main_blocks() {
             // Keep the module alive, plus every top-level decl inside the
             // `if __name__ == "__main__":` block.
-            ops.keep_alive(module_idx, MARKER.to_string());
+            ops.keep_alive(module_idx);
             for decl_idx in decl_indices {
-                ops.keep_alive(decl_idx, MARKER.to_string());
+                ops.keep_alive(decl_idx);
             }
         }
+        Ok(())
     }
 }
 

--- a/examples/per_file_decorated/src/lib.rs
+++ b/examples/per_file_decorated/src/lib.rs
@@ -1,20 +1,31 @@
-//! Example out-of-tree **per-file** native plugin that uses the ready-made
-//! file-local query API instead of hand-rolling an AST walk.
+//! Example out-of-tree plugin **pair** that demonstrates the flag and
+//! topic/fact registries end to end, using the ready-made file-local query
+//! API instead of hand-rolling an AST walk.
 //!
-//! It keeps every top-level function decorated with a Click command
+//! Goal: keep every top-level function decorated with a Click command
 //! decorator (`@command` / `@group`, imported directly from `click`)
-//! reachable — the kind of "decorated entrypoint" pattern a framework
-//! plugin exists for. The whole match is two calls:
+//! reachable — but instead of a single plugin calling `keep_alive`, the work
+//! is split across the per-file -> project-wide channel the runtime exposes:
 //!
-//! * [`PluginFileCtx::imports_any_module`] — a cheap presence guard that
-//!   skips files that don't import `click` at all.
-//! * [`PluginFileCtx::decorated_decls`] — the file-local indices of the
-//!   decorated decls, which pipe straight into [`FileOps::keep_alive`].
+//! * [`ClickCommandScanner`] is a **per-file** plugin. For each click-decorated
+//!   decl it [emits a fact](FileOps::emit_fact) under the topic
+//!   `click/commands`, pinned to that decl. Per-file output must be a pure
+//!   function of the file, so it emits by topic **name** (a salsa-stable
+//!   string) — a per-file plugin can't resolve a registry handle or flag bit,
+//!   which is exactly why the flag is stamped on the project-wide side, not
+//!   here. It finds the decls with [`PluginFileCtx::imports_any_module`] +
+//!   [`PluginFileCtx::decorated_decls`] (the same matcher core the in-tree
+//!   project-wide plugins drive — no raw `parsed()` walk).
+//! * [`ClickCommandKeeper`] is a **project-wide** plugin. It declares the
+//!   `click/command` node flag, resolves the `click/commands` topic handle with
+//!   [`PluginCtx::topic`], reads every collected fact via
+//!   [`PluginCtx::facts_for_topic`], and stamps the registered flag on each
+//!   fact's decl with [`PluginOps::flag_decl`] — keeping it alive.
 //!
-//! No raw `parsed()` walk, no re-implementing import/alias resolution: the
-//! query reuses the same decorator matcher core the in-tree project-wide
-//! native plugins drive, so this per-file plugin and a project-wide twin
-//! agree on what matches.
+//! Both plugins declare the `click/commands` topic with an identical
+//! [`TopicSpec`]; registration is idempotent, so they share one handle. The
+//! manifest exports both, so loading this one cdylib wires up the whole round
+//! trip.
 //!
 //! Build it with
 //! `dead-cst build-plugin examples/per_file_decorated/src/lib.rs` and load it
@@ -23,33 +34,56 @@
 use std::ffi::c_void;
 
 use dead_cst_runtime::native_plugins::plugin_api::{
-    ExternalPlugin, FileOps, PerFilePlugin, PluginFileCtx,
+    ExternalPlugin, FileOps, FlagSpec, PerFilePlugin, PluginCtx, PluginError, PluginFileCtx,
+    PluginOps, TopicSpec,
 };
 use dead_cst_runtime::native_plugins::{
     PluginDesc, PluginManifest, PLUGIN_ABI_FINGERPRINT, PLUGIN_MANIFEST_MAGIC,
 };
 
-const MARKER: &str = "<click-command>:per-file";
+/// The shared topic both plugins declare (idempotently) and exchange facts
+/// over: the per-file scanner publishes under it, the project-wide keeper
+/// reads from it.
+const TOPIC_NAME: &str = "click/commands";
+const TOPIC_DESC: &str = "fqname of each top-level Click-decorated command/group decl";
 
-struct PerFileDecorated;
+/// The node flag the keeper declares and stamps on each command decl. It sets
+/// both `seed` and `default_on`, putting it in the default keepalive mask, so
+/// a flagged decl is a reachability root.
+const FLAG_NAME: &str = "click/command";
+const FLAG_DESC: &str = "top-level Click command/group entrypoint";
 
-impl ExternalPlugin for PerFileDecorated {
+/// The one [`TopicSpec`] both sides register. Sharing a single builder keeps
+/// the name + description byte-identical, which is what makes the second
+/// registration idempotent rather than a conflicting re-declaration.
+fn click_commands_topic() -> TopicSpec {
+    TopicSpec {
+        name: TOPIC_NAME.to_string(),
+        description: TOPIC_DESC.to_string(),
+    }
+}
+
+// --- per-file emitter -------------------------------------------------------
+
+struct ClickCommandScanner;
+
+impl ExternalPlugin for ClickCommandScanner {
     fn name(&self) -> &str {
-        "ExternalPerFileDecoratedPlugin"
+        "ExternalClickCommandScanner"
     }
 
-    // Demonstrates the pre-graph hook — a real plugin might read a config
-    // file under `project_root` here. We only assert it's wired (the host
-    // forwards `NativePlugin.prepare` to this), so the body is a no-op.
-    fn prepare(&self, _project_root: &str) {}
+    fn declare_topics(&self) -> Vec<TopicSpec> {
+        vec![click_commands_topic()]
+    }
 
-    // Opt into per-file dispatch.
+    // Opt into per-file dispatch — the host ignores `run` and calls
+    // `run_on_file` (below) once per file through the salsa-cached query.
     fn per_file(&self) -> Option<&dyn PerFilePlugin> {
         Some(self)
     }
 }
 
-impl PerFilePlugin for PerFileDecorated {
+impl PerFilePlugin for ClickCommandScanner {
     fn run_on_file(&self, file: &PluginFileCtx<'_>, ops: &mut FileOps) {
         // Presence guard: nothing in a file that never imports `click`.
         if !file.imports_any_module(&["click"]) {
@@ -58,27 +92,97 @@ impl PerFilePlugin for PerFileDecorated {
         // File-local indices of decls decorated by `click.command` /
         // `click.group` (matched through this file's imports + aliases).
         for local_idx in file.decorated_decls(&["click"], &["command", "group"]) {
-            ops.keep_alive(local_idx, MARKER.to_string());
+            // Publish a fact pinned to the decl. The host translates the
+            // file-local index to a global node index when it collects the
+            // fact (dropping it if the decl didn't survive assembly); the
+            // value is the decl's fqname, for the reader to use or log.
+            let fqname = file.node(local_idx).map(|n| n.fqname).unwrap_or_default();
+            ops.emit_fact(TOPIC_NAME, Some(local_idx), fqname);
         }
     }
 }
 
-extern "C" fn make_per_file_decorated_plugin() -> *mut c_void {
-    let plugin: Box<dyn ExternalPlugin> = Box::new(PerFileDecorated);
+// --- project-wide reader ----------------------------------------------------
+
+struct ClickCommandKeeper;
+
+impl ExternalPlugin for ClickCommandKeeper {
+    fn name(&self) -> &str {
+        "ExternalClickCommandKeeper"
+    }
+
+    fn declare_node_flags(&self) -> Vec<FlagSpec> {
+        vec![FlagSpec {
+            name: FLAG_NAME.to_string(),
+            seed: true,
+            default_on: true,
+            description: FLAG_DESC.to_string(),
+        }]
+    }
+
+    // Declared on both sides (idempotent) so the handle resolves no matter
+    // which plugin the host registers first.
+    fn declare_topics(&self) -> Vec<TopicSpec> {
+        vec![click_commands_topic()]
+    }
+
+    // The pre-graph hook — a real plugin might read a config file under
+    // `project_root` here to stash project-wide `run` setup. No-op here.
+    fn prepare(&self, _project_root: &str) {}
+
+    fn run(&self, ctx: &PluginCtx<'_>, ops: &mut PluginOps) -> Result<(), PluginError> {
+        // The per-file scanner has already run (facts are collected during
+        // graph assembly, before this project-wide pass), so the topic's
+        // facts are ready to read.
+        let Some(handle) = ctx.topic(TOPIC_NAME) else {
+            return Ok(());
+        };
+        let flag = ctx
+            .node_flag(FLAG_NAME)
+            .expect("click/command is declared in declare_node_flags");
+        for fact in ctx.facts_for_topic(handle) {
+            // A fact pinned to a decl that survived assembly carries its
+            // global node index; stamp the keepalive flag on it.
+            if let Some(decl_idx) = fact.decl_idx {
+                ops.flag_decl(decl_idx, flag);
+            }
+        }
+        Ok(())
+    }
+}
+
+// --- manifest ---------------------------------------------------------------
+
+extern "C" fn make_click_command_scanner() -> *mut c_void {
+    let plugin: Box<dyn ExternalPlugin> = Box::new(ClickCommandScanner);
+    Box::into_raw(Box::new(plugin)) as *mut c_void
+}
+
+extern "C" fn make_click_command_keeper() -> *mut c_void {
+    let plugin: Box<dyn ExternalPlugin> = Box::new(ClickCommandKeeper);
     Box::into_raw(Box::new(plugin)) as *mut c_void
 }
 
 /// The self-contained manifest. Reads only inlined consts + plain data — no
 /// hashed runtime call — so the host can gate on the fingerprint before
-/// touching any version-hashed symbol.
+/// touching any version-hashed symbol. Exports **both** plugins, so loading
+/// this one cdylib registers the per-file emitter and the project-wide reader.
 #[no_mangle]
 pub extern "C" fn _dead_cst_plugin_manifest_v1() -> *const PluginManifest {
-    const NAME: &str = "ExternalPerFileDecoratedPlugin";
-    let descs: Box<[PluginDesc]> = Box::new([PluginDesc {
-        name: NAME.as_ptr(),
-        name_len: NAME.len(),
-        make: make_per_file_decorated_plugin,
-    }]);
+    const SCANNER: &str = "ExternalClickCommandScanner";
+    const KEEPER: &str = "ExternalClickCommandKeeper";
+    let descs: Box<[PluginDesc]> = Box::new([
+        PluginDesc {
+            name: SCANNER.as_ptr(),
+            name_len: SCANNER.len(),
+            make: make_click_command_scanner,
+        },
+        PluginDesc {
+            name: KEEPER.as_ptr(),
+            name_len: KEEPER.len(),
+            make: make_click_command_keeper,
+        },
+    ]);
     let plugins = descs.as_ptr();
     let plugins_len = descs.len();
     Box::leak(descs);

--- a/examples/per_file_main_block/src/lib.rs
+++ b/examples/per_file_main_block/src/lib.rs
@@ -24,13 +24,11 @@
 use std::ffi::c_void;
 
 use dead_cst_runtime::native_plugins::plugin_api::{
-    ExternalPlugin, FileOps, PerFilePlugin, PluginFileCtx, FLAG_ENTRYPOINT,
+    ExternalPlugin, FileOps, PerFilePlugin, PluginFileCtx,
 };
 use dead_cst_runtime::native_plugins::{
     PluginDesc, PluginManifest, PLUGIN_ABI_FINGERPRINT, PLUGIN_MANIFEST_MAGIC,
 };
-
-const MARKER_PREFIX: &str = "<__main__>:per-file:";
 
 struct PerFileMainBlock;
 
@@ -55,27 +53,19 @@ impl PerFilePlugin for PerFileMainBlock {
         };
         let (block_start, block_end) = file.line_span(block);
 
-        // Keep the module node (local index 0) plus every top-level decl
-        // whose source span falls inside the block. All indices are
-        // file-local — the host maps them to global indices at apply time.
-        let mut targets = vec![file.module_local_idx()];
+        // Keep the module node (local index 0) alive, plus every top-level
+        // decl whose source span falls inside the block. `keep_alive` flags
+        // each as a reachability seed directly — all indices are file-local,
+        // and the host maps them to global indices at apply time.
+        ops.keep_alive(file.module_local_idx());
         for node in file.nodes() {
             if node.local_idx != file.module_local_idx()
                 && node.start_line >= block_start
                 && node.end_line <= block_end
             {
-                targets.push(node.local_idx);
+                ops.keep_alive(node.local_idx);
             }
         }
-
-        // One synthetic entrypoint node per file, wired to those targets.
-        // No in-edges — the node is a reachability seed, not a sink.
-        ops.add_synthetic_node(
-            format!("{MARKER_PREFIX}{}", file.module_fqname()),
-            FLAG_ENTRYPOINT,
-            targets,
-            Vec::new(),
-        );
     }
 }
 

--- a/python/dead_cst/_native.pyi
+++ b/python/dead_cst/_native.pyi
@@ -1088,6 +1088,30 @@ class ProjectContext:
         ``None`` when no flag with that name is registered."""
         ...
 
+    # ----- Topic / fact registry --------------------------------------
+    #
+    # Topics are a plugin-only channel for a per-file plugin to publish
+    # facts to its project-wide reader. Plugins declare topics via
+    # ``declare_topics``; the host assigns handles during
+    # :meth:`materialize`. Unlike the flag registries there are no engine
+    # built-ins, and the registry is not serialized into the graph file —
+    # facts are an in-memory build-time side channel.
+
+    def topic_registry(self) -> list[tuple[str, int, str]]:
+        """Every registered topic as ``(name, handle, description)`` tuples
+        in handle (registration) order: the topics registered plugins
+        declared via ``declare_topics`` (empty before :meth:`materialize`)."""
+        ...
+
+    def facts_for_topic(self, name: str) -> list[tuple[str, int | None, str]]:
+        """Every fact published under topic ``name`` across the project, as
+        ``(path, decl_idx, value)`` tuples. ``path`` is the publishing file;
+        ``decl_idx`` is the global node index the fact was pinned to (or
+        ``None``); ``value`` is the plugin-defined payload. Empty for an
+        unknown topic or one nothing published under. Raises if called
+        before :meth:`materialize`."""
+        ...
+
 # ---------- Node-attribute rows ------------------------------------------
 
 class NodeAttrs:

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -18,7 +18,10 @@ use std::process::Command;
 /// registered node flag onto an existing decl, no marker node).
 /// 4 → 5: removed `PluginOps::add_synthetic_node` / `FileOps::add_synthetic_node`
 /// (plugins no longer mint nodes; the `kind="synthetic"` node kind is gone).
-const PLUGIN_API_EPOCH: u32 = 5;
+/// 5 → 6: added the topic/fact channel — `ExternalPlugin::declare_topics`, the
+/// re-exported `TopicSpec` + author-facing `Fact`, `FileOps::emit_fact`, and
+/// `PluginCtx::topic` / `facts_for_topic`.
+const PLUGIN_API_EPOCH: u32 = 6;
 
 /// Compose the ABI fingerprint that gates external native-plugin loading.
 /// It changes whenever anything that could break the dylib ABI changes:

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -38,6 +38,7 @@ pub mod native_plugins;
 mod progress;
 mod project;
 mod query;
+mod topic_registry;
 
 use pyo3::prelude::*;
 

--- a/runtime/src/native_plugins.rs
+++ b/runtime/src/native_plugins.rs
@@ -63,6 +63,7 @@ use crate::helpers::{
 };
 use crate::ingest::file_package_name;
 use crate::project::FrozenView;
+use crate::topic_registry::TopicRegistry;
 
 /// Map a curated [`plugin_api::PluginError`] onto a Python exception. The
 /// curated surface stays pyo3-free; this is the single crossing point where a
@@ -141,6 +142,17 @@ impl PluginJob {
     }
 }
 
+/// Output of [`extract_plugin_jobs`]: the registration-order plugin jobs and
+/// their display names, plus the post-declaration node/edge flag registries
+/// and the topic registry, all built in the one GIL-held pass.
+pub(crate) type ExtractedPlugins = (
+    Vec<PluginJob>,
+    Vec<String>,
+    FlagRegistry,
+    FlagRegistry,
+    TopicRegistry,
+);
+
 /// Pull every registered plugin into a `Send` [`PluginJob`] paired with
 /// its display name, in registration order, under the GIL. Doing the
 /// downcast + kind dispatch here (rather than inside the fan-out) keeps
@@ -151,7 +163,7 @@ impl PluginJob {
 pub(crate) fn extract_plugin_jobs(
     py: Python<'_>,
     plugins: &[PyObject],
-) -> PyResult<(Vec<PluginJob>, Vec<String>, FlagRegistry, FlagRegistry)> {
+) -> PyResult<ExtractedPlugins> {
     let mut jobs = Vec::with_capacity(plugins.len());
     let mut names = Vec::with_capacity(plugins.len());
     // Seed both registries with the engine built-ins, then fold in each
@@ -160,6 +172,10 @@ pub(crate) fn extract_plugin_jobs(
     // declaration surfaces here, on the GIL thread, before the parallel run.
     let mut node_reg = FlagRegistry::with_node_builtins();
     let mut edge_reg = FlagRegistry::with_edge_builtins();
+    // Topics carry no engine built-ins (they're a plugin-only channel); each
+    // plugin's declared topics fold in in the same registration-order pass, so
+    // handle allocation is likewise a pure function of plugin order.
+    let mut topic_reg = TopicRegistry::new();
     for plugin in plugins {
         let bound = plugin.bind(py);
         let native = match bound.downcast::<NativePlugin>() {
@@ -182,6 +198,9 @@ pub(crate) fn extract_plugin_jobs(
             for spec in plugin.declare_edge_flags() {
                 edge_reg.register_plugin(spec)?;
             }
+            for spec in plugin.declare_topics() {
+                topic_reg.register_plugin(spec)?;
+            }
         }
         let (job, name) = match &native_ref.kind {
             NativePluginKind::External {
@@ -200,7 +219,7 @@ pub(crate) fn extract_plugin_jobs(
         jobs.push(job);
         names.push(name);
     }
-    Ok((jobs, names, node_reg, edge_reg))
+    Ok((jobs, names, node_reg, edge_reg, topic_reg))
 }
 
 // ---------------------------------------------------------------------------
@@ -246,6 +265,19 @@ pub(crate) enum FileLocalOp {
     /// shape). ``decl_local_idx`` is a file-local index; unlike
     /// [`FileLocalOp::Entrypoint`] the bits are caller-supplied.
     FlagDecl { decl_local_idx: u32, flags: u32 },
+    /// Publish a fact under a topic **name** (not a registry handle — a handle
+    /// is allocated from the whole plugin set and would couple this file's
+    /// salsa cache to that set). ``decl_local_idx`` optionally pins the fact to
+    /// a file-local decl, translated to a global index at assemble time; a
+    /// fact whose decl fails to translate is dropped. Unlike the other
+    /// variants this does not mutate the graph — it rides the per-file salsa
+    /// cache into [`crate::project::BuildOutputs`] for the topic's project-wide
+    /// reader.
+    Fact {
+        topic: String,
+        decl_local_idx: Option<u32>,
+        value: String,
+    },
 }
 
 /// Read-only, single-file view a [`plugin_api::PerFilePlugin`] is run
@@ -1206,6 +1238,13 @@ pub mod plugin_api {
     // [`PluginCtx::node_flag`] / [`edge_flag`]. Pyo3-free.
     pub use crate::flag_registry::FlagSpec;
 
+    // Topic declaration vocabulary. A plugin returns these from
+    // [`ExternalPlugin::declare_topics`]; the host assigns each a handle and
+    // the plugin resolves a name to its handle via [`PluginCtx::topic`], then
+    // reads the collected [`Fact`]s with [`PluginCtx::facts_for_topic`].
+    // Pyo3-free.
+    pub use crate::topic_registry::TopicSpec;
+
     /// `NodeFlags::ENTRYPOINT` re-exported for plugin authors. The flag
     /// [`PluginOps::keep_alive`] / [`FileOps::keep_alive`] stamp on a decl to
     /// make it a reachability seed; also usable as a `flag_decl` bit.
@@ -1376,6 +1415,20 @@ pub mod plugin_api {
         fn declare_edge_flags(&self) -> Vec<FlagSpec> {
             Vec::new()
         }
+
+        /// Topics this plugin publishes facts under. Each returned
+        /// [`TopicSpec`] is assigned a handle by the host (in registration
+        /// order) before any run; a per-file run emits facts under the topic
+        /// **name** via [`FileOps::emit_fact`], and the project-wide
+        /// [`run`](Self::run) resolves a name to its handle with
+        /// [`PluginCtx::topic`] and reads the collected facts via
+        /// [`PluginCtx::facts_for_topic`]. Declaring the same `owner/name` spec
+        /// from two plugins is idempotent (they share one handle); a
+        /// conflicting re-declaration or an `engine/`-prefixed name fails the
+        /// whole materialize. Default none.
+        fn declare_topics(&self) -> Vec<TopicSpec> {
+            Vec::new()
+        }
     }
 
     /// Per-file capability for an [`ExternalPlugin`]. Invoked once per
@@ -1393,6 +1446,20 @@ pub mod plugin_api {
     pub trait PerFilePlugin: Send + Sync {
         /// Walk `file` and append this file's ops to `ops`.
         fn run_on_file(&self, file: &PluginFileCtx<'_>, ops: &mut FileOps);
+    }
+
+    /// One collected fact, returned by [`PluginCtx::facts_for_topic`] (and the
+    /// Python `ProjectContext.facts_for_topic`). `path` is the file the fact
+    /// was published from; `decl_idx`, when present, is the **global** node
+    /// index the publishing per-file plugin pinned the fact to (its file-local
+    /// index translated at assemble time — a fact whose decl failed to
+    /// translate is dropped, so a `Some` here always names a live node);
+    /// `value` is the plugin-defined payload.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct Fact {
+        pub path: String,
+        pub decl_idx: Option<usize>,
+        pub value: String,
     }
 
     /// Owned, plain-data snapshot of one graph node, returned by
@@ -1963,6 +2030,35 @@ pub mod plugin_api {
         pub fn edge_flag(&self, name: &str) -> Option<u8> {
             self.inner.edge_flags.get(name).map(|bit| bit as u8)
         }
+
+        // --- topic registry -------------------------------------------------
+
+        /// The handle a topic named `name` (`owner/name`) was assigned, or
+        /// `None` if no plugin declared it. A plugin resolves its own declared
+        /// topic this way: the host assigned the handle from
+        /// [`ExternalPlugin::declare_topics`] before `run`, so a plugin that
+        /// declared `name` can `.expect()` the lookup, then pass the handle to
+        /// [`Self::facts_for_topic`].
+        pub fn topic(&self, name: &str) -> Option<u32> {
+            self.inner.topics.get(name)
+        }
+
+        /// Every [`Fact`] published under the topic `handle` across the whole
+        /// project — the per-file plugins' [`FileOps::emit_fact`] output,
+        /// collected during graph assembly. Returns an empty vec for an
+        /// out-of-range handle or a topic nothing published under.
+        pub fn facts_for_topic(&self, handle: u32) -> Vec<Fact> {
+            match self.inner.topics.name_of(handle) {
+                Some(name) => self
+                    .inner
+                    .outputs
+                    .topic_facts
+                    .get(name)
+                    .cloned()
+                    .unwrap_or_default(),
+                None => Vec::new(),
+            }
+        }
     }
 
     /// Op sink for external plugins. Wraps the internal `PreparedOp` vec so
@@ -2232,6 +2328,28 @@ pub mod plugin_api {
                 src_local_idx,
                 dst_local_idx,
                 flags,
+            });
+        }
+
+        /// Publish a fact under topic `topic` (a name declared in
+        /// [`ExternalPlugin::declare_topics`] — emitted by name, not handle, so
+        /// the per-file salsa cache stays independent of the plugin set).
+        /// `decl_local_idx`, when `Some`, pins the fact to a position in
+        /// [`PluginFileCtx::nodes`], translated to a global node index at
+        /// assemble time (a fact whose decl fails to translate is dropped);
+        /// `None` leaves the fact file-scoped. The project-wide side reads it
+        /// back via [`PluginCtx::facts_for_topic`]. Emits a
+        /// [`FileLocalOp::Fact`].
+        pub fn emit_fact(
+            &mut self,
+            topic: impl Into<String>,
+            decl_local_idx: Option<u32>,
+            value: impl Into<String>,
+        ) {
+            self.sink.push(FileLocalOp::Fact {
+                topic: topic.into(),
+                decl_local_idx,
+                value: value.into(),
             });
         }
     }

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -45,6 +45,7 @@ use crate::progress::{
     PHASE_PLUGINS, PHASE_POPULATE,
 };
 use crate::query::_path_re_matches;
+use crate::topic_registry::TopicRegistry;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 /// A ty-backed analysis project with explicitly-injected configuration.
@@ -180,6 +181,15 @@ pub(crate) struct BuildOutputs {
     /// vs `unittest.case.TestCase`) and renamed re-exports to a single key
     /// by construction, so the query is an O(1) lookup with no scan.
     pub(crate) external_base_children: FxHashMap<(File, (u32, u32)), Vec<usize>>,
+    /// Per-file plugin facts, keyed by topic **name** (the salsa-stable key the
+    /// per-file side emits under — see [`crate::native_plugins::FileLocalOp`]).
+    /// Collected from every file's `per_file_plugin_ops` in `assemble_graph`,
+    /// with each fact's optional decl already translated to a global node idx.
+    /// The project-wide plugin pass reads it through
+    /// [`crate::native_plugins::plugin_api::PluginCtx::facts_for_topic`]
+    /// (handle → name → this map); Python reads it via
+    /// `ProjectContext.facts_for_topic`.
+    pub(crate) topic_facts: FxHashMap<String, Vec<crate::native_plugins::plugin_api::Fact>>,
 }
 
 /// Run the three build phases (ingest → hierarchy+imports → references)
@@ -504,6 +514,7 @@ pub(crate) fn build_project_graph(
     let module_nodes_by_file = assembled.module_nodes_by_file;
     let class_by_selection = assembled.class_by_selection;
     let decl_by_name_range = assembled.decl_by_name_range;
+    let topic_facts = assembled.topic_facts;
 
     counters.start_phase(PHASE_FQNAME, Some(builder.nodes.len()));
     let t4 = std::time::Instant::now();
@@ -572,6 +583,7 @@ pub(crate) fn build_project_graph(
         children_by_node,
         external_base_children,
         children_by_parent,
+        topic_facts,
     })
 }
 
@@ -602,6 +614,7 @@ struct AssembledGraph {
     module_nodes_by_file: FxHashMap<File, usize>,
     class_by_selection: FxHashMap<(File, (u32, u32)), usize>,
     decl_by_name_range: FxHashMap<(File, (u32, u32)), usize>,
+    topic_facts: FxHashMap<String, Vec<crate::native_plugins::plugin_api::Fact>>,
 }
 
 /// Serial pass that converts the salsa-tracked per-file payloads
@@ -941,7 +954,7 @@ fn assemble_graph<'db>(
     // global ones via `local_to_global`. Runs here, after the real
     // graph is fully assembled, so every decl endpoint a plugin
     // edge/flag op references already has its global index.
-    fold_per_file_plugin_ops(
+    let topic_facts = fold_per_file_plugin_ops(
         db,
         &mut builder,
         project_files,
@@ -961,6 +974,7 @@ fn assemble_graph<'db>(
         module_nodes_by_file,
         class_by_selection,
         decl_by_name_range,
+        topic_facts,
     })
 }
 
@@ -989,12 +1003,17 @@ fn fold_per_file_plugin_ops(
     project_files: &[File],
     per_file_plugin_ids: &[crate::native_plugins::PerFilePluginId],
     local_to_global: &FxHashMap<(File, u32), usize>,
-) -> PyResult<()> {
+) -> PyResult<FxHashMap<String, Vec<crate::native_plugins::plugin_api::Fact>>> {
+    use crate::native_plugins::plugin_api::Fact;
+    let mut topic_facts: FxHashMap<String, Vec<Fact>> = FxHashMap::default();
     if per_file_plugin_ids.is_empty() {
-        return Ok(());
+        return Ok(topic_facts);
     }
     use crate::native_plugins::{per_file_plugin_ops, FileLocalOp};
     for &file in project_files {
+        // The fact `path` is the same for every fact in this file; resolve
+        // it once, lazily, since most files emit no facts at all.
+        let mut file_path: Option<String> = None;
         for &id in per_file_plugin_ids {
             let file_ops = per_file_plugin_ops(db, file, id);
             if file_ops.is_empty() {
@@ -1032,11 +1051,36 @@ fn fold_per_file_plugin_ops(
                         };
                         builder.nodes[decl_idx].flags |= flags;
                     }
+                    FileLocalOp::Fact {
+                        topic,
+                        decl_local_idx,
+                        value,
+                    } => {
+                        // A fact that pinned a decl is dropped when that decl
+                        // doesn't resolve to a global node — same lenient
+                        // contract as edge/flag ops, and it keeps a `Some`
+                        // `decl_idx` always naming a live node.
+                        let decl_idx = match decl_local_idx {
+                            Some(local) => match to_global(*local) {
+                                Some(global) => Some(global),
+                                None => continue,
+                            },
+                            None => None,
+                        };
+                        let path = file_path
+                            .get_or_insert_with(|| file_path_string(db, file))
+                            .clone();
+                        topic_facts.entry(topic.clone()).or_default().push(Fact {
+                            path,
+                            decl_idx,
+                            value: value.clone(),
+                        });
+                    }
                 }
             }
         }
     }
-    Ok(())
+    Ok(topic_facts)
 }
 
 /// Collect the [`PerFilePluginId`](crate::native_plugins::PerFilePluginId)
@@ -1450,6 +1494,13 @@ pub(crate) struct ProjectContext {
     /// Edge-flag registry — the edge-space twin of
     /// [`Self::node_flag_registry`] (`u8`-width).
     pub(crate) edge_flag_registry: FlagRegistry,
+    /// Topic registry: every topic the registered plugins declared, in
+    /// registration order. Empty at construction (topics are plugin-only —
+    /// no engine built-ins) and overwritten by `materialize` with the
+    /// post-declaration registry. Read by the `topic_registry` /
+    /// `facts_for_topic` getters; not serialized (facts are an in-memory
+    /// build-time channel, not graph-file content).
+    pub(crate) topic_registry: TopicRegistry,
 }
 
 #[pymethods]
@@ -1487,6 +1538,7 @@ impl ProjectContext {
             progress: Arc::new(ProgressCounters::new()),
             node_flag_registry: FlagRegistry::with_node_builtins(),
             edge_flag_registry: FlagRegistry::with_edge_builtins(),
+            topic_registry: TopicRegistry::new(),
         })
     }
 
@@ -1531,6 +1583,40 @@ impl ProjectContext {
     /// :meth:`node_flag`), or ``None`` if undeclared.
     pub(crate) fn edge_flag(&self, name: &str) -> Option<u8> {
         self.edge_flag_registry.get(name).map(|bit| bit as u8)
+    }
+
+    /// Topic registry entries ``(name, handle, description)`` in handle
+    /// (registration) order: every topic the registered plugins declared
+    /// (populated by :meth:`materialize`; empty before then). Topics are a
+    /// plugin-only channel, so there are no engine built-ins.
+    pub(crate) fn topic_registry(&self) -> Vec<(String, u32, String)> {
+        self.topic_registry
+            .entries()
+            .into_iter()
+            .map(|(handle, spec)| (spec.name, handle, spec.description))
+            .collect()
+    }
+
+    /// Every fact published under topic ``name`` across the project, as
+    /// ``(path, decl_idx, value)`` tuples — ``decl_idx`` is the global node
+    /// index a fact was pinned to (or ``None``). Empty for an unknown topic or
+    /// one nothing published under. Errors only if called before
+    /// :meth:`materialize`.
+    pub(crate) fn facts_for_topic(
+        &self,
+        name: &str,
+    ) -> PyResult<Vec<(String, Option<usize>, String)>> {
+        let outputs = self.materialized("facts_for_topic")?;
+        Ok(outputs
+            .topic_facts
+            .get(name)
+            .map(|facts| {
+                facts
+                    .iter()
+                    .map(|f| (f.path.clone(), f.decl_idx, f.value.clone()))
+                    .collect()
+            })
+            .unwrap_or_default())
     }
 
     /// Override the rayon worker stack size (bytes) used by the
@@ -1714,7 +1800,7 @@ impl ProjectContext {
         // ops fold into the graph in one end-of-pass apply, in
         // registration order — the same frozen-graph contract the old
         // Python ``ThreadPoolExecutor`` driver honoured.
-        let (jobs, plugin_names, node_reg, edge_reg) =
+        let (jobs, plugin_names, node_reg, edge_reg, topic_reg) =
             match crate::native_plugins::extract_plugin_jobs(py, &slf.borrow(py).plugins) {
                 Ok(extracted) => extracted,
                 Err(e) => {
@@ -1758,6 +1844,10 @@ impl ProjectContext {
             // after the pass.
             let node_reg_ref = &node_reg;
             let edge_reg_ref = &edge_reg;
+            // The topic registry rides the same way — `&TopicRegistry` is
+            // `Send` (the registry is `Sync`); plugins resolve topic handles
+            // and read collected facts off it inside the GIL-free pass.
+            let topic_reg_ref = &topic_reg;
             // ``base_db`` + ``outputs_lock`` move *into* the closure: a
             // ``&ProjectDatabase`` is ``!Send`` (salsa's ``ZalsaLocal`` is
             // ``!Sync``), so — like every GIL-free per-file scan here — we
@@ -1781,6 +1871,7 @@ impl ProjectContext {
                                     root_ref,
                                     node_reg_ref,
                                     edge_reg_ref,
+                                    topic_reg_ref,
                                 );
                                 let mut sink: Vec<PreparedOp> = Vec::new();
                                 let res = job.run(&view, &mut sink).map(|()| sink);
@@ -1836,6 +1927,7 @@ impl ProjectContext {
             let mut this = slf.borrow_mut(py);
             this.node_flag_registry = node_reg;
             this.edge_flag_registry = edge_reg;
+            this.topic_registry = topic_reg;
         }
 
         // The plugin pass can still reload individual files on demand:
@@ -3548,6 +3640,11 @@ pub(crate) struct FrozenView<'a> {
     /// `edge_flag`.
     pub(crate) node_flags: &'a FlagRegistry,
     pub(crate) edge_flags: &'a FlagRegistry,
+    /// Frozen topic registry, lent the same way as the flag registries so a
+    /// plugin resolves a declared topic name to its handle via
+    /// [`crate::native_plugins::plugin_api::PluginCtx::topic`] and reads the
+    /// collected facts via `facts_for_topic`.
+    pub(crate) topics: &'a TopicRegistry,
 }
 
 impl<'a> FrozenView<'a> {
@@ -3557,6 +3654,7 @@ impl<'a> FrozenView<'a> {
         root: &'a str,
         node_flags: &'a FlagRegistry,
         edge_flags: &'a FlagRegistry,
+        topics: &'a TopicRegistry,
     ) -> Self {
         Self {
             db,
@@ -3564,6 +3662,7 @@ impl<'a> FrozenView<'a> {
             root,
             node_flags,
             edge_flags,
+            topics,
         }
     }
 

--- a/runtime/src/topic_registry.rs
+++ b/runtime/src/topic_registry.rs
@@ -1,0 +1,159 @@
+//! Topic registry: the declare side of the per-file → project-wide *fact*
+//! channel.
+//!
+//! A plugin declares topics via
+//! [`ExternalPlugin::declare_topics`](crate::native_plugins::plugin_api::ExternalPlugin::declare_topics);
+//! the host assigns each a small integer handle in registration order. A
+//! per-file plugin then publishes facts under a topic **name** (a salsa-stable
+//! string it hard-codes — a registry-allocated handle can't ride the per-file
+//! salsa cache without coupling it to the plugin set), and the project-wide
+//! side resolves a handle back to its name to read the collected facts via
+//! [`PluginCtx::facts_for_topic`](crate::native_plugins::plugin_api::PluginCtx::facts_for_topic).
+//!
+//! [`TopicSpec`] is the only author-facing type (re-exported from
+//! `plugin_api`); it is pyo3-free. [`TopicRegistry`] is host-internal and
+//! never crosses the plugin airlock — plugins resolve a name to a handle
+//! through `PluginCtx::topic`, which hands back a plain `Option<u32>`. The
+//! shape mirrors [`FlagRegistry`](crate::flag_registry::FlagRegistry); topics
+//! carry no bit-width cap (the handle is a sequential index, not a packed
+//! bit), so there is no engine-registration or exhaustion path.
+
+use rustc_hash::FxHashMap;
+
+use crate::native_plugins::plugin_api::PluginError;
+
+/// Declarative description of one topic. `name` is `owner/name` namespaced;
+/// the `engine/` owner is reserved (there are no engine topics today, but the
+/// namespace is held for symmetry with [`FlagSpec`](crate::flag_registry::FlagSpec)).
+#[derive(Debug, Clone)]
+pub struct TopicSpec {
+    pub name: String,
+    pub description: String,
+}
+
+/// A name↔handle registry over topics. Seeded empty (topics are
+/// plugin-declared — no engine built-ins), then frozen after the plugin
+/// declaration pass and lent read-only into the parallel plugin run.
+pub(crate) struct TopicRegistry {
+    by_name: FxHashMap<String, u32>,
+    /// Specs in registration order; the `Vec` index is the topic's handle.
+    specs: Vec<TopicSpec>,
+}
+
+impl TopicRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            by_name: FxHashMap::default(),
+            specs: Vec::new(),
+        }
+    }
+
+    /// Register a plugin topic, allocating the next sequential handle.
+    /// Idempotent on an identical spec (so a topic two plugins share collapses
+    /// to one handle); a conflicting re-registration (same name, different
+    /// description) or an `engine/`-prefixed name fails loudly.
+    pub(crate) fn register_plugin(&mut self, spec: TopicSpec) -> Result<u32, PluginError> {
+        if spec.name.starts_with("engine/") {
+            return Err(PluginError::value(format!(
+                "plugin topic {:?}: the 'engine/' namespace is reserved",
+                spec.name
+            )));
+        }
+        if let Some(&handle) = self.by_name.get(&spec.name) {
+            let existing = &self.specs[handle as usize];
+            if existing.description != spec.description {
+                return Err(PluginError::value(format!(
+                    "topic {:?} re-registered with a conflicting description",
+                    spec.name
+                )));
+            }
+            return Ok(handle);
+        }
+        let handle = self.specs.len() as u32;
+        self.by_name.insert(spec.name.clone(), handle);
+        self.specs.push(spec);
+        Ok(handle)
+    }
+
+    /// The handle for `name`, if registered.
+    pub(crate) fn get(&self, name: &str) -> Option<u32> {
+        self.by_name.get(name).copied()
+    }
+
+    /// The name for `handle`, if in range — the inverse of [`Self::get`], used
+    /// to look up a topic's collected facts from a handle.
+    pub(crate) fn name_of(&self, handle: u32) -> Option<&str> {
+        self.specs.get(handle as usize).map(|s| s.name.as_str())
+    }
+
+    /// All `(handle, spec)` entries in handle order — for the
+    /// `ProjectContext` getter.
+    pub(crate) fn entries(&self) -> Vec<(u32, TopicSpec)> {
+        self.specs
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(i, spec)| (i as u32, spec))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(name: &str, description: &str) -> TopicSpec {
+        TopicSpec {
+            name: name.to_string(),
+            description: description.to_string(),
+        }
+    }
+
+    #[test]
+    fn handles_allocate_sequentially_in_registration_order() {
+        let mut reg = TopicRegistry::new();
+        assert_eq!(reg.register_plugin(spec("acme/a", "")).unwrap(), 0);
+        assert_eq!(reg.register_plugin(spec("acme/b", "")).unwrap(), 1);
+        assert_eq!(reg.get("acme/a"), Some(0));
+        assert_eq!(reg.get("acme/b"), Some(1));
+        assert_eq!(reg.name_of(1), Some("acme/b"));
+        assert_eq!(reg.name_of(2), None);
+    }
+
+    #[test]
+    fn shared_topic_registration_is_idempotent() {
+        let mut reg = TopicRegistry::new();
+        let first = reg.register_plugin(spec("test/cases", "decl ids")).unwrap();
+        let again = reg.register_plugin(spec("test/cases", "decl ids")).unwrap();
+        assert_eq!(first, again);
+        assert_eq!(reg.entries().len(), 1);
+    }
+
+    #[test]
+    fn conflicting_reregistration_fails() {
+        let mut reg = TopicRegistry::new();
+        reg.register_plugin(spec("test/cases", "decl ids")).unwrap();
+        assert!(reg
+            .register_plugin(spec("test/cases", "something else"))
+            .is_err());
+    }
+
+    #[test]
+    fn engine_prefix_is_reserved() {
+        let mut reg = TopicRegistry::new();
+        assert!(reg.register_plugin(spec("engine/sneaky", "")).is_err());
+    }
+
+    #[test]
+    fn entries_are_handle_ordered() {
+        let mut reg = TopicRegistry::new();
+        reg.register_plugin(spec("acme/first", "1")).unwrap();
+        reg.register_plugin(spec("acme/second", "2")).unwrap();
+        let entries = reg.entries();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].0, 0);
+        assert_eq!(entries[0].1.name, "acme/first");
+        assert_eq!(entries[1].0, 1);
+        assert_eq!(entries[1].1.name, "acme/second");
+    }
+}

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -1,0 +1,35 @@
+"""Smoke tests for the topic/fact channel getters on ``ProjectContext``.
+
+The full declare-topic -> emit-fact -> read-fact round trip runs through an
+external (dylib) native plugin and is exercised by the CI-gated plugin-host
+suite; the dev/static build can't load external plugins. These tests pin the
+locally-observable surface: with no topic-declaring plugin registered the
+registry is empty, and ``facts_for_topic`` is guarded behind materialization.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dead_cst import _native as native
+
+
+def test_topic_registry_empty_without_topic_plugins(build_decl_graph):
+    graph = build_decl_graph({"mod.py": "def a(): pass\n"})
+    assert graph.topic_registry() == []
+    assert graph.facts_for_topic("acme/anything") == []
+
+
+def test_topic_registry_empty_before_materialize(tmp_path):
+    # ``topic_registry`` reads the registry built at construction time, so it
+    # decodes even on a never-materialized context (here: empty, no plugins).
+    ctx = native.ProjectContext(str(tmp_path))
+    assert ctx.topic_registry() == []
+
+
+def test_facts_for_topic_raises_before_materialize(tmp_path):
+    # Facts only exist after a build, so the getter rejects a call made
+    # outside an active materialize() (e.g. from a plugin's run()).
+    ctx = native.ProjectContext(str(tmp_path))
+    with pytest.raises(RuntimeError):
+        ctx.facts_for_topic("acme/anything")


### PR DESCRIPTION
## Summary

- Per-file native plugins can now hand structured facts up to their project-wide portion through a new topic/fact side channel, modeled on the existing flag-registry pattern (`engine/`-reserved, idempotent-on-identical-spec registration).
- A plugin declares topics with `ExternalPlugin::declare_topics() -> Vec<TopicSpec>`, emits per-file facts with `FileOps::emit_fact(topic_name, decl_local_idx, value)`, and reads them project-wide via `PluginCtx::topic(name) -> Option<u32>` + `facts_for_topic(handle) -> Vec<Fact>`. Each `Fact` carries the source path, an optional global decl index (the file-local decl translated at assemble time, or the fact dropped if it can't resolve), and a `String` value.
- Emit is **by topic name** (salsa-stable), so the per-file salsa cache stays a pure function of the file; the project-wide side resolves the name to a handle. Facts are an in-memory build-time channel — **not** graph-mutating and **not** serialized into the graph file.
- `ProjectContext.topic_registry()` / `facts_for_topic(name)` expose the same data to Python. Bumps `PLUGIN_API_EPOCH` to 6.

## Implementation

- New `runtime/src/topic_registry.rs` (`TopicSpec` / `TopicRegistry`, pyo3-free, with unit tests).
- `native_plugins.rs`: `Fact` author type, `FileLocalOp::Fact`, `declare_topics`, `emit_fact`, `PluginCtx::topic` / `facts_for_topic`; built into the existing registration-order `extract_plugin_jobs` pass.
- `project.rs`: `BuildOutputs.topic_facts` (keyed by name), collected + decl-translated in `fold_per_file_plugin_ops`, threaded through `FrozenView` and swapped onto `ProjectContext` at materialize; the two Python getters.
- `build.rs` epoch bump; `_native.pyi` + `NATIVE_PLUGINS.md` + `CHANGELOG.md` docs.

## Test plan

- [x] `cargo build` / `cargo clippy --all-targets` clean
- [x] `cargo fmt` clean; full `prek run --all-files` green
- [x] `uv run pytest` — 703 passed / 3 skipped (incl. new `tests/test_topics.py` getter smoke tests)
- [x] 5 `TopicRegistry` Rust unit tests (engine-reserved, idempotent, conflict, lookup)
- [ ] Full declare→emit→read round trip runs through an external dylib plugin and stays CI-gated (the dev/static build can't load external plugins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)