### PR TITLE
Evict per-file semantic indices after extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,8 +262,11 @@ two versions.
   AST ids) for lazy, ingredient-reusing rebuild on the next `load()`. The
   populate fan-out clears each file's index (alongside its parsed AST) as
   soon as the per-file extraction queries have memoized their owned
-  payloads, and the post-plugin-pass sweep re-clears any files the class
-  hierarchy / plugin passes reloaded on demand. On large projects the
+  payloads, and the post-plugin-pass sweep re-clears the files the
+  assembly / plugin passes reloaded on demand — tracked precisely via a
+  reload log on `resolve_member_in_file` (the one reload chokepoint), so
+  the sweep touches the handful of base-defining files instead of probing
+  every project file's salsa slots. On large projects the
   resident semantic indices were the dominant share of peak memory
   (~16 GB at 200k files); they are now transient per-file working state.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,18 @@ two versions.
 
 ### Changed
 
+- **Per-file semantic indices are evicted after extraction.** The vendored
+  ty fork now follows the `parsed_module` pattern for the semantic index:
+  the salsa query returns a cheap handle, consumers `load()` a guard, and
+  `clear()` drops the per-scope analysis data (place tables, use-def maps,
+  AST ids) for lazy, ingredient-reusing rebuild on the next `load()`. The
+  populate fan-out clears each file's index (alongside its parsed AST) as
+  soon as the per-file extraction queries have memoized their owned
+  payloads, and the post-plugin-pass sweep re-clears any files the class
+  hierarchy / plugin passes reloaded on demand. On large projects the
+  resident semantic indices were the dominant share of peak memory
+  (~16 GB at 200k files); they are now transient per-file working state.
+
 - **File-local reference specs; cross-file resolution moved to assembly.**
   The two per-file salsa edge queries (`file_to_edges` / `file_to_ref_edges`)
   are consolidated into one combined walk (`file_to_refspecs`) that emits

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,6 +2312,7 @@ dependencies = [
 name = "ty_python_core"
 version = "0.0.0"
 dependencies = [
+ "arc-swap",
  "bitflags",
  "bitvec",
  "get-size2",

--- a/runtime/src/file_payload.rs
+++ b/runtime/src/file_payload.rs
@@ -395,7 +395,7 @@ pub(crate) fn file_to_nodes(db: &dyn ProjectDb, file: File) -> FileNodes {
     refs.push(NodeRef::Module(file));
     ref_to_local.insert(NodeRef::Module(file), 0);
 
-    let index = semantic_index(db, file);
+    let index = semantic_index(db, file).load(db);
     let global = FileScopeId::global();
     let place_table = index.place_table(global);
     let use_def_map = index.use_def_map(global);

--- a/runtime/src/file_ref_edges.rs
+++ b/runtime/src/file_ref_edges.rs
@@ -34,7 +34,7 @@ use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::definition::{DefinitionKind, DefinitionState, TargetKind};
 use ty_python_core::place::PlaceExprRef;
 use ty_python_core::scope::FileScopeId;
-use ty_python_core::{semantic_index, SemanticIndex};
+use ty_python_core::{semantic_index, SemanticIndexRef};
 use ty_python_semantic::SemanticModel;
 
 use crate::file_payload::{
@@ -97,7 +97,7 @@ pub(crate) fn file_to_refspecs(db: &dyn ProjectDb, file: File) -> FileRefSpecs {
     let parsed = parsed_module(db, file).load(db);
     let dead_ranges = detect_dead_ranges(&parsed);
     let tc_ranges = detect_type_checking_ranges(&parsed);
-    let index = semantic_index(db, file);
+    let index = semantic_index(db, file).load(db);
     let global = FileScopeId::global();
     let use_def_map = index.use_def_map(global);
     let model = SemanticModel::new(db, file);
@@ -122,7 +122,7 @@ pub(crate) fn file_to_refspecs(db: &dyn ProjectDb, file: File) -> FileRefSpecs {
             file,
             db,
             parsed: &parsed,
-            index,
+            index: &index,
             self_nodes,
             model: &model,
             dead_ranges: &dead_ranges,
@@ -150,7 +150,7 @@ pub(crate) fn file_to_refspecs(db: &dyn ProjectDb, file: File) -> FileRefSpecs {
             file,
             db,
             parsed: &parsed,
-            index,
+            index: &index,
             self_nodes,
             model: &model,
             dead_ranges: &dead_ranges,
@@ -324,7 +324,7 @@ struct RefWalker<'a, 'db> {
     db: &'db dyn ProjectDb,
     #[allow(dead_code)]
     parsed: &'a ParsedModuleRef,
-    index: &'a SemanticIndex<'db>,
+    index: &'a SemanticIndexRef<'db>,
     self_nodes: &'a FileNodes,
     model: &'a SemanticModel<'db>,
     /// Statically-dead source regions for this file. Uses originating

--- a/runtime/src/helpers.rs
+++ b/runtime/src/helpers.rs
@@ -113,6 +113,30 @@ pub(crate) fn iter_top_level_classes(
 /// project classes (looked up via ``decl_by_fqname`` + the inverted
 /// ``class_by_selection``) and external classes (resolved through
 /// [`resolve_member_def`]).
+/// Files whose parsed module / semantic index were reloaded on demand
+/// *after* the populate-phase eviction: class-base resolution during
+/// assembly and class-seed relocation during the plugin pass / Python
+/// queries. [`resolve_member_in_file`] — the one chokepoint where
+/// those reloads happen — records every file it touches, and the
+/// post-plugin-pass sweep re-clears exactly this set instead of
+/// probing every project file's salsa slots.
+#[derive(Debug, Default)]
+pub(crate) struct ReloadLog(parking_lot::Mutex<FxHashSet<File>>);
+
+impl ReloadLog {
+    pub(crate) fn record(&self, file: File) {
+        self.0.lock().insert(file);
+    }
+
+    /// Take the recorded set, leaving the log empty so later on-demand
+    /// reloads (post-build Python queries) start a fresh set. Order is
+    /// irrelevant to the caller (clears are idempotent and
+    /// order-independent).
+    pub(crate) fn drain(&self) -> Vec<File> {
+        self.0.lock().drain().collect()
+    }
+}
+
 pub(crate) fn locate_class_seed(
     db: &ProjectDatabase,
     outputs: &BuildOutputs,
@@ -139,7 +163,7 @@ pub(crate) fn locate_class_seed(
     // by construction, not via a query-time string scan.
     let anchor = *outputs.project_files.first()?;
     let (seed_module, seed_name) = fqn.rsplit_once('.')?;
-    resolve_member_def(db, seed_module, seed_name, anchor, 0)
+    resolve_member_def(db, seed_module, seed_name, anchor, 0, &outputs.reload_log)
 }
 
 /// Maximum hops [`resolve_member_def`] / [`classify_base`] follow through
@@ -323,13 +347,14 @@ pub(crate) fn resolve_base_spec(
     local_file: File,
     anchor: File,
     depth: u32,
+    reloads: &ReloadLog,
 ) -> Option<(File, TextRange)> {
     match spec {
         ClassBaseSpec::LocalClass((start, end)) => {
             Some((local_file, TextRange::new((*start).into(), (*end).into())))
         }
         ClassBaseSpec::ModuleMember { module, name } => {
-            resolve_member_def(db, module, name, anchor, depth)
+            resolve_member_def(db, module, name, anchor, depth, reloads)
         }
     }
 }
@@ -344,13 +369,14 @@ pub(crate) fn resolve_member_def(
     name: &str,
     anchor: File,
     depth: u32,
+    reloads: &ReloadLog,
 ) -> Option<(File, TextRange)> {
     if depth > MEMBER_RESOLVE_DEPTH_CAP {
         return None;
     }
     let module_name = ModuleName::new(module)?;
     let module_file = resolve_module(db, anchor, &module_name)?.file(db)?;
-    resolve_member_in_file(db, module_file, name, anchor, depth)
+    resolve_member_in_file(db, module_file, name, anchor, depth, reloads)
 }
 
 /// Resolve `name` in `file`'s global scope to a canonical
@@ -367,13 +393,19 @@ fn resolve_member_in_file(
     name: &str,
     anchor: File,
     depth: u32,
+    reloads: &ReloadLog,
 ) -> Option<(File, TextRange)> {
+    // This load (and `local_member_defs`'s semantic-index load below)
+    // repopulates salsa slots the populate-phase eviction emptied —
+    // record the file so the post-plugin-pass sweep can re-clear
+    // exactly the touched set.
+    reloads.record(file);
     let parsed = parsed_module(db, file).load(db);
     local_member_defs(db, file, name)
         .into_iter()
         .find_map(|def| {
             let spec = classify_name_def(db, file, &parsed, def, name, depth)?;
-            resolve_base_spec(db, &spec, file, anchor, depth + 1)
+            resolve_base_spec(db, &spec, file, anchor, depth + 1, reloads)
         })
 }
 

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -40,7 +40,7 @@ use crate::flag_registry::FlagRegistry;
 use crate::graph::{intern_kind, DeclIndex, NativeGraph, SymbolNode};
 use crate::helpers::{
     file_path_string, is_dunder_name, locate_class_seed, range_key, rel_path, resolve_member_def,
-    CallArgs, MODULE_ALIAS_MARKER, NODE_FLAG_ENTRYPOINT, NODE_FLAG_UNRESOLVED,
+    CallArgs, ReloadLog, MODULE_ALIAS_MARKER, NODE_FLAG_ENTRYPOINT, NODE_FLAG_UNRESOLVED,
 };
 use crate::ingest::emit_visitor_warning;
 use crate::progress::{
@@ -198,6 +198,9 @@ pub(crate) struct BuildOutputs {
     /// (handle → name → this map); Python reads it via
     /// `ProjectContext.facts_for_topic`.
     pub(crate) topic_facts: FxHashMap<String, Vec<crate::native_plugins::plugin_api::Fact>>,
+    /// On-demand reload tracking for the post-plugin-pass eviction
+    /// sweep — see [`crate::helpers::ReloadLog`].
+    pub(crate) reload_log: ReloadLog,
 }
 
 /// Run the three build phases (ingest → hierarchy+imports → references)
@@ -509,6 +512,12 @@ pub(crate) fn build_project_graph(
     // memoized from the parallel pre-populate above so this pass
     // is pure hashmap/index work.
     let t_assemble = std::time::Instant::now();
+    // Records every file the assembly/plugin passes reload on demand
+    // after the populate-phase eviction; the post-plugin-pass sweep
+    // re-clears exactly that set. Created here so assembly's
+    // class-base resolution shares the log with the plugin pass (it
+    // moves into `BuildOutputs` below).
+    let reload_log = ReloadLog::default();
     let assembled = assemble_graph(
         py,
         db,
@@ -518,6 +527,7 @@ pub(crate) fn build_project_graph(
         &peer_pyi_to_py,
         per_file_plugin_ids,
         counters,
+        &reload_log,
     )?;
     let t_assemble_elapsed = t_assemble.elapsed();
     counters.finish_phase(PHASE_ASSEMBLE);
@@ -605,6 +615,7 @@ pub(crate) fn build_project_graph(
         external_base_children,
         children_by_parent,
         topic_facts,
+        reload_log,
     })
 }
 
@@ -687,6 +698,7 @@ fn assemble_graph<'db>(
     peer_pyi_to_py: &FxHashMap<File, File>,
     per_file_plugin_ids: &[crate::native_plugins::PerFilePluginId],
     counters: &Arc<ProgressCounters>,
+    reload_log: &ReloadLog,
 ) -> PyResult<AssembledGraph> {
     // `total_nodes` and `node_offsets` come from the fan-out's per-file
     // node-count prefix sum (see the populate phase). The exact total
@@ -939,7 +951,7 @@ fn assemble_graph<'db>(
         });
         let class_results: Vec<Option<(File, TextRange)>> =
             run_job(&pool, &class_work, |ldb, &(anchor, module, name)| {
-                resolve_member_def(ldb, module, name, anchor, 0)
+                resolve_member_def(ldb, module, name, anchor, 0, reload_log)
             });
 
         // Owned `(module, name, dir)` → resolved-base memo for the
@@ -2545,20 +2557,23 @@ impl ProjectContext {
             this.topic_registry = topic_reg;
         }
 
-        // The plugin pass can still reload individual files on demand:
-        // subclass resolution's `locate_class_seed` resolves an external base
-        // through ty (`resolve_member_def` → the module resolver + use-def
-        // chain), which loads the target module's `parsed_module` and
-        // rebuilds its semantic index's per-scope data to look up the
-        // member's binding, repopulating those files' salsa slots. Clear
-        // them again so the post-build resident set stays at the lean
-        // post-populate level instead of creeping back up — the same memory
-        // win `build_project_graph`'s populate phase secures.
+        // The assembly and plugin passes can still reload individual files
+        // on demand: class-base resolution and subclass resolution's
+        // `locate_class_seed` resolve members through ty
+        // (`resolve_member_def` → the module resolver + use-def chain),
+        // which loads the target module's `parsed_module` and rebuilds its
+        // semantic index's per-scope data, repopulating those files' salsa
+        // slots. Every such reload funnels through
+        // `resolve_member_in_file`, which records the file in
+        // `outputs.reload_log` — so the sweep re-clears exactly the touched
+        // set (typically a handful of base-defining files) instead of
+        // probing every project file's slots, and the post-build resident
+        // set stays at the lean post-populate level.
         {
             let this = slf.borrow(py);
             let outputs_ref = this.outputs.read();
             if let Some(outputs) = outputs_ref.as_ref() {
-                for &file in &outputs.project_files {
+                for file in outputs.reload_log.drain() {
                     ty_python_core::semantic_index(&this.db, file).clear();
                     parsed_module(&this.db, file).clear();
                 }

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -445,16 +445,22 @@ pub(crate) fn build_project_graph(
                                 }
                                 // Every per-file AST consumer for this file has
                                 // now run and memoized its result, so drop the
-                                // parsed AST rather than let it sit resident
-                                // through assembly and the project-wide plugin
-                                // pass — that's the memory win. Assembly, fqname,
-                                // and the class hierarchy read only the cached
+                                // parsed AST *and* the semantic index's per-scope
+                                // analysis data (place tables, use-def maps, AST
+                                // ids) rather than let them sit resident through
+                                // assembly and the project-wide plugin pass —
+                                // that's the memory win, and the index data is
+                                // the larger share of it. Assembly, fqname, and
+                                // the class hierarchy read only the cached
                                 // payloads (`class_bases`, `external_base_children`,
-                                // `children_by_node`), never the AST, so the
-                                // all-ASTs-resident peak never forms. Subclass
-                                // resolution can still pull an individual file's AST
-                                // back on demand to relocate a class seed; that rare
-                                // reload is re-cleared right after the plugin pass.
+                                // `children_by_node`), never the AST or index, so
+                                // the all-files-resident peak never forms. Subclass
+                                // resolution can still pull an individual file's
+                                // AST/index back on demand to relocate a class
+                                // seed — `SemanticIndex::load` lazily rebuilds in
+                                // ingredient-reuse mode — and that rare reload is
+                                // re-cleared right after the plugin pass.
+                                ty_python_core::semantic_index(local_db, file).clear();
                                 parsed_module(local_db, file).clear();
                             });
                             db_tx.send(local_db).expect("channel open");
@@ -2542,10 +2548,10 @@ impl ProjectContext {
         // The plugin pass can still reload individual files on demand:
         // subclass resolution's `locate_class_seed` resolves an external base
         // through ty (`resolve_member_def` → the module resolver + use-def
-        // chain), which loads the target module's `parsed_module` to look up
-        // the member's binding, repopulating those files' salsa
-        // `parsed_module` slots. Clear them
-        // again so the post-build resident set stays at the lean
+        // chain), which loads the target module's `parsed_module` and
+        // rebuilds its semantic index's per-scope data to look up the
+        // member's binding, repopulating those files' salsa slots. Clear
+        // them again so the post-build resident set stays at the lean
         // post-populate level instead of creeping back up — the same memory
         // win `build_project_graph`'s populate phase secures.
         {
@@ -2553,6 +2559,7 @@ impl ProjectContext {
             let outputs_ref = this.outputs.read();
             if let Some(outputs) = outputs_ref.as_ref() {
                 for &file in &outputs.project_files {
+                    ty_python_core::semantic_index(&this.db, file).clear();
                     parsed_module(&this.db, file).clear();
                 }
             }


### PR DESCRIPTION
## What

Evicts each file's semantic index as soon as the per-file extraction queries have memoized their owned payloads, the same way the parsed AST is already evicted — making the (large) per-file indices transient working state instead of revision-lifetime residents. At 200k-file scale the resident indices were ~16 GB of peak memory.

## How

- **Bumps `vendor/ruff` to `lpetre/ruff@ca70e77`**, which makes the semantic index clearable like the parsed module: `semantic_index(db, file)` now returns a cheap handle whose per-scope analysis data (place tables, use-def maps, AST ids) lives behind an `ArcSwapOption`; `load()` returns a guard, `clear()` drops the data, and the next `load()` lazily rebuilds it in ingredient-reuse mode (salsa ingredients — `Definition`, `ScopeId`, … — are retained on the handle and looked up by revision-stable node keys, so rebuilds are safe from whichever query triggers them).
- `file_to_nodes` / `file_to_refspecs` `load()` the guard for the duration of their walk (the guard type carries the per-scope accessors; node-keyed lookups still reach the handle via `Deref`).
- The **populate fan-out** clears each file's semantic index right where it already clears the parsed AST — after every per-file consumer (`file_to_nodes`, `file_to_refspecs`, `file_extraction`, per-file plugin ops) has memoized its owned payload. Assembly, fqname, and the class hierarchy read only those cached payloads, so the all-files-resident peak never forms.
- The **post-plugin-pass sweep** that re-clears on-demand parsed-module reloads (`locate_class_seed` → `resolve_member_def` paths) now re-clears the rebuilt semantic indices too — which also covers anything assemble-time class-base resolution rebuilt.

## Numbers

On the 1500-file synthetic corpus (small files, so the index share is modest — the win scales with index size):

| | before | after |
| --- | ---: | ---: |
| salsa memo fields | 333 MB | 171 MB |
| salsa total | 408 MB | 246 MB |
| RSS after materialize | 629 MB | 461 MB |

## Verification

- Full suite green (713 passed) + `prek run --all-files`.
- Edge/flag inventory bit-for-bit identical on both regression corpora (circular star re-export, duplicate-fqname externals) and the smoke tree.
- Build timing unchanged (apparent slowdowns in raw runs reproduced identically on the old vendor pin — container noise).

## Worth watching

Class-base resolution now pays a lazy index *rebuild* (reuse mode) for each distinct file it reaches into during assemble, where it previously got a salsa cache hit. The rebuild count is bounded by distinct base-defining files (the `(module, name, dir)` memo), but if pass-1's resolve split regresses on class-heavy corpora, that's the spot.

⚠️ Requires `lpetre/ruff@ca70e77` to remain reachable on the fork (the submodule pin references it).

https://claude.ai/code/session_01KYNAs8Y9ctXsM1waLmXEaP

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYNAs8Y9ctXsM1waLmXEaP)_