### PR TITLE
Consolidate per-file edges into file-local RefSpecs resolved at assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,7 +274,13 @@ two versions.
   binding failures stamp `NodeFlags::UNRESOLVED`. Graph output is unchanged
   (same nodes, edges, and flags); structural edges (decl → module anchors,
   overload anchors, module hierarchy) are now synthesized at assembly
-  straight from the node payloads.
+  straight from the node payloads. Assembly is structured for row volume:
+  every `Member`/`Dynamic` spec row is interned once into a dense id during
+  the gather (stamping and edge translation index a `Vec` instead of
+  re-hashing string-keyed rows), and all resolution families — member refs,
+  dynamic refs, the parent-module sweep, class bases — run on fine-grained
+  (16× worker count) chunks inside pass 1's rayon join, overlapped with the
+  node fill.
 
 - **`CompactString` in the salsa-cached payloads.** Every identifier-shaped
   string in the per-file salsa caches — `NodeData.fqname`, `ImportPayload`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,27 @@ two versions.
 
 ### Changed
 
+- **File-local reference specs; cross-file resolution moved to assembly.**
+  The two per-file salsa edge queries (`file_to_edges` / `file_to_ref_edges`)
+  are consolidated into one combined walk (`file_to_refspecs`) that emits
+  unresolved, file-local `RefSpec` rows — local node indices plus symbolic
+  `Member` / `Dynamic` descriptors — instead of resolved cross-file edges.
+  The walk query now has zero cross-file salsa dependencies, so editing one
+  file no longer invalidates any importer's (expensive) AST/use-def walk;
+  only the assembly-time resolution re-runs. Resolution itself is memoized
+  project-wide per `(ref, anchor directory)` and runs on rayon workers, so a
+  hot import repeated across thousands of use sites resolves once per
+  directory rather than once per use. The class-base fan-in
+  (`build_class_hierarchy_indices`) reuses the same memoized parallel
+  machinery (previously it re-resolved every base spelling once per class,
+  serially). Member resolution carries an explicit `Binding`/`Use` role:
+  binding-side edges keep skipping past star-reexport aliases to the real
+  decl while use-side edges keep landing on the star alias itself, and only
+  binding failures stamp `NodeFlags::UNRESOLVED`. Graph output is unchanged
+  (same nodes, edges, and flags); structural edges (decl → module anchors,
+  overload anchors, module hierarchy) are now synthesized at assembly
+  straight from the node payloads.
+
 - **Parallel edge-storage init and fqname-index map-reduce.** Two more serial
   build chunks now run on rayon workers with the GIL released. The assemble
   pass's bulk edge insert (`GraphBuilder::init_edges_bulk`) derives `edges`,

--- a/runtime/src/file_extraction.rs
+++ b/runtime/src/file_extraction.rs
@@ -12,8 +12,7 @@
 //! parsed module behind this query sound.
 //!
 //! Sibling of [`crate::file_payload::file_to_nodes`] /
-//! [`crate::file_payload::file_to_edges`] /
-//! [`crate::file_ref_edges::file_to_ref_edges`]; unlike `file_to_nodes`
+//! [`crate::file_ref_edges::file_to_refspecs`]; unlike `file_to_nodes`
 //! (the cross-file lookup primitive) this query is never called
 //! cross-file, so it carries no `'db` lifetime and absorbs facts freely.
 

--- a/runtime/src/file_payload.rs
+++ b/runtime/src/file_payload.rs
@@ -7,20 +7,15 @@
 //! * the per-file walk runs in parallel via salsa's lock-free worker
 //!   coordination (the same machinery that already gives `prewarm_file`
 //!   16k files/sec);
-//! * cross-file calls — e.g. `file_to_edges(A)` looking up a target
-//!   `Definition` in `B` via `file_to_nodes(B)` — are memoized for free
-//!   (`returns(ref)` returns a borrow straight into salsa's storage,
-//!   no clone).
+//! * cross-file calls — e.g. the assembly pass's `resolve_member`
+//!   looking up a target `Definition` in `B` via `file_to_nodes(B)` —
+//!   are memoized for free (`returns(ref)` returns a borrow straight
+//!   into salsa's storage, no clone).
 //!
 //! Pattern cribbed from `function_known_decorators` in
 //! `vendor/ruff/crates/ty_python_semantic/src/types/infer.rs`, which is
-//! the closest analogue (tracked fn, `'db`-lifetimed return, salsa::Update
-//! derive on the carrier struct).
-//!
-//! This module DOES NOT yet replace `ingest_decls` — the existing
-//! pipeline still runs. The function is wired into the crate but has
-//! no callers; landing it first lets us validate the salsa macro
-//! pattern + the `NodeData` shape before the driver swap.
+//! the closest analogue (tracked fn, salsa::Update derive on the
+//! carrier struct).
 
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
@@ -30,7 +25,7 @@ use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use std::collections::HashMap;
-use ty_module_resolver::{resolve_module, ModuleName};
+use ty_module_resolver::resolve_module;
 use ty_project::Db as ProjectDb;
 use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
 use ty_python_core::place::{PlaceExprRef, ScopedPlaceId};
@@ -46,10 +41,11 @@ use crate::helpers::{
 use crate::ingest::{decl_kind_str, file_package_name, from_module_string};
 
 /// Stable handle for a graph node, used as the public identity across
-/// the fan-out pipeline. Edge endpoints in `file_to_edges` are
-/// `(NodeRef, NodeRef, flags)`; the assembly pass translates each
-/// `NodeRef` to its final `u32` graph index after all per-file
-/// payloads are collected.
+/// the fan-out pipeline. Cross-file resolution outputs
+/// ([`crate::refspec::ResolvedNode`], `walk_exports_chain`) name nodes
+/// by `NodeRef`; the assembly pass translates each `NodeRef` to its
+/// final graph index via `ref_to_global` after all per-file payloads
+/// are collected.
 ///
 /// `NodeRef::Def` covers every binding ty enumerates as a `Definition`,
 /// keyed by an owned [`DeclKey`] (`(File, ScopedPlaceId, name_range)`)
@@ -61,14 +57,15 @@ use crate::ingest::{decl_kind_str, file_package_name, from_module_string};
 /// `NodeRef::Module` covers the synthetic `kind="module"` node per
 /// file — `File` is itself a salsa input ingredient, so its handle is
 /// stable and `Hash + Eq + Copy`.
-/// `NodeRef::External` covers the synthetic `[external dist] X` /
-/// `[external file] X` site-packages nodes via a globally-interned
-/// `ExternalKey` — same fqname produces the same key, dedup is free.
+///
+/// Synthetic `[external dist] X` / `[external file] X` nodes have no
+/// `NodeRef`: they only ever appear as resolution *outputs*
+/// ([`crate::refspec::ResolvedNode::External`]) and are interned
+/// directly into the builder by the assembly pass.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
-pub(crate) enum NodeRef<'db> {
+pub(crate) enum NodeRef {
     Def(DeclKey),
     Module(File),
-    External(ExternalKey<'db>),
     /// The kept `*<module>` node for a `from <module> import *` statement.
     /// Keyed on `(file, <star-token range>)` rather than a ty def: the
     /// per-name `StarImport` defs back the individual `STAR_REEXPORT`
@@ -95,35 +92,6 @@ pub(crate) fn def_key<'db>(
         range_key(def.kind(db).target_range(parsed)),
     )
 }
-
-/// Globally-interned synthetic external node identity. Same `fqname`
-/// → same key → same final graph node, regardless of which file
-/// emitted the edge.
-///
-/// Only site-packages targets mint an `ExternalKey`; the fqname
-/// conventions:
-///
-/// * `[external dist] X` — module resolves to a site-packages dist;
-///   `X` is the PEP 503 canonical dist name (via `external_fqname_for`).
-/// * `[external file] X` — a site-packages file with no owning dist;
-///   `X` is the top-level module name.
-///
-/// `file` is the resolved target's site-packages `File`, carried so the
-/// assembled `kind="external"` node can re-derive its path (for codemod
-/// / scoping exclusion) without re-resolving. Several keys may share an
-/// fqname with different files — e.g. two submodules of one dist;
-/// assembly dedups by fqname and keeps the first (path-sorted) file.
-/// Stdlib targets and genuinely-unresolved imports mint no `ExternalKey`:
-/// stdlib stays silent, and an unresolved import's alias node carries
-/// `NodeFlags::UNRESOLVED`.
-#[salsa::interned(debug)]
-pub(crate) struct ExternalKey<'db> {
-    pub(crate) fqname: String,
-    pub(crate) file: File,
-}
-
-// Salsa tracks the interned heap separately; report 0 from GetSize.
-impl get_size2::GetSize for ExternalKey<'_> {}
 
 /// Project-wide PEP 503 distribution lookup, salsa-tracked so it's
 /// memoized + accessible from per-file salsa-tracked queries. Wraps
