### PR TITLE
Parallelize the bulk edge insert and the fqname-index build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,17 @@ two versions.
 
 ### Changed
 
+- **Parallel edge-storage init and fqname-index map-reduce.** Two more serial
+  build chunks now run on rayon workers with the GIL released. The assemble
+  pass's bulk edge insert (`GraphBuilder::init_edges_bulk`) derives `edges`,
+  `edge_set`, and both adjacency tables from the sorted triple list on
+  concurrent tasks — the per-node adjacency lists are written as a partitioned
+  scatter over disjoint `&mut` windows, each list allocated once at its exact
+  size. `build_fqname_indices` becomes a rayon fold/reduce whose ordered merge
+  reproduces the serial loop's index order exactly. Both outputs are
+  bit-for-bit identical to the serial versions (parity-tested); on a 4-core
+  machine the edge insert runs ~2× faster and the fqname phase ~1.4×, another
+  ~12% off end-to-end `materialize()` on decl-heavy projects.
 - **Parallel node mint in the assemble pass.** The first phase of
   `assemble_graph` (per-file `GraphNode` minting plus the secondary index
   folds) now fans out across rayon workers with the GIL released, writing each

--- a/runtime/src/builder.rs
+++ b/runtime/src/builder.rs
@@ -255,6 +255,134 @@ impl GraphBuilder {
             }
         }
     }
