### PR TITLE
Test the per-file topic/fact channel round trip

### DIFF
--- a/tests/test_plugins/test_external_dylib_plugin.py
+++ b/tests/test_plugins/test_external_dylib_plugin.py
@@ -93,6 +93,31 @@ def test_external_per_file_plugin_keeps_main_alive(build_plugin_graph, reachable
     assert "pkg.lib.helper" not in reached
 
 
+# Source layout shared by the two decorated-plugin tests below: a Click
+# command, an aliased Click group, an undecorated helper, and a file that
+# never imports `click`.
+_DECORATED_FILES = {
+    "pkg/__init__.py": "",
+    "pkg/app.py": """
+    import click
+
+    @click.command()
+    def cli(): pass
+
+    def helper(): pass
+    """,
+    # Aliased direct import resolves through the same matcher.
+    "pkg/aliased.py": """
+    from click import group as grp
+
+    @grp()
+    def root(): pass
+    """,
+    # No `click` import -> the presence guard skips this file entirely.
+    "pkg/lib.py": "def untouched(): pass\n",
+}
+
+
 @pytest.mark.skipif(
     not (_PLUGIN_HOST and _PLUGIN_DYLIB_PER_FILE_DECORATED),
     reason="decorated per-file plugin requires PLUGIN_DYLIB_PER_FILE_DECORATED built via `dead-cst build-plugin`",
@@ -100,41 +125,75 @@ def test_external_per_file_plugin_keeps_main_alive(build_plugin_graph, reachable
 def test_external_per_file_decorated_plugin_keeps_decorated_alive(
     build_plugin_graph, reachable_fqnames
 ):
-    """The decorated per-file external plugin uses the ready-made file-local
-    query API (`imports_any_module` + `decorated_decls`) and `keep_alive`:
-    a `@click.command`-decorated function stays reachable, an undecorated
-    helper stays dead, and a file that never imports `click` is untouched."""
+    """The decorated example is a *pair* exported from one cdylib: a per-file
+    scanner emits a ``click/commands`` fact for each
+    `@click.command`/`@click.group` decl (matched via `imports_any_module` +
+    `decorated_decls`), and a project-wide keeper reads those facts and stamps
+    the declared ``click/command`` node flag — keeping each command reachable.
+    An undecorated helper stays dead, and a file that never imports `click` is
+    untouched."""
     from dead_cst import _native as native
 
     plugins = native.load_native_plugins(_PLUGIN_DYLIB_PER_FILE_DECORATED)
-    assert [p.name for p in plugins] == ["ExternalPerFileDecoratedPlugin"]
+    assert [p.name for p in plugins] == [
+        "ExternalClickCommandScanner",
+        "ExternalClickCommandKeeper",
+    ]
 
-    files = {
-        "pkg/__init__.py": "",
-        "pkg/app.py": """
-        import click
-
-        @click.command()
-        def cli(): pass
-
-        def helper(): pass
-        """,
-        # Aliased direct import resolves through the same matcher.
-        "pkg/aliased.py": """
-        from click import group as grp
-
-        @grp()
-        def root(): pass
-        """,
-        # No `click` import -> the presence guard skips this file entirely.
-        "pkg/lib.py": "def untouched(): pass\n",
-    }
-    ctx = build_plugin_graph(files, plugins)
+    ctx = build_plugin_graph(_DECORATED_FILES, plugins)
     reached = reachable_fqnames(ctx)
     assert "pkg.app.cli" in reached
     assert "pkg.app.helper" not in reached
     assert "pkg.aliased.root" in reached
     assert "pkg.lib.untouched" not in reached
+
+
+@pytest.mark.skipif(
+    not (_PLUGIN_HOST and _PLUGIN_DYLIB_PER_FILE_DECORATED),
+    reason="decorated per-file plugin requires PLUGIN_DYLIB_PER_FILE_DECORATED built via `dead-cst build-plugin`",
+)
+def test_external_per_file_decorated_plugin_topic_fact_round_trip(build_plugin_graph):
+    """End-to-end of the topic/fact channel the decorated pair drives: the
+    per-file scanner declares + publishes under the ``click/commands`` topic,
+    and the project-wide keeper reads the collected facts. Asserts the topic
+    is registered, each surviving Click decl produced one fact (value = the
+    decl's fqname, pinned to a real node index), and the keeper's
+    ``click/command`` flag landed on exactly those nodes."""
+    from dead_cst import _native as native
+
+    plugins = native.load_native_plugins(_PLUGIN_DYLIB_PER_FILE_DECORATED)
+    ctx = build_plugin_graph(_DECORATED_FILES, plugins)
+
+    # Both plugins declare the one topic (idempotently) -> a single handle.
+    registry = ctx.topic_registry()
+    assert len(registry) == 1
+    name, handle, description = registry[0]
+    assert name == "click/commands"
+    assert description == "fqname of each top-level Click-decorated command/group decl"
+    assert isinstance(handle, int)
+
+    # The keeper's node flag is registered and resolves to a real bit.
+    flag_bit = ctx.node_flag("click/command")
+    assert flag_bit
+    assert "click/command" in {entry[0] for entry in ctx.node_flag_registry()}
+
+    # One fact per surviving Click decl. Each fact's value is the decl's
+    # fqname and its decl_idx points at the matching node, which the keeper
+    # stamped with the flag.
+    facts = ctx.facts_for_topic("click/commands")
+    assert {value for (_path, _decl_idx, value) in facts} == {"pkg.app.cli", "pkg.aliased.root"}
+    assert {os.path.basename(path) for (path, _decl_idx, _value) in facts} == {
+        "app.py",
+        "aliased.py",
+    }
+    for _path, decl_idx, value in facts:
+        assert decl_idx is not None
+        node = ctx.nodes_at([decl_idx])[0]
+        assert node.fqname == value
+        assert node.flags & flag_bit, f"{node.fqname} missing the click/command flag"
+
+    # An unknown topic yields no facts (and does not raise).
+    assert ctx.facts_for_topic("click/unknown") == []
 
 
 def test_load_rejects_dylib_without_manifest():


### PR DESCRIPTION
## Summary
- The topic/fact channel landed in #292 without its tests. This adds them on a fresh branch off current `main`.
- The decorated per-file example became a two-plugin pair (`ExternalClickCommandScanner` + `ExternalClickCommandKeeper`) in #292, so its load test still asserted the old single-plugin name — fixed.
- Adds an end-to-end test of the channel: the per-file scanner publishes a `click/commands` fact per Click decl, and the project-wide keeper reads them back to stamp its declared `click/command` node flag. Asserts the topic registry, the resolved flag bit, one fact per surviving decl (value = fqname, pinned to the stamped node), and that an unknown topic returns `[]`.
- Both tests are gated on the plugin-host build (like the sibling dylib tests): they run in CI via the dynamic wheel and skip in a dev/static checkout.

## Test plan
- [x] `uv run pytest` — full suite green (703 passed; the 4 gated dylib tests skip locally, e2e deselected).
- [x] `tests/test_topics.py` (Python getter smoke tests) and Rust `topic_registry` unit tests green.
- [x] `uv run ruff check` / `ruff format --check` clean on the edited file.
- [ ] CI plugin-host job runs the two gated tests end to end against the dynamic wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)