@@ -212,8 +180,7 @@ pub(crate) enum NodeKind {
 }
 
 impl NodeKind {
-    // Used by the assembly pass that converts `NodeData → Py<SymbolNode>`
-    // once `file_to_edges` lands and the driver is swapped.
+    // Used by the assembly pass that converts `NodeData → Py<SymbolNode>`.
     #[allow(dead_code)]
     pub(crate) fn as_static_str(self) -> &'static str {
         match self {
@@ -244,7 +211,7 @@ impl NodeKind {
 /// Per-alias import metadata. Same fields as the python-facing
 /// `Import` pyclass, but without the `Py` envelope so it can live
 /// inside `NodeData`.
-#[derive(Debug, Clone, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, salsa::Update, get_size2::GetSize)]
 pub(crate) struct ImportPayload {
     pub(crate) module: String,
     pub(crate) decl: Option<String>,
@@ -294,10 +261,10 @@ pub(crate) struct ImportPayload {
 ///   in `nodes` and are excluded from `exports_by_name` so cross-module
 ///   `from mod import f` resolves to the impl only.
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
-pub(crate) struct FileNodes<'db> {
+pub(crate) struct FileNodes {
     pub(crate) nodes: Box<[NodeData]>,
-    pub(crate) refs: Box<[NodeRef<'db>]>,
-    pub(crate) ref_to_local: FxHashMap<NodeRef<'db>, u32>,
+    pub(crate) refs: Box<[NodeRef]>,
+    pub(crate) ref_to_local: FxHashMap<NodeRef, u32>,
     pub(crate) exports_by_name: FxHashMap<String, SmallVec<[u32; 2]>>,
     pub(crate) star_reexports: FxHashMap<String, String>,
     pub(crate) class_bases: Vec<ClassBaseEntry>,
@@ -390,7 +357,7 @@ fn is_overload_decorator(
 /// in place. The flag set is otherwise the same as today's
 /// `ingest_decls`.
 #[salsa::tracked(returns(ref), heap_size = ruff_memory_usage::heap_size)]
-pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNodes<'db> {
+pub(crate) fn file_to_nodes(db: &dyn ProjectDb, file: File) -> FileNodes {
     let parsed = parsed_module(db, file).load(db);
     let source = source_text(db, file);
     let line_index = line_index(db, file);
@@ -402,12 +369,12 @@ pub(crate) fn file_to_nodes<'db>(db: &'db dyn ProjectDb, file: File) -> FileNode
     let (msl, msc, mel, mec) = position(&line_index, &source, parsed.syntax().range);
 
     let mut nodes: Vec<NodeData> = Vec::new();
-    let mut refs: Vec<NodeRef<'db>> = Vec::new();
-    let mut ref_to_local: FxHashMap<NodeRef<'db>, u32> = FxHashMap::default();
+    let mut refs: Vec<NodeRef> = Vec::new();
+    let mut ref_to_local: FxHashMap<NodeRef, u32> = FxHashMap::default();
 
     // Index 0: the synthetic module node. Anchors reachability for
-    // every per-file decl via the `decl → module` edge `file_to_edges`
-    // will emit.
+    // every per-file decl via the `decl → module` anchor edge the
+    // assembly pass synthesizes.
     nodes.push(NodeData {
         fqname: module_fqname.clone(),
         kind: NodeKind::Module,
@@ -780,13 +747,13 @@ fn build_class_bases(
 /// star alias for `g`; we resolve B → file, look up `g` there, and
 /// recurse. Stops on a decl, on a non-star import, on a missed
 /// lookup (yields nothing past it), or on a cycle.
-pub(crate) fn walk_exports_chain<'db>(
-    db: &'db dyn ProjectDb,
+pub(crate) fn walk_exports_chain(
+    db: &dyn ProjectDb,
     target_file: File,
     symbol_name: &str,
-) -> Vec<NodeRef<'db>> {
+) -> Vec<NodeRef> {
     let mut seen: std::collections::HashSet<(File, String)> = std::collections::HashSet::new();
-    let mut out: Vec<NodeRef<'db>> = Vec::new();
+    let mut out: Vec<NodeRef> = Vec::new();
     let mut stack: Vec<(File, String)> = vec![(target_file, symbol_name.to_string())];
     while let Some(key) = stack.pop() {
         if !seen.insert(key.clone()) {
@@ -855,299 +822,30 @@ pub(crate) fn import_payload_for_pure<'db>(
 }
 
 // ---------------------------------------------------------------------------
-// file_to_edges
+// (file_to_edges removed)
+//
+// The old `file_to_edges` query — import-alias upstream edges, decl →
+// module anchors, overload anchors, the module-hierarchy edge — was
+// folded into the combined `file_to_refspecs` walk
+// (`crate::file_ref_edges`) and the assembly pass:
+//
+// * import-alias upstream resolution is now a `Member(Binding)`
+//   [`crate::refspec::RefSpec`] resolved project-wide at assembly
+//   (`crate::refspec::resolve_binding` carries the `_handle_fromlist`
+//   namespace-vs-submodule disambiguation and the unresolved-alias
+//   flagging that lived here);
+// * decl → module anchors, overload anchors, and the submodule →
+//   parent-package hierarchy edge are synthesized by the assembly
+//   pass straight from `FileNodes` / [`parent_module_file`], since
+//   they're fully derivable and would only bloat the payload.
 // ---------------------------------------------------------------------------
-
-/// Salsa-tracked output of [`file_to_edges`]. One entry per
-/// `(src, dst, flags)` edge originating in this file. `FxHashSet` so
-/// duplicate emissions within the file (a name used twice resolving
-/// to the same target) collapse to a single entry — matching today's
-/// `builder.edge_set` behavior.
-///
-/// Edges in this set are *unresolved-to-graph-idx*: endpoints are
-/// `NodeRef<'db>` handles, not `u32` graph indices. The assembly pass
-/// translates each `NodeRef` to its final `u32` after all per-file
-/// payloads are collected.
-#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
-pub(crate) struct FileEdges<'db> {
-    pub(crate) edges: FxHashSet<(NodeRef<'db>, NodeRef<'db>, u8)>,
-    /// Import-alias nodes in this file whose upstream module did not
-    /// resolve. The assembly pass ORs `NodeFlags::UNRESOLVED` into each
-    /// (in place of the old `[unresolved] X` sink edge).
-    pub(crate) unresolved_aliases: FxHashSet<NodeRef<'db>>,
-}
-
-/// Per-file edge emission. Salsa-tracked so the per-file walk
-/// parallelizes via salsa's worker coordination, and cross-file
-/// lookups (`file_to_nodes(target_file)`) are memoized for free.
-///
-/// Emits today:
-///
-/// * `Def → Module(file)` for every per-file decl — the reachability
-///   anchor that wires a file's decls to its module node.
-/// * `Module(file) → Module(parent_file)` when the file has a parent
-///   package whose `__init__.py` resolves into the project. Mirrors
-///   today's `emit_module_hierarchy`.
-/// * `Def(alias) → Module(target_file)` and (for from-imports)
-///   `Def(alias) → Def(target_decl)` for each import binding whose
-///   upstream resolves to a project file. The `target_decl` lookup
-///   goes through `file_to_nodes(target_file).exports_by_name`,
-///   which is the "for free" salsa memoization this whole
-///   refactor is built around.
-///
-/// Deliberately deferred (each is a self-contained follow-up):
-///
-/// * **External nodes.** `[external dist] X` / `[stdlib] X` /
-///   `[unresolved] X` need `NodeRef::External` + a `#[salsa::interned]`
-///   key. Imports that resolve outside the project are currently
-///   *skipped*, not redirected to external nodes.
-/// * **Attribute-chain edges.** `import a.b.c; a.b.c.f()` today
-///   emits parallel edges to every chain segment. This cut emits
-///   only the alias → `a` edge.
-/// * **Per-statement sibling-to-submodule edges.** `from .submod
-///   import X` in an `__init__.py` mints both an `X` alias and a
-///   `submod` submodule alias; today the X alias gets a sibling
-///   edge to the submodule alias so they stay alive together.
-/// * **Reference edges (Phase 3's `RefCollector` work).** `use →
-///   alias` and `use → upstream` from every Name reference in every
-///   owned expression. This is the biggest deferred chunk — the
-///   refactor of the ~1k-line `RefCollector` into a per-file
-///   producer is its own follow-up.
-/// * **Dynamic import edges** (`__import__('x')` /
-///   `importlib.import_module('x')`).
-/// * **Dead-branch edge flag.** Edges originating inside `if False:`
-///   / post-`return` blocks need `EdgeFlags::DEAD_BRANCH` set; needs
-///   `dead_ranges` on the payload.
-#[salsa::tracked(returns(ref), heap_size = ruff_memory_usage::heap_size)]
-pub(crate) fn file_to_edges<'db>(db: &'db dyn ProjectDb, file: File) -> FileEdges<'db> {
-    let self_nodes = file_to_nodes(db, file);
-    let module_ref = NodeRef::Module(file);
-    let mut edges: FxHashSet<(NodeRef<'db>, NodeRef<'db>, u8)> = FxHashSet::default();
-    let mut unresolved_aliases: FxHashSet<NodeRef<'db>> = FxHashSet::default();
-
-    // 1. Decl → module anchor edges. Every per-file def points at the
-    //    module node so reachability seeded from the module covers all
-    //    its decls. `refs[0]` is the module itself; skip it.
-    for &node_ref in self_nodes.refs.iter().skip(1) {
-        edges.insert((node_ref, module_ref, 0));
-    }
-
-    // 1a. `impl → stub` anchor edges for in-file `@typing.overload`
-    //     groups. Lets reachability propagate from a live impl to its
-    //     stubs and lets the codemod drop a dead impl's stubs in the
-    //     same pass. (`NodeData::is_overload` on the stub additionally
-    //     excludes it from cross-module `from mod import f` lookups.)
-    for &(impl_local, stub_local) in self_nodes.overload_anchors.iter() {
-        let impl_ref = self_nodes.refs[impl_local as usize];
-        let stub_ref = self_nodes.refs[stub_local as usize];
-        edges.insert((impl_ref, stub_ref, 0));
-    }
-
-    // 2. Submodule → parent module hierarchy edge. Mirrors today's
-    //    `emit_module_hierarchy`. Skipped when the parent doesn't
-    //    resolve into the project (top-level package, or sibling
-    //    outside the project root).
-    if let Some(parent_file) = parent_module_file(db, file) {
-        edges.insert((module_ref, NodeRef::Module(parent_file), 0));
-    }
-
-    // 3. Import alias edges. Walk each kind="import" Definition in
-    //    this file's global scope, resolve its upstream module via
-    //    `resolve_module`, and emit:
-    //
-    //    * `Def(alias) → Module(target_file)` always (for `import M`
-    //       and for the module-side reachability anchor of `from M
-    //       import x`).
-    //    * `Def(alias) → Def(target_decl)` for from-imports whose
-    //      `decl_name` resolves in the target's `exports_by_name`.
-    //
-    //    * `Def(alias) → External(key)` for site-packages targets.
-    //
-    //    Stdlib and genuinely-unresolved targets emit no edge here
-    //    (stdlib stays silent; unresolved aliases are flagged instead).
-    let index = semantic_index(db, file);
-    let global = FileScopeId::global();
-    let use_def_map = index.use_def_map(global);
-    let parsed = parsed_module(db, file).load(db);
-
-    for (_def_id, state, _used) in use_def_map.all_definitions_with_usage() {
-        let DefinitionState::Defined(def) = state else {
-            continue;
-        };
-        if def.file(db) != file || def.file_scope(db) != global {
-            continue;
-        }
-        let mut alias_ref = NodeRef::Def(def_key(db, def, &parsed));
-        // Skip Definitions that file_to_nodes didn't mint (non-symbol
-        // places, unsupported kinds). Keeps the edge set internally
-        // consistent with the node set.
-        if !self_nodes.ref_to_local.contains_key(&alias_ref) {
-            continue;
-        }
-
-        let kind = def.kind(db);
-        if !kind.is_import() {
-            continue;
-        }
-
-        let (target_module_str, decl_name): (String, Option<String>) = match kind {
-            DefinitionKind::Import(k) => {
-                // `import a.b.c` binds `a` locally. Resolving `a.b.c`
-                // here would target the deepest module; ty's runtime
-                // semantics bind only `a`. We resolve to `a` for the
-                // first-cut module-level edge. Full chain edges
-                // (parallel edges to `a.b` and `a.b.c`) are deferred.
-                let alias = k.alias(&parsed);
-                (alias.name.id.as_str().to_string(), None)
-            }
-            DefinitionKind::ImportFrom(k) => {
-                let module = from_module_string(db, file, k.import(&parsed));
-                let alias = k.alias(&parsed);
-                (module, Some(alias.name.id.as_str().to_string()))
-            }
-            DefinitionKind::ImportFromSubmodule(k) => {
-                // ImportFromSubmodule binds a submodule attribute on
-                // the containing package as a side effect of a
-                // `from X import …` statement inside __init__.py.
-                // The bound NAME (k.module) is the attribute, but the
-                // TARGET module is the from-clause itself — for
-                // `from pkg._internal import *` in pkg/__init__.py
-                // the side-effect attribute `_internal` on pkg
-                // points at the file `pkg._internal`, not at
-                // `pkg._internal._internal`. The from-clause module
-                // is what resolves.
-                let target = from_module_string(db, file, k.import(&parsed));
-                (target, None)
-            }
-            DefinitionKind::StarImport(k) => {
-                // `from X import *`. Each per-name `STAR_REEXPORT` node
-                // edges into the kept statement-level `*X` node, which in
-                // turn carries the module-level edge (`*X → Module(X)`).
-                // Rebind `alias_ref` to that `*X` node so the generic
-                // resolution below (stdlib / external / unresolved
-                // handling) emits the upstream edge from `*X`, not from
-                // the per-name node. Uses of star-bound names land on the
-                // per-name node (ty's use-def chain distinguishes them);
-                // `from <here> import name` lookups resolve per-name via
-                // walk_exports_chain.
-                let module = from_module_string(db, file, k.import(&parsed));
-                let star_ref = NodeRef::StarStmt(file, range_key(kind.target_range(&parsed)));
-                edges.insert((alias_ref, star_ref, 0));
-                alias_ref = star_ref;
-                (module, None)
-            }
-            _ => continue,
-        };
-
-        if target_module_str.is_empty() {
-            continue;
-        }
-
-        // Submodule disambiguation: `from p import functions` where
-        // `p.functions` is itself a submodule should point at the
-        // submodule file, not at `p` with a decl lookup. BUT: per
-        // CPython's `_handle_fromlist`, namespace bindings WIN over
-        // submodule lookups when both exist (e.g. `q = 42` in
-        // p/__init__.py with a sibling p/q.py — the int binds, not
-        // the submodule). Check namespace first; only switch to
-        // submodule when the namespace doesn't already export decl.
-        let (target_module_str, decl_name) = if let Some(decl) = &decl_name {
-            let candidate = format!("{target_module_str}.{decl}");
-            if crate::ingest::module_name_resolves(&candidate, file, db) {
-                let namespace_has_decl = ModuleName::new(&target_module_str)
-                    .and_then(|mn| resolve_module(db, file, &mn))
-                    .and_then(|m| m.file(db))
-                    .map(|f| {
-                        let nodes = file_to_nodes(db, f);
-                        nodes.exports_by_name.contains_key(decl)
-                    })
-                    .unwrap_or(false);
-                if namespace_has_decl {
-                    (target_module_str, Some(decl.clone()))
-                } else {
-                    (candidate, None)
-                }
-            } else {
-                (target_module_str, Some(decl.clone()))
-            }
-        } else {
-            (target_module_str, decl_name)
-        };
-        // Bad module name (relative-dots overflow, etc.), a module that
-        // doesn't resolve, or a resolved module with no backing file:
-        // flag the alias `NodeFlags::UNRESOLVED` (the assembly pass ORs
-        // it in) rather than minting an `[unresolved] X` sink.
-        let Some(target_module_name) = ModuleName::new(&target_module_str) else {
-            unresolved_aliases.insert(alias_ref);
-            continue;
-        };
-        let Some(target_module) = resolve_module(db, file, &target_module_name) else {
-            unresolved_aliases.insert(alias_ref);
-            continue;
-        };
-        let Some(target_file) = target_module.file(db) else {
-            unresolved_aliases.insert(alias_ref);
-            continue;
-        };
-        let top_level = target_module_str
-            .split('.')
-            .next()
-            .unwrap_or(&target_module_str);
-        // Stdlib targets emit no node: an unused stdlib import is still
-        // caught dead via its alias's zero in-edge count, so a stdlib
-        // endpoint would be pure noise.
-        if target_module
-            .search_path(db)
-            .is_some_and(|sp| sp.is_standard_library())
-        {
-            continue;
-        }
-        // Non-first-party (site-packages) → External node keyed on the
-        // PEP 503 dist name (or top-level module name) with the resolved
-        // target file (its path is re-derived at assembly).
-        if target_module
-            .search_path(db)
-            .is_some_and(|sp| !sp.is_first_party() && sp.is_site_packages())
-        {
-            let fqname = external_fqname_for(db, target_file, top_level);
-            let key = ExternalKey::new(db, fqname, target_file);
-            edges.insert((alias_ref, NodeRef::External(key), 0));
-            continue;
-        }
-        // Self-imports (re-importing from the same file) don't
-        // produce meaningful cross-file edges — skip to avoid the
-        // trivial alias → self-module cycle.
-        if target_file == file {
-            continue;
-        }
-
-        // Module-level edge.
-        edges.insert((alias_ref, NodeRef::Module(target_file), 0));
-
-        // Named-decl edge for from-imports. Walks the star-reexport
-        // chain so `from A import g` where A re-exports from B lands
-        // on B's real `g` rather than A's star alias node. salsa
-        // memoizes each file's payload on the way through, so the
-        // chain walk is hashmap lookups + a `seen` set.
-        if let Some(decl_name) = decl_name {
-            for target_ref in walk_exports_chain(db, target_file, &decl_name) {
-                edges.insert((alias_ref, target_ref, 0));
-            }
-        }
-    }
-
-    FileEdges {
-        edges,
-        unresolved_aliases,
-    }
-}
 
 /// Resolve a file's parent module to its `File` handle, when the
 /// parent's `__init__.py` is itself in the project. Mirrors today's
 /// `emit_module_hierarchy::parent_module_edge`. Returns `None` for
 /// top-level packages (no parent) and for parents that live outside
 /// the project (the cross-file hierarchy edge has nowhere to land).
-fn parent_module_file(db: &dyn ProjectDb, file: File) -> Option<File> {
+pub(crate) fn parent_module_file(db: &dyn ProjectDb, file: File) -> Option<File> {
     let module = crate::helpers::canonical_module_for_file(db, file)?;
     let parent_name = module.name(db).parent()?;
     let parent_module = resolve_module(db, file, &parent_name)?;

--- a/runtime/src/file_ref_edges.rs
+++ b/runtime/src/file_ref_edges.rs
@@ -1,45 +1,33 @@
-//! Per-file reference-edge collection. The Phase 3 port: walks the
-//! AST inside every owned expression and emits `use → reaching-def`
-//! edges keyed on `NodeRef` instead of `usize`.
+//! Per-file reference-spec collection: the combined walk that replaced
+//! the old `file_to_edges` / `file_to_ref_edges` pair.
 //!
-//! Status: **first-cut skeleton.** Emits the codemod-invariant
-//! `use → local-alias` edge for every `ExprName` reference whose
-//! reaching def is a local graph node. Sufficient to validate the
-//! salsa-tracked pattern + per-file ref walk shape against the
-//! existing `collect_reference_edges`.
+//! [`file_to_refspecs`] walks the AST inside every owned expression
+//! plus the file's import bindings, and emits a flat, sorted
+//! [`RefSpec`] list expressed entirely in local terms (local node
+//! indices, symbolic [`MemberRef`] / [`DynamicRef`] descriptors). The
+//! query is **file-local by construction**: its salsa dependencies are
+//! this file's parse, semantic index, and `file_to_nodes` payload plus
+//! search-path configuration — never another file's contents. Editing
+//! an imported file no longer invalidates the importer's walk; only
+//! the (much cheaper) assembly-time resolution re-runs.
 //!
-//! Deliberately deferred to follow-ups, each documented in-place
-//! when the corresponding code path is stubbed:
+//! Cross-file resolution — module resolver probes, upstream
+//! `exports_by_name` lookups, star-reexport chain walks, external
+//! classification — happens in the assembly pass via
+//! [`crate::refspec::resolve_member`] / [`crate::refspec::resolve_dynamic`],
+//! memoized project-wide.
 //!
-//! * **Parallel upstream reachability edges** (emit_upstream). For
-//!   `from foo import bar; bar()`, today's pipeline emits
-//!   `owner → alias` AND `owner → foo.bar` AND `owner → foo`. This
-//!   cut emits only the first.
-//! * **Attribute-chain edges.** `mod.bar.f()` collapses to a
-//!   bare-name use of `mod` here (the root); the chain segments
-//!   (`bar`, `f`) are not walked through the alias's resolution.
-//! * **Nested-context imports.** `import X` / `from X import y`
-//!   inside a function or class body emit no edges in this cut
-//!   (they go to dead-letter for now).
-//! * **String annotations.** Skipped entirely; `enter_string_annotation`
-//!   triggers ty type-inference and is the largest per-file salsa
-//!   cost we want to deliberately structure around.
-//! * **Dynamic imports.** `__import__(...)` / `importlib.import_module(...)`
-//!   walked as regular call expressions.
-//! * **Dead-branch flag.** Edges originating inside statically-dead
-//!   regions (`if False:`, post-`return`, …) emit no
-//!   `EdgeFlags::DEAD_BRANCH` flag.
-//! * **`__all__` edges.** Skipped.
-//!
-//! Each of those is its own follow-up commit on PR #226.
+//! Structural edges that are fully derivable from `file_to_nodes`
+//! payloads (decl → module anchors, overload impl → stub anchors, the
+//! submodule → parent-package hierarchy edge) are *not* emitted here;
+//! the assembly pass synthesizes them directly so the payload carries
+//! only real information.
 
 use ruff_db::files::File;
 use ruff_db::parsed::{parsed_module, ParsedModuleRef};
 use ruff_python_ast::visitor::{walk_expr, walk_stmt, Visitor};
 use ruff_python_ast::{Expr, ExprName, ExprStringLiteral, Stmt};
 use ruff_text_size::{Ranged, TextRange};
-use rustc_hash::FxHashSet;
-use ty_module_resolver::{resolve_module, ModuleName};
 use ty_project::Db as ProjectDb;
 use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::definition::{DefinitionKind, DefinitionState, TargetKind};
@@ -49,9 +37,10 @@ use ty_python_core::{semantic_index, SemanticIndex};
 use ty_python_semantic::SemanticModel;
 
 use crate::file_payload::{
-    def_key, file_to_nodes, import_payload_for_pure as import_payload_for, ExternalKey, FileNodes,
+    def_key, file_to_nodes, import_payload_for_pure as import_payload_for, FileNodes,
     ImportPayload, NodeData, NodeKind, NodeRef,
 };
+use crate::refspec::{DynamicRef, MemberRef, MemberRole, RefSpec, Target};
 
 /// Outcome of resolving a `Name` use to its reaching definition.
 ///
@@ -61,47 +50,47 @@ use crate::file_payload::{
 /// import binding in a non-global scope, so no graph node was
 /// minted, and the use's parallel upstream edges flow from the
 /// enclosing top-level owner instead.
-enum Resolution<'db> {
-    Alias(NodeRef<'db>),
+enum Resolution {
+    Alias(u32),
     NestedImport {
         spec: ImportPayload,
         bound_name: String,
     },
 }
 use crate::helpers::{
-    detect_dead_ranges, detect_type_checking_ranges, is_dunder_name, EDGE_FLAG_DEAD_BRANCH,
-    EDGE_FLAG_DYNAMIC_IMPORT,
+    detect_dead_ranges, detect_type_checking_ranges, is_dunder_name, range_key,
+    EDGE_FLAG_DEAD_BRANCH, EDGE_FLAG_DYNAMIC_IMPORT,
 };
 use crate::ingest::{
     collapse_attribute_chain, detect_dynamic_call, file_package_name, from_module_string,
-    module_name_resolves, paired_unpack_rhs, parse_dynamic_args, resolve_dynamic_target,
+    paired_unpack_rhs, parse_dynamic_args, resolve_dynamic_target,
     stmt_creates_top_level_definition, target_is_dunder_all, DynamicParseResult,
 };
 
-/// Salsa-tracked output of [`file_to_ref_edges`]. Set semantics so
-/// duplicate emissions (a name used twice resolving to the same
-/// target) collapse to a single entry. Edges are unresolved
-/// (`NodeRef` endpoints, not `u32` graph indices) — the assembly
-/// pass translates at the end.
+/// Salsa-tracked output of [`file_to_refspecs`]. `specs` is sorted +
+/// deduped, so the payload is deterministic and `Eq`-backdating
+/// compares plain content. The whole struct is `'static` — no
+/// `NodeRef` endpoints, no interned keys — so salsa id reshuffles
+/// across revisions can't defeat backdating.
 ///
 /// `warnings` are visitor messages (e.g. "Skipping dynamic import …")
 /// buffered per-file in pure rust. The driver flushes them to the
 /// `dead_cst._visitor` Python logger from the main thread once all
-/// per-file workers have finished — keeps `file_to_ref_edges` itself
+/// per-file workers have finished — keeps `file_to_refspecs` itself
 /// GIL-free so workers run inside `py.allow_threads` cleanly.
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
-pub(crate) struct FileRefEdges<'db> {
-    pub(crate) edges: FxHashSet<(NodeRef<'db>, NodeRef<'db>, u8)>,
-    pub(crate) warnings: Vec<String>,
+pub(crate) struct FileRefSpecs {
+    pub(crate) specs: Box<[RefSpec]>,
+    pub(crate) warnings: Box<[String]>,
 }
 
-/// Per-file reference-edge collection. Salsa-tracked so the AST
-/// walk parallelizes via salsa's worker coordination, and cross-file
-/// lookups into [`file_to_nodes`] are memoized.
+/// Per-file reference-spec collection. Salsa-tracked so the AST walk
+/// parallelizes via salsa's worker coordination. See the module docs
+/// for the file-locality contract.
 #[salsa::tracked(returns(ref), heap_size = ruff_memory_usage::heap_size)]
-pub(crate) fn file_to_ref_edges<'db>(db: &'db dyn ProjectDb, file: File) -> FileRefEdges<'db> {
+pub(crate) fn file_to_refspecs(db: &dyn ProjectDb, file: File) -> FileRefSpecs {
     let self_nodes = file_to_nodes(db, file);
-    let mut edges: FxHashSet<(NodeRef<'db>, NodeRef<'db>, u8)> = FxHashSet::default();
+    let mut specs: Vec<RefSpec> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();
 
     let parsed = parsed_module(db, file).load(db);
@@ -122,13 +111,13 @@ pub(crate) fn file_to_ref_edges<'db>(db: &'db dyn ProjectDb, file: File) -> File
             continue;
         }
         let owner_ref = NodeRef::Def(def_key(db, def, &parsed));
-        if !self_nodes.ref_to_local.contains_key(&owner_ref) {
+        let Some(&owner_local) = self_nodes.ref_to_local.get(&owner_ref) else {
             continue;
-        }
+        };
 
         let kind = def.kind(db);
         let mut walker = RefWalker {
-            owner: owner_ref,
+            owner_local,
             file,
             db,
             parsed: &parsed,
@@ -137,7 +126,7 @@ pub(crate) fn file_to_ref_edges<'db>(db: &'db dyn ProjectDb, file: File) -> File
             model: &model,
             dead_ranges: &dead_ranges,
             tc_ranges: &tc_ranges,
-            edges: &mut edges,
+            specs: &mut specs,
             warnings: &mut warnings,
             nested_context: false,
             current_flags: 0,
@@ -149,15 +138,14 @@ pub(crate) fn file_to_ref_edges<'db>(db: &'db dyn ProjectDb, file: File) -> File
 
     // (b) Module-level non-definition statements (top-level expression
     //     statements, `for`/`while`/`if` at module scope, …) attribute
-    //     to the module node. The per-decl pass above intentionally
-    //     skips these via `stmt_creates_top_level_definition`.
-    let module_ref = NodeRef::Module(file);
+    //     to the module node (local index 0). The per-decl pass above
+    //     intentionally skips these via `stmt_creates_top_level_definition`.
     for stmt in &parsed.syntax().body {
         if stmt_creates_top_level_definition(stmt) {
             continue;
         }
         let mut walker = RefWalker {
-            owner: module_ref,
+            owner_local: 0,
             file,
             db,
             parsed: &parsed,
@@ -166,7 +154,7 @@ pub(crate) fn file_to_ref_edges<'db>(db: &'db dyn ProjectDb, file: File) -> File
             model: &model,
             dead_ranges: &dead_ranges,
             tc_ranges: &tc_ranges,
-            edges: &mut edges,
+            specs: &mut specs,
             warnings: &mut warnings,
             nested_context: false,
             current_flags: 0,
@@ -190,21 +178,138 @@ pub(crate) fn file_to_ref_edges<'db>(db: &'db dyn ProjectDb, file: File) -> File
             .imports
             .as_ref()
             .is_some_and(|imp| imp.module == "__future__");
-        if is_dunder_decl || is_future_import {
-            let dst = self_nodes.refs[local_idx];
-            if dst != module_ref {
-                edges.insert((module_ref, dst, 0));
-            }
+        if (is_dunder_decl || is_future_import) && local_idx != 0 {
+            specs.push(RefSpec {
+                src: 0,
+                target: Target::Local(local_idx as u32),
+                flags: 0,
+            });
         }
     }
 
-    FileRefEdges { edges, warnings }
+    // (d) Import-alias binding specs. Walk each kind="import"
+    //     Definition in this file's global scope and emit one
+    //     `Member(Binding)` spec carrying the per-kind `(module, decl)`
+    //     resolution input. The assembly pass resolves it to
+    //     `alias → Module(target)` (+ `alias → target decl` for
+    //     from-imports), classifies stdlib / external / unresolved
+    //     targets, and applies the `_handle_fromlist`
+    //     namespace-vs-submodule disambiguation — all cross-file work
+    //     lives there, not here.
+    for (_def_id, state, _used) in use_def_map.all_definitions_with_usage() {
+        let DefinitionState::Defined(def) = state else {
+            continue;
+        };
+        if def.file(db) != file || def.file_scope(db) != global {
+            continue;
+        }
+        let alias_ref = NodeRef::Def(def_key(db, def, &parsed));
+        // Skip Definitions that file_to_nodes didn't mint (non-symbol
+        // places, unsupported kinds). Keeps the spec set internally
+        // consistent with the node set.
+        let Some(&alias_local) = self_nodes.ref_to_local.get(&alias_ref) else {
+            continue;
+        };
+
+        let kind = def.kind(db);
+        if !kind.is_import() {
+            continue;
+        }
+
+        let mut src_local = alias_local;
+        let (target_module_str, decl_name, is_star): (String, Option<String>, bool) = match kind {
+            DefinitionKind::Import(k) => {
+                // `import a.b.c` binds `a` locally, but the *statement*
+                // loads the deepest module; the binding spec resolves
+                // the full dotted path.
+                let alias = k.alias(&parsed);
+                (alias.name.id.as_str().to_string(), None, false)
+            }
+            DefinitionKind::ImportFrom(k) => {
+                let module = from_module_string(db, file, k.import(&parsed));
+                let alias = k.alias(&parsed);
+                (module, Some(alias.name.id.as_str().to_string()), false)
+            }
+            DefinitionKind::ImportFromSubmodule(k) => {
+                // ImportFromSubmodule binds a submodule attribute on
+                // the containing package as a side effect of a
+                // `from X import …` statement inside __init__.py.
+                // The bound NAME (k.module) is the attribute, but the
+                // TARGET module is the from-clause itself — for
+                // `from pkg._internal import *` in pkg/__init__.py
+                // the side-effect attribute `_internal` on pkg
+                // points at the file `pkg._internal`, not at
+                // `pkg._internal._internal`. The from-clause module
+                // is what resolves.
+                let target = from_module_string(db, file, k.import(&parsed));
+                (target, None, false)
+            }
+            DefinitionKind::StarImport(k) => {
+                // `from X import *`. Each per-name `STAR_REEXPORT` node
+                // edges into the kept statement-level `*X` node, which in
+                // turn carries the module-level upstream spec. Rebind
+                // `src_local` to that `*X` node so the binding spec
+                // (stdlib / external / unresolved handling included)
+                // resolves from `*X`, not from the per-name node. Uses
+                // of star-bound names land on the per-name node (ty's
+                // use-def chain distinguishes them); `from <here>
+                // import name` lookups resolve per-name via
+                // walk_exports_chain.
+                let module = from_module_string(db, file, k.import(&parsed));
+                let star_ref = NodeRef::StarStmt(file, range_key(kind.target_range(&parsed)));
+                if let Some(&star_local) = self_nodes.ref_to_local.get(&star_ref) {
+                    if star_local != alias_local {
+                        specs.push(RefSpec {
+                            src: alias_local,
+                            target: Target::Local(star_local),
+                            flags: 0,
+                        });
+                    }
+                    src_local = star_local;
+                }
+                (module, None, true)
+            }
+            _ => continue,
+        };
+
+        if target_module_str.is_empty() {
+            continue;
+        }
+
+        specs.push(RefSpec {
+            src: src_local,
+            target: Target::Member(MemberRef {
+                role: MemberRole::Binding,
+                spec: ImportPayload {
+                    module: target_module_str,
+                    decl: decl_name,
+                    star: is_star,
+                },
+                bound_name: String::new(),
+                chain: Vec::new(),
+            }),
+            flags: 0,
+        });
+    }
+
+    // Sorted + deduped so the payload is deterministic regardless of
+    // emission order, identical re-emissions collapse (a name used
+    // twice resolving to the same target), and `Eq` backdating is a
+    // cheap content compare.
+    specs.sort_unstable();
+    specs.dedup();
+
+    FileRefSpecs {
+        specs: specs.into_boxed_slice(),
+        warnings: warnings.into_boxed_slice(),
+    }
 }
 
-/// Per-owner walker. Mirrors today's `RefCollector` but with
-/// `NodeRef`-typed edges and a reduced feature set (see module docs).
+/// Per-owner walker. Mirrors the libcst pipeline's `RefCollector` but
+/// emits local-terms [`RefSpec`]s instead of resolved edges.
 struct RefWalker<'a, 'db> {
-    owner: NodeRef<'db>,
+    /// Local index (into `self_nodes.refs`) of the owning node.
+    owner_local: u32,
     file: File,
     /// The project db. We can't go through `self.model.db()` for
     /// `file_to_nodes` calls because that returns `&dyn
@@ -214,11 +319,11 @@ struct RefWalker<'a, 'db> {
     #[allow(dead_code)]
     parsed: &'a ParsedModuleRef,
     index: &'a SemanticIndex<'db>,
-    self_nodes: &'a FileNodes<'db>,
+    self_nodes: &'a FileNodes,
     model: &'a SemanticModel<'db>,
     /// Statically-dead source regions for this file. Uses originating
     /// inside any of these get `EDGE_FLAG_DEAD_BRANCH` stamped on
-    /// every edge they emit.
+    /// every spec they emit.
     dead_ranges: &'a [TextRange],
     /// Statement ranges inside `if TYPE_CHECKING:` blocks. A use whose
     /// flow-resolved binding falls inside one of these has had its
@@ -226,7 +331,7 @@ struct RefWalker<'a, 'db> {
     /// `TYPE_CHECKING` as `True`); `find_local_bindings` recovers it
     /// from the scope-wide reachable bindings.
     tc_ranges: &'a [TextRange],
-    edges: &'a mut FxHashSet<(NodeRef<'db>, NodeRef<'db>, u8)>,
+    specs: &'a mut Vec<RefSpec>,
     /// Per-file warnings buffer. Workers push pure-rust strings; the
     /// driver flushes them to Python logging from the main thread.
     warnings: &'a mut Vec<String>,
@@ -243,18 +348,43 @@ struct RefWalker<'a, 'db> {
     /// skip the position-sensitive `scoped_use_id` lookup that would
     /// otherwise panic.
     in_string_annotation: bool,
-    /// Flags stamped on each edge emitted by the current reference
+    /// Flags stamped on each spec emitted by the current reference
     /// (set by `emit_name_use` / nested-import handlers from
     /// `flags_for_range` on the reference's source position;
     /// reset to 0 after the reference completes).
     current_flags: u8,
 }
 
-impl<'a, 'db> RefWalker<'a, 'db> {
-    fn emit_edge(&mut self, dst: NodeRef<'db>) {
-        if dst != self.owner {
-            self.edges.insert((self.owner, dst, self.current_flags));
+impl<'db> RefWalker<'_, 'db> {
+    /// Emit a `use → local node` spec (the codemod-invariant alias
+    /// edge, `__all__` edges, …).
+    fn emit_local(&mut self, dst_local: u32) {
+        if dst_local != self.owner_local {
+            self.specs.push(RefSpec {
+                src: self.owner_local,
+                target: Target::Local(dst_local),
+                flags: self.current_flags,
+            });
         }
+    }
+
+    /// Emit an unresolved `Use`-role member spec (the parallel
+    /// upstream-reachability edges past an import alias). The
+    /// assembly pass resolves it via `resolve_member`.
+    fn emit_member_use(&mut self, spec: &ImportPayload, bound_name: &str, extra_chain: &[&str]) {
+        if spec.module.is_empty() {
+            return;
+        }
+        self.specs.push(RefSpec {
+            src: self.owner_local,
+            target: Target::Member(MemberRef {
+                role: MemberRole::Use,
+                spec: spec.clone(),
+                bound_name: bound_name.to_string(),
+                chain: extra_chain.iter().map(|s| s.to_string()).collect(),
+            }),
+            flags: self.current_flags,
+        });
     }
 
     /// Returns `EDGE_FLAG_DEAD_BRANCH` if `range` is contained in any
@@ -267,14 +397,6 @@ impl<'a, 'db> RefWalker<'a, 'db> {
         }
     }
 
-    /// Emit an edge from `self.owner` to a real External node carrying
-    /// the resolved upstream path: `[external dist] X` / `[external file] X`
-    /// for site-packages (via `external_fqname_for`'s PEP 503 lookup).
-    fn emit_external_node(&mut self, fqname: String, target_file: File) {
-        let key = ExternalKey::new(self.db, fqname, target_file);
-        self.emit_edge(NodeRef::External(key));
-    }
-
     /// True when `range` falls inside a recorded type-checking block
     /// (see [`detect_type_checking_ranges`]).
     fn range_in_tc_block(&self, range: TextRange) -> bool {
@@ -282,17 +404,11 @@ impl<'a, 'db> RefWalker<'a, 'db> {
     }
 
     /// Resolve a `Name` use to the reaching local Definition(s) via
-    /// ty's flow-sensitive use-def chain. Returns `NodeRef::Def` for
-    /// each reaching def whose graph node lives in this file.
-    ///
-    /// Differs from today's `find_local_bindings`:
-    ///
-    /// * No `Resolution::NestedImport` variant — nested-context
-    ///   imports are deferred. Bindings without a graph node are
-    ///   silently dropped.
-    /// * No `in_string_annotation` plumbing — string annotations
-    ///   aren't entered yet.
-    fn find_local_bindings(&self, name: &ExprName, extra_chain: &[&str]) -> Vec<Resolution<'db>> {
+    /// ty's flow-sensitive use-def chain. Returns the local index for
+    /// each reaching def whose graph node lives in this file, or a
+    /// `NestedImport` descriptor for import bindings in non-global
+    /// scopes (which have no node of their own).
+    fn find_local_bindings(&self, name: &ExprName, extra_chain: &[&str]) -> Vec<Resolution> {
         let db = self.model.db();
         // For names from a string-annotation sub-AST, ty doesn't know
         // their scope (we parsed them ourselves rather than going
@@ -339,7 +455,7 @@ impl<'a, 'db> RefWalker<'a, 'db> {
             // `True`, so in that case the *runtime* binding has been
             // narrowed away — `find_local_bindings` recovers it below.
             let mut resolved_in_tc = false;
-            let mut results: Vec<Resolution<'db>> = Vec::new();
+            let mut results: Vec<Resolution> = Vec::new();
             for binding in bindings {
                 let Some(def) = binding.binding.definition() else {
                     continue;
@@ -352,14 +468,14 @@ impl<'a, 'db> RefWalker<'a, 'db> {
                     resolved_in_tc = true;
                 }
                 let candidate = NodeRef::Def(def_key(self.db, def, self.parsed));
-                if self.self_nodes.ref_to_local.contains_key(&candidate) {
-                    results.push(Resolution::Alias(candidate));
+                if let Some(&local) = self.self_nodes.ref_to_local.get(&candidate) {
+                    results.push(Resolution::Alias(local));
                     continue;
                 }
                 // Nested-context import: ty sees an import binding in
                 // a non-global scope, so no graph node was minted. The
                 // use's parallel upstream edges flow from the
-                // enclosing top-level owner via emit_upstream; we
+                // enclosing top-level owner via emit_member_use; we
                 // package the spec + bound name into a NestedImport
                 // resolution so emit_name_use can drive that.
                 let kind = def.kind(db);
@@ -410,7 +526,7 @@ impl<'a, 'db> RefWalker<'a, 'db> {
                         };
                         if results
                             .iter()
-                            .any(|r| matches!(r, Resolution::Alias(d) if *d == candidate))
+                            .any(|r| matches!(r, Resolution::Alias(d) if *d == idx))
                         {
                             continue;
                         }
@@ -423,7 +539,7 @@ impl<'a, 'db> RefWalker<'a, 'db> {
                                 extra_chain,
                             );
                         if recovers_runtime_binding || on_access_chain {
-                            results.push(Resolution::Alias(candidate));
+                            results.push(Resolution::Alias(idx));
                         }
                     }
                 }
@@ -439,8 +555,8 @@ impl<'a, 'db> RefWalker<'a, 'db> {
                     continue;
                 }
                 let candidate = NodeRef::Def(def_key(self.db, def, self.parsed));
-                if self.self_nodes.ref_to_local.contains_key(&candidate) {
-                    results.push(Resolution::Alias(candidate));
+                if let Some(&local) = self.self_nodes.ref_to_local.get(&candidate) {
+                    results.push(Resolution::Alias(local));
                 }
             }
             if !results.is_empty() {
@@ -460,30 +576,20 @@ impl<'a, 'db> RefWalker<'a, 'db> {
         self.current_flags = self.flags_for_range(name.range());
         for resolution in self.find_local_bindings(name, extra_chain) {
             match resolution {
-                Resolution::Alias(dst) => {
-                    self.emit_edge(dst);
-                    // If the resolved alias is an import, emit
-                    // parallel reachability edges through it
-                    // (Principle 2).
-                    let import_spec: Option<ImportPayload> = self
-                        .self_nodes
-                        .ref_to_local
-                        .get(&dst)
-                        .copied()
-                        .and_then(|idx| {
-                            let node_data = &self.self_nodes.nodes[idx as usize];
-                            if matches!(node_data.kind, NodeKind::Import) {
-                                node_data.imports.clone()
-                            } else {
-                                None
-                            }
-                        });
-                    if let Some(spec) = import_spec {
-                        self.emit_upstream(&spec, name.id.as_str(), extra_chain);
+                Resolution::Alias(dst_local) => {
+                    self.emit_local(dst_local);
+                    // If the resolved alias is an import, emit a
+                    // parallel `Use` member spec through it
+                    // (Principle 2) — resolved at assembly.
+                    let node_data = &self.self_nodes.nodes[dst_local as usize];
+                    if matches!(node_data.kind, NodeKind::Import) {
+                        if let Some(spec) = node_data.imports.clone() {
+                            self.emit_member_use(&spec, name.id.as_str(), extra_chain);
+                        }
                     }
                 }
                 Resolution::NestedImport { spec, bound_name } => {
-                    self.emit_upstream(&spec, &bound_name, extra_chain);
+                    self.emit_member_use(&spec, &bound_name, extra_chain);
                 }
             }
         }
@@ -491,9 +597,8 @@ impl<'a, 'db> RefWalker<'a, 'db> {
     }
 
     /// `import X[.Y.Z][ as A]` inside a function/class body. No alias
-    /// node is minted (binding lives in non-global scope); emit
-    /// parallel upstream edges from `self.owner` directly. Mirrors
-    /// `ingest::RefCollector::emit_nested_import` (lines 2044–2061).
+    /// node is minted (binding lives in non-global scope); emit a
+    /// `Use` member spec from `self.owner_local` directly.
     fn emit_nested_import(&mut self, stmt: &ruff_python_ast::StmtImport) {
         self.current_flags = self.flags_for_range(stmt.range);
         for alias in &stmt.names {
@@ -508,17 +613,18 @@ impl<'a, 'db> RefWalker<'a, 'db> {
                 decl: None,
                 star: false,
             };
-            self.emit_upstream(&spec, bound_name, &synthetic_chain);
+            self.emit_member_use(&spec, bound_name, &synthetic_chain);
         }
         self.current_flags = 0;
     }
 
     /// `from X import name` inside a function/class body. Resolves the
     /// from-clause through ty (so relative imports get level dots
-    /// converted to absolute), then walks each alias and emits the
-    /// upstream edges. A nested `from X import *` is a SyntaxError
-    /// ("import * only allowed at module level") so it cannot occur in
-    /// runnable Python — it is skipped rather than fanned out.
+    /// converted to absolute — a self-property, still file-local),
+    /// then walks each alias and emits the `Use` member specs. A
+    /// nested `from X import *` is a SyntaxError ("import * only
+    /// allowed at module level") so it cannot occur in runnable
+    /// Python — it is skipped rather than fanned out.
     fn emit_nested_import_from(&mut self, stmt: &ruff_python_ast::StmtImportFrom) {
         let module_str = from_module_string(self.model.db(), self.file, stmt);
         if module_str.is_empty() {
@@ -541,7 +647,7 @@ impl<'a, 'db> RefWalker<'a, 'db> {
                 decl: Some(name.to_string()),
                 star: false,
             };
-            self.emit_upstream(&spec, bound_name, &[]);
+            self.emit_member_use(&spec, bound_name, &[]);
         }
         self.current_flags = 0;
     }
@@ -588,11 +694,16 @@ impl<'a, 'db> RefWalker<'a, 'db> {
         self.in_string_annotation = prev;
     }
 
-    /// Recognize and emit edges for a dynamic-import call. Returns
+    /// Recognize and emit a spec for a dynamic-import call. Returns
     /// `true` if the call was a dynamic-import shape (so the visitor
     /// doesn't fall through to walk its arguments as ordinary names).
-    /// Mirrors today's `RefCollector::try_emit_dynamic_import` +
-    /// `emit_dynamic_edges` + `emit_resolved_module`.
+    ///
+    /// `resolve_dynamic_target` runs here, at walk time: it is pure
+    /// string manipulation whose only context is the owning file's
+    /// package name (a self-property), so the emitted [`DynamicRef`]
+    /// carries an already-absolutized dotted target and its error
+    /// messages stay in the file-local warnings buffer. The actual
+    /// cross-file resolution happens at assembly via `resolve_dynamic`.
     fn try_emit_dynamic_import(&mut self, call: &ruff_python_ast::ExprCall) -> bool {
         let Some(kind) = detect_dynamic_call(&call.func) else {
             return false;
@@ -607,7 +718,18 @@ impl<'a, 'db> RefWalker<'a, 'db> {
                 let file_pkg = file_package_name(self.model.db(), self.file);
                 let pkg = explicit_package.or(file_pkg.as_deref());
                 match resolve_dynamic_target(kind, &name, explicit_level, pkg) {
-                    Ok(target) => self.emit_dynamic_edges(&target, &fromlist),
+                    Ok(target) => self.specs.push(RefSpec {
+                        src: self.owner_local,
+                        target: Target::Dynamic(DynamicRef {
+                            target,
+                            fromlist: fromlist
+                                .iter()
+                                .filter(|e| !e.is_empty())
+                                .map(|e| e.to_string())
+                                .collect(),
+                        }),
+                        flags: self.current_flags | EDGE_FLAG_DYNAMIC_IMPORT,
+                    }),
                     Err(message) => self.warnings.push(message),
                 }
                 true
@@ -620,78 +742,9 @@ impl<'a, 'db> RefWalker<'a, 'db> {
         }
     }
 
-    /// Emit `owner → target` plus per-fromlist-entry edges for a
-    /// dynamic import, each tagged with `EDGE_FLAG_DYNAMIC_IMPORT`.
-    fn emit_dynamic_edges(&mut self, target: &str, fromlist: &[&str]) {
-        let saved = self.current_flags;
-        self.current_flags |= EDGE_FLAG_DYNAMIC_IMPORT;
-        if fromlist.is_empty() {
-            self.emit_resolved_module(target);
-        } else {
-            self.emit_resolved_module(target);
-            for entry in fromlist {
-                if entry.is_empty() {
-                    continue;
-                }
-                let candidate = format!("{target}.{entry}");
-                if module_name_resolves(&candidate, self.file, self.model.db()) {
-                    self.emit_resolved_module(&candidate);
-                    continue;
-                }
-                // Treat as decl-style: resolve target to file, look up
-                // entry in its exports_by_name.
-                let target_file = ModuleName::new(target)
-                    .and_then(|n| resolve_module(self.db, self.file, &n))
-                    .and_then(|m| m.file(self.db));
-                if let Some(target_file) = target_file {
-                    let target_nodes = file_to_nodes(self.db, target_file);
-                    if let Some(locals) = target_nodes.exports_by_name.get(*entry) {
-                        for &local_idx in locals {
-                            self.emit_edge(target_nodes.refs[local_idx as usize]);
-                        }
-                    }
-                }
-            }
-        }
-        self.current_flags = saved;
-    }
-
-    /// Emit a single edge to the resolved module's NodeRef. First-party
-    /// modules route to a `Module` ref; site-packages modules become real
-    /// `External` nodes carrying the upstream path; stdlib and
-    /// genuinely-unresolved targets emit nothing.
-    fn emit_resolved_module(&mut self, dotted: &str) {
-        let top_level = dotted.split('.').next().unwrap_or(dotted);
-        let Some(mn) = ModuleName::new(dotted) else {
-            return;
-        };
-        let Some(module) = resolve_module(self.db, self.file, &mn) else {
-            return;
-        };
-        let Some(target_file) = module.file(self.db) else {
-            return;
-        };
-        if module
-            .search_path(self.db)
-            .is_some_and(|sp| sp.is_standard_library())
-        {
-            return;
-        }
-        if module
-            .search_path(self.db)
-            .is_some_and(|sp| !sp.is_first_party() && sp.is_site_packages())
-        {
-            let fqname = crate::file_payload::external_fqname_for(self.db, target_file, top_level);
-            self.emit_external_node(fqname, target_file);
-            return;
-        }
-        self.emit_edge(NodeRef::Module(target_file));
-    }
-
     /// `__all__ = ["foo", "bar"]`: each string literal resolves to a
-    /// module-scope binding; emit edges to each one. Mirrors today's
-    /// `emit_dunder_all_edges`. Computed-`__all__` shapes (concat,
-    /// `list(...)`) silently skip.
+    /// module-scope binding; emit local edges to each one.
+    /// Computed-`__all__` shapes (concat, `list(...)`) silently skip.
     fn emit_dunder_all_edges(&mut self, value: &Expr) {
         let elements = match value {
             Expr::List(l) => &l.elts,
@@ -700,23 +753,22 @@ impl<'a, 'db> RefWalker<'a, 'db> {
         };
         for elem in elements {
             if let Expr::StringLiteral(s) = elem {
-                if let Some(dst) = self.lookup_module_scope_name(s.value.to_str()) {
-                    self.emit_edge(dst);
+                if let Some(dst_local) = self.lookup_module_scope_name(s.value.to_str()) {
+                    self.emit_local(dst_local);
                 }
             }
         }
     }
 
-    /// Resolve a bare name to its module-scope live binding's NodeRef.
-    /// Used by [`emit_dunder_all_edges`]; mirrors today's
-    /// `RefCollector::lookup_module_scope_name`.
-    fn lookup_module_scope_name(&self, name: &str) -> Option<NodeRef<'db>> {
+    /// Resolve a bare name to its module-scope live binding's local
+    /// index. Used by [`emit_dunder_all_edges`].
+    fn lookup_module_scope_name(&self, name: &str) -> Option<u32> {
         let global = FileScopeId::global();
         let place_table = self.index.place_table(global);
         let symbol_id = place_table.symbol_id(name)?;
         if let Some(locals) = self.self_nodes.exports_by_name.get(name) {
             if let Some(&local_idx) = locals.first() {
-                return Some(self.self_nodes.refs[local_idx as usize]);
+                return Some(local_idx);
             }
         }
         // Fallback: walk end-of-scope bindings (matches today's
@@ -730,165 +782,18 @@ impl<'a, 'db> RefWalker<'a, 'db> {
                 continue;
             }
             let candidate = NodeRef::Def(def_key(self.db, def, self.parsed));
-            if self.self_nodes.ref_to_local.contains_key(&candidate) {
-                return Some(candidate);
+            if let Some(&local) = self.self_nodes.ref_to_local.get(&candidate) {
+                return Some(local);
             }
         }
         None
     }
-
-    /// Emit parallel reachability edges past a local import alias.
-    /// First-party targets walk the submodule chain; site-packages
-    /// targets emit a single `NodeRef::External` edge and stop; stdlib
-    /// and genuinely-unresolved targets silently drop.
-    ///
-    /// Mirrors today's `ingest::RefCollector::emit_upstream` (lines
-    /// 1880–2032): classify the loading target, walk the submodule
-    /// chain, emit edges to the deepest module reached plus any
-    /// terminal decl.
-    fn emit_upstream(&mut self, spec: &ImportPayload, bound_name: &str, extra_chain: &[&str]) {
-        if spec.module.is_empty() {
-            return;
-        }
-        let db = self.model.db();
-        let module_first_seg = spec.module.split('.').next().unwrap_or("").to_string();
-
-        let mut adjusted_chain: Vec<&str> = extra_chain.to_vec();
-        let loading_target: String;
-        let mut decl_tail: Option<String> = None;
-
-        if spec.star {
-            let candidate = format!("{}.{}", spec.module, bound_name);
-            if module_name_resolves(&candidate, self.file, db) {
-                loading_target = candidate;
-            } else {
-                loading_target = spec.module.clone();
-                decl_tail = Some(bound_name.to_string());
-            }
-        } else {
-            match &spec.decl {
-                Some(decl) => {
-                    let candidate = format!("{}.{}", spec.module, decl);
-                    if module_name_resolves(&candidate, self.file, db) {
-                        loading_target = candidate;
-                    } else {
-                        loading_target = spec.module.clone();
-                        decl_tail = Some(decl.clone());
-                    }
-                }
-                None => {
-                    let no_asname = bound_name == module_first_seg;
-                    if no_asname && spec.module != module_first_seg {
-                        let loading_extras: Vec<&str> = spec.module.split('.').skip(1).collect();
-                        let n = loading_extras.len();
-                        let prefix_matches = adjusted_chain.len() >= n
-                            && adjusted_chain
-                                .iter()
-                                .take(n)
-                                .zip(&loading_extras)
-                                .all(|(a, b)| *a == *b);
-                        if prefix_matches {
-                            adjusted_chain.drain(..n);
-                            loading_target = spec.module.clone();
-                        } else {
-                            loading_target = module_first_seg;
-                        }
-                    } else {
-                        loading_target = spec.module.clone();
-                    }
-                }
-            }
-        }
-
-        // Classify the loading target. Site-packages targets emit a
-        // single edge to a globally-interned External node carrying the
-        // upstream path and stop (no submodule chain walk through them,
-        // since they don't have file_to_nodes payloads to look up
-        // against). Stdlib and genuinely-unresolved targets emit nothing.
-        let top_level = loading_target.split('.').next().unwrap_or(&loading_target);
-        let Some(start_mn) = ModuleName::new(&loading_target) else {
-            return;
-        };
-        let Some(start_module) = resolve_module(db, self.file, &start_mn) else {
-            return;
-        };
-        let Some(start_file) = start_module.file(db) else {
-            return;
-        };
-        if start_module
-            .search_path(db)
-            .is_some_and(|sp| sp.is_standard_library())
-        {
-            return;
-        }
-        // Non-first-party (site-packages / external paths). Mint an
-        // External node keyed by PEP 503 canonical dist name via
-        // project_dist_lookup; falls back to `[external file] X` for
-        // orphan site-packages files.
-        if start_module
-            .search_path(db)
-            .is_some_and(|sp| !sp.is_first_party() && sp.is_site_packages())
-        {
-            let fqname = crate::file_payload::external_fqname_for(self.db, start_file, top_level);
-            self.emit_external_node(fqname, start_file);
-            return;
-        }
-
-        // Decl-style alias: emit edge to the upstream module and the
-        // decl inside it. Attribute access past a decl is field access
-        // on the decl's value, which we don't model.
-        if let Some(decl_name) = decl_tail {
-            // Use sites land on whatever's in exports_by_name
-            // (including star-reexport aliases). Don't walk through
-            // star aliases here — the from-import binding side uses
-            // walk_exports_chain to skip past stars; this is the
-            // *use* side, which should reach the star alias itself.
-            self.emit_edge(NodeRef::Module(start_file));
-            let target_nodes = file_to_nodes(self.db, start_file);
-            if let Some(locals) = target_nodes.exports_by_name.get(&decl_name) {
-                for &local_idx in locals {
-                    self.emit_edge(target_nodes.refs[local_idx as usize]);
-                }
-            }
-            return;
-        }
-
-        // Module-style alias: walk the chain submodule-by-submodule,
-        // emit one module edge (deepest reached) plus at most one
-        // terminal decl edge.
-        let mut current_file = start_file;
-        let mut current_path = loading_target.clone();
-        let mut terminal_decl_refs: Vec<NodeRef<'db>> = Vec::new();
-        for seg in &adjusted_chain {
-            let candidate = format!("{current_path}.{seg}");
-            let submodule_file = ModuleName::new(&candidate)
-                .and_then(|mn| resolve_module(db, self.file, &mn))
-                .and_then(|m| m.file(db));
-            if let Some(sub_file) = submodule_file {
-                current_file = sub_file;
-                current_path = candidate;
-                continue;
-            }
-            // Not a submodule — check for decl in current_file's exports.
-            let target_nodes = file_to_nodes(self.db, current_file);
-            if let Some(locals) = target_nodes.exports_by_name.get(*seg) {
-                for &local_idx in locals {
-                    terminal_decl_refs.push(target_nodes.refs[local_idx as usize]);
-                }
-            }
-            break;
-        }
-        self.emit_edge(NodeRef::Module(current_file));
-        for r in terminal_decl_refs {
-            self.emit_edge(r);
-        }
-    }
 }
 
-impl<'ast, 'db> Visitor<'ast> for RefWalker<'_, 'db> {
+impl<'ast> Visitor<'ast> for RefWalker<'_, '_> {
     fn visit_expr(&mut self, expr: &'ast Expr) {
         // Inside an annotation context, route string literals through
-        // ty's `enter_string_annotation` so `List["Foo"]`-style refs
+        // the deferred-annotation parse so `List["Foo"]`-style refs
         // resolve. Gating on `in_annotation` avoids paying the
         // scope-type-inference cost for every dict-key / log-message /
         // docstring literal.
@@ -903,8 +808,9 @@ impl<'ast, 'db> Visitor<'ast> for RefWalker<'_, 'db> {
             return;
         }
         // Collapse attribute chains rooted at a `Name`. The chain
-        // segments past the root become `extra_chain` so emit_upstream
-        // can walk submodule segments past an aliased module.
+        // segments past the root become `extra_chain` so the `Use`
+        // member spec can walk submodule segments past an aliased
+        // module at resolution time.
         if matches!(expr, Expr::Attribute(_)) {
             if let Some((root, segments)) = collapse_attribute_chain(expr) {
                 self.emit_name_use(root, &segments);
@@ -914,9 +820,9 @@ impl<'ast, 'db> Visitor<'ast> for RefWalker<'_, 'db> {
         // Recognize dynamic-import calls before falling through to a
         // normal Call walk. Matches today's RefCollector::visit_expr
         // sequencing — receiver gets its own emit_name_use, args walk
-        // normally, but the literal name/fromlist are handled by
-        // emit_dynamic_edges so they don't get attributed as string
-        // refs to something else.
+        // normally, but the literal name/fromlist are handled by the
+        // Dynamic spec so they don't get attributed as string refs to
+        // something else.
         if let Expr::Call(call) = expr {
             if self.try_emit_dynamic_import(call) {
                 if let Expr::Attribute(attr) = &*call.func {
@@ -999,11 +905,6 @@ fn plain_import_matches_chain(node: &NodeData, root: &str, extra_chain: &[&str])
 
 /// Walk every value-bearing AST node a Definition owns. Mirrors
 /// `ingest::walk_owned` but takes the new `RefWalker` collector.
-///
-/// TODO(file_to_ref_edges follow-up): port the `__all__` special case
-/// (currently the assignment value is walked as a generic expression,
-/// which is wrong — names listed inside `__all__` should resolve as
-/// module-scope binding lookups, not the strings themselves).
 fn walk_owned<'a, 'db>(
     kind: &DefinitionKind<'db>,
     parsed: &'a ParsedModuleRef,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -38,6 +38,7 @@ pub mod native_plugins;
 mod progress;
 mod project;
 mod query;
+mod refspec;
 mod topic_registry;
 
 use pyo3::prelude::*;

--- a/runtime/src/progress.rs
+++ b/runtime/src/progress.rs
@@ -25,8 +25,7 @@ use pyo3::types::PyDict;
 pub(crate) const PHASE_NONE: usize = 0;
 /// File enumeration (`db.project().files(db)`).
 pub(crate) const PHASE_ENUM: usize = 1;
-/// Parallel rayon ingest (`file_to_nodes` / `file_to_edges` /
-/// `file_to_ref_edges`).
+/// Parallel rayon ingest (`file_to_nodes` / `file_to_refspecs`).
 pub(crate) const PHASE_POPULATE: usize = 2;
 /// Fan-in (`assemble_graph`).
 pub(crate) const PHASE_ASSEMBLE: usize = 3;

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -775,17 +775,12 @@ fn assemble_graph<'db>(
         });
     }
 
-    // Pass 0: resolution gather. Runs before pass 1 so the resolve
-    // fan-out can share pass 1's rayon section: the resolves touch
-    // only salsa snapshots — never the builder — so they overlap the
-    // node fill instead of serializing after it.
-    //
-    // Every `Member` / `Dynamic` spec row is interned HERE, exactly
-    // once, into a dense id (`spec_ids[pos][i]` parallels
-    // `spec_payloads[pos].specs`), so the downstream passes —
-    // unresolved stamping, edge translation — index a Vec instead of
-    // re-hashing string-keyed rows. At tens-of-millions-of-rows scale
-    // the repeated row hashing dominated assemble time.
+    // Pass 0: serial-only resolution prep — fetch the spec payloads
+    // (salsa cache reads that borrow from the main db handle, so they
+    // can't move off this thread), derive the per-file anchor-directory
+    // ids, and pre-clone the snapshot pool. Everything row-shaped (the
+    // unique-key interning, the class-base gather) runs inside pass 1's
+    // resolve arm instead, overlapped with the node fill.
     let t_pass0_start = std::time::Instant::now();
     let mut spec_payloads: Vec<&FileRefSpecs> = Vec::with_capacity(project_files.len());
     for &file in project_files {
@@ -813,72 +808,13 @@ fn assemble_graph<'db>(
         dir_ids.push(id);
     }
 
-    // Unique-key interning, in encounter order (deterministic: the
-    // file list and each payload's specs are sorted). External mint
-    // order does not depend on this order — the External pre-mint
-    // sorts by (fqname, path) itself. Hot imports repeated across a
-    // directory (or project-wide, one entry per directory) resolve
-    // once, not once per use site.
-    const LOCAL_SPEC: u32 = u32::MAX;
-    let mut member_keys: FxHashMap<(&MemberRef, u32), u32> = FxHashMap::default();
-    let mut member_work: Vec<(File, &MemberRef)> = Vec::new();
-    let mut dynamic_keys: FxHashMap<(&DynamicRef, u32), u32> = FxHashMap::default();
-    let mut dynamic_work: Vec<(File, &DynamicRef)> = Vec::new();
-    let mut spec_ids: Vec<Box<[u32]>> = Vec::with_capacity(project_files.len());
-    for (pos, payload) in spec_payloads.iter().enumerate() {
-        let dir = dir_ids[pos];
-        let anchor = dir_anchors[dir as usize];
-        let mut ids: Vec<u32> = Vec::with_capacity(payload.specs.len());
-        for spec in payload.specs.iter() {
-            let id = match &spec.target {
-                Target::Local(_) => LOCAL_SPEC,
-                Target::Member(m) => *member_keys.entry((m, dir)).or_insert_with(|| {
-                    member_work.push((anchor, m));
-                    (member_work.len() - 1) as u32
-                }),
-                Target::Dynamic(d) => *dynamic_keys.entry((d, dir)).or_insert_with(|| {
-                    dynamic_work.push((anchor, d));
-                    (dynamic_work.len() - 1) as u32
-                }),
-            };
-            ids.push(id);
-        }
-        spec_ids.push(ids.into_boxed_slice());
-    }
-    drop(member_keys);
-    drop(dynamic_keys);
-
-    // Class-base member gather: the unique `(module, name, dir)` rows
-    // the post-assembly class-hierarchy fan-in needs resolved. Joining
-    // them into this pass's resolve arm overlaps them with the node
-    // fill; `class_keys` is kept to build the owned memo handed back
-    // through `AssembledGraph`.
-    let mut class_keys: FxHashMap<(&str, &str, u32), u32> = FxHashMap::default();
-    let mut class_work: Vec<(File, &str, &str)> = Vec::new();
-    for (pos, mint) in mints.iter().enumerate() {
-        let dir = dir_ids[pos];
-        let anchor = dir_anchors[dir as usize];
-        for (_cls_rk, bases) in &mint.payload.class_bases {
-            for base in bases.iter() {
-                if let ClassBaseSpec::ModuleMember { module, name } = base {
-                    class_keys
-                        .entry((module.as_str(), name.as_str(), dir))
-                        .or_insert_with(|| {
-                            class_work.push((anchor, module.as_str(), name.as_str()));
-                            (class_work.len() - 1) as u32
-                        });
-                }
-            }
-        }
-    }
-
-    // Per-chunk salsa snapshots, cloned here on the main thread (a
-    // salsa clone must not race a worker mid-query — the populate
-    // fan-out documents the same hazard).
-    let member_job = prepare_job(db, &member_work);
-    let dynamic_job = prepare_job(db, &dynamic_work);
-    let parent_job = prepare_job(db, project_files);
-    let class_job = prepare_job(db, &class_work);
+    // Snapshot pool for the resolve fan-out, cloned here on the main
+    // thread (a salsa clone must not race a worker mid-query — the
+    // populate fan-out documents the same hazard). A recycled pool
+    // rather than per-chunk clones because the chunk counts aren't
+    // known until the gather runs (on a worker, overlapped with the
+    // node fill).
+    let pool = DbPool::new(db);
 
     if std::env::var_os("DEAD_CST_TIMING").is_some() {
         eprintln!("[dead-cst-timing] pass0={:?}", t_pass0_start.elapsed());
@@ -897,35 +833,137 @@ fn assemble_graph<'db>(
         rest = tail;
     }
 
-    // The resolve arm: every cross-file resolution family — member
-    // refs, dynamic refs, the parent-module sweep, class bases — run
-    // concurrently with the node fill on the same rayon pool. Touches
-    // only salsa snapshots, never the builder, so it composes with
-    // pass 1's mutable folds. (The pass1 timing line therefore covers
-    // the resolves too.)
-    let resolve_arm = move || {
+    /// Everything the resolve arm hands back across the pass-1 join.
+    /// All `'static` row data — no payload borrows escape the arm.
+    struct ResolveOutputs {
+        member_results: Vec<crate::refspec::ResolvedMember>,
+        dynamic_results: Vec<SmallVec<[ResolvedNode; 4]>>,
+        parent_results: Vec<Option<File>>,
+        spec_ids: Vec<Box<[u32]>>,
+        class_base_memo: ClassBaseMemo,
+        gather_time: std::time::Duration,
+        resolve_time: std::time::Duration,
+    }
+
+    // The resolve arm: the row-shaped gather plus every cross-file
+    // resolution family — member refs, dynamic refs, the parent-module
+    // sweep, class bases — run concurrently with the node fill on the
+    // same rayon pool. Touches only salsa snapshots (via the pool),
+    // never the builder, so it composes with pass 1's mutable folds.
+    let spec_payloads_ref = &spec_payloads;
+    let dir_ids_ref = &dir_ids;
+    let dir_anchors_ref = &dir_anchors;
+    let mints_for_arm = &mints;
+    let resolve_arm = move || -> ResolveOutputs {
+        // Gather: intern every `Member` / `Dynamic` spec row, exactly
+        // once, into a dense id (`spec_ids[pos][i]` parallels
+        // `spec_payloads[pos].specs`), so the downstream passes —
+        // unresolved stamping, edge translation — index a Vec instead
+        // of re-hashing string-keyed rows. At tens-of-millions-of-rows
+        // scale the repeated row hashing dominated assemble time.
+        // Encounter order is deterministic (the file list and each
+        // payload's specs are sorted); External mint order does not
+        // depend on it — the External pre-mint sorts by (fqname, path)
+        // itself. Hot imports repeated across a directory (or
+        // project-wide, one entry per directory) resolve once, not
+        // once per use site.
+        let t_gather = std::time::Instant::now();
+        const LOCAL_SPEC: u32 = u32::MAX;
+        let mut member_keys: FxHashMap<(&MemberRef, u32), u32> = FxHashMap::default();
+        let mut member_work: Vec<(File, &MemberRef)> = Vec::new();
+        let mut dynamic_keys: FxHashMap<(&DynamicRef, u32), u32> = FxHashMap::default();
+        let mut dynamic_work: Vec<(File, &DynamicRef)> = Vec::new();
+        let mut spec_ids: Vec<Box<[u32]>> = Vec::with_capacity(spec_payloads_ref.len());
+        for (pos, payload) in spec_payloads_ref.iter().enumerate() {
+            let dir = dir_ids_ref[pos];
+            let anchor = dir_anchors_ref[dir as usize];
+            let mut ids: Vec<u32> = Vec::with_capacity(payload.specs.len());
+            for spec in payload.specs.iter() {
+                let id = match &spec.target {
+                    Target::Local(_) => LOCAL_SPEC,
+                    Target::Member(m) => *member_keys.entry((m, dir)).or_insert_with(|| {
+                        member_work.push((anchor, m));
+                        (member_work.len() - 1) as u32
+                    }),
+                    Target::Dynamic(d) => *dynamic_keys.entry((d, dir)).or_insert_with(|| {
+                        dynamic_work.push((anchor, d));
+                        (dynamic_work.len() - 1) as u32
+                    }),
+                };
+                ids.push(id);
+            }
+            spec_ids.push(ids.into_boxed_slice());
+        }
+        drop(member_keys);
+        drop(dynamic_keys);
+
+        // Class-base member gather: the unique `(module, name, dir)`
+        // rows the post-assembly class-hierarchy fan-in needs resolved.
+        let mut class_keys: FxHashMap<(&str, &str, u32), u32> = FxHashMap::default();
+        let mut class_work: Vec<(File, &str, &str)> = Vec::new();
+        for (pos, mint) in mints_for_arm.iter().enumerate() {
+            let dir = dir_ids_ref[pos];
+            let anchor = dir_anchors_ref[dir as usize];
+            for (_cls_rk, bases) in &mint.payload.class_bases {
+                for base in bases.iter() {
+                    if let ClassBaseSpec::ModuleMember { module, name } = base {
+                        class_keys
+                            .entry((module.as_str(), name.as_str(), dir))
+                            .or_insert_with(|| {
+                                class_work.push((anchor, module.as_str(), name.as_str()));
+                                (class_work.len() - 1) as u32
+                            });
+                    }
+                }
+            }
+        }
+        let gather_time = t_gather.elapsed();
+
+        let t_resolve = std::time::Instant::now();
         let member_results: Vec<crate::refspec::ResolvedMember> =
-            run_job(member_job, |ldb, &(anchor, m)| {
+            run_job(&pool, &member_work, |ldb, &(anchor, m)| {
                 resolve_member(ldb, anchor, m)
             });
         let dynamic_results: Vec<SmallVec<[ResolvedNode; 4]>> =
-            run_job(dynamic_job, |ldb, &(anchor, d)| {
+            run_job(&pool, &dynamic_work, |ldb, &(anchor, d)| {
                 resolve_dynamic(ldb, anchor, d)
             });
-        let parent_results: Vec<Option<File>> =
-            run_job(parent_job, |ldb, &file| parent_module_file(ldb, file));
+        let parent_results: Vec<Option<File>> = run_job(&pool, project_files, |ldb, &file| {
+            parent_module_file(ldb, file)
+        });
         let class_results: Vec<Option<(File, TextRange)>> =
-            run_job(class_job, |ldb, &(anchor, module, name)| {
+            run_job(&pool, &class_work, |ldb, &(anchor, module, name)| {
                 resolve_member_def(ldb, module, name, anchor, 0)
             });
-        (
+
+        // Owned `(module, name, dir)` → resolved-base memo for the
+        // post-assembly class-hierarchy fan-in (scatter-only; the
+        // resolves just ran, overlapped with the node fill).
+        let mut class_base_memo: ClassBaseMemo =
+            FxHashMap::with_capacity_and_hasher(class_work.len(), Default::default());
+        for ((module, name, dir), id) in &class_keys {
+            class_base_memo.insert(
+                (
+                    CompactString::from(*module),
+                    CompactString::from(*name),
+                    *dir,
+                ),
+                class_results[*id as usize],
+            );
+        }
+
+        ResolveOutputs {
             member_results,
             dynamic_results,
             parent_results,
-            class_results,
-        )
+            spec_ids,
+            class_base_memo,
+            gather_time,
+            resolve_time: t_resolve.elapsed(),
+        }
     };
 
+    // 1b: parallel node fill + concurrent index folds.
     // 1b: parallel node fill + concurrent index folds.
     let mints_ref = &mints;
     let counters_ref: &ProgressCounters = counters;
@@ -935,149 +973,142 @@ fn assemble_graph<'db>(
     let module_nodes_mut = &mut module_nodes_by_file;
     let class_by_selection_mut = &mut class_by_selection;
     let decl_by_name_range_mut = &mut decl_by_name_range;
-    let ((key_rows, ()), (member_results, dynamic_results, parent_results, class_results)) = py
-        .allow_threads(move || {
-            use rayon::prelude::*;
-            rayon::join(
-                || {
-                    rayon::join(
-                        move || -> PyResult<Vec<Vec<(NodeKey, usize)>>> {
-                            mints_ref
-                                .par_iter()
-                                .zip_eq(file_slices)
-                                .map(|(mint, slots)| {
-                                    let mut keys: Vec<(NodeKey, usize)> =
-                                        Vec::with_capacity(mint.payload.nodes.len());
-                                    for (local_idx, node_data) in
-                                        mint.payload.nodes.iter().enumerate()
-                                    {
-                                        let node_ref = mint.payload.refs[local_idx];
+    let ((key_rows, ()), resolve_outputs) = py.allow_threads(move || {
+        use rayon::prelude::*;
+        rayon::join(
+            || {
+                rayon::join(
+                    move || -> PyResult<Vec<Vec<(NodeKey, usize)>>> {
+                        mints_ref
+                            .par_iter()
+                            .zip_eq(file_slices)
+                            .map(|(mint, slots)| {
+                                let mut keys: Vec<(NodeKey, usize)> =
+                                    Vec::with_capacity(mint.payload.nodes.len());
+                                for (local_idx, node_data) in mint.payload.nodes.iter().enumerate()
+                                {
+                                    let node_ref = mint.payload.refs[local_idx];
 
-                                        // Apply stub-only ENTRYPOINT flag if needed.
-                                        let mut flags = node_data.flags;
-                                        if mint.is_stub && matches!(node_ref, NodeRef::Def(_)) {
-                                            let has_runtime = match mint.twin_payload {
-                                                Some(py_payload) => {
-                                                    let name = node_data
-                                                        .fqname
-                                                        .rsplit('.')
-                                                        .next()
-                                                        .unwrap_or("");
-                                                    py_payload.exports_by_name.contains_key(name)
-                                                }
-                                                None => false,
-                                            };
-                                            if !has_runtime {
-                                                flags |= NODE_FLAG_ENTRYPOINT;
+                                    // Apply stub-only ENTRYPOINT flag if needed.
+                                    let mut flags = node_data.flags;
+                                    if mint.is_stub && matches!(node_ref, NodeRef::Def(_)) {
+                                        let has_runtime = match mint.twin_payload {
+                                            Some(py_payload) => {
+                                                let name = node_data
+                                                    .fqname
+                                                    .rsplit('.')
+                                                    .next()
+                                                    .unwrap_or("");
+                                                py_payload.exports_by_name.contains_key(name)
                                             }
-                                        }
-
-                                        let node = GraphNode {
-                                            fqname: node_data.fqname.to_string(),
-                                            kind: intern_kind(node_data.kind.as_static_str())?,
-                                            // Every node in this file's payload shares
-                                            // the file, so its path is the per-file
-                                            // `path_str` — re-derived once per file
-                                            // instead of stored per `NodeData`.
-                                            path: mint.path_str.clone(),
-                                            start_line: node_data.start_line,
-                                            start_column: node_data.start_column,
-                                            end_line: node_data.end_line,
-                                            end_column: node_data.end_column,
-                                            flags,
-                                            is_overload: node_data.is_overload,
-                                            imports: node_data.imports.clone(),
+                                            None => false,
                                         };
-                                        keys.push((node.key(mint.file), mint.base + local_idx));
-                                        slots[local_idx] = node;
-                                    }
-                                    counters_ref.assemble_inc();
-                                    Ok(keys)
-                                })
-                                .collect()
-                        },
-                        move || {
-                            // Each index fold is a serial insert loop over `Copy`
-                            // keys — cheap enough per map that one task per map
-                            // (rather than per-file sharding + merge) hides them
-                            // behind the node fill.
-                            rayon::join(
-                                move || {
-                                    for mint in mints_ref {
-                                        for (local_idx, &node_ref) in
-                                            mint.payload.refs.iter().enumerate()
-                                        {
-                                            ref_to_global_mut
-                                                .insert(node_ref, mint.base + local_idx);
+                                        if !has_runtime {
+                                            flags |= NODE_FLAG_ENTRYPOINT;
                                         }
                                     }
-                                },
-                                move || {
-                                    rayon::join(
-                                        move || {
-                                            for mint in mints_ref {
-                                                for local_idx in 0..mint.payload.refs.len() {
-                                                    local_to_global_mut.insert(
-                                                        (mint.file, local_idx as u32),
-                                                        mint.base + local_idx,
-                                                    );
-                                                }
+
+                                    let node = GraphNode {
+                                        fqname: node_data.fqname.to_string(),
+                                        kind: intern_kind(node_data.kind.as_static_str())?,
+                                        // Every node in this file's payload shares
+                                        // the file, so its path is the per-file
+                                        // `path_str` — re-derived once per file
+                                        // instead of stored per `NodeData`.
+                                        path: mint.path_str.clone(),
+                                        start_line: node_data.start_line,
+                                        start_column: node_data.start_column,
+                                        end_line: node_data.end_line,
+                                        end_column: node_data.end_column,
+                                        flags,
+                                        is_overload: node_data.is_overload,
+                                        imports: node_data.imports.clone(),
+                                    };
+                                    keys.push((node.key(mint.file), mint.base + local_idx));
+                                    slots[local_idx] = node;
+                                }
+                                counters_ref.assemble_inc();
+                                Ok(keys)
+                            })
+                            .collect()
+                    },
+                    move || {
+                        // Each index fold is a serial insert loop over `Copy`
+                        // keys — cheap enough per map that one task per map
+                        // (rather than per-file sharding + merge) hides them
+                        // behind the node fill.
+                        rayon::join(
+                            move || {
+                                for mint in mints_ref {
+                                    for (local_idx, &node_ref) in
+                                        mint.payload.refs.iter().enumerate()
+                                    {
+                                        ref_to_global_mut.insert(node_ref, mint.base + local_idx);
+                                    }
+                                }
+                            },
+                            move || {
+                                rayon::join(
+                                    move || {
+                                        for mint in mints_ref {
+                                            for local_idx in 0..mint.payload.refs.len() {
+                                                local_to_global_mut.insert(
+                                                    (mint.file, local_idx as u32),
+                                                    mint.base + local_idx,
+                                                );
                                             }
-                                        },
-                                        move || {
-                                            for mint in mints_ref {
-                                                for (local_idx, &node_ref) in
-                                                    mint.payload.refs.iter().enumerate()
-                                                {
-                                                    let global_idx = mint.base + local_idx;
-                                                    match node_ref {
-                                                        NodeRef::Module(_) => {
-                                                            module_nodes_mut
-                                                                .insert(mint.file, global_idx);
-                                                        }
-                                                        NodeRef::Def(d) => {
-                                                            // `d` is already the `(file,
-                                                            // place_id, name_range)` triple
-                                                            // `global_index` keys on.
-                                                            global_index_mut.insert(d, global_idx);
-                                                            let node_data =
-                                                                &mint.payload.nodes[local_idx];
-                                                            let rk = node_data.name_range;
-                                                            if matches!(
-                                                                node_data.kind,
-                                                                NodeKind::Class
-                                                            ) {
-                                                                class_by_selection_mut.insert(
-                                                                    (mint.file, rk),
-                                                                    global_idx,
-                                                                );
-                                                            }
-                                                            decl_by_name_range_mut.insert(
+                                        }
+                                    },
+                                    move || {
+                                        for mint in mints_ref {
+                                            for (local_idx, &node_ref) in
+                                                mint.payload.refs.iter().enumerate()
+                                            {
+                                                let global_idx = mint.base + local_idx;
+                                                match node_ref {
+                                                    NodeRef::Module(_) => {
+                                                        module_nodes_mut
+                                                            .insert(mint.file, global_idx);
+                                                    }
+                                                    NodeRef::Def(d) => {
+                                                        // `d` is already the `(file,
+                                                        // place_id, name_range)` triple
+                                                        // `global_index` keys on.
+                                                        global_index_mut.insert(d, global_idx);
+                                                        let node_data =
+                                                            &mint.payload.nodes[local_idx];
+                                                        let rk = node_data.name_range;
+                                                        if matches!(node_data.kind, NodeKind::Class)
+                                                        {
+                                                            class_by_selection_mut.insert(
                                                                 (mint.file, rk),
                                                                 global_idx,
                                                             );
                                                         }
-                                                        NodeRef::StarStmt(_, _) => {
-                                                            // The kept `*<src>` star-statement
-                                                            // node. Not a real decl, so it
-                                                            // contributes nothing to the decl
-                                                            // indices; the `ref_to_global` /
-                                                            // `local_to_global` folds already
-                                                            // wired it up.
-                                                        }
+                                                        decl_by_name_range_mut
+                                                            .insert((mint.file, rk), global_idx);
+                                                    }
+                                                    NodeRef::StarStmt(_, _) => {
+                                                        // The kept `*<src>` star-statement
+                                                        // node. Not a real decl, so it
+                                                        // contributes nothing to the decl
+                                                        // indices; the `ref_to_global` /
+                                                        // `local_to_global` folds already
+                                                        // wired it up.
                                                     }
                                                 }
                                             }
-                                        },
-                                    );
-                                },
-                            );
-                        },
-                    )
-                },
-                resolve_arm,
-            )
-        });
+                                        }
+                                    },
+                                );
+                            },
+                        );
+                    },
+                )
+            },
+            resolve_arm,
+        )
+    });
 
     // 1c: fold the parallel fill's key rows into `node_index`. Payload
     // nodes are position-distinct (`CLAUDE.md` principle 3), so no two
@@ -1095,8 +1126,26 @@ fn assemble_graph<'db>(
         }
     }
 
+    let ResolveOutputs {
+        member_results,
+        dynamic_results,
+        parent_results,
+        spec_ids,
+        class_base_memo,
+        gather_time,
+        resolve_time,
+    } = resolve_outputs;
+
     if std::env::var_os("DEAD_CST_TIMING").is_some() {
-        eprintln!("[dead-cst-timing] pass1={:?}", t_pass1_start.elapsed());
+        // pass1 is the wall time of the whole join: node mint + index
+        // folds on one arm, the gather + resolves on the other.
+        // gather/resolve are the resolve arm's internal split.
+        eprintln!(
+            "[dead-cst-timing] pass1={:?} (resolve arm: gather={:?} resolve={:?})",
+            t_pass1_start.elapsed(),
+            gather_time,
+            resolve_time,
+        );
     }
 
     // Pass 2: edge translation. All cross-file resolution already ran
@@ -1355,22 +1404,6 @@ fn assemble_graph<'db>(
         emit_visitor_warning(py, msg);
     }
 
-    // Owned `(module, name, dir)` → resolved-base memo for the
-    // post-assembly class-hierarchy fan-in (scatter-only now — the
-    // resolves already ran in pass 1's resolve arm).
-    let mut class_base_memo: ClassBaseMemo =
-        FxHashMap::with_capacity_and_hasher(class_work.len(), Default::default());
-    for ((module, name, dir), id) in &class_keys {
-        class_base_memo.insert(
-            (
-                CompactString::from(*module),
-                CompactString::from(*name),
-                *dir,
-            ),
-            class_results[*id as usize],
-        );
-    }
-
     Ok(AssembledGraph {
         builder,
         global_index,
@@ -1404,47 +1437,67 @@ fn translate_resolved(
     }
 }
 
-/// One pre-chunked family of cross-file resolution work, with one
-/// salsa snapshot per chunk. Prepared on the main thread by
-/// [`prepare_job`] (a salsa clone must not race a worker mid-query —
-/// the populate fan-out documents the same hazard), executed by
-/// [`run_job`] inside an already-parallel rayon section.
-struct ChunkedJob<'w, T> {
-    chunks: Vec<&'w [T]>,
-    dbs: Vec<ProjectDatabase>,
+/// Fixed pool of salsa snapshots for the resolve fan-out, cloned on
+/// the main thread up front (a salsa clone must not race a worker
+/// mid-query — the populate fan-out documents the same hazard) and
+/// recycled through a bounded channel. A pool rather than per-chunk
+/// clones because the resolve arm's chunk counts aren't known until
+/// its gather runs, on a rayon worker.
+///
+/// Sized to the executing rayon pool, so at most `num_workers` chunk
+/// tasks run at once and a `recv` can never starve: every checked-out
+/// snapshot belongs to a task that is actively running on some thread
+/// and will send it back.
+struct DbPool {
+    tx: crossbeam_channel::Sender<ProjectDatabase>,
+    rx: crossbeam_channel::Receiver<ProjectDatabase>,
+    num_workers: usize,
 }
 
-/// Chunk `work` 16× finer than the worker count: resolution cost is
-/// skewed (one package's imports cluster in encounter order), so
-/// fine-grained chunks let rayon's work-stealing even out the tail
-/// instead of one worker dragging a fat chunk — and the small families
-/// (class bases, parent modules) still spread across every core.
-fn prepare_job<'w, T>(db: &ProjectDatabase, work: &'w [T]) -> ChunkedJob<'w, T> {
-    let num_workers = std::thread::available_parallelism()
-        .map(std::num::NonZeroUsize::get)
-        .unwrap_or(4);
-    let chunk_size = work.len().div_ceil(num_workers * 16).max(1);
-    let chunks: Vec<&'w [T]> = work.chunks(chunk_size).collect();
-    let dbs: Vec<ProjectDatabase> = (0..chunks.len()).map(|_| db.clone()).collect();
-    ChunkedJob { chunks, dbs }
+impl DbPool {
+    fn new(db: &ProjectDatabase) -> Self {
+        let num_workers = std::thread::available_parallelism()
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(4);
+        let (tx, rx) = crossbeam_channel::bounded::<ProjectDatabase>(num_workers);
+        for _ in 0..num_workers {
+            tx.send(db.clone()).expect("channel open");
+        }
+        DbPool {
+            tx,
+            rx,
+            num_workers,
+        }
+    }
 }
 
-/// Run `f` over a prepared job on the current rayon pool. Results come
-/// back in `work` order, so deterministic inputs give deterministic
-/// outputs regardless of scheduling. Pure rust — composes inside
-/// `py.allow_threads` / a rayon join arm.
+/// Run `f` over `work` on the current rayon pool, drawing snapshots
+/// from the pool per chunk. Chunked 16× finer than the worker count:
+/// resolution cost is skewed (one package's imports cluster in
+/// encounter order), so fine-grained chunks let work-stealing even out
+/// the tail, and the small families (class bases, parent modules)
+/// still spread across every core. Results come back in `work` order,
+/// so deterministic inputs give deterministic outputs regardless of
+/// scheduling. Pure rust — composes inside `py.allow_threads` / a
+/// rayon join arm.
 fn run_job<T: Sync, R: Send>(
-    job: ChunkedJob<'_, T>,
+    pool: &DbPool,
+    work: &[T],
     f: impl Fn(&ProjectDatabase, &T) -> R + Send + Sync,
 ) -> Vec<R> {
     use rayon::prelude::*;
-    let nested: Vec<Vec<R>> = job
-        .dbs
-        .into_par_iter()
-        .zip(job.chunks.into_par_iter())
-        .map(|(local_db, chunk)| {
+    if work.is_empty() {
+        return Vec::new();
+    }
+    let chunk_size = work.len().div_ceil(pool.num_workers * 16).max(1);
+    let nested: Vec<Vec<R>> = work
+        .par_chunks(chunk_size)
+        .map(|chunk| {
+            let local_db = pool.rx.recv().expect("snapshot available");
             use salsa::Database as _;
-            local_db.attach(|ldb| chunk.iter().map(|item| f(ldb, item)).collect())
+            let out = local_db.attach(|ldb| chunk.iter().map(|item| f(ldb, item)).collect());
+            pool.tx.send(local_db).expect("channel open");
+            out
         })
         .collect();
     nested.into_iter().flatten().collect()

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -1025,8 +1025,29 @@ fn assemble_graph<'db>(
             resolve_dynamic(ldb, dir_anchors_ref[dir as usize], d)
         });
 
-    // 2c: serial fold into idx-level memos. External nodes intern on
-    // first encounter, in sorted-key order — deterministic indices.
+    // 2c: serial fold into idx-level memos.
+    //
+    // External nodes are pre-minted in (fqname, path) order across every
+    // resolution output — the same deterministic order the old pipeline
+    // used — so duplicate-fqname externals keep the lexicographically
+    // smallest path and land at the same graph indices.
+    // `intern_external` dedups by fqname, so the memo folds below hit
+    // the pre-minted nodes.
+    {
+        let mut externals: Vec<(&str, String, File)> = Vec::new();
+        let member_nodes = member_results.iter().flat_map(|res| res.targets.iter());
+        let dynamic_nodes = dynamic_results.iter().flatten();
+        for node in member_nodes.chain(dynamic_nodes) {
+            if let ResolvedNode::External { fqname, file } = node {
+                externals.push((fqname.as_str(), file_path_string(db, *file), *file));
+            }
+        }
+        externals.sort_unstable();
+        for (fqname, path, file) in externals {
+            builder.intern_external(fqname.to_string(), path, file);
+        }
+    }
+
     struct MemberSlot {
         idxs: SmallVec<[usize; 4]>,
         unresolved: bool,
@@ -1142,12 +1163,26 @@ fn assemble_graph<'db>(
                                     // the old `target_file == file` skip,
                                     // which must apply per importing file,
                                     // not per memo entry).
-                                    let self_import = matches!(m.role, MemberRole::Binding)
-                                        && slot.start_file == Some(file);
-                                    if !self_import {
-                                        for &idx in &slot.idxs {
-                                            if idx != src_idx {
-                                                out.push((src_idx, idx, flags));
+                                    match m.role {
+                                        MemberRole::Binding => {
+                                            // Old file_to_edges had no self
+                                            // filter: a circular star
+                                            // re-export can land the chain
+                                            // walk back on the alias itself,
+                                            // and that self-loop is kept.
+                                            if slot.start_file != Some(file) {
+                                                for &idx in &slot.idxs {
+                                                    out.push((src_idx, idx, flags));
+                                                }
+                                            }
+                                        }
+                                        MemberRole::Use => {
+                                            // Use side mirrors the old
+                                            // emit_edge `dst != owner` skip.
+                                            for &idx in &slot.idxs {
+                                                if idx != src_idx {
+                                                    out.push((src_idx, idx, flags));
+                                                }
                                             }
                                         }
                                     }

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -52,6 +52,7 @@ use crate::refspec::{
     resolve_dynamic, resolve_member, DynamicRef, MemberRef, MemberRole, ResolvedNode, Target,
 };
 use crate::topic_registry::TopicRegistry;
+use compact_str::CompactString;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 
@@ -521,6 +522,8 @@ pub(crate) fn build_project_graph(
     let class_by_selection = assembled.class_by_selection;
     let decl_by_name_range = assembled.decl_by_name_range;
     let topic_facts = assembled.topic_facts;
+    let class_base_memo = assembled.class_base_memo;
+    let assemble_dir_ids = assembled.dir_ids;
 
     counters.start_phase(PHASE_FQNAME, Some(builder.nodes.len()));
     let t4 = std::time::Instant::now();
@@ -537,7 +540,13 @@ pub(crate) fn build_project_graph(
     let ClassHierarchyIndices {
         children_by_node,
         external_base_children,
-    } = build_class_hierarchy_indices(py, db, &project_files, &class_by_selection);
+    } = build_class_hierarchy_indices(
+        db,
+        &project_files,
+        &class_by_selection,
+        &class_base_memo,
+        &assemble_dir_ids,
+    );
     let t_hierarchy_elapsed = t_hierarchy.elapsed();
     if timing {
         eprintln!(
@@ -621,6 +630,10 @@ struct AssembledGraph {
     class_by_selection: FxHashMap<(File, (u32, u32)), usize>,
     decl_by_name_range: FxHashMap<(File, (u32, u32)), usize>,
     topic_facts: FxHashMap<String, Vec<crate::native_plugins::plugin_api::Fact>>,
+    /// Resolved class-base memo + the per-file anchor-dir ids that key
+    /// it, for the post-assembly class-hierarchy scatter.
+    class_base_memo: ClassBaseMemo,
+    dir_ids: Vec<u32>,
 }
 
 /// Fan-in pass that converts the salsa-tracked per-file payloads
@@ -762,6 +775,115 @@ fn assemble_graph<'db>(
         });
     }
 
+    // Pass 0: resolution gather. Runs before pass 1 so the resolve
+    // fan-out can share pass 1's rayon section: the resolves touch
+    // only salsa snapshots — never the builder — so they overlap the
+    // node fill instead of serializing after it.
+    //
+    // Every `Member` / `Dynamic` spec row is interned HERE, exactly
+    // once, into a dense id (`spec_ids[pos][i]` parallels
+    // `spec_payloads[pos].specs`), so the downstream passes —
+    // unresolved stamping, edge translation — index a Vec instead of
+    // re-hashing string-keyed rows. At tens-of-millions-of-rows scale
+    // the repeated row hashing dominated assemble time.
+    let t_pass0_start = std::time::Instant::now();
+    let mut spec_payloads: Vec<&FileRefSpecs> = Vec::with_capacity(project_files.len());
+    for &file in project_files {
+        spec_payloads.push(file_to_refspecs(db, file));
+    }
+
+    // Per-file anchor-directory ids. ty's `resolve_module` is anchor-
+    // sensitive only through its desperate-resolution fallback, which
+    // depends on the importing file's ancestor directories — so files
+    // sharing a directory share resolutions. `mints` is path-sorted,
+    // so the first file seen for a directory is deterministic; that
+    // file is the directory's representative resolution anchor.
+    let mut dir_to_id: FxHashMap<&str, u32> = FxHashMap::default();
+    let mut dir_anchors: Vec<File> = Vec::new();
+    let mut dir_ids: Vec<u32> = Vec::with_capacity(project_files.len());
+    for mint in &mints {
+        let dir = match mint.path_str.rsplit_once(['/', '\\']) {
+            Some((dir, _)) => dir,
+            None => "",
+        };
+        let id = *dir_to_id.entry(dir).or_insert_with(|| {
+            dir_anchors.push(mint.file);
+            (dir_anchors.len() - 1) as u32
+        });
+        dir_ids.push(id);
+    }
+
+    // Unique-key interning, in encounter order (deterministic: the
+    // file list and each payload's specs are sorted). External mint
+    // order does not depend on this order — the External pre-mint
+    // sorts by (fqname, path) itself. Hot imports repeated across a
+    // directory (or project-wide, one entry per directory) resolve
+    // once, not once per use site.
+    const LOCAL_SPEC: u32 = u32::MAX;
+    let mut member_keys: FxHashMap<(&MemberRef, u32), u32> = FxHashMap::default();
+    let mut member_work: Vec<(File, &MemberRef)> = Vec::new();
+    let mut dynamic_keys: FxHashMap<(&DynamicRef, u32), u32> = FxHashMap::default();
+    let mut dynamic_work: Vec<(File, &DynamicRef)> = Vec::new();
+    let mut spec_ids: Vec<Box<[u32]>> = Vec::with_capacity(project_files.len());
+    for (pos, payload) in spec_payloads.iter().enumerate() {
+        let dir = dir_ids[pos];
+        let anchor = dir_anchors[dir as usize];
+        let mut ids: Vec<u32> = Vec::with_capacity(payload.specs.len());
+        for spec in payload.specs.iter() {
+            let id = match &spec.target {
+                Target::Local(_) => LOCAL_SPEC,
+                Target::Member(m) => *member_keys.entry((m, dir)).or_insert_with(|| {
+                    member_work.push((anchor, m));
+                    (member_work.len() - 1) as u32
+                }),
+                Target::Dynamic(d) => *dynamic_keys.entry((d, dir)).or_insert_with(|| {
+                    dynamic_work.push((anchor, d));
+                    (dynamic_work.len() - 1) as u32
+                }),
+            };
+            ids.push(id);
+        }
+        spec_ids.push(ids.into_boxed_slice());
+    }
+    drop(member_keys);
+    drop(dynamic_keys);
+
+    // Class-base member gather: the unique `(module, name, dir)` rows
+    // the post-assembly class-hierarchy fan-in needs resolved. Joining
+    // them into this pass's resolve arm overlaps them with the node
+    // fill; `class_keys` is kept to build the owned memo handed back
+    // through `AssembledGraph`.
+    let mut class_keys: FxHashMap<(&str, &str, u32), u32> = FxHashMap::default();
+    let mut class_work: Vec<(File, &str, &str)> = Vec::new();
+    for (pos, mint) in mints.iter().enumerate() {
+        let dir = dir_ids[pos];
+        let anchor = dir_anchors[dir as usize];
+        for (_cls_rk, bases) in &mint.payload.class_bases {
+            for base in bases.iter() {
+                if let ClassBaseSpec::ModuleMember { module, name } = base {
+                    class_keys
+                        .entry((module.as_str(), name.as_str(), dir))
+                        .or_insert_with(|| {
+                            class_work.push((anchor, module.as_str(), name.as_str()));
+                            (class_work.len() - 1) as u32
+                        });
+                }
+            }
+        }
+    }
+
+    // Per-chunk salsa snapshots, cloned here on the main thread (a
+    // salsa clone must not race a worker mid-query — the populate
+    // fan-out documents the same hazard).
+    let member_job = prepare_job(db, &member_work);
+    let dynamic_job = prepare_job(db, &dynamic_work);
+    let parent_job = prepare_job(db, project_files);
+    let class_job = prepare_job(db, &class_work);
+
+    if std::env::var_os("DEAD_CST_TIMING").is_some() {
+        eprintln!("[dead-cst-timing] pass0={:?}", t_pass0_start.elapsed());
+    }
+
     // Disjoint per-file `&mut` windows over the prefilled payload
     // region. The offsets are the exclusive prefix sum of the payload
     // lengths, so successive `split_at_mut` calls reproduce them
@@ -775,6 +897,35 @@ fn assemble_graph<'db>(
         rest = tail;
     }
 
+    // The resolve arm: every cross-file resolution family — member
+    // refs, dynamic refs, the parent-module sweep, class bases — run
+    // concurrently with the node fill on the same rayon pool. Touches
+    // only salsa snapshots, never the builder, so it composes with
+    // pass 1's mutable folds. (The pass1 timing line therefore covers
+    // the resolves too.)
+    let resolve_arm = move || {
+        let member_results: Vec<crate::refspec::ResolvedMember> =
+            run_job(member_job, |ldb, &(anchor, m)| {
+                resolve_member(ldb, anchor, m)
+            });
+        let dynamic_results: Vec<SmallVec<[ResolvedNode; 4]>> =
+            run_job(dynamic_job, |ldb, &(anchor, d)| {
+                resolve_dynamic(ldb, anchor, d)
+            });
+        let parent_results: Vec<Option<File>> =
+            run_job(parent_job, |ldb, &file| parent_module_file(ldb, file));
+        let class_results: Vec<Option<(File, TextRange)>> =
+            run_job(class_job, |ldb, &(anchor, module, name)| {
+                resolve_member_def(ldb, module, name, anchor, 0)
+            });
+        (
+            member_results,
+            dynamic_results,
+            parent_results,
+            class_results,
+        )
+    };
+
     // 1b: parallel node fill + concurrent index folds.
     let mints_ref = &mints;
     let counters_ref: &ProgressCounters = counters;
@@ -784,126 +935,149 @@ fn assemble_graph<'db>(
     let module_nodes_mut = &mut module_nodes_by_file;
     let class_by_selection_mut = &mut class_by_selection;
     let decl_by_name_range_mut = &mut decl_by_name_range;
-    let (key_rows, ()) = py.allow_threads(move || {
-        use rayon::prelude::*;
-        rayon::join(
-            move || -> PyResult<Vec<Vec<(NodeKey, usize)>>> {
-                mints_ref
-                    .par_iter()
-                    .zip_eq(file_slices)
-                    .map(|(mint, slots)| {
-                        let mut keys: Vec<(NodeKey, usize)> =
-                            Vec::with_capacity(mint.payload.nodes.len());
-                        for (local_idx, node_data) in mint.payload.nodes.iter().enumerate() {
-                            let node_ref = mint.payload.refs[local_idx];
-
-                            // Apply stub-only ENTRYPOINT flag if needed.
-                            let mut flags = node_data.flags;
-                            if mint.is_stub && matches!(node_ref, NodeRef::Def(_)) {
-                                let has_runtime = match mint.twin_payload {
-                                    Some(py_payload) => {
-                                        let name =
-                                            node_data.fqname.rsplit('.').next().unwrap_or("");
-                                        py_payload.exports_by_name.contains_key(name)
-                                    }
-                                    None => false,
-                                };
-                                if !has_runtime {
-                                    flags |= NODE_FLAG_ENTRYPOINT;
-                                }
-                            }
-
-                            let node = GraphNode {
-                                fqname: node_data.fqname.to_string(),
-                                kind: intern_kind(node_data.kind.as_static_str())?,
-                                // Every node in this file's payload shares
-                                // the file, so its path is the per-file
-                                // `path_str` — re-derived once per file
-                                // instead of stored per `NodeData`.
-                                path: mint.path_str.clone(),
-                                start_line: node_data.start_line,
-                                start_column: node_data.start_column,
-                                end_line: node_data.end_line,
-                                end_column: node_data.end_column,
-                                flags,
-                                is_overload: node_data.is_overload,
-                                imports: node_data.imports.clone(),
-                            };
-                            keys.push((node.key(mint.file), mint.base + local_idx));
-                            slots[local_idx] = node;
-                        }
-                        counters_ref.assemble_inc();
-                        Ok(keys)
-                    })
-                    .collect()
-            },
-            move || {
-                // Each index fold is a serial insert loop over `Copy`
-                // keys — cheap enough per map that one task per map
-                // (rather than per-file sharding + merge) hides them
-                // behind the node fill.
-                rayon::join(
-                    move || {
-                        for mint in mints_ref {
-                            for (local_idx, &node_ref) in mint.payload.refs.iter().enumerate() {
-                                ref_to_global_mut.insert(node_ref, mint.base + local_idx);
-                            }
-                        }
-                    },
-                    move || {
-                        rayon::join(
-                            move || {
-                                for mint in mints_ref {
-                                    for local_idx in 0..mint.payload.refs.len() {
-                                        local_to_global_mut.insert(
-                                            (mint.file, local_idx as u32),
-                                            mint.base + local_idx,
-                                        );
-                                    }
-                                }
-                            },
-                            move || {
-                                for mint in mints_ref {
-                                    for (local_idx, &node_ref) in
-                                        mint.payload.refs.iter().enumerate()
+    let ((key_rows, ()), (member_results, dynamic_results, parent_results, class_results)) = py
+        .allow_threads(move || {
+            use rayon::prelude::*;
+            rayon::join(
+                || {
+                    rayon::join(
+                        move || -> PyResult<Vec<Vec<(NodeKey, usize)>>> {
+                            mints_ref
+                                .par_iter()
+                                .zip_eq(file_slices)
+                                .map(|(mint, slots)| {
+                                    let mut keys: Vec<(NodeKey, usize)> =
+                                        Vec::with_capacity(mint.payload.nodes.len());
+                                    for (local_idx, node_data) in
+                                        mint.payload.nodes.iter().enumerate()
                                     {
-                                        let global_idx = mint.base + local_idx;
-                                        match node_ref {
-                                            NodeRef::Module(_) => {
-                                                module_nodes_mut.insert(mint.file, global_idx);
-                                            }
-                                            NodeRef::Def(d) => {
-                                                // `d` is already the `(file,
-                                                // place_id, name_range)` triple
-                                                // `global_index` keys on.
-                                                global_index_mut.insert(d, global_idx);
-                                                let node_data = &mint.payload.nodes[local_idx];
-                                                let rk = node_data.name_range;
-                                                if matches!(node_data.kind, NodeKind::Class) {
-                                                    class_by_selection_mut
-                                                        .insert((mint.file, rk), global_idx);
+                                        let node_ref = mint.payload.refs[local_idx];
+
+                                        // Apply stub-only ENTRYPOINT flag if needed.
+                                        let mut flags = node_data.flags;
+                                        if mint.is_stub && matches!(node_ref, NodeRef::Def(_)) {
+                                            let has_runtime = match mint.twin_payload {
+                                                Some(py_payload) => {
+                                                    let name = node_data
+                                                        .fqname
+                                                        .rsplit('.')
+                                                        .next()
+                                                        .unwrap_or("");
+                                                    py_payload.exports_by_name.contains_key(name)
                                                 }
-                                                decl_by_name_range_mut
-                                                    .insert((mint.file, rk), global_idx);
-                                            }
-                                            NodeRef::StarStmt(_, _) => {
-                                                // The kept `*<src>` star-statement
-                                                // node. Not a real decl, so it
-                                                // contributes nothing to the decl
-                                                // indices; the `ref_to_global` /
-                                                // `local_to_global` folds already
-                                                // wired it up.
+                                                None => false,
+                                            };
+                                            if !has_runtime {
+                                                flags |= NODE_FLAG_ENTRYPOINT;
                                             }
                                         }
+
+                                        let node = GraphNode {
+                                            fqname: node_data.fqname.to_string(),
+                                            kind: intern_kind(node_data.kind.as_static_str())?,
+                                            // Every node in this file's payload shares
+                                            // the file, so its path is the per-file
+                                            // `path_str` — re-derived once per file
+                                            // instead of stored per `NodeData`.
+                                            path: mint.path_str.clone(),
+                                            start_line: node_data.start_line,
+                                            start_column: node_data.start_column,
+                                            end_line: node_data.end_line,
+                                            end_column: node_data.end_column,
+                                            flags,
+                                            is_overload: node_data.is_overload,
+                                            imports: node_data.imports.clone(),
+                                        };
+                                        keys.push((node.key(mint.file), mint.base + local_idx));
+                                        slots[local_idx] = node;
                                     }
-                                }
-                            },
-                        );
-                    },
-                );
-            },
-        )
-    });
+                                    counters_ref.assemble_inc();
+                                    Ok(keys)
+                                })
+                                .collect()
+                        },
+                        move || {
+                            // Each index fold is a serial insert loop over `Copy`
+                            // keys — cheap enough per map that one task per map
+                            // (rather than per-file sharding + merge) hides them
+                            // behind the node fill.
+                            rayon::join(
+                                move || {
+                                    for mint in mints_ref {
+                                        for (local_idx, &node_ref) in
+                                            mint.payload.refs.iter().enumerate()
+                                        {
+                                            ref_to_global_mut
+                                                .insert(node_ref, mint.base + local_idx);
+                                        }
+                                    }
+                                },
+                                move || {
+                                    rayon::join(
+                                        move || {
+                                            for mint in mints_ref {
+                                                for local_idx in 0..mint.payload.refs.len() {
+                                                    local_to_global_mut.insert(
+                                                        (mint.file, local_idx as u32),
+                                                        mint.base + local_idx,
+                                                    );
+                                                }
+                                            }
+                                        },
+                                        move || {
+                                            for mint in mints_ref {
+                                                for (local_idx, &node_ref) in
+                                                    mint.payload.refs.iter().enumerate()
+                                                {
+                                                    let global_idx = mint.base + local_idx;
+                                                    match node_ref {
+                                                        NodeRef::Module(_) => {
+                                                            module_nodes_mut
+                                                                .insert(mint.file, global_idx);
+                                                        }
+                                                        NodeRef::Def(d) => {
+                                                            // `d` is already the `(file,
+                                                            // place_id, name_range)` triple
+                                                            // `global_index` keys on.
+                                                            global_index_mut.insert(d, global_idx);
+                                                            let node_data =
+                                                                &mint.payload.nodes[local_idx];
+                                                            let rk = node_data.name_range;
+                                                            if matches!(
+                                                                node_data.kind,
+                                                                NodeKind::Class
+                                                            ) {
+                                                                class_by_selection_mut.insert(
+                                                                    (mint.file, rk),
+                                                                    global_idx,
+                                                                );
+                                                            }
+                                                            decl_by_name_range_mut.insert(
+                                                                (mint.file, rk),
+                                                                global_idx,
+                                                            );
+                                                        }
+                                                        NodeRef::StarStmt(_, _) => {
+                                                            // The kept `*<src>` star-statement
+                                                            // node. Not a real decl, so it
+                                                            // contributes nothing to the decl
+                                                            // indices; the `ref_to_global` /
+                                                            // `local_to_global` folds already
+                                                            // wired it up.
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                    );
+                                },
+                            );
+                        },
+                    )
+                },
+                resolve_arm,
+            )
+        });
 
     // 1c: fold the parallel fill's key rows into `node_index`. Payload
     // nodes are position-distinct (`CLAUDE.md` principle 3), so no two
@@ -925,105 +1099,14 @@ fn assemble_graph<'db>(
         eprintln!("[dead-cst-timing] pass1={:?}", t_pass1_start.elapsed());
     }
 
-    // Pass 2: reference-spec resolution + edge translation.
-    //
-    // The per-file payloads are file-local `RefSpec`s (see
-    // `crate::refspec`), so this pass owns ALL cross-file resolution.
-    // Four sub-phases:
-    //
-    //   2a. Serial fetch of every file's salsa-tracked `FileRefSpecs`
-    //       payload, plus the per-file anchor-directory ids that key
-    //       the resolution memo. ty's `resolve_module` is anchor-
-    //       sensitive only through its desperate-resolution fallback,
-    //       which depends on the importing file's ancestor directories
-    //       — so files sharing a directory share memo entries.
-    //   2b. Gather the project-wide unique `(member, dir)` /
-    //       `(dynamic, dir)` resolution keys (sorted, for determinism)
-    //       and resolve them on rayon workers, each against its own
-    //       salsa db snapshot — parallel salsa reads, the same pattern
-    //       the populate fan-out uses. Hot imports repeated across a
-    //       directory (or project-wide, one entry per directory)
-    //       resolve once, not once per use site.
-    //   2c. Serial fold of the resolution results into idx-level memo
-    //       maps: translate each `ResolvedNode` through
-    //       `ref_to_global`, interning External nodes on first
-    //       encounter (sorted-key order keeps their indices
-    //       deterministic), and stamp `NodeFlags::UNRESOLVED` on
-    //       aliases whose `Binding` resolution failed (in place of the
-    //       old `[unresolved] X` sink node).
-    //   2d. `Python::allow_threads` + parallel per-file translation of
-    //       every `RefSpec` into `(usize, usize, u8)` triples — pure
-    //       hashmap probes against the memo maps, no salsa access —
-    //       chained with the structural edges synthesized from the
-    //       node payloads (decl → module anchors, overload impl → stub
-    //       anchors, submodule → parent-package hierarchy). Sort +
-    //       dedup + bulk-init the edge storage via `init_edges_bulk`.
-    //
-    // Dropped triples reference Definitions in non-project files.
+    // Pass 2: edge translation. All cross-file resolution already ran
+    // in pass 0 (gather) + pass 1's resolve arm (overlapped with the
+    // node fill); this pass folds the results into idx-level memo
+    // slots and translates every `RefSpec` into `(usize, usize, u8)`
+    // triples. Dropped triples reference Definitions in non-project
+    // files.
 
     let t_pass2_start = std::time::Instant::now();
-
-    // 2a: serial fetch. Hold borrows for the whole pass.
-    let mut spec_payloads: Vec<&FileRefSpecs> = Vec::with_capacity(project_files.len());
-    for &file in project_files {
-        spec_payloads.push(file_to_refspecs(db, file));
-    }
-
-    // Per-file anchor-directory ids. `mints` is path-sorted, so the
-    // first file seen for a directory is deterministic; that file is
-    // the directory's representative resolution anchor.
-    let mut dir_to_id: FxHashMap<&str, u32> = FxHashMap::default();
-    let mut dir_anchors: Vec<File> = Vec::new();
-    let mut dir_ids: Vec<u32> = Vec::with_capacity(project_files.len());
-    for mint in &mints {
-        let dir = match mint.path_str.rsplit_once(['/', '\\']) {
-            Some((dir, _)) => dir,
-            None => "",
-        };
-        let id = *dir_to_id.entry(dir).or_insert_with(|| {
-            dir_anchors.push(mint.file);
-            (dir_anchors.len() - 1) as u32
-        });
-        dir_ids.push(id);
-    }
-
-    // 2b: gather unique resolution keys. Keys borrow straight out of
-    // the payloads (alive for the whole pass), so gathering is
-    // clone-free.
-    let mut member_work: Vec<(&MemberRef, u32)> = {
-        let mut seen: FxHashSet<(&MemberRef, u32)> = FxHashSet::default();
-        for (pos, payload) in spec_payloads.iter().enumerate() {
-            for spec in payload.specs.iter() {
-                if let Target::Member(m) = &spec.target {
-                    seen.insert((m, dir_ids[pos]));
-                }
-            }
-        }
-        seen.into_iter().collect()
-    };
-    member_work.sort_unstable();
-    let mut dynamic_work: Vec<(&DynamicRef, u32)> = {
-        let mut seen: FxHashSet<(&DynamicRef, u32)> = FxHashSet::default();
-        for (pos, payload) in spec_payloads.iter().enumerate() {
-            for spec in payload.specs.iter() {
-                if let Target::Dynamic(d) = &spec.target {
-                    seen.insert((d, dir_ids[pos]));
-                }
-            }
-        }
-        seen.into_iter().collect()
-    };
-    dynamic_work.sort_unstable();
-
-    let dir_anchors_ref = &dir_anchors;
-    let member_results: Vec<crate::refspec::ResolvedMember> =
-        resolve_chunked(py, db, &member_work, |ldb, &(m, dir)| {
-            resolve_member(ldb, dir_anchors_ref[dir as usize], m)
-        });
-    let dynamic_results: Vec<SmallVec<[ResolvedNode; 4]>> =
-        resolve_chunked(py, db, &dynamic_work, |ldb, &(d, dir)| {
-            resolve_dynamic(ldb, dir_anchors_ref[dir as usize], d)
-        });
 
     // 2c: serial fold into idx-level memos.
     //
@@ -1048,39 +1131,36 @@ fn assemble_graph<'db>(
         }
     }
 
+    // Memo slots indexed by the dense ids assigned in pass 0 — the
+    // stamping and translation passes below never hash a key.
     struct MemberSlot {
         idxs: SmallVec<[usize; 4]>,
         unresolved: bool,
         start_file: Option<File>,
     }
-    let mut member_memo: FxHashMap<(&MemberRef, u32), MemberSlot> =
-        FxHashMap::with_capacity_and_hasher(member_work.len(), Default::default());
-    for (&(m, dir), res) in member_work.iter().zip(&member_results) {
+    let mut member_slots: Vec<MemberSlot> = Vec::with_capacity(member_results.len());
+    for res in &member_results {
         let mut idxs: SmallVec<[usize; 4]> = SmallVec::new();
         for node in &res.targets {
             if let Some(idx) = translate_resolved(db, &mut builder, &ref_to_global, node) {
                 idxs.push(idx);
             }
         }
-        member_memo.insert(
-            (m, dir),
-            MemberSlot {
-                idxs,
-                unresolved: res.unresolved,
-                start_file: res.start_file,
-            },
-        );
+        member_slots.push(MemberSlot {
+            idxs,
+            unresolved: res.unresolved,
+            start_file: res.start_file,
+        });
     }
-    let mut dynamic_memo: FxHashMap<(&DynamicRef, u32), SmallVec<[usize; 4]>> =
-        FxHashMap::with_capacity_and_hasher(dynamic_work.len(), Default::default());
-    for (&(d, dir), nodes) in dynamic_work.iter().zip(&dynamic_results) {
+    let mut dynamic_slots: Vec<SmallVec<[usize; 4]>> = Vec::with_capacity(dynamic_results.len());
+    for nodes in &dynamic_results {
         let mut idxs: SmallVec<[usize; 4]> = SmallVec::new();
         for node in nodes {
             if let Some(idx) = translate_resolved(db, &mut builder, &ref_to_global, node) {
                 idxs.push(idx);
             }
         }
-        dynamic_memo.insert((d, dir), idxs);
+        dynamic_slots.push(idxs);
     }
 
     // Stamp `NodeFlags::UNRESOLVED` on every import alias whose
@@ -1088,16 +1168,16 @@ fn assemble_graph<'db>(
     // directly. Only `Binding`-role refs are eligible (one flag per
     // alias; a use through it resolves or drops silently).
     for (pos, payload) in spec_payloads.iter().enumerate() {
-        let dir = dir_ids[pos];
         let base = node_offsets[pos];
-        for spec in payload.specs.iter() {
+        let ids = &spec_ids[pos];
+        for (i, spec) in payload.specs.iter().enumerate() {
             let Target::Member(m) = &spec.target else {
                 continue;
             };
             if !matches!(m.role, MemberRole::Binding) {
                 continue;
             }
-            if member_memo.get(&(m, dir)).is_some_and(|s| s.unresolved) {
+            if member_slots[ids[i] as usize].unresolved {
                 builder.nodes[base + spec.src as usize].flags |= NODE_FLAG_UNRESOLVED;
             }
         }
@@ -1110,7 +1190,7 @@ fn assemble_graph<'db>(
     // the submodule → parent-package hierarchy edge (skipped when the
     // parent doesn't resolve into the project).
     let mut structural: Vec<(usize, usize, u8)> = Vec::with_capacity(total_nodes);
-    for mint in &mints {
+    for (pos, mint) in mints.iter().enumerate() {
         for local in 1..mint.payload.nodes.len() {
             structural.push((mint.base + local, mint.base, 0));
         }
@@ -1121,19 +1201,20 @@ fn assemble_graph<'db>(
                 0,
             ));
         }
-        if let Some(parent_file) = parent_module_file(db, mint.file) {
+        if let Some(parent_file) = parent_results[pos] {
             if let Some(&parent_idx) = module_nodes_by_file.get(&parent_file) {
                 structural.push((mint.base, parent_idx, 0));
             }
         }
     }
 
-    // 2d: parallel translation. The memo maps are owned + read-only
-    // from here; no GIL needed, no salsa access — pure hashmap probes.
-    let member_memo_ref = &member_memo;
-    let dynamic_memo_ref = &dynamic_memo;
+    // 2d: parallel translation. The memo slots are owned + read-only
+    // from here; no GIL needed, no salsa access, no key hashing — the
+    // dense id rows from pass 0 turn every probe into an array index.
+    let member_slots_ref = &member_slots;
+    let dynamic_slots_ref = &dynamic_slots;
     let spec_payloads_ref = &spec_payloads;
-    let dir_ids_ref = &dir_ids;
+    let spec_ids_ref = &spec_ids;
     let mut triples: Vec<(usize, usize, u8)> = py.allow_threads(move || {
         use rayon::prelude::*;
         let from_specs =
@@ -1142,9 +1223,9 @@ fn assemble_graph<'db>(
                 .enumerate()
                 .flat_map_iter(|(pos, payload)| {
                     let base = node_offsets[pos];
-                    let dir = dir_ids_ref[pos];
+                    let ids = &spec_ids_ref[pos];
                     let file = project_files[pos];
-                    payload.specs.iter().flat_map(move |spec| {
+                    payload.specs.iter().enumerate().flat_map(move |(i, spec)| {
                         let src_idx = base + spec.src as usize;
                         let flags = spec.flags;
                         let mut out: SmallVec<[(usize, usize, u8); 4]> = SmallVec::new();
@@ -1155,45 +1236,42 @@ fn assemble_graph<'db>(
                                 }
                             }
                             Target::Member(m) => {
-                                if let Some(slot) = member_memo_ref.get(&(m, dir)) {
-                                    // Self-import suppression: a Binding ref
-                                    // whose upstream resolves to the importing
-                                    // file itself emits nothing — the whole
-                                    // emission, decl edges included (mirrors
-                                    // the old `target_file == file` skip,
-                                    // which must apply per importing file,
-                                    // not per memo entry).
-                                    match m.role {
-                                        MemberRole::Binding => {
-                                            // Old file_to_edges had no self
-                                            // filter: a circular star
-                                            // re-export can land the chain
-                                            // walk back on the alias itself,
-                                            // and that self-loop is kept.
-                                            if slot.start_file != Some(file) {
-                                                for &idx in &slot.idxs {
-                                                    out.push((src_idx, idx, flags));
-                                                }
+                                let slot = &member_slots_ref[ids[i] as usize];
+                                // Self-import suppression: a Binding ref
+                                // whose upstream resolves to the importing
+                                // file itself emits nothing — the whole
+                                // emission, decl edges included (mirrors
+                                // the old `target_file == file` skip,
+                                // which must apply per importing file,
+                                // not per memo entry).
+                                match m.role {
+                                    MemberRole::Binding => {
+                                        // Old file_to_edges had no self
+                                        // filter: a circular star
+                                        // re-export can land the chain
+                                        // walk back on the alias itself,
+                                        // and that self-loop is kept.
+                                        if slot.start_file != Some(file) {
+                                            for &idx in &slot.idxs {
+                                                out.push((src_idx, idx, flags));
                                             }
                                         }
-                                        MemberRole::Use => {
-                                            // Use side mirrors the old
-                                            // emit_edge `dst != owner` skip.
-                                            for &idx in &slot.idxs {
-                                                if idx != src_idx {
-                                                    out.push((src_idx, idx, flags));
-                                                }
+                                    }
+                                    MemberRole::Use => {
+                                        // Use side mirrors the old
+                                        // emit_edge `dst != owner` skip.
+                                        for &idx in &slot.idxs {
+                                            if idx != src_idx {
+                                                out.push((src_idx, idx, flags));
                                             }
                                         }
                                     }
                                 }
                             }
-                            Target::Dynamic(d) => {
-                                if let Some(idxs) = dynamic_memo_ref.get(&(d, dir)) {
-                                    for &idx in idxs {
-                                        if idx != src_idx {
-                                            out.push((src_idx, idx, flags));
-                                        }
+                            Target::Dynamic(_) => {
+                                for &idx in &dynamic_slots_ref[ids[i] as usize] {
+                                    if idx != src_idx {
+                                        out.push((src_idx, idx, flags));
                                     }
                                 }
                             }
@@ -1277,6 +1355,22 @@ fn assemble_graph<'db>(
         emit_visitor_warning(py, msg);
     }
 
+    // Owned `(module, name, dir)` → resolved-base memo for the
+    // post-assembly class-hierarchy fan-in (scatter-only now — the
+    // resolves already ran in pass 1's resolve arm).
+    let mut class_base_memo: ClassBaseMemo =
+        FxHashMap::with_capacity_and_hasher(class_work.len(), Default::default());
+    for ((module, name, dir), id) in &class_keys {
+        class_base_memo.insert(
+            (
+                CompactString::from(*module),
+                CompactString::from(*name),
+                *dir,
+            ),
+            class_results[*id as usize],
+        );
+    }
+
     Ok(AssembledGraph {
         builder,
         global_index,
@@ -1284,6 +1378,8 @@ fn assemble_graph<'db>(
         class_by_selection,
         decl_by_name_range,
         topic_facts,
+        class_base_memo,
+        dir_ids,
     })
 }
 
@@ -1308,38 +1404,49 @@ fn translate_resolved(
     }
 }
 
-/// Run `f` over `work` on rayon workers, each contiguous chunk against
-/// its own salsa db snapshot. Snapshots are cloned on the calling
-/// thread before the fan-out (a salsa clone must not race a worker
-/// mid-query — the same hazard the populate fan-out documents), then
-/// moved onto the workers with the GIL released. Results come back in
-/// `work` order, so sorted inputs give deterministic outputs
-/// regardless of scheduling.
-fn resolve_chunked<'w, T: Sync, R: Send>(
-    py: Python<'_>,
-    db: &ProjectDatabase,
-    work: &'w [T],
-    f: impl Fn(&ProjectDatabase, &'w T) -> R + Send + Sync,
-) -> Vec<R> {
-    use rayon::prelude::*;
-    if work.is_empty() {
-        return Vec::new();
-    }
+/// One pre-chunked family of cross-file resolution work, with one
+/// salsa snapshot per chunk. Prepared on the main thread by
+/// [`prepare_job`] (a salsa clone must not race a worker mid-query —
+/// the populate fan-out documents the same hazard), executed by
+/// [`run_job`] inside an already-parallel rayon section.
+struct ChunkedJob<'w, T> {
+    chunks: Vec<&'w [T]>,
+    dbs: Vec<ProjectDatabase>,
+}
+
+/// Chunk `work` 16× finer than the worker count: resolution cost is
+/// skewed (one package's imports cluster in encounter order), so
+/// fine-grained chunks let rayon's work-stealing even out the tail
+/// instead of one worker dragging a fat chunk — and the small families
+/// (class bases, parent modules) still spread across every core.
+fn prepare_job<'w, T>(db: &ProjectDatabase, work: &'w [T]) -> ChunkedJob<'w, T> {
     let num_workers = std::thread::available_parallelism()
         .map(std::num::NonZeroUsize::get)
         .unwrap_or(4);
-    let chunk_size = work.len().div_ceil(num_workers).max(1);
+    let chunk_size = work.len().div_ceil(num_workers * 16).max(1);
     let chunks: Vec<&'w [T]> = work.chunks(chunk_size).collect();
     let dbs: Vec<ProjectDatabase> = (0..chunks.len()).map(|_| db.clone()).collect();
-    let nested: Vec<Vec<R>> = py.allow_threads(move || {
-        dbs.into_par_iter()
-            .zip(chunks.into_par_iter())
-            .map(|(local_db, chunk)| {
-                use salsa::Database as _;
-                local_db.attach(|ldb| chunk.iter().map(|item| f(ldb, item)).collect())
-            })
-            .collect()
-    });
+    ChunkedJob { chunks, dbs }
+}
+
+/// Run `f` over a prepared job on the current rayon pool. Results come
+/// back in `work` order, so deterministic inputs give deterministic
+/// outputs regardless of scheduling. Pure rust — composes inside
+/// `py.allow_threads` / a rayon join arm.
+fn run_job<T: Sync, R: Send>(
+    job: ChunkedJob<'_, T>,
+    f: impl Fn(&ProjectDatabase, &T) -> R + Send + Sync,
+) -> Vec<R> {
+    use rayon::prelude::*;
+    let nested: Vec<Vec<R>> = job
+        .dbs
+        .into_par_iter()
+        .zip(job.chunks.into_par_iter())
+        .map(|(local_db, chunk)| {
+            use salsa::Database as _;
+            local_db.attach(|ldb| chunk.iter().map(|item| f(ldb, item)).collect())
+        })
+        .collect();
     nested.into_iter().flatten().collect()
 }
 
@@ -1480,6 +1587,13 @@ fn extract_per_file_plugin_ids(
     ids
 }
 
+/// Owned `(module, name, anchor-dir)` → resolved class-base memo.
+/// Built by `assemble_graph` (the resolves run in pass 1's resolve
+/// arm, overlapped with the node fill) and consumed by the
+/// scatter-only [`build_class_hierarchy_indices`].
+pub(crate) type ClassBaseMemo =
+    FxHashMap<(CompactString, CompactString, u32), Option<(File, TextRange)>>;
+
 /// Project-wide class-hierarchy indices produced in a single pass over
 /// the per-file `class_bases` payloads by [`build_class_hierarchy_indices`].
 pub(crate) struct ClassHierarchyIndices {
@@ -1509,11 +1623,13 @@ pub(crate) struct ClassHierarchyIndices {
 /// `LocalClass(range)` for a same-file class or a `ModuleMember{module,
 /// name}` symbolic reference — deliberately *not* resolved at store time
 /// so the per-file payload stays salsa-invalidation-local (see
-/// `build_class_bases`). Assembly resolves each spec here, to the
-/// `(File, name_range)` key of the class's name token; `ModuleMember`
-/// rows chase through [`crate::helpers::resolve_member_def`] (ty's
-/// module resolver + re-export / assignment-alias following). Dispatch
-/// is then a single hashmap probe per resolved base:
+/// `build_class_bases`). The `ModuleMember` resolutions (through
+/// [`crate::helpers::resolve_member_def`] — ty's module resolver +
+/// re-export / assignment-alias following) already ran inside
+/// `assemble_graph`'s resolve arm, memoized per `(module, name, anchor
+/// directory)` and overlapped with the node fill; this fan-in is a
+/// scatter over the handed-back [`ClassBaseMemo`]. Dispatch is a single
+/// hashmap probe per resolved base:
 ///
 /// * the key hits `class_by_selection` → it's a project class; record a
 ///   `children_by_node` edge to that parent (every value in the map is a
@@ -1526,83 +1642,19 @@ pub(crate) struct ClassHierarchyIndices {
 /// (direct, aliased, re-exported, sibling-module) collapses to the same
 /// `(File, name_range)` key by construction — the query side
 /// ([`crate::helpers::locate_class_seed`]) lands on the identical key.
-///
-/// The `ModuleMember` resolutions are memoized project-wide on
-/// `(module, name, anchor directory)` — the same key scheme as the
-/// assemble pass's RefSpec memo (`resolve_member_def` is
-/// anchor-sensitive only through ty's desperate-resolution fallback,
-/// which depends on ancestor directories) — and resolved on rayon
-/// workers. A base every file subclasses (`pydantic.BaseModel`,
-/// `unittest.TestCase`) resolves once per directory instead of once
-/// per class.
 fn build_class_hierarchy_indices(
-    py: Python<'_>,
     db: &ProjectDatabase,
     project_files: &[File],
     class_by_selection: &FxHashMap<(File, (u32, u32)), usize>,
+    class_base_memo: &ClassBaseMemo,
+    dir_ids: &[u32],
 ) -> ClassHierarchyIndices {
     let mut by_node: FxHashMap<usize, Vec<usize>> = FxHashMap::default();
     let mut external_base_children: FxHashMap<(File, (u32, u32)), Vec<usize>> =
         FxHashMap::default();
 
-    // Serial prefetch: per-file payloads (cache reads after the
-    // populate fan-out) + anchor-directory ids.
-    let payloads: Vec<&FileNodes> = project_files
-        .iter()
-        .map(|&f| file_to_nodes(db, f))
-        .collect();
-    let mut dir_to_id: FxHashMap<String, u32> = FxHashMap::default();
-    let mut dir_anchors: Vec<File> = Vec::new();
-    let mut dir_ids: Vec<u32> = Vec::with_capacity(project_files.len());
-    for &file in project_files {
-        let path = file_path_string(db, file);
-        let dir = match path.rsplit_once(['/', '\\']) {
-            Some((d, _)) => d.to_string(),
-            None => String::new(),
-        };
-        let id = *dir_to_id.entry(dir).or_insert_with(|| {
-            dir_anchors.push(file);
-            (dir_anchors.len() - 1) as u32
-        });
-        dir_ids.push(id);
-    }
-
-    // Gather the unique `(module, name, dir)` member keys (sorted, for
-    // deterministic worker output order) and resolve them in parallel.
-    let mut work: Vec<(&str, &str, u32)> = {
-        let mut seen: FxHashSet<(&str, &str, u32)> = FxHashSet::default();
-        for (pos, payload) in payloads.iter().enumerate() {
-            for (_cls_rk, bases) in &payload.class_bases {
-                for base in bases.iter() {
-                    if let ClassBaseSpec::ModuleMember { module, name } = base {
-                        seen.insert((module.as_str(), name.as_str(), dir_ids[pos]));
-                    }
-                }
-            }
-        }
-        seen.into_iter().collect()
-    };
-    work.sort_unstable();
-
-    /// `(module, name, anchor-dir)` member key → resolved base decl.
-    type BaseMemo<'k> = FxHashMap<(&'k str, &'k str, u32), Option<(File, TextRange)>>;
-    let dir_anchors_ref = &dir_anchors;
-    let results: Vec<Option<(File, TextRange)>> =
-        resolve_chunked(py, db, &work, |ldb, &(module, name, dir)| {
-            resolve_member_def(ldb, module, name, dir_anchors_ref[dir as usize], 0)
-        });
-    let mut memo: BaseMemo<'_> =
-        FxHashMap::with_capacity_and_hasher(work.len(), Default::default());
-    for (&key, res) in work.iter().zip(&results) {
-        memo.insert(key, *res);
-    }
-
-    // Scatter: dispatch each class's resolved bases against
-    // `class_by_selection` (project parent) or `external_base_children`
-    // (external parent). `LocalClass` specs resolve inline — the spec
-    // range IS the `(File, name_range)` key.
-    for (pos, payload) in payloads.iter().enumerate() {
-        let file = project_files[pos];
+    for (pos, &file) in project_files.iter().enumerate() {
+        let payload = file_to_nodes(db, file);
         let dir = dir_ids[pos];
         for (cls_rk, bases) in &payload.class_bases {
             let Some(&child_idx) = class_by_selection.get(&(file, *cls_rk)) else {
@@ -1610,11 +1662,13 @@ fn build_class_hierarchy_indices(
             };
             for base in bases.iter() {
                 let resolved = match base {
+                    // `LocalClass` resolves inline — the spec range IS
+                    // the `(File, name_range)` key.
                     ClassBaseSpec::LocalClass((start, end)) => {
                         Some((file, TextRange::new((*start).into(), (*end).into())))
                     }
-                    ClassBaseSpec::ModuleMember { module, name } => memo
-                        .get(&(module.as_str(), name.as_str(), dir))
+                    ClassBaseSpec::ModuleMember { module, name } => class_base_memo
+                        .get(&(module.clone(), name.clone(), dir))
                         .copied()
                         .flatten(),
                 };

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -32,12 +32,14 @@ use crate::file_extraction::{
     file_extraction, imports_local_from_facts, match_callee_chain, match_callee_descriptor,
     CallSiteFact, FileExtraction,
 };
-use crate::file_payload::{file_to_edges, file_to_nodes, FileEdges, FileNodes, NodeKind, NodeRef};
-use crate::file_ref_edges::{file_to_ref_edges, FileRefEdges};
+use crate::file_payload::{
+    file_to_nodes, parent_module_file, ClassBaseSpec, FileNodes, NodeKind, NodeRef,
+};
+use crate::file_ref_edges::{file_to_refspecs, FileRefSpecs};
 use crate::flag_registry::FlagRegistry;
 use crate::graph::{intern_kind, DeclIndex, NativeGraph, SymbolNode};
 use crate::helpers::{
-    file_path_string, is_dunder_name, locate_class_seed, range_key, rel_path, resolve_base_spec,
+    file_path_string, is_dunder_name, locate_class_seed, range_key, rel_path, resolve_member_def,
     CallArgs, MODULE_ALIAS_MARKER, NODE_FLAG_ENTRYPOINT, NODE_FLAG_UNRESOLVED,
 };
 use crate::ingest::emit_visitor_warning;
@@ -46,8 +48,12 @@ use crate::progress::{
     PHASE_PLUGINS, PHASE_POPULATE,
 };
 use crate::query::_path_re_matches;
+use crate::refspec::{
+    resolve_dynamic, resolve_member, DynamicRef, MemberRef, MemberRole, ResolvedNode, Target,
+};
 use crate::topic_registry::TopicRegistry;
 use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
 
 /// A ty-backed analysis project with explicitly-injected configuration.
 #[pyclass(unsendable)]
@@ -320,10 +326,10 @@ pub(crate) fn build_project_graph(
     // separate parallel pass was a no-op at every corpus size we
     // measured. See PR #226 follow-up for the A/B data.)
 
-    // Parallel pre-populate: run file_to_nodes, file_to_edges, and
-    // file_to_ref_edges as #[salsa::tracked] queries across all
+    // Parallel pre-populate: run file_to_nodes and file_to_refspecs
+    // as #[salsa::tracked] queries across all
     // project files. Workers are pure-rust (GIL released via
-    // py.allow_threads). Each file's three queries are attached on
+    // py.allow_threads). Each file's queries are attached on
     // whatever rayon worker thread picks them up — work-stealing
     // distributes load across cores; salsa-tracked machinery owns
     // the lock-free coordination between workers. The salsa cache
@@ -419,8 +425,7 @@ pub(crate) fn build_project_graph(
                                     file_to_nodes(local_db, file).nodes.len(),
                                     Ordering::Relaxed,
                                 );
-                                let _ = file_to_edges(local_db, file);
-                                let _ = file_to_ref_edges(local_db, file);
+                                let _ = file_to_refspecs(local_db, file);
                                 // Owned per-file facts for the project-wide
                                 // plugin queries. Warmed here, while the AST
                                 // is live, so the queries below run as cache
@@ -532,7 +537,7 @@ pub(crate) fn build_project_graph(
     let ClassHierarchyIndices {
         children_by_node,
         external_base_children,
-    } = build_class_hierarchy_indices(db, &project_files, &class_by_selection);
+    } = build_class_hierarchy_indices(py, db, &project_files, &class_by_selection);
     let t_hierarchy_elapsed = t_hierarchy.elapsed();
     if timing {
         eprintln!(
@@ -619,8 +624,8 @@ struct AssembledGraph {
 }
 
 /// Fan-in pass that converts the salsa-tracked per-file payloads
-/// (`file_to_nodes` / `file_to_edges` / `file_to_ref_edges`) into a
-/// fully-populated `GraphBuilder`.
+/// (`file_to_nodes` / `file_to_refspecs`) into a fully-populated
+/// `GraphBuilder`.
 ///
 /// Three sub-passes:
 ///
@@ -635,18 +640,22 @@ struct AssembledGraph {
 ///    for `.pyi` decls whose runtime twin doesn't expose the same
 ///    name.
 ///
-/// 2. **Edge translation** — walk each file's `FileEdges` and
-///    `FileRefEdges`, translate every `NodeRef` to its `usize`
-///    index via the map. Synthetic External nodes get lazily
-///    minted as encountered. Edges whose endpoint isn't recognised
-///    (e.g. a Definition in a non-project file that ty's resolver
-///    reached but we didn't enumerate) silently drop.
+/// 2. **Spec resolution + edge translation** — resolve the
+///    project-wide unique `Member` / `Dynamic` refs on rayon
+///    workers (memoized per `(ref, anchor directory)`), then
+///    translate each file's `RefSpec`s to `(usize, usize, u8)`
+///    triples. Synthetic External nodes mint during the memo fold.
+///    Edges whose endpoint isn't recognised (e.g. a Definition in a
+///    non-project file that ty's resolver reached but we didn't
+///    enumerate) silently drop. Structural edges (decl → module
+///    anchors, overload anchors, module hierarchy) are synthesized
+///    here straight from the node payloads.
 ///
 /// 3. **Peer .pyi/.py edges** — for each peer pair, walk both
 ///    files' `exports_by_name` and emit `pyi_decl -> py_decl`
 ///    edges for any name present in both.
 ///
-/// Warnings buffered in each `FileRefEdges.warnings` are flushed to
+/// Warnings buffered in each `FileRefSpecs.warnings` are flushed to
 /// the `dead_cst._visitor` Python logger at the end — once per
 /// warning, on the main thread, with the GIL we already hold.
 #[allow(clippy::too_many_arguments)]
@@ -686,7 +695,7 @@ fn assemble_graph<'db>(
         FxHashMap::with_capacity_and_hasher(total_decls / 4 + 1, Default::default());
     let mut decl_by_name_range: FxHashMap<(File, (u32, u32)), usize> =
         FxHashMap::with_capacity_and_hasher(total_decls, Default::default());
-    let mut ref_to_global: FxHashMap<NodeRef<'db>, usize> =
+    let mut ref_to_global: FxHashMap<NodeRef, usize> =
         FxHashMap::with_capacity_and_hasher(total_nodes, Default::default());
     let mut local_to_global: FxHashMap<(File, u32), usize> =
         FxHashMap::with_capacity_and_hasher(total_nodes, Default::default());
@@ -723,14 +732,14 @@ fn assemble_graph<'db>(
         /// `[base, base + payload.nodes.len())`; each local ref lands
         /// at `base + local_idx`.
         base: usize,
-        payload: &'db FileNodes<'db>,
+        payload: &'db FileNodes,
         path_str: String,
         is_stub: bool,
         /// Stub-only ENTRYPOINT context: if this is a .pyi without a
         /// .py twin (`None`), every decl needs ENTRYPOINT. If it has a
         /// twin, only decls whose name isn't in the twin's exports
         /// need it.
-        twin_payload: Option<&'db FileNodes<'db>>,
+        twin_payload: Option<&'db FileNodes>,
     }
     let mut mints: Vec<FileMint<'db>> = Vec::with_capacity(project_files.len());
     for (file_pos, &file) in project_files.iter().enumerate() {
@@ -885,15 +894,6 @@ fn assemble_graph<'db>(
                                                 // `local_to_global` folds already
                                                 // wired it up.
                                             }
-                                            NodeRef::External(_) => {
-                                                // External NodeRefs never appear in
-                                                // FileNodes.refs; they're only
-                                                // emitted as edge endpoints. This
-                                                // branch is unreachable in practice
-                                                // but kept exhaustive so a future
-                                                // variant addition fails loudly
-                                                // instead of silently dropping.
-                                            }
                                         }
                                     }
                                 }
@@ -925,127 +925,249 @@ fn assemble_graph<'db>(
         eprintln!("[dead-cst-timing] pass1={:?}", t_pass1_start.elapsed());
     }
 
-    // Pass 2: edge translation.
+    // Pass 2: reference-spec resolution + edge translation.
     //
-    // The pipeline is three sub-phases, designed so the heavy
-    // FxHashMap-probe loop runs without the GIL on rayon workers:
+    // The per-file payloads are file-local `RefSpec`s (see
+    // `crate::refspec`), so this pass owns ALL cross-file resolution.
+    // Four sub-phases:
     //
-    //   2a. Serial fetch of every file's salsa-tracked `FileEdges` /
-    //       `FileRefEdges`. Salsa returns `&'db` refs valid for the
-    //       whole assemble call; we stash them in a `Vec`.
-    //   2b. Serial pre-mint of every `NodeRef::External` endpoint
-    //       referenced by any payload. This pulls the fqname out of
-    //       salsa under the GIL and interns the external node so
-    //       the parallel phase only has to read `ref_to_global`.
-    //   2c. `Python::allow_threads` + `par_iter().flat_map(...)` to
-    //       translate every `(NodeRef, NodeRef, flags)` triple into
-    //       `(usize, usize, u8)` via two `ref_to_global` probes.
-    //       Drops endpoints whose owning file wasn't enumerated.
+    //   2a. Serial fetch of every file's salsa-tracked `FileRefSpecs`
+    //       payload, plus the per-file anchor-directory ids that key
+    //       the resolution memo. ty's `resolve_module` is anchor-
+    //       sensitive only through its desperate-resolution fallback,
+    //       which depends on the importing file's ancestor directories
+    //       — so files sharing a directory share memo entries.
+    //   2b. Gather the project-wide unique `(member, dir)` /
+    //       `(dynamic, dir)` resolution keys (sorted, for determinism)
+    //       and resolve them on rayon workers, each against its own
+    //       salsa db snapshot — parallel salsa reads, the same pattern
+    //       the populate fan-out uses. Hot imports repeated across a
+    //       directory (or project-wide, one entry per directory)
+    //       resolve once, not once per use site.
+    //   2c. Serial fold of the resolution results into idx-level memo
+    //       maps: translate each `ResolvedNode` through
+    //       `ref_to_global`, interning External nodes on first
+    //       encounter (sorted-key order keeps their indices
+    //       deterministic), and stamp `NodeFlags::UNRESOLVED` on
+    //       aliases whose `Binding` resolution failed (in place of the
+    //       old `[unresolved] X` sink node).
+    //   2d. `Python::allow_threads` + parallel per-file translation of
+    //       every `RefSpec` into `(usize, usize, u8)` triples — pure
+    //       hashmap probes against the memo maps, no salsa access —
+    //       chained with the structural edges synthesized from the
+    //       node payloads (decl → module anchors, overload impl → stub
+    //       anchors, submodule → parent-package hierarchy). Sort +
+    //       dedup + bulk-init the edge storage via `init_edges_bulk`.
     //
-    // After the parallel phase, sort + dedup the triple list and
-    // bulk-initialize the edge storage via `init_edges_bulk` — the
-    // builder has no edges yet, so the adjacency lists are scattered
-    // from the sorted triples on rayon workers instead of looping
-    // `extend_edges`'s serial per-edge probe.
-    //
-    // Skipped endpoints reference Definitions in non-project files.
+    // Dropped triples reference Definitions in non-project files.
 
     let t_pass2_start = std::time::Instant::now();
 
     // 2a: serial fetch. Hold borrows for the whole pass.
-    let mut edge_payloads: Vec<&FileEdges<'db>> = Vec::with_capacity(project_files.len());
-    let mut ref_edge_payloads: Vec<&FileRefEdges<'db>> = Vec::with_capacity(project_files.len());
+    let mut spec_payloads: Vec<&FileRefSpecs> = Vec::with_capacity(project_files.len());
     for &file in project_files {
-        edge_payloads.push(file_to_edges(db, file));
-        ref_edge_payloads.push(file_to_ref_edges(db, file));
+        spec_payloads.push(file_to_refspecs(db, file));
     }
 
-    // Stamp `NodeFlags::UNRESOLVED` on every import alias whose upstream
-    // module didn't resolve — the flag rides the alias node directly,
-    // in place of the old `[unresolved] X` sink node. Pass 1 has
-    // fully populated `ref_to_global`, so every in-project alias
-    // resolves; a ref with no global node is skipped.
-    for payload in &edge_payloads {
-        for r in &payload.unresolved_aliases {
-            if let Some(&idx) = ref_to_global.get(r) {
-                builder.nodes[idx].flags |= NODE_FLAG_UNRESOLVED;
+    // Per-file anchor-directory ids. `mints` is path-sorted, so the
+    // first file seen for a directory is deterministic; that file is
+    // the directory's representative resolution anchor.
+    let mut dir_to_id: FxHashMap<&str, u32> = FxHashMap::default();
+    let mut dir_anchors: Vec<File> = Vec::new();
+    let mut dir_ids: Vec<u32> = Vec::with_capacity(project_files.len());
+    for mint in &mints {
+        let dir = match mint.path_str.rsplit_once(['/', '\\']) {
+            Some((dir, _)) => dir,
+            None => "",
+        };
+        let id = *dir_to_id.entry(dir).or_insert_with(|| {
+            dir_anchors.push(mint.file);
+            (dir_anchors.len() - 1) as u32
+        });
+        dir_ids.push(id);
+    }
+
+    // 2b: gather unique resolution keys. Keys borrow straight out of
+    // the payloads (alive for the whole pass), so gathering is
+    // clone-free.
+    let mut member_work: Vec<(&MemberRef, u32)> = {
+        let mut seen: FxHashSet<(&MemberRef, u32)> = FxHashSet::default();
+        for (pos, payload) in spec_payloads.iter().enumerate() {
+            for spec in payload.specs.iter() {
+                if let Target::Member(m) = &spec.target {
+                    seen.insert((m, dir_ids[pos]));
+                }
+            }
+        }
+        seen.into_iter().collect()
+    };
+    member_work.sort_unstable();
+    let mut dynamic_work: Vec<(&DynamicRef, u32)> = {
+        let mut seen: FxHashSet<(&DynamicRef, u32)> = FxHashSet::default();
+        for (pos, payload) in spec_payloads.iter().enumerate() {
+            for spec in payload.specs.iter() {
+                if let Target::Dynamic(d) = &spec.target {
+                    seen.insert((d, dir_ids[pos]));
+                }
+            }
+        }
+        seen.into_iter().collect()
+    };
+    dynamic_work.sort_unstable();
+
+    let dir_anchors_ref = &dir_anchors;
+    let member_results: Vec<crate::refspec::ResolvedMember> =
+        resolve_chunked(py, db, &member_work, |ldb, &(m, dir)| {
+            resolve_member(ldb, dir_anchors_ref[dir as usize], m)
+        });
+    let dynamic_results: Vec<SmallVec<[ResolvedNode; 4]>> =
+        resolve_chunked(py, db, &dynamic_work, |ldb, &(d, dir)| {
+            resolve_dynamic(ldb, dir_anchors_ref[dir as usize], d)
+        });
+
+    // 2c: serial fold into idx-level memos. External nodes intern on
+    // first encounter, in sorted-key order — deterministic indices.
+    struct MemberSlot {
+        idxs: SmallVec<[usize; 4]>,
+        unresolved: bool,
+        start_file: Option<File>,
+    }
+    let mut member_memo: FxHashMap<(&MemberRef, u32), MemberSlot> =
+        FxHashMap::with_capacity_and_hasher(member_work.len(), Default::default());
+    for (&(m, dir), res) in member_work.iter().zip(&member_results) {
+        let mut idxs: SmallVec<[usize; 4]> = SmallVec::new();
+        for node in &res.targets {
+            if let Some(idx) = translate_resolved(db, &mut builder, &ref_to_global, node) {
+                idxs.push(idx);
+            }
+        }
+        member_memo.insert(
+            (m, dir),
+            MemberSlot {
+                idxs,
+                unresolved: res.unresolved,
+                start_file: res.start_file,
+            },
+        );
+    }
+    let mut dynamic_memo: FxHashMap<(&DynamicRef, u32), SmallVec<[usize; 4]>> =
+        FxHashMap::with_capacity_and_hasher(dynamic_work.len(), Default::default());
+    for (&(d, dir), nodes) in dynamic_work.iter().zip(&dynamic_results) {
+        let mut idxs: SmallVec<[usize; 4]> = SmallVec::new();
+        for node in nodes {
+            if let Some(idx) = translate_resolved(db, &mut builder, &ref_to_global, node) {
+                idxs.push(idx);
+            }
+        }
+        dynamic_memo.insert((d, dir), idxs);
+    }
+
+    // Stamp `NodeFlags::UNRESOLVED` on every import alias whose
+    // upstream module didn't resolve — the flag rides the alias node
+    // directly. Only `Binding`-role refs are eligible (one flag per
+    // alias; a use through it resolves or drops silently).
+    for (pos, payload) in spec_payloads.iter().enumerate() {
+        let dir = dir_ids[pos];
+        let base = node_offsets[pos];
+        for spec in payload.specs.iter() {
+            let Target::Member(m) = &spec.target else {
+                continue;
+            };
+            if !matches!(m.role, MemberRole::Binding) {
+                continue;
+            }
+            if member_memo.get(&(m, dir)).is_some_and(|s| s.unresolved) {
+                builder.nodes[base + spec.src as usize].flags |= NODE_FLAG_UNRESOLVED;
             }
         }
     }
 
-    // 2b: pre-mint External nodes. Walk both payload streams once and
-    // intern every `External` endpoint we haven't seen. Externals dedup
-    // by fqname project-wide, so this is at most `O(distinct externals)`
-    // GIL-bound interns.
-    let mut external_keys: FxHashSet<NodeRef<'db>> = FxHashSet::default();
-    for payload in &edge_payloads {
-        for &(src, dst, _) in &payload.edges {
-            if matches!(src, NodeRef::External(_)) && !ref_to_global.contains_key(&src) {
-                external_keys.insert(src);
-            }
-            if matches!(dst, NodeRef::External(_)) && !ref_to_global.contains_key(&dst) {
-                external_keys.insert(dst);
+    // Structural edges synthesized straight from the node payloads —
+    // deliberately not part of the RefSpec payload since they're fully
+    // derivable: decl → module anchors (every per-file node points at
+    // its module node, `refs[0]`), overload impl → stub anchors, and
+    // the submodule → parent-package hierarchy edge (skipped when the
+    // parent doesn't resolve into the project).
+    let mut structural: Vec<(usize, usize, u8)> = Vec::with_capacity(total_nodes);
+    for mint in &mints {
+        for local in 1..mint.payload.nodes.len() {
+            structural.push((mint.base + local, mint.base, 0));
+        }
+        for &(impl_local, stub_local) in mint.payload.overload_anchors.iter() {
+            structural.push((
+                mint.base + impl_local as usize,
+                mint.base + stub_local as usize,
+                0,
+            ));
+        }
+        if let Some(parent_file) = parent_module_file(db, mint.file) {
+            if let Some(&parent_idx) = module_nodes_by_file.get(&parent_file) {
+                structural.push((mint.base, parent_idx, 0));
             }
         }
-    }
-    for payload in &ref_edge_payloads {
-        for &(src, dst, _) in &payload.edges {
-            if matches!(src, NodeRef::External(_)) && !ref_to_global.contains_key(&src) {
-                external_keys.insert(src);
-            }
-            if matches!(dst, NodeRef::External(_)) && !ref_to_global.contains_key(&dst) {
-                external_keys.insert(dst);
-            }
-        }
-    }
-    // Mint the External nodes in a deterministic order.
-    // `external_keys` is an FxHashSet whose iteration order tracks
-    // the salsa id layout and so varies run-to-run; minting in that
-    // order would hand the externals run-dependent graph indices.
-    // Sort by (fqname, path) — `intern_external` dedups on fqname, so
-    // the first path after the sort wins deterministically, and every
-    // External lands at the same index every run.
-    let mut externals: Vec<(String, String, File, NodeRef<'db>)> = external_keys
-        .into_iter()
-        .filter_map(|r| match r {
-            NodeRef::External(key) => {
-                let file = key.file(db);
-                Some((key.fqname(db).clone(), file_path_string(db, file), file, r))
-            }
-            _ => None,
-        })
-        .collect();
-    externals.sort_unstable_by(|a, b| (&a.0, &a.1).cmp(&(&b.0, &b.1)));
-    for (fqname, path, file, r) in externals {
-        let idx = builder.intern_external(fqname, path, file);
-        ref_to_global.insert(r, idx);
     }
 
-    // 2c: parallel translation. `ref_to_global` is owned + read-
-    // only from here; no GIL needed. We release the GIL with
-    // `Python::allow_threads` so rayon workers don't contend with
-    // anyone else holding it. The closure is pure-Rust HashMap
-    // probes, no salsa DB access, no Py allocations.
-    let ref_to_global_ref = &ref_to_global;
-    let edge_payloads_ref = &edge_payloads;
-    let ref_edge_payloads_ref = &ref_edge_payloads;
-    let mut triples: Vec<(usize, usize, u8)> = py.allow_threads(|| {
+    // 2d: parallel translation. The memo maps are owned + read-only
+    // from here; no GIL needed, no salsa access — pure hashmap probes.
+    let member_memo_ref = &member_memo;
+    let dynamic_memo_ref = &dynamic_memo;
+    let spec_payloads_ref = &spec_payloads;
+    let dir_ids_ref = &dir_ids;
+    let mut triples: Vec<(usize, usize, u8)> = py.allow_threads(move || {
         use rayon::prelude::*;
-        let from_edges = edge_payloads_ref.par_iter().flat_map_iter(|payload| {
-            payload.edges.iter().filter_map(|&(src, dst, flags)| {
-                let src_idx = *ref_to_global_ref.get(&src)?;
-                let dst_idx = *ref_to_global_ref.get(&dst)?;
-                Some((src_idx, dst_idx, flags))
-            })
-        });
-        let from_refs = ref_edge_payloads_ref.par_iter().flat_map_iter(|payload| {
-            payload.edges.iter().filter_map(|&(src, dst, flags)| {
-                let src_idx = *ref_to_global_ref.get(&src)?;
-                let dst_idx = *ref_to_global_ref.get(&dst)?;
-                Some((src_idx, dst_idx, flags))
-            })
-        });
-        let mut t: Vec<(usize, usize, u8)> = from_edges.chain(from_refs).collect();
+        let from_specs =
+            spec_payloads_ref
+                .par_iter()
+                .enumerate()
+                .flat_map_iter(|(pos, payload)| {
+                    let base = node_offsets[pos];
+                    let dir = dir_ids_ref[pos];
+                    let file = project_files[pos];
+                    payload.specs.iter().flat_map(move |spec| {
+                        let src_idx = base + spec.src as usize;
+                        let flags = spec.flags;
+                        let mut out: SmallVec<[(usize, usize, u8); 4]> = SmallVec::new();
+                        match &spec.target {
+                            Target::Local(dst_local) => {
+                                if *dst_local != spec.src {
+                                    out.push((src_idx, base + *dst_local as usize, flags));
+                                }
+                            }
+                            Target::Member(m) => {
+                                if let Some(slot) = member_memo_ref.get(&(m, dir)) {
+                                    // Self-import suppression: a Binding ref
+                                    // whose upstream resolves to the importing
+                                    // file itself emits nothing — the whole
+                                    // emission, decl edges included (mirrors
+                                    // the old `target_file == file` skip,
+                                    // which must apply per importing file,
+                                    // not per memo entry).
+                                    let self_import = matches!(m.role, MemberRole::Binding)
+                                        && slot.start_file == Some(file);
+                                    if !self_import {
+                                        for &idx in &slot.idxs {
+                                            if idx != src_idx {
+                                                out.push((src_idx, idx, flags));
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            Target::Dynamic(d) => {
+                                if let Some(idxs) = dynamic_memo_ref.get(&(d, dir)) {
+                                    for &idx in idxs {
+                                        if idx != src_idx {
+                                            out.push((src_idx, idx, flags));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        out
+                    })
+                });
+        let mut t: Vec<(usize, usize, u8)> = from_specs.collect();
+        t.extend(structural);
         t.par_sort_unstable();
         t.dedup();
         t
@@ -1054,12 +1176,12 @@ fn assemble_graph<'db>(
     // Bulk-initialize the edge storage from the translated triples.
     // The builder is edge-less here (pass 1 mints only nodes), so the
     // adjacency fills run as a parallel scatter; the GIL is released
-    // for the same reason as 2c.
+    // for the same reason as 2d.
     let bulk_triples = std::mem::take(&mut triples);
     py.allow_threads(|| builder.init_edges_bulk(bulk_triples));
 
-    // Warnings are still serial — they live on `FileRefEdges` only.
-    for payload in &ref_edge_payloads {
+    // Warnings are still serial — they live on `FileRefSpecs` only.
+    for payload in &spec_payloads {
         all_warnings.extend(payload.warnings.iter().cloned());
     }
 
@@ -1128,6 +1250,62 @@ fn assemble_graph<'db>(
         decl_by_name_range,
         topic_facts,
     })
+}
+
+/// Translate one `'static` resolution output node to its global graph
+/// index. `Module` / `Def` / `StarStmt` probe `ref_to_global` (built
+/// in pass 1; a miss means the owning file wasn't enumerated — drop).
+/// `External` interns into the builder, which dedups by fqname, so the
+/// first (sorted-key-order) encounter pins the node deterministically.
+fn translate_resolved(
+    db: &ProjectDatabase,
+    builder: &mut GraphBuilder,
+    ref_to_global: &FxHashMap<NodeRef, usize>,
+    node: &ResolvedNode,
+) -> Option<usize> {
+    match node {
+        ResolvedNode::Module(f) => ref_to_global.get(&NodeRef::Module(*f)).copied(),
+        ResolvedNode::Def(k) => ref_to_global.get(&NodeRef::Def(*k)).copied(),
+        ResolvedNode::StarStmt(f, rk) => ref_to_global.get(&NodeRef::StarStmt(*f, *rk)).copied(),
+        ResolvedNode::External { fqname, file } => {
+            Some(builder.intern_external(fqname.clone(), file_path_string(db, *file), *file))
+        }
+    }
+}
+
+/// Run `f` over `work` on rayon workers, each contiguous chunk against
+/// its own salsa db snapshot. Snapshots are cloned on the calling
+/// thread before the fan-out (a salsa clone must not race a worker
+/// mid-query — the same hazard the populate fan-out documents), then
+/// moved onto the workers with the GIL released. Results come back in
+/// `work` order, so sorted inputs give deterministic outputs
+/// regardless of scheduling.
+fn resolve_chunked<'w, T: Sync, R: Send>(
+    py: Python<'_>,
+    db: &ProjectDatabase,
+    work: &'w [T],
+    f: impl Fn(&ProjectDatabase, &'w T) -> R + Send + Sync,
+) -> Vec<R> {
+    use rayon::prelude::*;
+    if work.is_empty() {
+        return Vec::new();
+    }
+    let num_workers = std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(4);
+    let chunk_size = work.len().div_ceil(num_workers).max(1);
+    let chunks: Vec<&'w [T]> = work.chunks(chunk_size).collect();
+    let dbs: Vec<ProjectDatabase> = (0..chunks.len()).map(|_| db.clone()).collect();
+    let nested: Vec<Vec<R>> = py.allow_threads(move || {
+        dbs.into_par_iter()
+            .zip(chunks.into_par_iter())
+            .map(|(local_db, chunk)| {
+                use salsa::Database as _;
+                local_db.attach(|ldb| chunk.iter().map(|item| f(ldb, item)).collect())
+            })
+            .collect()
+    });
+    nested.into_iter().flatten().collect()
 }
 
 /// Fold every registered per-file native plugin's file-local ops into
@@ -1293,12 +1471,11 @@ pub(crate) struct ClassHierarchyIndices {
 /// `LocalClass(range)` for a same-file class or a `ModuleMember{module,
 /// name}` symbolic reference — deliberately *not* resolved at store time
 /// so the per-file payload stays salsa-invalidation-local (see
-/// `build_class_bases`). Assembly resolves each spec here, through
-/// [`crate::helpers::resolve_base_spec`], to the `(File, name_range)` key
-/// of the class's name token; `resolve_base_spec` chases `ModuleMember`
-/// rows via [`crate::helpers::resolve_member_def`] (ty's module resolver +
-/// re-export / assignment-alias following). Dispatch is then a single
-/// hashmap probe per resolved base:
+/// `build_class_bases`). Assembly resolves each spec here, to the
+/// `(File, name_range)` key of the class's name token; `ModuleMember`
+/// rows chase through [`crate::helpers::resolve_member_def`] (ty's
+/// module resolver + re-export / assignment-alias following). Dispatch
+/// is then a single hashmap probe per resolved base:
 ///
 /// * the key hits `class_by_selection` → it's a project class; record a
 ///   `children_by_node` edge to that parent (every value in the map is a
@@ -1311,7 +1488,17 @@ pub(crate) struct ClassHierarchyIndices {
 /// (direct, aliased, re-exported, sibling-module) collapses to the same
 /// `(File, name_range)` key by construction — the query side
 /// ([`crate::helpers::locate_class_seed`]) lands on the identical key.
+///
+/// The `ModuleMember` resolutions are memoized project-wide on
+/// `(module, name, anchor directory)` — the same key scheme as the
+/// assemble pass's RefSpec memo (`resolve_member_def` is
+/// anchor-sensitive only through ty's desperate-resolution fallback,
+/// which depends on ancestor directories) — and resolved on rayon
+/// workers. A base every file subclasses (`pydantic.BaseModel`,
+/// `unittest.TestCase`) resolves once per directory instead of once
+/// per class.
 fn build_class_hierarchy_indices(
+    py: Python<'_>,
     db: &ProjectDatabase,
     project_files: &[File],
     class_by_selection: &FxHashMap<(File, (u32, u32)), usize>,
@@ -1320,15 +1507,80 @@ fn build_class_hierarchy_indices(
     let mut external_base_children: FxHashMap<(File, (u32, u32)), Vec<usize>> =
         FxHashMap::default();
 
+    // Serial prefetch: per-file payloads (cache reads after the
+    // populate fan-out) + anchor-directory ids.
+    let payloads: Vec<&FileNodes> = project_files
+        .iter()
+        .map(|&f| file_to_nodes(db, f))
+        .collect();
+    let mut dir_to_id: FxHashMap<String, u32> = FxHashMap::default();
+    let mut dir_anchors: Vec<File> = Vec::new();
+    let mut dir_ids: Vec<u32> = Vec::with_capacity(project_files.len());
     for &file in project_files {
-        let payload = file_to_nodes(db, file);
+        let path = file_path_string(db, file);
+        let dir = match path.rsplit_once(['/', '\\']) {
+            Some((d, _)) => d.to_string(),
+            None => String::new(),
+        };
+        let id = *dir_to_id.entry(dir).or_insert_with(|| {
+            dir_anchors.push(file);
+            (dir_anchors.len() - 1) as u32
+        });
+        dir_ids.push(id);
+    }
+
+    // Gather the unique `(module, name, dir)` member keys (sorted, for
+    // deterministic worker output order) and resolve them in parallel.
+    let mut work: Vec<(&str, &str, u32)> = {
+        let mut seen: FxHashSet<(&str, &str, u32)> = FxHashSet::default();
+        for (pos, payload) in payloads.iter().enumerate() {
+            for (_cls_rk, bases) in &payload.class_bases {
+                for base in bases.iter() {
+                    if let ClassBaseSpec::ModuleMember { module, name } = base {
+                        seen.insert((module.as_str(), name.as_str(), dir_ids[pos]));
+                    }
+                }
+            }
+        }
+        seen.into_iter().collect()
+    };
+    work.sort_unstable();
+
+    /// `(module, name, anchor-dir)` member key → resolved base decl.
+    type BaseMemo<'k> = FxHashMap<(&'k str, &'k str, u32), Option<(File, TextRange)>>;
+    let dir_anchors_ref = &dir_anchors;
+    let results: Vec<Option<(File, TextRange)>> =
+        resolve_chunked(py, db, &work, |ldb, &(module, name, dir)| {
+            resolve_member_def(ldb, module, name, dir_anchors_ref[dir as usize], 0)
+        });
+    let mut memo: BaseMemo<'_> =
+        FxHashMap::with_capacity_and_hasher(work.len(), Default::default());
+    for (&key, res) in work.iter().zip(&results) {
+        memo.insert(key, *res);
+    }
+
+    // Scatter: dispatch each class's resolved bases against
+    // `class_by_selection` (project parent) or `external_base_children`
+    // (external parent). `LocalClass` specs resolve inline — the spec
+    // range IS the `(File, name_range)` key.
+    for (pos, payload) in payloads.iter().enumerate() {
+        let file = project_files[pos];
+        let dir = dir_ids[pos];
         for (cls_rk, bases) in &payload.class_bases {
             let Some(&child_idx) = class_by_selection.get(&(file, *cls_rk)) else {
                 continue;
             };
-            for base in bases {
-                let Some((base_file, base_range)) = resolve_base_spec(db, base, file, file, 0)
-                else {
+            for base in bases.iter() {
+                let resolved = match base {
+                    ClassBaseSpec::LocalClass((start, end)) => {
+                        Some((file, TextRange::new((*start).into(), (*end).into())))
+                    }
+                    ClassBaseSpec::ModuleMember { module, name } => memo
+                        .get(&(module.as_str(), name.as_str(), dir))
+                        .copied()
+                        .flatten(),
+                };
+                let Some((base_file, base_range)) = resolved else {
                     continue;
                 };
                 let base_rk = range_key(base_range);
@@ -1433,8 +1685,8 @@ pub(crate) fn build_fqname_indices(
             // `@typing.overload`-decorated stubs of an in-file overload group
             // are excluded from the fqname trie so cross-module `from mod
             // import f` resolves to the impl only. Reachability still anchors
-            // them via the explicit `impl → stub` edge emitted in
-            // `file_to_edges`.
+            // them via the explicit `impl → stub` anchor edge the
+            // assembly pass synthesizes.
             if node.is_overload {
                 return acc;
             }

--- a/runtime/src/refspec.rs
+++ b/runtime/src/refspec.rs
@@ -1,0 +1,493 @@
+//! File-local reference specs and their assembly-side resolution.
+//!
+//! [`RefSpec`] is the unit the combined per-file walk
+//! ([`crate::file_ref_edges::file_to_refspecs`]) emits: one unresolved
+//! reference edge, expressed entirely in the owning file's local terms.
+//! Crucially the type is `'static` plain data — no interned keys —
+//! so the walk query has **zero cross-file salsa
+//! dependencies**: editing an imported file's contents never
+//! invalidates an importer's walk. All cross-file work (ty's module
+//! resolver, upstream `exports_by_name` lookups, star-reexport chain
+//! walks, external classification) happens in the assembly pass via
+//! [`resolve_member`] / [`resolve_dynamic`], memoized project-wide on
+//! `(anchor directory, ref)` keys.
+//!
+//! This mirrors the existing [`ClassBaseSpec`](crate::file_payload::ClassBaseSpec)
+//! pattern — a symbolic per-file descriptor resolved at fan-in — and
+//! generalizes it to every reference edge.
+
+use ruff_db::files::File;
+use smallvec::SmallVec;
+use ty_module_resolver::{resolve_module, ModuleName};
+use ty_project::Db as ProjectDb;
+
+use crate::file_payload::{
+    external_fqname_for, file_to_nodes, walk_exports_chain, ImportPayload, NodeRef,
+};
+use crate::graph::DeclKey;
+use crate::ingest::module_name_resolves;
+
+/// One unresolved reference edge, expressed entirely in this file's
+/// local terms. `src` is the local index (into
+/// [`FileNodes::refs`](crate::file_payload::FileNodes::refs)) of the
+/// owning node; `flags` are the edge flags (dead-branch /
+/// dynamic-import) computed locally. The `target` is resolved by the
+/// assembly pass — see [`Target`].
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, salsa::Update, get_size2::GetSize)]
+pub(crate) struct RefSpec {
+    pub(crate) src: u32,
+    pub(crate) target: Target,
+    pub(crate) flags: u8,
+}
+
+/// A [`RefSpec`]'s destination.
+///
+/// * `Local` — already resolved: a local index in *this* file (a
+///   use→alias edge, a module→dunder edge, an `__all__` edge, a
+///   per-name star alias → star statement edge). The assembly pass
+///   maps both endpoints through the file's node-offset base.
+/// * `Member` — an unresolved cross-file member/module access. The
+///   assembly pass runs [`resolve_member`] to turn it into
+///   zero-or-more upstream nodes.
+/// * `Dynamic` — an unresolved `__import__` / `importlib.import_module`
+///   target. The assembly pass runs [`resolve_dynamic`].
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, salsa::Update, get_size2::GetSize)]
+pub(crate) enum Target {
+    Local(u32),
+    Member(MemberRef),
+    Dynamic(DynamicRef),
+}
+
+/// Which side of the import-edge contract a [`MemberRef`] encodes.
+/// The two roles share the module-resolution front-end but
+/// deliberately land differently (see `CLAUDE.md` principle 2):
+///
+/// * `Binding` — the import alias's own upstream edge (`alias →
+///   Module(target)` + `alias → target decl`). Resolution walks
+///   star-reexport chains past intermediary star aliases
+///   ([`walk_exports_chain`]) so the alias reaches the *real* decl,
+///   applies CPython's `_handle_fromlist` namespace-vs-submodule
+///   disambiguation, and reports resolution failure so the assembly
+///   pass can stamp `NodeFlags::UNRESOLVED` on the alias.
+/// * `Use` — a use site flowing through an import alias (or a
+///   nested-context import). Resolution lands *on* whatever is in the
+///   upstream namespace — including star-reexport aliases, which the
+///   use keeps alive — and silently drops failures.
+#[derive(
+    Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, salsa::Update, get_size2::GetSize,
+)]
+pub(crate) enum MemberRole {
+    Binding,
+    Use,
+}
+
+/// Unresolved descriptor for a reference that flows through an import.
+/// For `Use` it mirrors the `(spec, bound_name, extra_chain)` arguments
+/// the old `emit_upstream` took; for `Binding` it carries the per-kind
+/// `(module, decl)` resolution input the old `file_to_edges` alias loop
+/// computed (with `bound_name` empty and `chain` unused).
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, salsa::Update, get_size2::GetSize)]
+pub(crate) struct MemberRef {
+    pub(crate) role: MemberRole,
+    pub(crate) spec: ImportPayload,
+    pub(crate) bound_name: String,
+    pub(crate) chain: Vec<String>,
+}
+
+/// Unresolved descriptor for a dynamic import. `target` is already
+/// absolutized at walk time via `resolve_dynamic_target` (which needs
+/// only the owning file's package name — a self-property), so
+/// resolution here is anchor-light: module probes + upstream
+/// `exports_by_name` lookups.
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, salsa::Update, get_size2::GetSize)]
+pub(crate) struct DynamicRef {
+    pub(crate) target: String,
+    pub(crate) fromlist: Vec<String>,
+}
+
+/// A resolved cross-file target, in `'static` terms, so resolution can
+/// run on rayon workers against per-worker db snapshots and hand
+/// results back to the main thread.
+///
+/// `External` defers the graph-node interning to the serial
+/// translation step — workers only read.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) enum ResolvedNode {
+    Module(File),
+    Def(DeclKey),
+    StarStmt(File, (u32, u32)),
+    External { fqname: String, file: File },
+}
+
+impl ResolvedNode {
+    fn from_node_ref(r: NodeRef) -> Self {
+        match r {
+            NodeRef::Module(f) => ResolvedNode::Module(f),
+            NodeRef::Def(k) => ResolvedNode::Def(k),
+            NodeRef::StarStmt(f, rk) => ResolvedNode::StarStmt(f, rk),
+        }
+    }
+}
+
+/// Output of [`resolve_member`].
+///
+/// * `targets` — the upstream nodes the ref reaches.
+/// * `unresolved` — `Binding` only: the upstream module didn't resolve;
+///   the assembly pass ORs `NodeFlags::UNRESOLVED` into the alias.
+/// * `start_file` — the resolved upstream module's file, when it
+///   resolved to a first-party file. The assembly pass uses it to
+///   suppress self-imports (`Binding` refs whose target is the
+///   importing file itself emit nothing — mirrors the old
+///   `file_to_edges` `target_file == file` skip, which must be applied
+///   per importing file, not per memo entry).
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ResolvedMember {
+    pub(crate) targets: SmallVec<[ResolvedNode; 4]>,
+    pub(crate) unresolved: bool,
+    pub(crate) start_file: Option<File>,
+}
+
+/// Resolve a [`MemberRef`] from `anchor`. `anchor` only feeds ty's
+/// module resolver, whose anchor-sensitivity is limited to the
+/// desperate-resolution fallback (ancestor-directory search) — which is
+/// why the assembly pass may memoize results per *directory* rather
+/// than per file.
+pub(crate) fn resolve_member(
+    db: &dyn ProjectDb,
+    anchor: File,
+    member: &MemberRef,
+) -> ResolvedMember {
+    match member.role {
+        MemberRole::Binding => resolve_binding(db, anchor, &member.spec),
+        MemberRole::Use => resolve_use(db, anchor, member),
+    }
+}
+
+/// `Binding` arm: port of the old `file_to_edges` import-alias
+/// resolution. Emits `Module(target)` + (for from-imports) the decl
+/// reached through [`walk_exports_chain`]; classifies stdlib (silent),
+/// site-packages (External), and unresolved (flag) targets.
+fn resolve_binding(db: &dyn ProjectDb, anchor: File, spec: &ImportPayload) -> ResolvedMember {
+    let mut out = ResolvedMember::default();
+    if spec.module.is_empty() {
+        return out;
+    }
+
+    // Submodule disambiguation: `from p import functions` where
+    // `p.functions` is itself a submodule should point at the
+    // submodule file, not at `p` with a decl lookup. BUT: per
+    // CPython's `_handle_fromlist`, namespace bindings WIN over
+    // submodule lookups when both exist (e.g. `q = 42` in
+    // p/__init__.py with a sibling p/q.py — the int binds, not
+    // the submodule). Check namespace first; only switch to
+    // submodule when the namespace doesn't already export decl.
+    let (target_module_str, decl_name): (String, Option<String>) = match &spec.decl {
+        Some(decl) => {
+            let candidate = format!("{}.{}", spec.module, decl);
+            if module_name_resolves(&candidate, anchor, db) {
+                let namespace_has_decl = ModuleName::new(&spec.module)
+                    .and_then(|mn| resolve_module(db, anchor, &mn))
+                    .and_then(|m| m.file(db))
+                    .map(|f| file_to_nodes(db, f).exports_by_name.contains_key(decl))
+                    .unwrap_or(false);
+                if namespace_has_decl {
+                    (spec.module.clone(), Some(decl.clone()))
+                } else {
+                    (candidate, None)
+                }
+            } else {
+                (spec.module.clone(), Some(decl.clone()))
+            }
+        }
+        None => (spec.module.clone(), None),
+    };
+
+    // Bad module name (relative-dots overflow, etc.), a module that
+    // doesn't resolve, or a resolved module with no backing file:
+    // report `unresolved` so the assembly pass flags the alias.
+    let Some(target_module_name) = ModuleName::new(&target_module_str) else {
+        out.unresolved = true;
+        return out;
+    };
+    let Some(target_module) = resolve_module(db, anchor, &target_module_name) else {
+        out.unresolved = true;
+        return out;
+    };
+    let Some(target_file) = target_module.file(db) else {
+        out.unresolved = true;
+        return out;
+    };
+    let top_level = target_module_str
+        .split('.')
+        .next()
+        .unwrap_or(&target_module_str);
+    // Stdlib targets emit no node: an unused stdlib import is still
+    // caught dead via its alias's zero in-edge count, so a stdlib
+    // endpoint would be pure noise.
+    if target_module
+        .search_path(db)
+        .is_some_and(|sp| sp.is_standard_library())
+    {
+        return out;
+    }
+    // Non-first-party (site-packages) → External node keyed on the
+    // PEP 503 dist name (or top-level module name) with the resolved
+    // target file (its path is re-derived at assembly).
+    if target_module
+        .search_path(db)
+        .is_some_and(|sp| !sp.is_first_party() && sp.is_site_packages())
+    {
+        let fqname = external_fqname_for(db, target_file, top_level);
+        out.targets.push(ResolvedNode::External {
+            fqname,
+            file: target_file,
+        });
+        return out;
+    }
+    // First-party target: record `start_file` so the assembly pass can
+    // suppress self-imports (the whole emission, decl edges included —
+    // mirroring the old `target_file == file { continue; }`).
+    out.start_file = Some(target_file);
+
+    // Module-level edge.
+    out.targets.push(ResolvedNode::Module(target_file));
+
+    // Named-decl edge for from-imports. Walks the star-reexport
+    // chain so `from A import g` where A re-exports from B lands
+    // on B's real `g` rather than A's star alias node. salsa
+    // memoizes each file's payload on the way through, so the
+    // chain walk is hashmap lookups + a `seen` set.
+    if let Some(decl_name) = decl_name {
+        for target_ref in walk_exports_chain(db, target_file, &decl_name) {
+            out.targets.push(ResolvedNode::from_node_ref(target_ref));
+        }
+    }
+    out
+}
+
+/// `Use` arm: port of the old `RefWalker::emit_upstream`. Classifies
+/// the loading target, walks the submodule chain, lands on the deepest
+/// module reached plus any terminal decl — *without* skipping past
+/// star-reexport aliases (the use side keeps the intermediary star
+/// import alive; see [`MemberRole`]).
+fn resolve_use(db: &dyn ProjectDb, anchor: File, member: &MemberRef) -> ResolvedMember {
+    let mut out = ResolvedMember::default();
+    let spec = &member.spec;
+    let bound_name = member.bound_name.as_str();
+    if spec.module.is_empty() {
+        return out;
+    }
+    let module_first_seg = spec.module.split('.').next().unwrap_or("").to_string();
+
+    let mut adjusted_chain: Vec<&str> = member.chain.iter().map(String::as_str).collect();
+    let loading_target: String;
+    let mut decl_tail: Option<String> = None;
+
+    if spec.star {
+        let candidate = format!("{}.{}", spec.module, bound_name);
+        if module_name_resolves(&candidate, anchor, db) {
+            loading_target = candidate;
+        } else {
+            loading_target = spec.module.clone();
+            decl_tail = Some(bound_name.to_string());
+        }
+    } else {
+        match &spec.decl {
+            Some(decl) => {
+                let candidate = format!("{}.{}", spec.module, decl);
+                if module_name_resolves(&candidate, anchor, db) {
+                    loading_target = candidate;
+                } else {
+                    loading_target = spec.module.clone();
+                    decl_tail = Some(decl.clone());
+                }
+            }
+            None => {
+                let no_asname = bound_name == module_first_seg;
+                if no_asname && spec.module != module_first_seg {
+                    let loading_extras: Vec<&str> = spec.module.split('.').skip(1).collect();
+                    let n = loading_extras.len();
+                    let prefix_matches = adjusted_chain.len() >= n
+                        && adjusted_chain
+                            .iter()
+                            .take(n)
+                            .zip(&loading_extras)
+                            .all(|(a, b)| *a == *b);
+                    if prefix_matches {
+                        adjusted_chain.drain(..n);
+                        loading_target = spec.module.clone();
+                    } else {
+                        loading_target = module_first_seg;
+                    }
+                } else {
+                    loading_target = spec.module.clone();
+                }
+            }
+        }
+    }
+
+    // Classify the loading target. Site-packages targets land on a
+    // single External node carrying the upstream path and stop (no
+    // submodule chain walk through them, since they don't have
+    // file_to_nodes payloads to look up against). Stdlib and
+    // genuinely-unresolved targets emit nothing.
+    let top_level = loading_target.split('.').next().unwrap_or(&loading_target);
+    let Some(start_mn) = ModuleName::new(&loading_target) else {
+        return out;
+    };
+    let Some(start_module) = resolve_module(db, anchor, &start_mn) else {
+        return out;
+    };
+    let Some(start_file) = start_module.file(db) else {
+        return out;
+    };
+    if start_module
+        .search_path(db)
+        .is_some_and(|sp| sp.is_standard_library())
+    {
+        return out;
+    }
+    if start_module
+        .search_path(db)
+        .is_some_and(|sp| !sp.is_first_party() && sp.is_site_packages())
+    {
+        let fqname = external_fqname_for(db, start_file, top_level);
+        out.targets.push(ResolvedNode::External {
+            fqname,
+            file: start_file,
+        });
+        return out;
+    }
+
+    // Decl-style alias: land on the upstream module and the decl
+    // inside it. Attribute access past a decl is field access on the
+    // decl's value, which we don't model.
+    //
+    // Use sites land on whatever's in exports_by_name (including
+    // star-reexport aliases). Don't walk through star aliases here —
+    // the from-import binding side uses walk_exports_chain to skip
+    // past stars; this is the *use* side, which should reach the star
+    // alias itself.
+    if let Some(decl_name) = decl_tail {
+        out.targets.push(ResolvedNode::Module(start_file));
+        let target_nodes = file_to_nodes(db, start_file);
+        if let Some(locals) = target_nodes.exports_by_name.get(&decl_name) {
+            for &local_idx in locals {
+                out.targets.push(ResolvedNode::from_node_ref(
+                    target_nodes.refs[local_idx as usize],
+                ));
+            }
+        }
+        return out;
+    }
+
+    // Module-style alias: walk the chain submodule-by-submodule,
+    // land on one module (deepest reached) plus at most one
+    // terminal decl.
+    let mut current_file = start_file;
+    let mut current_path = loading_target.clone();
+    let mut terminal_decl_refs: Vec<ResolvedNode> = Vec::new();
+    for seg in &adjusted_chain {
+        let candidate = format!("{current_path}.{seg}");
+        let submodule_file = ModuleName::new(&candidate)
+            .and_then(|mn| resolve_module(db, anchor, &mn))
+            .and_then(|m| m.file(db));
+        if let Some(sub_file) = submodule_file {
+            current_file = sub_file;
+            current_path = candidate;
+            continue;
+        }
+        // Not a submodule — check for decl in current_file's exports.
+        let target_nodes = file_to_nodes(db, current_file);
+        if let Some(locals) = target_nodes.exports_by_name.get(*seg) {
+            for &local_idx in locals {
+                terminal_decl_refs.push(ResolvedNode::from_node_ref(
+                    target_nodes.refs[local_idx as usize],
+                ));
+            }
+        }
+        break;
+    }
+    out.targets.push(ResolvedNode::Module(current_file));
+    out.targets.extend(terminal_decl_refs);
+    out
+}
+
+/// Resolve a [`DynamicRef`] from `anchor`: the target module itself
+/// plus per-fromlist-entry edges (submodule-or-decl, mirroring
+/// CPython's `_handle_fromlist`). Port of the old
+/// `RefWalker::emit_dynamic_edges` + `emit_resolved_module`.
+pub(crate) fn resolve_dynamic(
+    db: &dyn ProjectDb,
+    anchor: File,
+    dynamic: &DynamicRef,
+) -> SmallVec<[ResolvedNode; 4]> {
+    let mut out: SmallVec<[ResolvedNode; 4]> = SmallVec::new();
+    resolve_module_target(db, anchor, &dynamic.target, &mut out);
+    for entry in &dynamic.fromlist {
+        if entry.is_empty() {
+            continue;
+        }
+        let candidate = format!("{}.{entry}", dynamic.target);
+        if module_name_resolves(&candidate, anchor, db) {
+            resolve_module_target(db, anchor, &candidate, &mut out);
+            continue;
+        }
+        // Treat as decl-style: resolve target to file, look up
+        // entry in its exports_by_name.
+        let target_file = ModuleName::new(&dynamic.target)
+            .and_then(|n| resolve_module(db, anchor, &n))
+            .and_then(|m| m.file(db));
+        if let Some(target_file) = target_file {
+            let target_nodes = file_to_nodes(db, target_file);
+            if let Some(locals) = target_nodes.exports_by_name.get(entry.as_str()) {
+                for &local_idx in locals {
+                    out.push(ResolvedNode::from_node_ref(
+                        target_nodes.refs[local_idx as usize],
+                    ));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Resolve one dotted module path. First-party modules land on a
+/// `Module` node; site-packages modules become External nodes carrying
+/// the upstream path; stdlib and genuinely-unresolved targets land
+/// nothing.
+fn resolve_module_target(
+    db: &dyn ProjectDb,
+    anchor: File,
+    dotted: &str,
+    out: &mut SmallVec<[ResolvedNode; 4]>,
+) {
+    let top_level = dotted.split('.').next().unwrap_or(dotted);
+    let Some(mn) = ModuleName::new(dotted) else {
+        return;
+    };
+    let Some(module) = resolve_module(db, anchor, &mn) else {
+        return;
+    };
+    let Some(target_file) = module.file(db) else {
+        return;
+    };
+    if module
+        .search_path(db)
+        .is_some_and(|sp| sp.is_standard_library())
+    {
+        return;
+    }
+    if module
+        .search_path(db)
+        .is_some_and(|sp| !sp.is_first_party() && sp.is_site_packages())
+    {
+        let fqname = external_fqname_for(db, target_file, top_level);
+        out.push(ResolvedNode::External {
+            fqname,
+            file: target_file,
+        });
+        return;
+    }
+    out.push(ResolvedNode::Module(target_file));
+}

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1236,6 +1236,29 @@ def test_star_reexport_mints_per_name_and_statement_nodes(build_decl_graph):
     assert per_name == {"pkg.g", "pkg.h"}
 
 
+def test_circular_star_reexport_keeps_binding_self_loop(build_decl_graph):
+    """A circular star re-export keeps the binding-side self-loop.
+
+    ``a.py: from pkg.b import g`` / ``b.py: from pkg.a import *`` — the
+    alias's chain walk hops through b's star re-export and lands back on
+    a's own ``g`` alias. The resulting ``pkg.a.g -> pkg.a.g`` self-edge
+    is deliberately kept: the binding side has never filtered
+    self-edges (only use-site emission skips ``dst == owner``), and
+    edge inventories must stay stable across pipeline refactors.
+    Reachability is unaffected either way.
+    """
+    graph = build_decl_graph(
+        {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "from pkg.b import g",
+            "pkg/b.py": "from pkg.a import *",
+        }
+    )
+    nodes = graph.nodes()
+    self_loops = {nodes[u].fqname for u, v, _ in graph.edges() if u == v}
+    assert "pkg.a.g" in self_loops, self_loops
+
+
 def test_cross_dep_submodule_import(tmp_path, make_analysis, assert_edges):
     """Importing a submodule from a dep base resolves through the dep's exported trie.
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1236,27 +1236,140 @@ def test_star_reexport_mints_per_name_and_statement_nodes(build_decl_graph):
     assert per_name == {"pkg.g", "pkg.h"}
 
 
-def test_circular_star_reexport_keeps_binding_self_loop(build_decl_graph):
-    """A circular star re-export keeps the binding-side self-loop.
+@pytest.mark.parametrize(
+    ("files", "expected_self_loops"),
+    [
+        pytest.param(
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": "from pkg.b import g",
+                "pkg/b.py": "from pkg.a import *",
+            },
+            {"pkg.a.g"},
+            id="binding-circular-star",
+        ),
+        pytest.param(
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": "from pkg.b import g",
+                "pkg/b.py": "from pkg.c import *",
+                "pkg/c.py": "from pkg.a import *",
+            },
+            {"pkg.a.g"},
+            id="binding-two-hop-circular-star",
+        ),
+        pytest.param(
+            # The chain walk stops on a non-star import, so mutual
+            # from-imports form a 2-cycle (a.g -> b.g -> a.g), never a
+            # self-loop.
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": "from pkg.b import g",
+                "pkg/b.py": "from pkg.a import g",
+            },
+            set(),
+            id="binding-mutual-from-imports",
+        ),
+        pytest.param(
+            # Self-imports suppress the whole binding emission (module
+            # and decl edges included), so no self-loop can form.
+            {
+                "pkg/__init__.py": "x = 1\nfrom pkg import x as y\n",
+            },
+            set(),
+            id="binding-self-import-suppressed",
+        ),
+        pytest.param(
+            # `as h` re-keys the alias: b's star re-export binds `h`,
+            # so the chain walk for `g` finds nothing in b and the
+            # cycle never closes.
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": "from pkg.b import g as h",
+                "pkg/b.py": "from pkg.a import *",
+            },
+            set(),
+            id="binding-aliased-circular-star",
+        ),
+        pytest.param(
+            # A real upstream decl terminates the chain walk — the
+            # star hop is pass-through, not circular.
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": "from pkg.b import g",
+                "pkg/b.py": "from pkg.c import *",
+                "pkg/c.py": "def g(): pass",
+            },
+            set(),
+            id="binding-star-chain-real-decl",
+        ),
+        pytest.param(
+            # Use side: a module-level use of the module's own alias
+            # resolves to the module node itself and is filtered
+            # (`dst == owner`); the binding side independently
+            # suppresses the self-import.
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": "import pkg.a\nprint(pkg.a)\n",
+            },
+            set(),
+            id="use-module-self-import",
+        ),
+        pytest.param(
+            # Use side: a nested-context self-import used inside the
+            # very decl it resolves back to (`g` importing and
+            # returning itself) is filtered; only the
+            # `g -> Module(pkg.a)` reachability edge survives.
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": "def g():\n    from pkg.a import g as gg\n    return gg\n",
+            },
+            set(),
+            id="use-nested-self-import",
+        ),
+        pytest.param(
+            # A module-level use of the circularly-star-bound name
+            # adds use edges (module -> alias, module -> upstream) but
+            # no new self-loops — the binding self-loop is the only
+            # one.
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": "from pkg.b import g\ng()\n",
+                "pkg/b.py": "from pkg.a import *",
+            },
+            {"pkg.a.g"},
+            id="use-on-circular-star-binding",
+        ),
+        pytest.param(
+            # Same, with the use on the star-importing side: b's use
+            # of its star-bound `g` lands back on a's alias (a
+            # cross-file edge, not a self-loop).
+            {
+                "pkg/__init__.py": "",
+                "pkg/a.py": "from pkg.b import g",
+                "pkg/b.py": "from pkg.a import *\nVALUE = g\n",
+            },
+            {"pkg.a.g"},
+            id="use-downstream-of-circular-star",
+        ),
+    ],
+)
+def test_self_loop_edges(build_decl_graph, files, expected_self_loops):
+    """Self-loop parity, binding side vs use side.
 
-    ``a.py: from pkg.b import g`` / ``b.py: from pkg.a import *`` — the
-    alias's chain walk hops through b's star re-export and lands back on
-    a's own ``g`` alias. The resulting ``pkg.a.g -> pkg.a.g`` self-edge
-    is deliberately kept: the binding side has never filtered
-    self-edges (only use-site emission skips ``dst == owner``), and
-    edge inventories must stay stable across pipeline refactors.
-    Reachability is unaffected either way.
+    The binding side (an import alias's own upstream edges) has never
+    filtered self-edges: a circular star re-export can land
+    `walk_exports_chain` back on the alias itself, and that self-loop
+    is kept. The use side (name uses flowing through an alias) mirrors
+    the old ``emit_edge`` ``dst != owner`` skip and never produces one.
+    Reachability is unaffected either way, but edge inventories must
+    stay stable across pipeline refactors — every expectation here is
+    pinned against the pre-RefSpec pipeline's output.
     """
-    graph = build_decl_graph(
-        {
-            "pkg/__init__.py": "",
-            "pkg/a.py": "from pkg.b import g",
-            "pkg/b.py": "from pkg.a import *",
-        }
-    )
+    graph = build_decl_graph(files)
     nodes = graph.nodes()
     self_loops = {nodes[u].fqname for u, v, _ in graph.edges() if u == v}
-    assert "pkg.a.g" in self_loops, self_loops
+    assert self_loops == expected_self_loops
 
 
 def test_cross_dep_submodule_import(tmp_path, make_analysis, assert_edges):


### PR DESCRIPTION
## What

Replaces the two per-file salsa edge queries (`file_to_edges` / `file_to_ref_edges`) with one combined walk, **`file_to_refspecs`**, that emits unresolved, file-local `RefSpec` rows — `Local(u32)` indices plus symbolic `Member` / `Dynamic` descriptors (`runtime/src/refspec.rs`). All cross-file resolution moves to the assembly pass.

## Why

The payload is `'static` plain data with **zero cross-file salsa dependencies**: editing one file no longer invalidates any importer's expensive AST/use-def walk — only the (much cheaper) assembly-time resolution re-runs. This generalizes the existing `ClassBaseSpec` pattern (symbolic per-file descriptor, resolved at fan-in) to every reference edge.

## How

- **Resolution at assembly** (`refspec::resolve_member` / `resolve_dynamic`), memoized project-wide per `(ref, anchor directory)` and run on rayon workers against per-chunk salsa snapshots. Dir-keying is provably equivalent to per-file anchoring: ty's `resolve_module` is anchor-sensitive only through its desperate-resolution fallback, which depends solely on the importing file's ancestor directories. A hot import repeated across thousands of use sites resolves once per directory.
- **`MemberRef.role: Binding | Use`** makes the two landing semantics explicit: binding-side edges walk star-reexport chains to the real decl (plus the `_handle_fromlist` namespace-vs-submodule disambiguation and `UNRESOLVED` flagging); use-side edges land on the star alias itself, keeping the intermediary star import alive.
- **Class-base fan-in** (`build_class_hierarchy_indices`) reuses the same memoized parallel machinery — previously it re-resolved every base spelling once per class, serially.
- **Structural edges** (decl → module anchors, overload impl → stub anchors, submodule → parent-package hierarchy) are synthesized at assembly straight from `FileNodes` instead of being stored per file.
- **`resolve_dynamic_target` stays at walk time** — pure string work whose only context is the file's own package name — so `DynamicRef` carries an absolutized target and dynamic-import warnings stay file-local.
- Fallout simplifications: `NodeRef::External` and the salsa-interned `ExternalKey` are gone (externals only appear as resolution outputs and intern directly into the builder); `NodeRef` / `FileNodes` drop their `'db` lifetime.

## Behavior

Deliberately behavior-preserving, including the pre-existing binding/use divergence in fromlist disambiguation (use side still prefers the submodule without the namespace-wins check); unifying that is a small follow-up in `resolve_use` now that both sides funnel through one resolver.

## Verification

- Full suite passes untouched (703 passed) + `prek run --all-files` green.
- **A/B parity**: the full `fqname@path:line → fqname@path:line [flags]` edge inventory plus per-node flags, dumped on a real tree with the baseline build and this branch, is **bit-for-bit identical**.
- `DEAD_CST_TIMING` smoke run via `dead-cst analyze` end-to-end.

https://claude.ai/code/session_01KYNAs8Y9ctXsM1waLmXEaP

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYNAs8Y9ctXsM1waLmXEaP)_