+
+    /// Bulk-*initialize* the edge storage from a pre-sorted,
+    /// pre-deduplicated triple list — the assemble pass's one big
+    /// batch. Requires an edge-less builder (debug-asserted): with no
+    /// pre-existing edges to merge against, every piece of the edge
+    /// storage is derived from `triples` independently, on concurrent
+    /// rayon tasks. Callers should release the GIL around this.
+    ///
+    /// * `edges` is the triple list itself (moved in, no copy).
+    /// * `edge_set` is folded by a sibling task — still needed, since
+    ///   later `add_edge` / `extend_edges` calls (peer-stub edges, the
+    ///   plugin apply pass) dedup against it.
+    /// * `forward_adj`: `triples` is sorted by `(src, dst, flags)`, so
+    ///   each node's out-list is one contiguous run; [`scatter_adjacency`]
+    ///   partitions the runs into worker chunks and writes each chunk's
+    ///   disjoint `forward_adj[lo..hi]` window in parallel.
+    /// * `reverse_adj`: the same scatter over a copy re-sorted by
+    ///   `(dst, src, flags)`.
+    ///
+    /// The result — including every per-node adjacency order — is
+    /// identical to looping the same triples through [`extend_edges`].
+    pub(crate) fn init_edges_bulk(&mut self, triples: Vec<(usize, usize, u8)>) {
+        debug_assert!(
+            self.edges.is_empty() && self.edge_set.is_empty(),
+            "init_edges_bulk requires an edge-less builder"
+        );
+        debug_assert!(
+            triples.windows(2).all(|w| w[0] < w[1]),
+            "init_edges_bulk requires sorted + deduplicated triples"
+        );
+        if triples.is_empty() {
+            return;
+        }
+        let mut edge_set = std::mem::take(&mut self.edge_set);
+        let forward = self.forward_adj.as_mut_slice();
+        let reverse = self.reverse_adj.as_mut_slice();
+        let triples_ref = &triples;
+        rayon::join(
+            || {
+                edge_set.reserve(triples_ref.len());
+                edge_set.extend(triples_ref.iter().copied());
+            },
+            || {
+                rayon::join(
+                    || {
+                        scatter_adjacency(forward, triples_ref, |&(src, dst, flags)| {
+                            (src, (dst, flags))
+                        })
+                    },
+                    || {
+                        use rayon::prelude::*;
+                        let mut by_dst = triples_ref.clone();
+                        by_dst.par_sort_unstable_by_key(|&(src, dst, flags)| (dst, src, flags));
+                        scatter_adjacency(reverse, &by_dst, |&(src, dst, flags)| {
+                            (dst, (src, flags))
+                        });
+                    },
+                );
+            },
+        );
+        self.edge_set = edge_set;
+        self.edges = triples;
+    }
+}
+
+/// Scatter `rows` — sorted by the key half of `key_entry`'s return —
+/// into `adj`, writing each key's contiguous run as that node's
+/// adjacency list (replacing the empty placeholder `Vec`, so each list
+/// is allocated exactly once at its final size).
+///
+/// This is a partitioned scatter, not a reduction: rows are chunked at
+/// run boundaries (~8 chunks per worker for load balance), so chunk
+/// `i`'s keys are all strictly smaller than chunk `i + 1`'s and each
+/// chunk owns a disjoint `adj[lo..hi]` window carved off with
+/// `split_at_mut` — no locks, no merge pass.
+#[allow(clippy::type_complexity)]
+fn scatter_adjacency(
+    adj: &mut [Vec<(usize, u8)>],
+    rows: &[(usize, usize, u8)],
+    key_entry: fn(&(usize, usize, u8)) -> (usize, (usize, u8)),
+) {
+    use rayon::prelude::*;
+    if rows.is_empty() {
+        return;
+    }
+    let n_chunks = (rayon::current_num_threads() * 8).max(1);
+    let approx = rows.len().div_ceil(n_chunks);
+    // Row ranges aligned to run boundaries: extend each chunk until the
+    // key changes so no run straddles two chunks.
+    let mut chunks: Vec<(usize, usize)> = Vec::with_capacity(n_chunks + 1);
+    let mut start = 0;
+    while start < rows.len() {
+        let mut end = (start + approx).min(rows.len());
+        let key = key_entry(&rows[end - 1]).0;
+        while end < rows.len() && key_entry(&rows[end]).0 == key {
+            end += 1;
+        }
+        chunks.push((start, end));
+        start = end;
+    }
+    // Carve a disjoint `adj` window per chunk. Chunk keys are sorted
+    // and chunk-exclusive, so splitting after each chunk's last key
+    // hands every window to exactly one worker.
+    let mut windows: Vec<(usize, &mut [Vec<(usize, u8)>], usize, usize)> =
+        Vec::with_capacity(chunks.len());
+    let mut rest = adj;
+    let mut consumed = 0usize;
+    for &(row_start, row_end) in &chunks {
+        let last_key = key_entry(&rows[row_end - 1]).0;
+        let (head, tail) = rest.split_at_mut(last_key + 1 - consumed);
+        windows.push((consumed, head, row_start, row_end));
+        consumed = last_key + 1;
+        rest = tail;
+    }
+    windows
+        .into_par_iter()
+        .for_each(|(base, window, row_start, row_end)| {
+            let mut i = row_start;
+            while i < row_end {
+                let key = key_entry(&rows[i]).0;
+                let mut j = i + 1;
+                while j < row_end && key_entry(&rows[j]).0 == key {
+                    j += 1;
+                }
+                window[key - base] = rows[i..j].iter().map(|r| key_entry(r).1).collect();
+                i = j;
+            }
+        });
 }
 
 pub(crate) fn not_materialized(op: &str) -> PyErr {
@@ -618,6 +746,80 @@ mod tests {
         let r = bfs(&b, [0], Direction::Forward, 0);
         assert!(r.contains(&0));
         assert_eq!(r.len(), 1);
+    }
+
+    // -- init_edges_bulk ----------------------------------------------------
+
+    /// Deterministic pseudo-random `(src, dst, flags)` triples over
+    /// `n_nodes`, sorted + deduplicated — the exact precondition
+    /// `init_edges_bulk` documents. Plain LCG; no rng dependency.
+    fn make_sorted_triples(n_nodes: usize, n_edges: usize, seed: u64) -> Vec<(usize, usize, u8)> {
+        let mut state = seed;
+        let mut next = || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (state >> 33) as usize
+        };
+        let mut t: Vec<(usize, usize, u8)> = (0..n_edges)
+            .map(|_| (next() % n_nodes, next() % n_nodes, (next() % 3) as u8))
+            .collect();
+        t.sort_unstable();
+        t.dedup();
+        t
+    }
+
+    /// Assert every edge-side field of two builders matches, including
+    /// per-node adjacency order (the documented bit-for-bit contract).
+    fn assert_same_edges(a: &GraphBuilder, b: &GraphBuilder) {
+        assert_eq!(a.edges, b.edges);
+        assert_eq!(a.edge_set, b.edge_set);
+        assert_eq!(a.forward_adj, b.forward_adj);
+        assert_eq!(a.reverse_adj, b.reverse_adj);
+    }
+
+    #[test]
+    fn init_edges_bulk_matches_extend_edges() {
+        for (n_nodes, n_edges, seed) in [(1, 5, 7), (10, 40, 1), (50, 600, 2), (500, 5000, 3)] {
+            let triples = make_sorted_triples(n_nodes, n_edges, seed);
+            let mut serial = empty_builder_with_n_slots(n_nodes);
+            serial.extend_edges(triples.clone());
+            let mut bulk = empty_builder_with_n_slots(n_nodes);
+            bulk.init_edges_bulk(triples);
+            assert_same_edges(&serial, &bulk);
+        }
+    }
+
+    #[test]
+    fn init_edges_bulk_empty_is_noop() {
+        let mut b = empty_builder_with_n_slots(3);
+        b.init_edges_bulk(Vec::new());
+        assert!(b.edges.is_empty());
+        assert!(b.edge_set.is_empty());
+        assert!(b.forward_adj.iter().all(Vec::is_empty));
+        assert!(b.reverse_adj.iter().all(Vec::is_empty));
+    }
+
+    #[test]
+    fn init_edges_bulk_trailing_isolated_nodes_stay_empty() {
+        // Edges touch only node 0; nodes 1..4 keep their empty lists
+        // (the scatter's final `split_at_mut` window never reaches them).
+        let mut b = empty_builder_with_n_slots(5);
+        b.init_edges_bulk(vec![(0, 0, 0)]);
+        assert_eq!(b.forward_adj[0], vec![(0, 0)]);
+        assert!(b.forward_adj[1..].iter().all(Vec::is_empty));
+        assert!(b.reverse_adj[1..].iter().all(Vec::is_empty));
+    }
+
+    #[test]
+    fn init_edges_bulk_seeds_edge_set_for_later_extend() {
+        // A later extend_edges (the pass-3 / plugin path) must dedup
+        // against the bulk-initialized edge_set.
+        let mut b = empty_builder_with_n_slots(3);
+        b.init_edges_bulk(vec![(0, 1, 0), (1, 2, 0)]);
+        b.extend_edges(vec![(0, 1, 0), (2, 0, 0)]);
+        assert_eq!(b.edges, vec![(0, 1, 0), (1, 2, 0), (2, 0, 0)]);
+        assert_eq!(b.forward_adj[0], vec![(1, 0)]);
     }
 
     #[test]

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -520,7 +520,7 @@ pub(crate) fn build_project_graph(
     counters.start_phase(PHASE_FQNAME, Some(builder.nodes.len()));
     let t4 = std::time::Instant::now();
     let (decl_by_fqname, module_by_fqname, imports_by_module, children_by_parent) =
-        build_fqname_indices(&builder, counters);
+        py.allow_threads(|| build_fqname_indices(&builder, counters));
     let t_fqname = t4.elapsed();
     counters.finish_phase(PHASE_FQNAME);
 
@@ -943,8 +943,10 @@ fn assemble_graph<'db>(
     //       Drops endpoints whose owning file wasn't enumerated.
     //
     // After the parallel phase, sort + dedup the triple list and
-    // bulk-insert via `extend_edges` (which still probes `edge_set`
-    // so any pre-existing edges merge cleanly).
+    // bulk-initialize the edge storage via `init_edges_bulk` — the
+    // builder has no edges yet, so the adjacency lists are scattered
+    // from the sorted triples on rayon workers instead of looping
+    // `extend_edges`'s serial per-edge probe.
     //
     // Skipped endpoints reference Definitions in non-project files.
 
@@ -1049,9 +1051,12 @@ fn assemble_graph<'db>(
         t
     });
 
