### PR TITLE
Use CompactString in the salsa-cached payload types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,18 @@ two versions.
 
 ### Changed
 
+- **`CompactString` in the salsa-cached payloads.** Every identifier-shaped
+  string in the per-file salsa caches — `NodeData.fqname`, `ImportPayload`,
+  `exports_by_name` / `star_reexports`, `ClassBaseSpec`, `ExternalKey`, the
+  whole `FileExtraction` fact family, the shared `{local → target}` imports
+  maps (new `helpers::LocalImports` alias), and `FileLocalOp::Fact` — now uses
+  `compact_str::CompactString`, which stores up to 24 bytes inline. Typical
+  Python identifiers and dotted module paths fit inline, so the cached
+  payloads skip one heap allocation per string and pack tighter. Human-prose
+  `warnings` and the graph-side types (`GraphNode` / `SymbolNode` / the dcg
+  file) stay `String`; conversions happen at the assemble boundary where a
+  clone already happened. No behavior change.
+
 - **Parallel edge-storage init and fqname-index map-reduce.** Two more serial
   build chunks now run on rayon workers with the GIL released. The assemble
   pass's bulk edge insert (`GraphBuilder::init_edges_bulk`) derives `edges`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,7 @@ name = "dead-cst-runtime"
 version = "0.13.0"
 dependencies = [
  "bincode",
+ "compact_str",
  "crossbeam-channel",
  "get-size2",
  "indicatif",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -17,7 +17,12 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 pyo3 = { version = "0.22", features = ["abi3-py311", "multiple-pymethods"] }
-salsa = "0.26"
+# `compact_str` must stay version-compatible with the vendored ruff/ty
+# workspace (vendor/ruff pins 0.9) so the inline-string types unify.
+# salsa's `compact_str` feature provides `salsa::Update` for it;
+# get-size2's `compact-str` feature provides `GetSize`.
+compact_str = "0.9"
+salsa = { version = "0.26", features = ["compact_str"] }
 libloading = "0.8"
 ty_project = { path = "../vendor/ruff/crates/ty_project" }
 ty_python_core = { path = "../vendor/ruff/crates/ty_python_core" }
@@ -30,7 +35,7 @@ ruff_source_file = { path = "../vendor/ruff/crates/ruff_source_file" }
 ruff_text_size = { path = "../vendor/ruff/crates/ruff_text_size" }
 ty_ide = { path = "../vendor/ruff/crates/ty_ide" }
 ruff_memory_usage = { path = "../vendor/ruff/crates/ruff_memory_usage" }
-get-size2 = { version = "0.8.0", features = ["smallvec"] }
+get-size2 = { version = "0.8.0", features = ["smallvec", "compact-str"] }
 rustc-hash = "2.0"
 smallvec = { version = "1.13", features = ["union", "const_generics", "const_new"] }
 indicatif = "0.17"

--- a/runtime/src/builder.rs
+++ b/runtime/src/builder.rs
@@ -89,8 +89,8 @@ impl GraphNode {
             Some(ip) => Some(Py::new(
                 py,
                 Import {
-                    module: ip.module.clone(),
-                    decl: ip.decl.clone(),
+                    module: ip.module.to_string(),
+                    decl: ip.decl.as_ref().map(|d| d.to_string()),
                     star: ip.star,
                 },
             )?),

--- a/runtime/src/file_extraction.rs
+++ b/runtime/src/file_extraction.rs
@@ -17,6 +17,7 @@
 //! (the cross-file lookup primitive) this query is never called
 //! cross-file, so it carries no `'db` lifetime and absorbs facts freely.
 
+use compact_str::{CompactString, ToCompactString};
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
@@ -29,7 +30,8 @@ use ty_project::Db as ProjectDb;
 
 use crate::helpers::{
     extract_call_kwargs, find_main_block_range, range_key, resolve_relative_import,
-    top_level_assign_to_name, unwrap_subscripted_callee, CallArgs, MODULE_ALIAS_MARKER,
+    top_level_assign_to_name, unwrap_subscripted_callee, CallArgs, LocalImports,
+    MODULE_ALIAS_MARKER,
 };
 use crate::ingest::{collapse_attribute_chain, file_package_name, string_literal_list};
 
@@ -57,8 +59,8 @@ type ByNameRange<T> = Vec<((u32, u32), T)>;
 /// rejects non-`Name` roots, so deeper shapes can't match anyway.
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct CalleeDescriptor {
-    pub(crate) root_name: String,
-    pub(crate) attrs: SmallVec<[String; 2]>,
+    pub(crate) root_name: CompactString,
+    pub(crate) attrs: SmallVec<[CompactString; 2]>,
     pub(crate) kwargs: CallArgs,
 }
 
@@ -73,12 +75,14 @@ pub(crate) enum ImportFact {
     /// `from <absolute> import <name> [as <local>], …` — `names` is
     /// `(imported_name, local_name)` for each alias.
     From {
-        absolute: String,
-        names: Vec<(String, String)>,
+        absolute: CompactString,
+        names: Vec<(CompactString, CompactString)>,
     },
     /// `import <module> [as <local>], …` — `entries` is
     /// `(module_name, local_name)` for each alias.
-    Plain { entries: Vec<(String, String)> },
+    Plain {
+        entries: Vec<(CompactString, CompactString)>,
+    },
 }
 
 /// The `Name`-rooted callee chain of a call — root name + trailing
@@ -88,8 +92,8 @@ pub(crate) enum ImportFact {
 /// the `<owner>.<attr>` shape (`attrs == [attr]`, `root_name == owner`).
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct CalleeChain {
-    pub(crate) root_name: String,
-    pub(crate) attrs: SmallVec<[String; 2]>,
+    pub(crate) root_name: CompactString,
+    pub(crate) attrs: SmallVec<[CompactString; 2]>,
 }
 
 /// String content of a positional call argument, recorded so the
@@ -99,11 +103,11 @@ pub(crate) struct CalleeChain {
 pub(crate) enum StringArg {
     /// A single `"…"` literal — `nth_positional_string` returns it; a
     /// collection read sees a one-element list.
-    Lit(String),
+    Lit(CompactString),
     /// A list/tuple of string literals (non-string elements dropped, as
     /// `string_or_string_collection` does) — `nth_positional_string`
     /// returns `None`; a collection read sees every element.
-    Coll(Vec<String>),
+    Coll(Vec<CompactString>),
 }
 
 /// One call site reduced to the config-independent data the three
@@ -115,7 +119,7 @@ pub(crate) struct CallSiteFact {
     /// Last attribute segment of the callee (`load_extension` in
     /// `bot.load_extension(x)`), for *any* receiver shape; `None` when the
     /// callee isn't an attribute access. Powers `find_calls_on_attr`.
-    pub(crate) callee_attr: Option<String>,
+    pub(crate) callee_attr: Option<CompactString>,
     /// `Name`-rooted callee chain, when the callee bottoms out at a bare
     /// `Name`. Powers `find_calls_to_imported` / `find_calls_on_var`.
     pub(crate) callee: Option<CalleeChain>,
@@ -143,7 +147,7 @@ impl CallSiteFact {
     /// Replay `helpers::string_or_string_collection` for `arg_index`: the
     /// string values (one for a single literal, many for a list/tuple),
     /// or empty.
-    pub(crate) fn string_or_collection(&self, arg_index: usize) -> &[String] {
+    pub(crate) fn string_or_collection(&self, arg_index: usize) -> &[CompactString] {
         self.string_args
             .iter()
             .find_map(|(i, arg)| {
@@ -169,14 +173,14 @@ pub(crate) struct FileExtraction {
     /// assignments whose RHS is a list/tuple of string literals, as
     /// `(target_name, entries)`. Powers `find_literal_list_entries` and
     /// the `__all__` export query.
-    pub(crate) literal_list_rows: Vec<(String, Vec<String>)>,
+    pub(crate) literal_list_rows: Vec<(CompactString, Vec<CompactString>)>,
     /// Per top-level `def`, its positional + keyword-only parameter
     /// names in source order. Powers `function_parameters`.
-    pub(crate) function_params: ByNameRange<Vec<String>>,
+    pub(crate) function_params: ByNameRange<Vec<CompactString>>,
     /// Per top-level `class`, the de-duplicated parameter names across
     /// all its methods, excluding `self` / `cls`. Powers
     /// `class_method_parameters`.
-    pub(crate) class_method_params: ByNameRange<Vec<String>>,
+    pub(crate) class_method_params: ByNameRange<Vec<CompactString>>,
     /// Per `class` *anywhere* in the file (not just top level), the
     /// names of the methods defined directly in its body. Powers
     /// `find_classes_defining_method`, whose original enumeration went
@@ -185,7 +189,7 @@ pub(crate) struct FileExtraction {
     /// let the `class_by_selection` fan-in keep only the global-scope
     /// ones — name-ranges never collide, so nested classes never
     /// produce a false match.
-    pub(crate) class_method_defs: ByNameRange<Vec<String>>,
+    pub(crate) class_method_defs: ByNameRange<Vec<CompactString>>,
     /// Every top-level `import` / `from … import …` statement, resolved
     /// to absolute modules. Powers the import-resolving decorator /
     /// construction / call queries via [`imports_local_from_facts`].
@@ -225,17 +229,17 @@ pub(crate) struct FileExtraction {
 /// defined classes are captured; the project-wide fan-in filters to
 /// global-scope classes via `class_by_selection`.
 struct ClassMethodDefsCollector {
-    rows: ByNameRange<Vec<String>>,
+    rows: ByNameRange<Vec<CompactString>>,
 }
 
 impl<'a> Visitor<'a> for ClassMethodDefsCollector {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         if let Stmt::ClassDef(cls) = stmt {
-            let methods: Vec<String> = cls
+            let methods: Vec<CompactString> = cls
                 .body
                 .iter()
                 .filter_map(|s| match s {
-                    Stmt::FunctionDef(f) => Some(f.name.as_str().to_string()),
+                    Stmt::FunctionDef(f) => Some(f.name.as_str().to_compact_string()),
                     _ => None,
                 })
                 .collect();
@@ -324,7 +328,7 @@ fn build_call_site_fact(call: &ExprCall) -> Option<CallSiteFact> {
     // *any* receiver shape (incl. `foo().attr(…)`), so it is computed off the
     // unwrapped callee directly rather than the `Name`-rooted chain.
     let callee_attr = match unwrap_subscripted_callee(call.func.as_ref()) {
-        Expr::Attribute(attr) => Some(attr.attr.as_str().to_string()),
+        Expr::Attribute(attr) => Some(attr.attr.as_str().to_compact_string()),
         _ => None,
     };
     let callee = collapse_callee(call.func.as_ref())
@@ -346,7 +350,7 @@ fn build_call_site_fact(call: &ExprCall) -> Option<CallSiteFact> {
 /// a hit), so the call isn't recorded on its account.
 fn string_arg(expr: &Expr) -> Option<StringArg> {
     match expr {
-        Expr::StringLiteral(s) => Some(StringArg::Lit(s.value.to_str().to_string())),
+        Expr::StringLiteral(s) => Some(StringArg::Lit(s.value.to_str().to_compact_string())),
         Expr::List(list) => {
             let elems = collect_string_elems(&list.elts);
             (!elems.is_empty()).then_some(StringArg::Coll(elems))
@@ -361,10 +365,10 @@ fn string_arg(expr: &Expr) -> Option<StringArg> {
 
 /// String-literal elements of a list/tuple, non-string elements dropped —
 /// the collection half of `helpers::string_or_string_collection`.
-fn collect_string_elems(elts: &[Expr]) -> Vec<String> {
+fn collect_string_elems(elts: &[Expr]) -> Vec<CompactString> {
     elts.iter()
         .filter_map(|e| match e {
-            Expr::StringLiteral(s) => Some(s.value.to_str().to_string()),
+            Expr::StringLiteral(s) => Some(s.value.to_str().to_compact_string()),
             _ => None,
         })
         .collect()
@@ -409,11 +413,11 @@ fn param_names(params: &ruff_python_ast::Parameters) -> impl Iterator<Item = &st
 /// single subscripted-generic callee, then collapse the attribute chain.
 /// Returns `None` when the callee doesn't bottom out at a bare `Name`
 /// (a call result, a subscript mid chain, …) — those never matched.
-fn collapse_callee(expr: &Expr) -> Option<(String, SmallVec<[String; 2]>)> {
+fn collapse_callee(expr: &Expr) -> Option<(CompactString, SmallVec<[CompactString; 2]>)> {
     let (root, segs) = collapse_attribute_chain(unwrap_subscripted_callee(expr))?;
     Some((
-        root.id.as_str().to_string(),
-        segs.iter().map(|s| s.to_string()).collect(),
+        root.id.as_str().to_compact_string(),
+        segs.iter().map(|s| s.to_compact_string()).collect(),
     ))
 }
 
@@ -464,9 +468,9 @@ pub(crate) fn file_extraction(db: &dyn ProjectDb, file: File) -> FileExtraction 
         None
     };
 
-    let mut literal_list_rows: Vec<(String, Vec<String>)> = Vec::new();
-    let mut function_params: ByNameRange<Vec<String>> = Vec::new();
-    let mut class_method_params: ByNameRange<Vec<String>> = Vec::new();
+    let mut literal_list_rows: Vec<(CompactString, Vec<CompactString>)> = Vec::new();
+    let mut function_params: ByNameRange<Vec<CompactString>> = Vec::new();
+    let mut class_method_params: ByNameRange<Vec<CompactString>> = Vec::new();
     let mut class_defs = ClassMethodDefsCollector { rows: Vec::new() };
     let mut import_facts: Vec<ImportFact> = Vec::new();
     let mut decorator_rows: ByNameRange<Vec<CalleeDescriptor>> = Vec::new();
@@ -483,8 +487,9 @@ pub(crate) fn file_extraction(db: &dyn ProjectDb, file: File) -> FileExtraction 
         collect_call_sites(stmt, &mut call_sites_by_decl, &mut module_call_sites);
         match stmt {
             Stmt::FunctionDef(func) => {
-                let names: Vec<String> =
-                    param_names(&func.parameters).map(str::to_string).collect();
+                let names: Vec<CompactString> = param_names(&func.parameters)
+                    .map(CompactString::from)
+                    .collect();
                 function_params.push((range_key(func.name.range()), names));
                 let descriptors: Vec<CalleeDescriptor> = func
                     .decorator_list
@@ -498,7 +503,7 @@ pub(crate) fn file_extraction(db: &dyn ProjectDb, file: File) -> FileExtraction 
             }
             Stmt::ClassDef(cls) => {
                 let mut seen: FxHashSet<&str> = FxHashSet::default();
-                let mut names: Vec<String> = Vec::new();
+                let mut names: Vec<CompactString> = Vec::new();
                 for body_stmt in &cls.body {
                     let Stmt::FunctionDef(method) = body_stmt else {
                         continue;
@@ -508,7 +513,7 @@ pub(crate) fn file_extraction(db: &dyn ProjectDb, file: File) -> FileExtraction 
                             continue;
                         }
                         if seen.insert(n) {
-                            names.push(n.to_string());
+                            names.push(n.to_compact_string());
                         }
                     }
                 }
@@ -518,7 +523,7 @@ pub(crate) fn file_extraction(db: &dyn ProjectDb, file: File) -> FileExtraction 
             Stmt::ImportFrom(im) => {
                 let tail = im.module.as_ref().map(|n| n.as_str()).unwrap_or("");
                 let absolute = if im.level == 0 {
-                    (!tail.is_empty()).then(|| tail.to_string())
+                    (!tail.is_empty()).then(|| tail.to_compact_string())
                 } else {
                     resolve_relative_import(im.level, tail, file_package.as_deref())
                 };
@@ -527,13 +532,13 @@ pub(crate) fn file_extraction(db: &dyn ProjectDb, file: File) -> FileExtraction 
                         .names
                         .iter()
                         .map(|alias| {
-                            let name = alias.name.as_str().to_string();
+                            let name = alias.name.as_str().to_compact_string();
                             let local = alias
                                 .asname
                                 .as_ref()
                                 .map(|n| n.as_str())
                                 .unwrap_or(alias.name.as_str())
-                                .to_string();
+                                .to_compact_string();
                             (name, local)
                         })
                         .collect();
@@ -545,13 +550,13 @@ pub(crate) fn file_extraction(db: &dyn ProjectDb, file: File) -> FileExtraction 
                     .names
                     .iter()
                     .map(|alias| {
-                        let module_name = alias.name.as_str().to_string();
+                        let module_name = alias.name.as_str().to_compact_string();
                         let local = alias
                             .asname
                             .as_ref()
                             .map(|n| n.as_str())
                             .unwrap_or(alias.name.as_str())
-                            .to_string();
+                            .to_compact_string();
                         (module_name, local)
                     })
                     .collect();
@@ -562,10 +567,10 @@ pub(crate) fn file_extraction(db: &dyn ProjectDb, file: File) -> FileExtraction 
                     continue;
                 };
                 if let Some(entries) = string_literal_list(value) {
-                    let name = source
-                        [target_range.start().to_usize()..target_range.end().to_usize()]
-                        .to_string();
-                    literal_list_rows.push((name, entries.into_iter().map(String::from).collect()));
+                    let name = CompactString::from(
+                        &source[target_range.start().to_usize()..target_range.end().to_usize()],
+                    );
+                    literal_list_rows.push((name, entries.into_iter().map(Into::into).collect()));
                 } else if let Expr::Call(call) = value {
                     // `NAME = <callee>(...)` — record the callee descriptor so
                     // `find_instance_constructions` can resolve it at fan-in.
@@ -604,8 +609,8 @@ pub(crate) fn imports_local_from_facts(
     facts: &[ImportFact],
     modules: &[String],
     allowed: &FxHashSet<&str>,
-) -> FxHashMap<String, String> {
-    let mut out: FxHashMap<String, String> = FxHashMap::default();
+) -> LocalImports {
+    let mut out: LocalImports = FxHashMap::default();
     for module in modules {
         let parent_last = module.rsplit_once('.');
         for fact in facts {
@@ -621,7 +626,10 @@ pub(crate) fn imports_local_from_facts(
                         if absolute == parent {
                             for (name, local) in names {
                                 if name == last {
-                                    out.insert(local.clone(), MODULE_ALIAS_MARKER.to_string());
+                                    out.insert(
+                                        local.clone(),
+                                        CompactString::const_new(MODULE_ALIAS_MARKER),
+                                    );
                                 }
                             }
                         }
@@ -630,7 +638,10 @@ pub(crate) fn imports_local_from_facts(
                 ImportFact::Plain { entries } => {
                     for (module_name, local) in entries {
                         if module_name == module {
-                            out.insert(local.clone(), MODULE_ALIAS_MARKER.to_string());
+                            out.insert(
+                                local.clone(),
+                                CompactString::const_new(MODULE_ALIAS_MARKER),
+                            );
                         }
                     }
                 }
@@ -656,17 +667,17 @@ pub(crate) fn imports_local_from_facts(
 /// the call-site query (on [`CallSiteFact::callee`]).
 pub(crate) fn match_callee_chain(
     root_name: &str,
-    attrs: &[String],
-    imports: &FxHashMap<String, String>,
+    attrs: &[CompactString],
+    imports: &LocalImports,
     modules: &[String],
     allowed: &FxHashSet<&str>,
-) -> Option<String> {
+) -> Option<CompactString> {
     match attrs {
         [] => imports
             .get(root_name)
             .filter(|target| allowed.contains(target.as_str()))
             .cloned(),
-        [attr] => (imports.get(root_name).map(String::as_str) == Some(MODULE_ALIAS_MARKER)
+        [attr] => (imports.get(root_name).map(CompactString::as_str) == Some(MODULE_ALIAS_MARKER)
             && allowed.contains(attr.as_str()))
         .then(|| attr.clone()),
         segs => {
@@ -696,9 +707,9 @@ pub(crate) fn match_callee_chain(
 /// [`CalleeChain`].
 pub(crate) fn match_callee_descriptor(
     desc: &CalleeDescriptor,
-    imports: &FxHashMap<String, String>,
+    imports: &LocalImports,
     modules: &[String],
     allowed: &FxHashSet<&str>,
-) -> Option<String> {
+) -> Option<CompactString> {
     match_callee_chain(&desc.root_name, &desc.attrs, imports, modules, allowed)
 }

--- a/runtime/src/file_payload.rs
+++ b/runtime/src/file_payload.rs
@@ -22,6 +22,7 @@
 //! no callers; landing it first lets us validate the salsa macro
 //! pattern + the `NodeData` shape before the driver swap.
 
+use compact_str::{CompactString, ToCompactString};
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_db::source::{line_index, source_text};
@@ -118,7 +119,7 @@ pub(crate) fn def_key<'db>(
 /// `NodeFlags::UNRESOLVED`.
 #[salsa::interned(debug)]
 pub(crate) struct ExternalKey<'db> {
-    pub(crate) fqname: String,
+    pub(crate) fqname: CompactString,
     pub(crate) file: File,
 }
 
@@ -131,7 +132,7 @@ impl get_size2::GetSize for ExternalKey<'_> {}
 /// derives needed for salsa-tracked return.
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct ProjectDistLookup {
-    pub(crate) map: std::collections::HashMap<std::path::PathBuf, String>,
+    pub(crate) map: std::collections::HashMap<std::path::PathBuf, CompactString>,
 }
 
 #[salsa::tracked(returns(ref), heap_size = ruff_memory_usage::heap_size)]
@@ -150,18 +151,18 @@ pub(crate) fn external_fqname_for(
     db: &dyn ProjectDb,
     target_file: ruff_db::files::File,
     fallback_top_level: &str,
-) -> String {
+) -> CompactString {
     use ruff_db::files::FilePath;
     let path_str = match target_file.path(db) {
         FilePath::System(p) => p.to_string(),
-        _ => return format!("[external file] {fallback_top_level}"),
+        _ => return compact_str::format_compact!("[external file] {fallback_top_level}"),
     };
     let canonical =
         std::fs::canonicalize(&path_str).unwrap_or_else(|_| std::path::PathBuf::from(&path_str));
     let lookup = project_dist_lookup(db);
     match lookup.map.get(&canonical) {
-        Some(dist_name) => format!("[external dist] {dist_name}"),
-        None => format!("[external file] {fallback_top_level}"),
+        Some(dist_name) => compact_str::format_compact!("[external dist] {dist_name}"),
+        None => compact_str::format_compact!("[external file] {fallback_top_level}"),
     }
 }
 
@@ -172,7 +173,7 @@ pub(crate) fn external_fqname_for(
 /// single GIL acquisition at the end of the build.
 #[derive(Debug, Clone, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct NodeData {
-    pub(crate) fqname: String,
+    pub(crate) fqname: CompactString,
     pub(crate) kind: NodeKind,
     /// The file this node belongs to. Every node in a `file_to_nodes`
     /// payload shares it; the assembly pass re-derives the path string
@@ -246,8 +247,8 @@ impl NodeKind {
 /// inside `NodeData`.
 #[derive(Debug, Clone, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct ImportPayload {
-    pub(crate) module: String,
-    pub(crate) decl: Option<String>,
+    pub(crate) module: CompactString,
+    pub(crate) decl: Option<CompactString>,
     pub(crate) star: bool,
 }
 
@@ -298,8 +299,8 @@ pub(crate) struct FileNodes<'db> {
     pub(crate) nodes: Box<[NodeData]>,
     pub(crate) refs: Box<[NodeRef<'db>]>,
     pub(crate) ref_to_local: FxHashMap<NodeRef<'db>, u32>,
-    pub(crate) exports_by_name: FxHashMap<String, SmallVec<[u32; 2]>>,
-    pub(crate) star_reexports: FxHashMap<String, String>,
+    pub(crate) exports_by_name: FxHashMap<CompactString, SmallVec<[u32; 2]>>,
+    pub(crate) star_reexports: FxHashMap<CompactString, CompactString>,
     pub(crate) class_bases: Vec<ClassBaseEntry>,
     pub(crate) overload_anchors: Box<[(u32, u32)]>,
 }
@@ -330,7 +331,10 @@ pub(crate) type ClassBaseEntry = ((u32, u32), SmallVec<[ClassBaseSpec; 2]>);
 #[derive(Debug, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 pub(crate) enum ClassBaseSpec {
     LocalClass((u32, u32)),
-    ModuleMember { module: String, name: String },
+    ModuleMember {
+        module: CompactString,
+        name: CompactString,
+    },
 }
 
 /// Modules whose `.overload` attribute marks a function decl as a stub.
@@ -348,7 +352,7 @@ const OVERLOAD_MODULES: &[&str] = &["typing", "typing_extensions"];
 ///   `imports` map already records `"ovl" -> "typing.overload"`).
 fn is_overload_decorator(
     dec: &ruff_python_ast::Decorator,
-    imports: &rustc_hash::FxHashMap<String, String>,
+    imports: &crate::helpers::LocalImports,
 ) -> bool {
     // Unwrap call form (`@overload()`) so we look at the callee.
     let mut expr = &dec.expression;
@@ -437,7 +441,7 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
     // returning `None` means this is the first name of the statement.
     let mut star_local_name_cache: HashMap<TextRange, String> = HashMap::new();
 
-    let mut star_reexports: FxHashMap<String, String> = FxHashMap::default();
+    let mut star_reexports: FxHashMap<CompactString, CompactString> = FxHashMap::default();
 
     // Pre-scan top-level `Stmt::FunctionDef` decorator lists to identify
     // `@typing.overload`-decorated function defs. The set is keyed on the
@@ -486,7 +490,7 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         let PlaceExprRef::Symbol(symbol) = place_table.place(place_id) else {
             continue;
         };
-        let per_name = symbol.name().as_str().to_string();
+        let per_name = symbol.name().as_str().to_compact_string();
 
         let target_range = kind.target_range(&parsed);
         let is_star = matches!(kind, DefinitionKind::StarImport(_));
@@ -550,7 +554,7 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
         // per-file query.
 
         let node = NodeData {
-            fqname: format!("{module_fqname}.{local_name}"),
+            fqname: compact_str::format_compact!("{module_fqname}.{local_name}"),
             kind: node_kind,
             file,
             start_line: sl,
@@ -587,7 +591,7 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
                         star_flags |= NODE_FLAGS_NOQA_PIN;
                     }
                     let star_node = NodeData {
-                        fqname: star_fqname,
+                        fqname: star_fqname.into(),
                         kind: NodeKind::Import,
                         file,
                         start_line: sl,
@@ -632,7 +636,7 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
     // emit no anchor; reachability falls back to the module-anchor
     // edge.
     let mut overload_anchors: Vec<(u32, u32)> = Vec::new();
-    let mut by_name: FxHashMap<String, Vec<u32>> = FxHashMap::default();
+    let mut by_name: FxHashMap<&str, Vec<u32>> = FxHashMap::default();
     for (i, node) in nodes.iter().enumerate() {
         if !matches!(node.kind, NodeKind::Function) {
             continue;
@@ -642,10 +646,7 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
             .rsplit_once('.')
             .map(|p| p.1)
             .unwrap_or(&node.fqname);
-        by_name
-            .entry(simple.to_string())
-            .or_default()
-            .push(i as u32);
+        by_name.entry(simple).or_default().push(i as u32);
     }
     for group in by_name.values() {
         // Find the last non-overload entry — that's the impl. Groups
@@ -675,12 +676,12 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
     // resolves to the impl only — the impl `def f` shadows them via
     // ty's end-of-scope binding anyway, but pyi stub files (every
     // `def f` decorated `@overload`) need the explicit filter.
-    let mut exports_by_name: FxHashMap<String, SmallVec<[u32; 2]>> = FxHashMap::default();
+    let mut exports_by_name: FxHashMap<CompactString, SmallVec<[u32; 2]>> = FxHashMap::default();
     for (symbol_id, bindings) in use_def_map.all_end_of_scope_symbol_bindings() {
         let PlaceExprRef::Symbol(sym) = place_table.place(ScopedPlaceId::Symbol(symbol_id)) else {
             continue;
         };
-        let name = sym.name().as_str().to_string();
+        let name = sym.name().as_str().to_compact_string();
         let mut live: SmallVec<[u32; 2]> = SmallVec::new();
         for binding in bindings {
             let Some(def) = binding.binding.definition() else {
@@ -797,7 +798,7 @@ pub(crate) fn walk_exports_chain<'db>(
         // into the upstream file's same-name lookup. The star alias
         // itself isn't useful as a target — uses should land on the
         // upstream decl. Skip emitting it here.
-        if let Some(upstream_module) = target_nodes.star_reexports.get(&key.1) {
+        if let Some(upstream_module) = target_nodes.star_reexports.get(key.1.as_str()) {
             if let Some(mn) = ty_module_resolver::ModuleName::new(upstream_module) {
                 if let Some(upstream) = ty_module_resolver::resolve_module(db, key.0, &mn) {
                     if let Some(upstream_file) = upstream.file(db) {
@@ -807,7 +808,7 @@ pub(crate) fn walk_exports_chain<'db>(
                 }
             }
         }
-        let Some(locals) = target_nodes.exports_by_name.get(&key.1) else {
+        let Some(locals) = target_nodes.exports_by_name.get(key.1.as_str()) else {
             continue;
         };
         for &local_idx in locals {
@@ -827,7 +828,7 @@ pub(crate) fn import_payload_for_pure<'db>(
         DefinitionKind::Import(k) => {
             let alias = k.alias(parsed);
             ImportPayload {
-                module: alias.name.id.as_str().to_string(),
+                module: alias.name.id.as_str().to_compact_string(),
                 decl: None,
                 star: false,
             }
@@ -836,13 +837,13 @@ pub(crate) fn import_payload_for_pure<'db>(
             let alias = k.alias(parsed);
             ImportPayload {
                 module: from_module_string(db, file, k.import(parsed)),
-                decl: Some(alias.name.id.as_str().to_string()),
+                decl: Some(alias.name.id.as_str().to_compact_string()),
                 star: false,
             }
         }
         DefinitionKind::ImportFromSubmodule(k) => ImportPayload {
             module: from_module_string(db, file, k.import(parsed)),
-            decl: Some(k.module(parsed).id.as_str().to_string()),
+            decl: Some(k.module(parsed).id.as_str().to_compact_string()),
             star: false,
         },
         DefinitionKind::StarImport(k) => ImportPayload {
@@ -990,7 +991,7 @@ pub(crate) fn file_to_edges<'db>(db: &'db dyn ProjectDb, file: File) -> FileEdge
             continue;
         }
 
-        let (target_module_str, decl_name): (String, Option<String>) = match kind {
+        let (target_module_str, decl_name): (CompactString, Option<CompactString>) = match kind {
             DefinitionKind::Import(k) => {
                 // `import a.b.c` binds `a` locally. Resolving `a.b.c`
                 // here would target the deepest module; ty's runtime
@@ -998,12 +999,12 @@ pub(crate) fn file_to_edges<'db>(db: &'db dyn ProjectDb, file: File) -> FileEdge
                 // first-cut module-level edge. Full chain edges
                 // (parallel edges to `a.b` and `a.b.c`) are deferred.
                 let alias = k.alias(&parsed);
-                (alias.name.id.as_str().to_string(), None)
+                (alias.name.id.as_str().to_compact_string(), None)
             }
             DefinitionKind::ImportFrom(k) => {
                 let module = from_module_string(db, file, k.import(&parsed));
                 let alias = k.alias(&parsed);
-                (module, Some(alias.name.id.as_str().to_string()))
+                (module, Some(alias.name.id.as_str().to_compact_string()))
             }
             DefinitionKind::ImportFromSubmodule(k) => {
                 // ImportFromSubmodule binds a submodule attribute on
@@ -1059,13 +1060,13 @@ pub(crate) fn file_to_edges<'db>(db: &'db dyn ProjectDb, file: File) -> FileEdge
                     .and_then(|m| m.file(db))
                     .map(|f| {
                         let nodes = file_to_nodes(db, f);
-                        nodes.exports_by_name.contains_key(decl)
+                        nodes.exports_by_name.contains_key(decl.as_str())
                     })
                     .unwrap_or(false);
                 if namespace_has_decl {
                     (target_module_str, Some(decl.clone()))
                 } else {
-                    (candidate, None)
+                    (candidate.into(), None)
                 }
             } else {
                 (target_module_str, Some(decl.clone()))

--- a/runtime/src/file_ref_edges.rs
+++ b/runtime/src/file_ref_edges.rs
@@ -270,7 +270,7 @@ impl<'a, 'db> RefWalker<'a, 'db> {
     /// Emit an edge from `self.owner` to a real External node carrying
     /// the resolved upstream path: `[external dist] X` / `[external file] X`
     /// for site-packages (via `external_fqname_for`'s PEP 503 lookup).
-    fn emit_external_node(&mut self, fqname: String, target_file: File) {
+    fn emit_external_node(&mut self, fqname: compact_str::CompactString, target_file: File) {
         let key = ExternalKey::new(self.db, fqname, target_file);
         self.emit_edge(NodeRef::External(key));
     }
@@ -504,7 +504,7 @@ impl<'a, 'db> RefWalker<'a, 'db> {
                 None => (first_seg, dotted.split('.').skip(1).collect()),
             };
             let spec = ImportPayload {
-                module: dotted.to_string(),
+                module: compact_str::ToCompactString::to_compact_string(&dotted),
                 decl: None,
                 star: false,
             };
@@ -537,8 +537,8 @@ impl<'a, 'db> RefWalker<'a, 'db> {
                 None => name,
             };
             let spec = ImportPayload {
-                module: module_str.clone(),
-                decl: Some(name.to_string()),
+                module: module_str.as_str().into(),
+                decl: Some(compact_str::CompactString::from(name)),
                 star: false,
             };
             self.emit_upstream(&spec, bound_name, &[]);
@@ -762,7 +762,7 @@ impl<'a, 'db> RefWalker<'a, 'db> {
             if module_name_resolves(&candidate, self.file, db) {
                 loading_target = candidate;
             } else {
-                loading_target = spec.module.clone();
+                loading_target = spec.module.to_string();
                 decl_tail = Some(bound_name.to_string());
             }
         } else {
@@ -772,8 +772,8 @@ impl<'a, 'db> RefWalker<'a, 'db> {
                     if module_name_resolves(&candidate, self.file, db) {
                         loading_target = candidate;
                     } else {
-                        loading_target = spec.module.clone();
-                        decl_tail = Some(decl.clone());
+                        loading_target = spec.module.to_string();
+                        decl_tail = Some(decl.to_string());
                     }
                 }
                 None => {
@@ -789,12 +789,12 @@ impl<'a, 'db> RefWalker<'a, 'db> {
                                 .all(|(a, b)| *a == *b);
                         if prefix_matches {
                             adjusted_chain.drain(..n);
-                            loading_target = spec.module.clone();
+                            loading_target = spec.module.to_string();
                         } else {
                             loading_target = module_first_seg;
                         }
                     } else {
-                        loading_target = spec.module.clone();
+                        loading_target = spec.module.to_string();
                     }
                 }
             }
@@ -845,7 +845,7 @@ impl<'a, 'db> RefWalker<'a, 'db> {
             // *use* side, which should reach the star alias itself.
             self.emit_edge(NodeRef::Module(start_file));
             let target_nodes = file_to_nodes(self.db, start_file);
-            if let Some(locals) = target_nodes.exports_by_name.get(&decl_name) {
+            if let Some(locals) = target_nodes.exports_by_name.get(decl_name.as_str()) {
                 for &local_idx in locals {
                     self.emit_edge(target_nodes.refs[local_idx as usize]);
                 }

--- a/runtime/src/helpers.rs
+++ b/runtime/src/helpers.rs
@@ -3,6 +3,7 @@
 //! dead-region detection, noqa scanning, position/file helpers, and the
 //! shared `NodeFlags`/`EdgeFlags` constant aliases.
 
+use compact_str::{CompactString, ToCompactString};
 use pyo3::prelude::*;
 use ruff_db::files::{File, FilePath};
 use ruff_db::parsed::{parsed_module, ParsedModuleRef};
@@ -35,6 +36,14 @@ use crate::project::BuildOutputs;
 /// string when classifying attribute-style decorator / call references.
 pub(crate) const MODULE_ALIAS_MARKER: &str = "<module>";
 
+/// ``{local name -> imported target}`` map shared by every
+/// import-resolving matcher (decorator / construction / call walks).
+/// Values are a dotted target (``module.decl``), an absolute module
+/// name, or the [`MODULE_ALIAS_MARKER`] sentinel for module-object
+/// bindings. `CompactString` keeps the typical short identifier
+/// inline; probes with `&str` go through `Borrow<str>`.
+pub(crate) type LocalImports = FxHashMap<CompactString, CompactString>;
+
 pub(crate) fn is_dunder_name(fqname: &str) -> bool {
     let name = fqname.rsplit('.').next().unwrap_or("");
     name.len() > 4 && name.starts_with("__") && name.ends_with("__")
@@ -55,7 +64,7 @@ pub(crate) fn is_dunder_name(fqname: &str) -> bool {
 ///   (covers ``import module`` and ``import module as alias``).
 pub(crate) fn decorators_match_imports<'ast>(
     decorators: &'ast [ruff_python_ast::Decorator],
-    imports: &FxHashMap<String, String>,
+    imports: &LocalImports,
     names: &FxHashSet<&str>,
 ) -> Option<Option<&'ast ruff_python_ast::ExprCall>> {
     for dec in decorators {
@@ -77,7 +86,7 @@ pub(crate) fn decorators_match_imports<'ast>(
             }
             Expr::Attribute(attr) => {
                 if let Expr::Name(prefix) = attr.value.as_ref() {
-                    if imports.get(prefix.id.as_str()).map(String::as_str)
+                    if imports.get(prefix.id.as_str()).map(CompactString::as_str)
                         == Some(MODULE_ALIAS_MARKER)
                         && names.contains(attr.attr.as_str())
                     {
@@ -224,7 +233,7 @@ fn classify_name_def<'db>(
             }
             Some(ClassBaseSpec::ModuleMember {
                 module,
-                name: import_from.alias(parsed).name.as_str().to_string(),
+                name: import_from.alias(parsed).name.as_str().to_compact_string(),
             })
         }
         DefinitionKind::StarImport(star_import) => {
@@ -234,7 +243,7 @@ fn classify_name_def<'db>(
             }
             Some(ClassBaseSpec::ModuleMember {
                 module,
-                name: name.to_string(),
+                name: name.to_compact_string(),
             })
         }
         DefinitionKind::Assignment(assign) => {
@@ -256,16 +265,16 @@ fn attribute_to_module_member(
     file: File,
     parsed: &ParsedModuleRef,
     expr: &Expr,
-) -> Option<(String, String)> {
+) -> Option<(CompactString, CompactString)> {
     let (root, segments) = collapse_attribute_chain(expr)?;
     let (member, middle) = segments.split_last()?;
     let prefix = root_module_prefix(db, file, parsed, root)?;
     let module = if middle.is_empty() {
-        prefix
+        CompactString::from(prefix)
     } else {
-        format!("{prefix}.{}", middle.join("."))
+        compact_str::format_compact!("{prefix}.{}", middle.join("."))
     };
-    Some((module, (*member).to_string()))
+    Some((module, (*member).to_compact_string()))
 }
 
 /// Resolve the chain-root name of an attribute-form base to the absolute
@@ -437,8 +446,8 @@ pub(crate) fn is_string_literal(expr: &Expr, value: &str) -> bool {
 pub(crate) fn collect_all_imports_local(
     parsed: &ParsedModuleRef,
     file_package: Option<&str>,
-) -> FxHashMap<String, String> {
-    let mut out: FxHashMap<String, String> = FxHashMap::default();
+) -> LocalImports {
+    let mut out: LocalImports = FxHashMap::default();
     for stmt in &parsed.syntax().body {
         match stmt {
             Stmt::ImportFrom(im) => {
@@ -450,7 +459,7 @@ pub(crate) fn collect_all_imports_local(
                 // a bogus top-level `bases.TestCase`.
                 let tail = im.module.as_ref().map(|n| n.as_str()).unwrap_or("");
                 let module = if im.level == 0 {
-                    (!tail.is_empty()).then(|| tail.to_string())
+                    (!tail.is_empty()).then(|| tail.to_compact_string())
                 } else {
                     resolve_relative_import(im.level, tail, file_package)
                 };
@@ -458,7 +467,10 @@ pub(crate) fn collect_all_imports_local(
                 for alias in &im.names {
                     let target = alias.name.as_str();
                     let local = alias.asname.as_ref().map(|n| n.as_str()).unwrap_or(target);
-                    out.insert(local.to_string(), format!("{module}.{target}"));
+                    out.insert(
+                        local.to_compact_string(),
+                        compact_str::format_compact!("{module}.{target}"),
+                    );
                 }
             }
             Stmt::Import(im) => {
@@ -467,13 +479,16 @@ pub(crate) fn collect_all_imports_local(
                     if let Some(asname) = alias.asname.as_ref() {
                         // ``import foo.bar as fb`` binds ``fb`` to the
                         // ``foo.bar`` module object.
-                        out.insert(asname.as_str().to_string(), name.to_string());
+                        out.insert(
+                            asname.as_str().to_compact_string(),
+                            name.to_compact_string(),
+                        );
                     } else {
                         // ``import foo`` binds ``foo``.
                         // ``import foo.bar`` binds ``foo`` (Python
                         // binds the leftmost segment).
                         let leftmost = name.split('.').next().unwrap_or(name);
-                        out.insert(leftmost.to_string(), leftmost.to_string());
+                        out.insert(leftmost.to_compact_string(), leftmost.to_compact_string());
                     }
                 }
             }
@@ -500,8 +515,8 @@ pub(crate) fn collect_modules_imports_local(
     modules: &[String],
     allowed: &FxHashSet<&str>,
     file_package: Option<&str>,
-) -> FxHashMap<String, String> {
-    let mut out: FxHashMap<String, String> = FxHashMap::default();
+) -> LocalImports {
+    let mut out: LocalImports = FxHashMap::default();
     for module in modules {
         let one = collect_module_imports_local(parsed, module, allowed, file_package);
         out.extend(one);
@@ -526,7 +541,7 @@ pub(crate) fn resolve_relative_import(
     level: u32,
     tail: &str,
     file_package: Option<&str>,
-) -> Option<String> {
+) -> Option<CompactString> {
     if level == 0 {
         return None;
     }
@@ -544,7 +559,7 @@ pub(crate) fn resolve_relative_import(
     if parts.is_empty() {
         return None;
     }
-    Some(parts.join("."))
+    Some(parts.join(".").into())
 }
 
 /// Build the file-local imports map ``{local_name: target}`` for
@@ -560,7 +575,7 @@ pub(crate) fn collect_module_imports_local(
     module: &str,
     allowed: &FxHashSet<&str>,
     file_package: Option<&str>,
-) -> FxHashMap<String, String> {
+) -> LocalImports {
     // Submodule binding: ``from <parent> import <last_seg>`` makes
     // ``last_seg`` a local alias for the queried module (e.g.
     // ``from unittest import mock`` for module ``unittest.mock``).
@@ -574,11 +589,11 @@ pub(crate) fn collect_module_imports_local(
                 // package. ``mod_name`` is just the dotted suffix; ty
                 // exposes the dot count via ``im.level``.
                 let tail = im.module.as_ref().map(|n| n.as_str()).unwrap_or("");
-                let absolute: Option<String> = if im.level == 0 {
+                let absolute: Option<CompactString> = if im.level == 0 {
                     if tail.is_empty() {
                         None
                     } else {
-                        Some(tail.to_string())
+                        Some(tail.to_compact_string())
                     }
                 } else {
                     resolve_relative_import(im.level, tail, file_package)
@@ -591,7 +606,7 @@ pub(crate) fn collect_module_imports_local(
                             continue;
                         }
                         let local = alias.asname.as_ref().map(|n| n.as_str()).unwrap_or(target);
-                        out.insert(local.to_string(), target.to_string());
+                        out.insert(local.to_compact_string(), target.to_compact_string());
                     }
                 } else if let Some((parent, last)) = parent_last {
                     if absolute == parent {
@@ -600,7 +615,10 @@ pub(crate) fn collect_module_imports_local(
                                 continue;
                             }
                             let local = alias.asname.as_ref().map(|n| n.as_str()).unwrap_or(last);
-                            out.insert(local.to_string(), MODULE_ALIAS_MARKER.to_string());
+                            out.insert(
+                                local.to_compact_string(),
+                                CompactString::const_new(MODULE_ALIAS_MARKER),
+                            );
                         }
                     }
                 }
@@ -611,7 +629,10 @@ pub(crate) fn collect_module_imports_local(
                         continue;
                     }
                     let local = alias.asname.as_ref().map(|n| n.as_str()).unwrap_or(module);
-                    out.insert(local.to_string(), MODULE_ALIAS_MARKER.to_string());
+                    out.insert(
+                        local.to_compact_string(),
+                        CompactString::const_new(MODULE_ALIAS_MARKER),
+                    );
                 }
             }
             _ => {}
@@ -635,10 +656,10 @@ pub(crate) fn unwrap_subscripted_callee(expr: &Expr) -> &Expr {
 /// the query forms that accept a list of modules to match against.
 pub(crate) fn matched_call_target_any(
     call: &ruff_python_ast::ExprCall,
-    imports: &FxHashMap<String, String>,
+    imports: &LocalImports,
     modules: &[String],
     allowed: &FxHashSet<&str>,
-) -> Option<String> {
+) -> Option<CompactString> {
     for module in modules {
         if let Some(name) = matched_call_target(call, imports, module, allowed) {
             return Some(name);
@@ -661,10 +682,10 @@ pub(crate) fn matched_call_target_any(
 /// Returns the matched upstream name (``"Flask"``) on hit, else ``None``.
 pub(crate) fn matched_call_target(
     call: &ruff_python_ast::ExprCall,
-    imports: &FxHashMap<String, String>,
+    imports: &LocalImports,
     module: &str,
     allowed: &FxHashSet<&str>,
-) -> Option<String> {
+) -> Option<CompactString> {
     // Unwrap a leading ``Expr::Subscript`` once so subscripted-generic
     // constructors (``Worker[int](...)``, ``Logger[Self]("foo")``)
     // classify the same as their bare ``Worker(...)`` form. Generics
@@ -683,9 +704,9 @@ pub(crate) fn matched_call_target(
                 return None;
             }
             match attr.value.as_ref() {
-                Expr::Name(prefix) => (imports.get(prefix.id.as_str()).map(String::as_str)
+                Expr::Name(prefix) => (imports.get(prefix.id.as_str()).map(CompactString::as_str)
                     == Some(MODULE_ALIAS_MARKER))
-                .then(|| attr_name.to_string()),
+                .then(|| attr_name.to_compact_string()),
                 _ => {
                     let (root, segs) = collapse_attribute_chain(attr.value.as_ref())?;
                     let mut dotted = String::with_capacity(module.len());
@@ -694,7 +715,7 @@ pub(crate) fn matched_call_target(
                         dotted.push('.');
                         dotted.push_str(seg);
                     }
-                    (dotted == module).then(|| attr_name.to_string())
+                    (dotted == module).then(|| attr_name.to_compact_string())
                 }
             }
         }
@@ -732,7 +753,7 @@ pub(crate) fn top_level_assign_to_name(stmt: &Stmt) -> Option<(TextRange, &Expr)
 /// of ``modules`` (OR semantics — for single-module callers pass a
 /// one-element slice).
 pub(crate) struct FactoryCallFinder<'a> {
-    pub(crate) imports: &'a FxHashMap<String, String>,
+    pub(crate) imports: &'a LocalImports,
     pub(crate) modules: &'a [String],
     pub(crate) allowed: &'a FxHashSet<&'a str>,
     pub(crate) kinds: FxHashSet<String>,
@@ -744,7 +765,7 @@ impl<'ast, 'a> Visitor<'ast> for FactoryCallFinder<'a> {
             if let Some(name) =
                 matched_call_target_any(call, self.imports, self.modules, self.allowed)
             {
-                self.kinds.insert(name);
+                self.kinds.insert(name.into_string());
             }
         }
         walk_expr(self, expr);
@@ -759,7 +780,7 @@ impl<'ast, 'a> Visitor<'ast> for FactoryCallFinder<'a> {
 /// can read decorator/constructor arguments too.
 #[derive(Clone, Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 pub enum ArgValue {
-    Str(String),
+    Str(CompactString),
     Unknown,
 }
 
@@ -769,7 +790,7 @@ pub enum ArgValue {
 /// the [`CallArgs::get`] / [`CallArgs::str_value`] accessors.
 #[derive(Clone, Debug, Default, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 pub struct CallArgs {
-    pub(crate) kwargs: FxHashMap<String, ArgValue>,
+    pub(crate) kwargs: FxHashMap<CompactString, ArgValue>,
 }
 
 impl CallArgs {
@@ -854,7 +875,7 @@ impl NodeAttrs {
 /// literals are captured; every other expression is ``Unknown``.
 pub(crate) fn extract_arg_value(expr: &Expr) -> ArgValue {
     match expr {
-        Expr::StringLiteral(s) => ArgValue::Str(s.value.to_str().to_string()),
+        Expr::StringLiteral(s) => ArgValue::Str(s.value.to_str().to_compact_string()),
         _ => ArgValue::Unknown,
     }
 }
@@ -862,12 +883,15 @@ pub(crate) fn extract_arg_value(expr: &Expr) -> ArgValue {
 /// Extract keyword arguments from a call. Positional args are not
 /// captured — no consumer reads them.
 pub(crate) fn extract_call_kwargs(call: &ruff_python_ast::ExprCall) -> CallArgs {
-    let mut kwargs: FxHashMap<String, ArgValue> = FxHashMap::default();
+    let mut kwargs: FxHashMap<CompactString, ArgValue> = FxHashMap::default();
     for kw in &call.arguments.keywords {
         let Some(name) = kw.arg.as_ref() else {
             continue;
         };
-        kwargs.insert(name.as_str().to_string(), extract_arg_value(&kw.value));
+        kwargs.insert(
+            name.as_str().to_compact_string(),
+            extract_arg_value(&kw.value),
+        );
     }
     CallArgs { kwargs }
 }
@@ -1667,9 +1691,9 @@ pub(crate) fn canonical_module_name_for_file(
     None
 }
 
-pub(crate) fn module_fqname_for_file(db: &dyn ProjectDb, file: File) -> String {
+pub(crate) fn module_fqname_for_file(db: &dyn ProjectDb, file: File) -> CompactString {
     if let Some(name) = canonical_module_name_for_file(db, file) {
-        return name.as_str().to_string();
+        return name.as_str().to_compact_string();
     }
     // Fallback for files ty doesn't classify (e.g. ``gunicorn.conf.py`` at
     // the project root — there's no ``__init__.py`` and the stem contains
@@ -1688,7 +1712,7 @@ pub(crate) fn module_fqname_for_file(db: &dyn ProjectDb, file: File) -> String {
         .strip_suffix(".pyi")
         .or_else(|| rel.strip_suffix(".py"))
         .unwrap_or(rel);
-    stem.replace(['/', '\\'], ".")
+    stem.replace(['/', '\\'], ".").into()
 }
 
 #[cfg(test)]
@@ -2395,7 +2419,7 @@ mod tests {
             Stmt::FunctionDef(f) => &f.decorator_list,
             _ => unreachable!(),
         };
-        let mut imports: FxHashMap<String, String> = FxHashMap::default();
+        let mut imports: LocalImports = FxHashMap::default();
         imports.insert("register".into(), "register".into());
         let mut allowed: FxHashSet<&str> = FxHashSet::default();
         allowed.insert("register");
@@ -2410,7 +2434,7 @@ mod tests {
             Stmt::FunctionDef(f) => &f.decorator_list,
             _ => unreachable!(),
         };
-        let mut imports: FxHashMap<String, String> = FxHashMap::default();
+        let mut imports: LocalImports = FxHashMap::default();
         imports.insert("flask".into(), MODULE_ALIAS_MARKER.into());
         let mut allowed: FxHashSet<&str> = FxHashSet::default();
         allowed.insert("route");
@@ -2426,7 +2450,7 @@ mod tests {
             Stmt::FunctionDef(f) => &f.decorator_list,
             _ => unreachable!(),
         };
-        let mut imports: FxHashMap<String, String> = FxHashMap::default();
+        let mut imports: LocalImports = FxHashMap::default();
         imports.insert("app".into(), MODULE_ALIAS_MARKER.into());
         let mut allowed: FxHashSet<&str> = FxHashSet::default();
         allowed.insert("task");
@@ -2442,7 +2466,7 @@ mod tests {
             Stmt::FunctionDef(f) => &f.decorator_list,
             _ => unreachable!(),
         };
-        let imports: FxHashMap<String, String> = FxHashMap::default();
+        let imports: LocalImports = FxHashMap::default();
         let allowed: FxHashSet<&str> = FxHashSet::default();
         assert!(decorators_match_imports(decorators, &imports, &allowed).is_none());
     }
@@ -2452,7 +2476,7 @@ mod tests {
     #[test]
     fn matched_call_target_via_local_name() {
         let call = first_call("Flask(__name__)");
-        let mut imports: FxHashMap<String, String> = FxHashMap::default();
+        let mut imports: LocalImports = FxHashMap::default();
         imports.insert("Flask".into(), "Flask".into());
         let mut allowed: FxHashSet<&str> = FxHashSet::default();
         allowed.insert("Flask");
@@ -2465,7 +2489,7 @@ mod tests {
     #[test]
     fn matched_call_target_via_module_alias_attr() {
         let call = first_call("flask.Flask(__name__)");
-        let mut imports: FxHashMap<String, String> = FxHashMap::default();
+        let mut imports: LocalImports = FxHashMap::default();
         imports.insert("flask".into(), MODULE_ALIAS_MARKER.into());
         let mut allowed: FxHashSet<&str> = FxHashSet::default();
         allowed.insert("Flask");
@@ -2480,7 +2504,7 @@ mod tests {
         let call = first_call("unittest.mock.patch('x')");
         // No file imports entry for the leftmost name — fallback to the
         // literal dotted match against ``module``.
-        let imports: FxHashMap<String, String> = FxHashMap::default();
+        let imports: LocalImports = FxHashMap::default();
         let mut allowed: FxHashSet<&str> = FxHashSet::default();
         allowed.insert("patch");
         assert_eq!(
@@ -2492,7 +2516,7 @@ mod tests {
     #[test]
     fn matched_call_target_rejects_unknown_name() {
         let call = first_call("unrelated()");
-        let imports: FxHashMap<String, String> = FxHashMap::default();
+        let imports: LocalImports = FxHashMap::default();
         let allowed: FxHashSet<&str> = FxHashSet::default();
         assert!(matched_call_target(&call, &imports, "x", &allowed).is_none());
     }
@@ -2500,7 +2524,7 @@ mod tests {
     #[test]
     fn matched_call_target_rejects_disallowed_name() {
         let call = first_call("Flask()");
-        let mut imports: FxHashMap<String, String> = FxHashMap::default();
+        let mut imports: LocalImports = FxHashMap::default();
         imports.insert("Flask".into(), "Flask".into());
         // Empty allowed set: target is present but not allowed.
         let allowed: FxHashSet<&str> = FxHashSet::default();

--- a/runtime/src/ingest.rs
+++ b/runtime/src/ingest.rs
@@ -23,6 +23,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use compact_str::{CompactString, ToCompactString};
 use pyo3::prelude::*;
 use ruff_db::files::{File, FilePath};
 use ruff_python_ast::{Expr, ExprName, Stmt};
@@ -61,9 +62,9 @@ pub(crate) fn from_module_string(
     db: &dyn ty_python_semantic::Db,
     file: File,
     stmt: &ruff_python_ast::StmtImportFrom,
-) -> String {
+) -> CompactString {
     ModuleName::from_import_statement(db, file, stmt)
-        .map(|n| n.as_str().to_string())
+        .map(|n| n.as_str().to_compact_string())
         .unwrap_or_default()
 }
 
@@ -81,14 +82,14 @@ pub(crate) fn from_module_string(
 /// filesystem — no Python callback, so the same lookup works in
 /// pyo3 contexts where issuing ``importlib.metadata.distributions()``
 /// would round-trip through the runtime.
-pub(crate) type DistLookup = HashMap<PathBuf, String>;
+pub(crate) type DistLookup = HashMap<PathBuf, CompactString>;
 
 /// PEP 503 normalization. Replaces every run of ``[-_.]`` with a
 /// single ``-`` and lowercases the rest. Equivalent to Python's
 /// ``re.sub(r"[-_.]+", "-", name).lower()`` from libcst's
 /// ``_canonical_dist_name``.
-pub(crate) fn pep503_canonicalize(name: &str) -> String {
-    let mut out = String::with_capacity(name.len());
+pub(crate) fn pep503_canonicalize(name: &str) -> CompactString {
+    let mut out = CompactString::with_capacity(name.len());
     let mut prev_sep = false;
     for ch in name.chars() {
         if matches!(ch, '-' | '_' | '.') {
@@ -161,7 +162,7 @@ pub(crate) fn build_dist_lookup(site_packages: &[PathBuf]) -> DistLookup {
 /// One ``*.dist-info/`` directory's ``(absolute file path, canonical
 /// dist name)`` pairs. ``None`` when METADATA / RECORD are missing or
 /// the ``Name:`` header isn't found.
-fn process_dist_info(dist_info: &Path, sp_root: &Path) -> Option<Vec<(PathBuf, String)>> {
+fn process_dist_info(dist_info: &Path, sp_root: &Path) -> Option<Vec<(PathBuf, CompactString)>> {
     let metadata = std::fs::read_to_string(dist_info.join("METADATA")).ok()?;
     let canonical = metadata
         .lines()

--- a/runtime/src/native_plugins.rs
+++ b/runtime/src/native_plugins.rs
@@ -274,9 +274,9 @@ pub(crate) enum FileLocalOp {
     /// cache into [`crate::project::BuildOutputs`] for the topic's project-wide
     /// reader.
     Fact {
-        topic: String,
+        topic: compact_str::CompactString,
         decl_local_idx: Option<u32>,
-        value: String,
+        value: compact_str::CompactString,
     },
 }
 
@@ -379,7 +379,7 @@ impl<'db> FileContext<'db> {
         parsed: &ruff_db::parsed::ParsedModuleRef,
         modules: &[String],
         names: &FxHashSet<&str>,
-    ) -> rustc_hash::FxHashMap<String, String> {
+    ) -> crate::helpers::LocalImports {
         collect_modules_imports_local(parsed, modules, names, self.file_package().as_deref())
     }
 
@@ -402,7 +402,7 @@ impl<'db> FileContext<'db> {
                     if tail.is_empty() {
                         return false;
                     }
-                    tail.to_string()
+                    compact_str::CompactString::from(tail)
                 } else {
                     match crate::helpers::resolve_relative_import(
                         im.level,
@@ -2160,15 +2160,15 @@ pub mod plugin_api {
     ) -> FileNodeView {
         FileNodeView {
             local_idx,
-            fqname: node.fqname.clone(),
+            fqname: node.fqname.to_string(),
             kind: node.kind.as_static_str().to_string(),
             path: path.to_string(),
             start_line: node.start_line,
             end_line: node.end_line,
             flags: node.flags,
             imports: node.imports.as_ref().map(|i| ImportRef {
-                module: i.module.clone(),
-                decl: i.decl.clone(),
+                module: i.module.to_string(),
+                decl: i.decl.as_ref().map(|d| d.to_string()),
                 star: i.star,
             }),
         }
@@ -2347,9 +2347,9 @@ pub mod plugin_api {
             value: impl Into<String>,
         ) {
             self.sink.push(FileLocalOp::Fact {
-                topic: topic.into(),
+                topic: topic.into().into(),
                 decl_local_idx,
-                value: value.into(),
+                value: value.into().into(),
             });
         }
     }
@@ -4064,11 +4064,12 @@ impl plugin_api::ExternalPlugin for PytestPluginImpl {
         // binding name -> [fixture idx]. Binding is the `name=` kwarg literal
         // when present, else the function's simple name.
         let fixture_attrs = ctx.nodes_at(&fixture_idxs_all);
-        let mut fixtures_by_name: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+        let mut fixtures_by_name: FxHashMap<compact_str::CompactString, Vec<usize>> =
+            FxHashMap::default();
         for ((idx, args), attr) in fixture_refs.iter().zip(fixture_attrs.iter()) {
             let binding = match args.kwargs.get("name") {
                 Some(ArgValue::Str(alias)) => alias.clone(),
-                _ => simple_name(&attr.fqname).to_string(),
+                _ => simple_name(&attr.fqname).into(),
             };
             fixtures_by_name.entry(binding).or_default().push(*idx);
         }
@@ -4077,7 +4078,7 @@ impl plugin_api::ExternalPlugin for PytestPluginImpl {
             let params = ctx.function_parameters(&test_function_idxs);
             for (test_idx, names) in test_function_idxs.iter().zip(params) {
                 for name in names {
-                    if let Some(fixture_idxs) = fixtures_by_name.get(&name) {
+                    if let Some(fixture_idxs) = fixtures_by_name.get(name.as_str()) {
                         for &fixture_idx in fixture_idxs {
                             ops.add_edge(*test_idx, fixture_idx, 0);
                         }
@@ -4089,7 +4090,7 @@ impl plugin_api::ExternalPlugin for PytestPluginImpl {
             let params = ctx.class_method_parameters(&test_class_idxs);
             for (cls_idx, names) in test_class_idxs.iter().zip(params) {
                 for name in names {
-                    if let Some(fixture_idxs) = fixtures_by_name.get(&name) {
+                    if let Some(fixture_idxs) = fixtures_by_name.get(name.as_str()) {
                         for &fixture_idx in fixture_idxs {
                             ops.add_edge(*cls_idx, fixture_idx, 0);
                         }

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -805,7 +805,7 @@ fn assemble_graph<'db>(
                             }
 
                             let node = GraphNode {
-                                fqname: node_data.fqname.clone(),
+                                fqname: node_data.fqname.to_string(),
                                 kind: intern_kind(node_data.kind.as_static_str())?,
                                 // Every node in this file's payload shares
                                 // the file, so its path is the per-file
@@ -1005,19 +1005,20 @@ fn assemble_graph<'db>(
     // Sort by (fqname, path) — `intern_external` dedups on fqname, so
     // the first path after the sort wins deterministically, and every
     // External lands at the same index every run.
-    let mut externals: Vec<(String, String, File, NodeRef<'db>)> = external_keys
-        .into_iter()
-        .filter_map(|r| match r {
-            NodeRef::External(key) => {
-                let file = key.file(db);
-                Some((key.fqname(db).clone(), file_path_string(db, file), file, r))
-            }
-            _ => None,
-        })
-        .collect();
+    let mut externals: Vec<(compact_str::CompactString, String, File, NodeRef<'db>)> =
+        external_keys
+            .into_iter()
+            .filter_map(|r| match r {
+                NodeRef::External(key) => {
+                    let file = key.file(db);
+                    Some((key.fqname(db).clone(), file_path_string(db, file), file, r))
+                }
+                _ => None,
+            })
+            .collect();
     externals.sort_unstable_by(|a, b| (&a.0, &a.1).cmp(&(&b.0, &b.1)));
     for (fqname, path, file, r) in externals {
-        let idx = builder.intern_external(fqname, path, file);
+        let idx = builder.intern_external(fqname.into(), path, file);
         ref_to_global.insert(r, idx);
     }
 
@@ -1222,11 +1223,14 @@ fn fold_per_file_plugin_ops(
                         let path = file_path
                             .get_or_insert_with(|| file_path_string(db, file))
                             .clone();
-                        topic_facts.entry(topic.clone()).or_default().push(Fact {
-                            path,
-                            decl_idx,
-                            value: value.clone(),
-                        });
+                        topic_facts
+                            .entry(topic.to_string())
+                            .or_default()
+                            .push(Fact {
+                                path,
+                                decl_idx,
+                                value: value.to_string(),
+                            });
                     }
                 }
             }
@@ -1452,7 +1456,7 @@ pub(crate) fn build_fqname_indices(
                     acc.decls.entry(node.fqname.clone()).or_default().push(idx);
                     if let Some(import) = node.imports.as_ref() {
                         acc.imports_by_module
-                            .entry(import.module.clone())
+                            .entry(import.module.to_string())
                             .or_default()
                             .push(idx);
                     }
@@ -3115,7 +3119,7 @@ fn find_literal_list_entries_in(
                 continue;
             }
             found_any = true;
-            out.extend(entries.iter().cloned());
+            out.extend(entries.iter().map(|e| e.to_string()));
         }
     }
     found_any.then_some(out)
@@ -3216,7 +3220,7 @@ fn function_parameters_in(
     for (&file, rk_to_idx) in &by_file {
         for (rk, names) in &file_extraction(db, file).function_params {
             if let Some(&idx) = rk_to_idx.get(rk) {
-                params_for_idx.insert(idx, names.clone());
+                params_for_idx.insert(idx, names.iter().map(|n| n.to_string()).collect());
             }
         }
     }
@@ -3261,7 +3265,7 @@ fn class_method_parameters_in(
     for (&file, rk_to_idx) in &by_file {
         for (rk, names) in &file_extraction(db, file).class_method_params {
             if let Some(&idx) = rk_to_idx.get(rk) {
-                params_for_idx.insert(idx, names.clone());
+                params_for_idx.insert(idx, names.iter().map(|n| n.to_string()).collect());
             }
         }
     }
@@ -3341,7 +3345,9 @@ fn find_decorated_decls_core(
                     // `@alias.attr` / `@alias.attr(...)` where `alias` is the
                     // module (`import <module> [as alias]`).
                     [attr] => {
-                        imports.get(&desc.root_name).map(String::as_str)
+                        imports
+                            .get(&desc.root_name)
+                            .map(compact_str::CompactString::as_str)
                             == Some(MODULE_ALIAS_MARKER)
                             && names.contains(attr.as_str())
                     }
@@ -3398,7 +3404,7 @@ fn find_instance_constructions_core(
             } else {
                 CallArgs::default()
             };
-            out.push((idx, matched, call_args));
+            out.push((idx, matched.into_string(), call_args));
         }
     }
     out
@@ -3442,7 +3448,7 @@ fn find_handler_decorators_core(
                 } else {
                     CallArgs::default()
                 };
-                out.push((desc.root_name.clone(), idx, call_args));
+                out.push((desc.root_name.to_string(), idx, call_args));
             }
         }
     }
@@ -3488,7 +3494,7 @@ fn find_handler_decorators_via_core(
                 } else {
                     CallArgs::default()
                 };
-                out.push((desc.root_name.clone(), idx, call_args));
+                out.push((desc.root_name.to_string(), idx, call_args));
             }
         }
     }
@@ -3560,7 +3566,7 @@ fn find_calls_on_attr_core(
                 CallArgs::default()
             };
             for s in hits {
-                out.push((owner_idx, s.clone(), call_args.clone()));
+                out.push((owner_idx, s.to_string(), call_args.clone()));
             }
         });
     }
@@ -3593,7 +3599,7 @@ fn find_factory_decls_core(
             let mut kinds: FxHashSet<String> = FxHashSet::default();
             for desc in descriptors {
                 if let Some(name) = match_callee_descriptor(desc, &imports, modules, &allowed) {
-                    kinds.insert(name);
+                    kinds.insert(name.into_string());
                 }
             }
             if kinds.is_empty() {
@@ -4582,7 +4588,7 @@ mod tests {
                     decls.entry(node.fqname.clone()).or_default().push(idx);
                     if let Some(import) = node.imports.as_ref() {
                         imports_by_module
-                            .entry(import.module.clone())
+                            .entry(import.module.to_string())
                             .or_default()
                             .push(idx);
                     }
@@ -4624,7 +4630,7 @@ mod tests {
         b.nodes.push(node("pkg.mod.x", "variable"));
         let mut imp = node("pkg.mod.os", "import");
         imp.imports = Some(ImportPayload {
-            module: "os".to_string(),
+            module: "os".into(),
             decl: None,
             star: false,
         });
@@ -4659,8 +4665,8 @@ mod tests {
                 3 => {
                     let mut imp = node(&format!("pkg.m{}.dep", i % 11), "import");
                     imp.imports = Some(ImportPayload {
-                        module: format!("dep{}", i % 3),
-                        decl: Some("thing".to_string()),
+                        module: compact_str::format_compact!("dep{}", i % 3),
+                        decl: Some("thing".into()),
                         star: false,
                     });
                     b.nodes.push(imp);


### PR DESCRIPTION
## Summary

Converts every identifier-shaped string in the per-file salsa-cached payload types from `String` to `compact_str::CompactString`, which stores up to 24 bytes inline. Typical Python identifiers and dotted module paths fit the inline buffer, so the cached payloads skip one heap allocation per string and pack tighter in salsa's storage.

### Converted

- **`file_payload`**: `NodeData.fqname`, `ImportPayload.module/decl`, `FileNodes.exports_by_name` / `star_reexports`, `ClassBaseSpec`, `ExternalKey.fqname` (salsa-interned), `ProjectDistLookup` values
- **`file_extraction`**: the whole fact family — `CalleeDescriptor`, `CalleeChain`, `ImportFact`, `StringArg`, `CallSiteFact`, and the params / literal-list / method-defs row vectors
- **`file_ref_edges`**: external-node fqnames
- **`native_plugins`**: `FileLocalOp::Fact` topic/value
- **`helpers`**: the shared `{local → target}` imports-map shape gets a proper name — `helpers::LocalImports = FxHashMap<CompactString, CompactString>` (was 24 scattered `FxHashMap<String, String>`s) — plus `CallArgs`/`ArgValue` and the producer helpers (`from_module_string`, `module_fqname_for_file`, `pep503_canonicalize`, `resolve_relative_import`, `attribute_to_module_member`)

### Deliberately kept `String`

- `warnings` (sentence-long prose, no inline win)
- the graph-side types (`GraphNode` / `NodeKey` / `SymbolNode` / the dcg file) at the pyo3/bincode boundary — conversions happen at the assemble boundary where a clone already happened, so the build does no extra work

### Trait plumbing

None needed: the vendored ruff/ty workspace already enables salsa's `compact_str` feature (`salsa::Update for CompactString`) and get-size2's `compact-str` feature (`GetSize` for the `heap_size = ruff_memory_usage::heap_size` hook). The runtime crate now states both features explicitly rather than riding feature unification.

## Benchmarks

Interleaved A/B (alternating wheel installs in the same time window, 5 rounds, heavy shape: 1000 files × 50 decls, 103k nodes / 157k edges):

| metric | main | this PR |
|---|---|---|
| RSS, 1st iteration | 391–392MB | **376–385MB** (−6 to −15MB) |
| RSS, 4th iteration | 428–432MB | **414–424MB** (−8 to −16MB) |
| total materialize | 298–305ms | 299–318ms (within noise — deltas flip sign across rounds) |

So: **~2–4% RSS reduction, wall-time neutral**. One caveat: the synthetic's fqnames (~22 chars) sit right at the 24-byte inline edge; real codebases with shorter identifiers in the extraction maps (param names, kwargs, import locals) should inline more, deeper dotted paths less.

No behavior change — the graph is identical; only the in-memory representation of the cached payloads changes.

## Testing

- `cargo test --no-default-features --locked -p dead-cst-runtime` — 141 passed
- `uv run pytest` — 703 passed, 4 skipped
- `uv run prek run --all-files` — all hooks green (ruff, ty, cargo fmt, cargo clippy)

https://claude.ai/code/session_01XzpwVFkdEkqLZGb2STrgLM

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzpwVFkdEkqLZGb2STrgLM)_