-    // Bulk-insert the translated triples. `extend_edges` keeps
-    // the `edge_set` dedup so any prior edges merge correctly.
-    builder.extend_edges(std::mem::take(&mut triples));
+    // Bulk-initialize the edge storage from the translated triples.
+    // The builder is edge-less here (pass 1 mints only nodes), so the
+    // adjacency fills run as a parallel scatter; the GIL is released
+    // for the same reason as 2c.
+    let bulk_triples = std::mem::take(&mut triples);
+    py.allow_threads(|| builder.init_edges_bulk(bulk_triples));
 
     // Warnings are still serial — they live on `FileRefEdges` only.
     for payload in &ref_edge_payloads {
@@ -1354,11 +1359,12 @@ fn build_class_hierarchy_indices(
 
 /// Pre-build the fqname -> idx maps used by ``find_declarations``,
 /// ``find_module``, ``find_imports_of``, and ``module_surface``. One
-/// pass over interned nodes; module entries are 1:1 (one module node
-/// per fqname) while decl entries (and per-upstream-module import
-/// entries) can have multiple binders for the same key — try/except
-/// rebinds, conditional re-imports, and multiple ``from X import Y, Z``
-/// aliases all bind into the same upstream module.
+/// map-reduce pass over interned nodes (callers should release the
+/// GIL); module entries are 1:1 (one module node per fqname) while
+/// decl entries (and per-upstream-module import entries) can have
+/// multiple binders for the same key — try/except rebinds, conditional
+/// re-imports, and multiple ``from X import Y, Z`` aliases all bind
+/// into the same upstream module.
 ///
 /// ``children_by_parent`` is the fqname-tree index used by
 /// :meth:`ProjectContext::module_surface` and
@@ -1376,52 +1382,111 @@ pub(crate) fn build_fqname_indices(
     FxHashMap<String, Vec<usize>>,
     FxHashMap<String, Vec<usize>>,
 ) {
-    let mut decls: FxHashMap<String, Vec<usize>> = FxHashMap::default();
-    let mut modules: FxHashMap<String, usize> = FxHashMap::default();
-    let mut imports_by_module: FxHashMap<String, Vec<usize>> = FxHashMap::default();
-    let mut children_by_parent: FxHashMap<String, Vec<usize>> = FxHashMap::default();
-    for (idx, node) in builder.nodes.iter().enumerate() {
-        counters.fqname_inc();
-        // `@typing.overload`-decorated stubs of an in-file overload group
-        // are excluded from the fqname trie so cross-module `from mod
-        // import f` resolves to the impl only. Reachability still anchors
-        // them via the explicit `impl → stub` edge emitted in
-        // `file_to_edges`.
-        if node.is_overload {
-            continue;
+    use rayon::prelude::*;
+    use std::collections::hash_map::Entry;
+
+    /// Per-range accumulator for the rayon `fold`: the four maps, built
+    /// over one contiguous slice of `builder.nodes`.
+    #[derive(Default)]
+    struct FqnameAcc {
+        decls: FxHashMap<String, Vec<usize>>,
+        modules: FxHashMap<String, usize>,
+        imports_by_module: FxHashMap<String, Vec<usize>>,
+        children_by_parent: FxHashMap<String, Vec<usize>>,
+    }
+
+    /// Merge a right-range multi-map into the left one, appending the
+    /// right's index lists after the left's. Entries move (no String
+    /// re-clone); an empty left steals the right map outright so
+    /// reducing against the identity accumulator is free.
+    fn merge_multi(into: &mut FxHashMap<String, Vec<usize>>, from: FxHashMap<String, Vec<usize>>) {
+        if into.is_empty() {
+            *into = from;
+            return;
         }
-        let mut index_child = false;
-        match node.kind {
-            "module" => {
-                modules.insert(node.fqname.clone(), idx);
-                index_child = true;
-            }
-            "function" | "class" | "variable" => {
-                decls.entry(node.fqname.clone()).or_default().push(idx);
-                index_child = true;
-            }
-            "import" => {
-                decls.entry(node.fqname.clone()).or_default().push(idx);
-                if let Some(import) = node.imports.as_ref() {
-                    imports_by_module
-                        .entry(import.module.clone())
-                        .or_default()
-                        .push(idx);
+        into.reserve(from.len());
+        for (k, v) in from {
+            match into.entry(k) {
+                Entry::Occupied(mut e) => e.get_mut().extend(v),
+                Entry::Vacant(e) => {
+                    e.insert(v);
                 }
-                index_child = true;
             }
-            _ => {}
-        }
-        if index_child {
-            let parent = node
-                .fqname
-                .rsplit_once('.')
-                .map(|(p, _)| p.to_string())
-                .unwrap_or_default();
-            children_by_parent.entry(parent).or_default().push(idx);
         }
     }
-    (decls, modules, imports_by_module, children_by_parent)
+
+    // Map-reduce over the node table. The fold builds per-range maps
+    // (where the String clones + hashing happen, on rayon workers);
+    // the reduce merges adjacent ranges left-to-right. rayon's reduce
+    // tree combines accumulators in sequence order — `op(left, right)`
+    // over adjacent ranges, never reordered — so appending right after
+    // left reproduces the serial loop's idx order in every Vec, and
+    // `modules.extend` (right wins) reproduces its last-write-wins.
+    // Output is deterministic and identical to the serial fold.
+    let acc = builder
+        .nodes
+        .par_iter()
+        .enumerate()
+        .with_min_len(1024)
+        .fold(FqnameAcc::default, |mut acc, (idx, node)| {
+            counters.fqname_inc();
+            // `@typing.overload`-decorated stubs of an in-file overload group
+            // are excluded from the fqname trie so cross-module `from mod
+            // import f` resolves to the impl only. Reachability still anchors
+            // them via the explicit `impl → stub` edge emitted in
+            // `file_to_edges`.
+            if node.is_overload {
+                return acc;
+            }
+            let mut index_child = false;
+            match node.kind {
+                "module" => {
+                    acc.modules.insert(node.fqname.clone(), idx);
+                    index_child = true;
+                }
+                "function" | "class" | "variable" => {
+                    acc.decls.entry(node.fqname.clone()).or_default().push(idx);
+                    index_child = true;
+                }
+                "import" => {
+                    acc.decls.entry(node.fqname.clone()).or_default().push(idx);
+                    if let Some(import) = node.imports.as_ref() {
+                        acc.imports_by_module
+                            .entry(import.module.clone())
+                            .or_default()
+                            .push(idx);
+                    }
+                    index_child = true;
+                }
+                _ => {}
+            }
+            if index_child {
+                let parent = node
+                    .fqname
+                    .rsplit_once('.')
+                    .map(|(p, _)| p.to_string())
+                    .unwrap_or_default();
+                acc.children_by_parent.entry(parent).or_default().push(idx);
+            }
+            acc
+        })
+        .reduce(FqnameAcc::default, |mut a, b| {
+            merge_multi(&mut a.decls, b.decls);
+            if a.modules.is_empty() {
+                a.modules = b.modules;
+            } else {
+                a.modules.extend(b.modules);
+            }
+            merge_multi(&mut a.imports_by_module, b.imports_by_module);
+            merge_multi(&mut a.children_by_parent, b.children_by_parent);
+            a
+        });
+    (
+        acc.decls,
+        acc.modules,
+        acc.imports_by_module,
+        acc.children_by_parent,
+    )
 }
 
 /// Plugin-aware project graph builder.
@@ -4466,4 +4531,149 @@ pub(crate) fn make_db(root: &str, env: EnvironmentOptions) -> PyResult<ProjectDa
     })?;
     let system = OsSystem::new(cwd);
     Ok(ProjectDatabase::use_defaults(metadata, system))
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pure-rust tests for the project-level index builders. The
+    //! salsa/pyo3-backed pipeline is exercised end-to-end by the
+    //! python suite; here we cover `build_fqname_indices`' map-reduce
+    //! against a serial reference over hand-built `GraphNode` tables.
+    use super::*;
+    use crate::file_payload::ImportPayload;
+
+    fn node(fqname: &str, kind: &'static str) -> GraphNode {
+        GraphNode {
+            fqname: fqname.to_string(),
+            kind,
+            ..GraphNode::default()
+        }
+    }
+
+    /// The pre-map-reduce serial loop, kept verbatim as the reference.
+    #[allow(clippy::type_complexity)]
+    fn serial_reference(
+        builder: &GraphBuilder,
+    ) -> (
+        FxHashMap<String, Vec<usize>>,
+        FxHashMap<String, usize>,
+        FxHashMap<String, Vec<usize>>,
+        FxHashMap<String, Vec<usize>>,
+    ) {
+        let mut decls: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+        let mut modules: FxHashMap<String, usize> = FxHashMap::default();
+        let mut imports_by_module: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+        let mut children_by_parent: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+        for (idx, node) in builder.nodes.iter().enumerate() {
+            if node.is_overload {
+                continue;
+            }
+            let mut index_child = false;
+            match node.kind {
+                "module" => {
+                    modules.insert(node.fqname.clone(), idx);
+                    index_child = true;
+                }
+                "function" | "class" | "variable" => {
+                    decls.entry(node.fqname.clone()).or_default().push(idx);
+                    index_child = true;
+                }
+                "import" => {
+                    decls.entry(node.fqname.clone()).or_default().push(idx);
+                    if let Some(import) = node.imports.as_ref() {
+                        imports_by_module
+                            .entry(import.module.clone())
+                            .or_default()
+                            .push(idx);
+                    }
+                    index_child = true;
+                }
+                _ => {}
+            }
+            if index_child {
+                let parent = node
+                    .fqname
+                    .rsplit_once('.')
+                    .map(|(p, _)| p.to_string())
+                    .unwrap_or_default();
+                children_by_parent.entry(parent).or_default().push(idx);
+            }
+        }
+        (decls, modules, imports_by_module, children_by_parent)
+    }
+
+    fn assert_matches_reference(builder: &GraphBuilder) {
+        let counters = Arc::new(ProgressCounters::new());
+        let expected = serial_reference(builder);
+        let actual = build_fqname_indices(builder, &counters);
+        // Vec orders matter: multi-binder decl lists and
+        // children_by_parent buckets are index-ordered in the serial
+        // loop, and the ordered reduce must reproduce that exactly.
+        assert_eq!(actual.0, expected.0);
+        assert_eq!(actual.1, expected.1);
+        assert_eq!(actual.2, expected.2);
+        assert_eq!(actual.3, expected.3);
+    }
+
+    #[test]
+    fn fqname_indices_match_serial_reference_small() {
+        let mut b = GraphBuilder::with_capacity(0);
+        b.nodes.push(node("pkg.mod", "module"));
+        b.nodes.push(node("pkg.mod.f", "function"));
+        b.nodes.push(node("pkg.mod.C", "class"));
+        b.nodes.push(node("pkg.mod.x", "variable"));
+        let mut imp = node("pkg.mod.os", "import");
+        imp.imports = Some(ImportPayload {
+            module: "os".to_string(),
+            decl: None,
+            star: false,
+        });
+        b.nodes.push(imp);
+        // Shadowed decl: same fqname, second binder — multi-entry list.
+        b.nodes.push(node("pkg.mod.f", "function"));
+        // Overload stubs are skipped entirely.
+        let mut ov = node("pkg.mod.g", "function");
+        ov.is_overload = true;
+        b.nodes.push(ov);
+        // External nodes don't index.
+        b.nodes.push(node("[external dist] numpy", "external"));
+        // Top-level name buckets under the empty-string parent.
+        b.nodes.push(node("toplevel", "module"));
+        assert_matches_reference(&b);
+    }
+
+    #[test]
+    fn fqname_indices_match_serial_reference_large() {
+        // Big enough that rayon actually splits (with_min_len = 1024),
+        // with heavy fqname collisions so the ordered reduce's
+        // append-after semantics are really exercised: every Vec must
+        // come back in ascending idx order.
+        let mut b = GraphBuilder::with_capacity(0);
+        for i in 0..6000 {
+            match i % 5 {
+                0 => b.nodes.push(node(&format!("pkg.m{}", i % 7), "module")),
+                1 => b
+                    .nodes
+                    .push(node(&format!("pkg.m{}.f", i % 11), "function")),
+                2 => b.nodes.push(node(&format!("pkg.m{}.C", i % 13), "class")),
+                3 => {
+                    let mut imp = node(&format!("pkg.m{}.dep", i % 11), "import");
+                    imp.imports = Some(ImportPayload {
+                        module: format!("dep{}", i % 3),
+                        decl: Some("thing".to_string()),
+                        star: false,
+                    });
+                    b.nodes.push(imp);
+                }
+                _ => b
+                    .nodes
+                    .push(node(&format!("pkg.m{}.x", i % 17), "variable")),
+            }
+        }
+        let (decls, ..) = build_fqname_indices(&b, &Arc::new(ProgressCounters::new()));
+        for list in decls.values() {
+            assert!(list.windows(2).all(|w| w[0] < w[1]), "idx order scrambled");
+        }
+        assert_matches_reference(&b);
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #293. Instrumenting the post-#293 build showed the two biggest remaining serial chunks (heavy shape: 1000 files × 50 decls, 103k nodes / 157k edges, 4 cores):

- `extend_edges`' bulk insert in assemble pass 2: **~36ms** of serial `edge_set` probes + adjacency pushes
- `build_fqname_indices`: **~46ms** of serial String-keyed map inserts

Both now run on rayon workers with the GIL released. Both outputs are **bit-for-bit identical** to the serial versions, pinned by parity unit tests.

### Bulk edge insert → `GraphBuilder::init_edges_bulk` (partitioned scatter)

The assemble pass is the one caller with an edge-less builder and a pre-sorted, pre-deduplicated triple list, so every piece of the edge storage derives from the triples independently on concurrent tasks:

- `edges` is the triple vec itself (moved, no copy)
- `edge_set` folds on a sibling task (still needed — pass 3 and the plugin apply pass dedup against it)
- the adjacency tables are **partitioned scatters**: triples sorted by `(src, dst, flags)` make each node's out-list one contiguous run; runs chunk at key boundaries and each chunk owns a disjoint `adj[lo..hi]` window via `split_at_mut` — no locks, no unsafe, each list allocated once at its exact size. `reverse_adj` scatters a copy re-sorted by `(dst, src, flags)`, which preserves the serial per-node order exactly.

Pass 3's small peer-stub batch keeps using `extend_edges`' merge path.

### `build_fqname_indices` → rayon fold/reduce (map-reduce)

The fold builds per-range maps on workers (where the String clones + hashing happen); the reduce merges adjacent ranges left-to-right. rayon combines accumulators in sequence order — `op(left, right)` over adjacent ranges, never reordered — so appending right after left reproduces the serial loop's idx order in every Vec, and `modules.extend` reproduces its last-write-wins. The call site releases the GIL.

## Benchmarks

Interleaved A/B (alternating wheel installs of `main` vs this branch in the same time window, 3 rounds, heavy shape):

| phase | main | this PR |
|---|---|---|
| pass2 | 44–49ms | **21–25ms** |
| fqname | 46–50ms | **29–37ms** |
| assemble | 93–103ms | **70–75ms** |
| total materialize | 431–460ms | **378–409ms** (~−12%) |

`pass1` (untouched by this PR) measured identical on both sides across all rounds, confirming the comparison window was fair.

## Testing

- New parity tests: `init_edges_bulk` vs `extend_edges` over pseudo-random sorted triple sets (including empty / isolated-node / later-merge cases), and `build_fqname_indices` vs the serial loop kept verbatim as a test reference (small handcrafted table + a 6000-node collision-heavy table that forces real rayon splits and checks every Vec comes back in ascending idx order)
- `cargo test --no-default-features --locked -p dead-cst-runtime` — 141 passed
- `uv run pytest` — 703 passed, 3 skipped
- `uv run prek run --all-files` — all hooks green (ruff, ty, cargo fmt, cargo clippy)

https://claude.ai/code/session_01XzpwVFkdEkqLZGb2STrgLM

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzpwVFkdEkqLZGb2STrgLM)_