### PR TITLE
Path table + builder file-identity layer (re_materialize surgery, steps 1–2/5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,14 @@ two versions.
 
 ### Changed
 
+- **Graph-file path table (`FORMAT_VERSION` 2 → 3).** Node paths in the
+  `.dcg` file are stored once in a path table with a per-node `path_idx`
+  indirection, instead of one owned string per node. Old graph files are
+  rejected (rebuild them — no migration logic, as before). Besides
+  shrinking the file, the table gives the format an explicit
+  file-identity axis: the foundation the upcoming `re_materialize`
+  graph-surgery work keys per-file node blocks on.
+
 - **Per-file semantic indices are evicted after extraction.** The vendored
   ty fork now follows the `parsed_module` pattern for the semantic index:
   the salsa query returns a cheap handle, consumers `load()` a guard, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,15 @@ two versions.
 
 ### Changed
 
+- **Builder file-identity layer; populate-side node counting removed.**
+  `GraphBuilder` now records `node_file` (dense node idx → owning-file
+  ordinal, `NO_FILE` for synthetic nodes) and `file_blocks` (per-file
+  contiguous `(start, len)` block) — the in-memory foundation graph
+  surgery will tombstone/append per-file blocks against. The per-file
+  node-count atomics and offset prefix-sum in the populate fan-out are
+  gone: assembly derives the offsets from the cached payload lengths
+  during its existing serial prefetch.
+
 - **Graph-file path table (`FORMAT_VERSION` 2 → 3).** Node paths in the
   `.dcg` file are stored once in a path table with a per-node `path_idx`
   indirection, instead of one owned string per node. Old graph files are

--- a/runtime/src/builder.rs
+++ b/runtime/src/builder.rs
@@ -114,8 +114,24 @@ impl GraphNode {
     }
 }
 
+/// Sentinel file ordinal for nodes that belong to no per-file block:
+/// synthetic externals and plugin-minted nodes. They survive graph
+/// surgery untouched.
+pub(crate) const NO_FILE: u32 = u32::MAX;
+
 pub(crate) struct GraphBuilder {
     pub(crate) nodes: Vec<GraphNode>,
+    /// Dense node idx → owning-file ordinal (position in the build's
+    /// sorted project-file list), [`NO_FILE`] for synthetic nodes.
+    /// In-memory only — never serialized; the on-disk format carries
+    /// per-node `path_idx` instead. Maintained alongside `nodes` by
+    /// every append path so graph surgery can answer "which file owns
+    /// this node" in O(1).
+    pub(crate) node_file: Vec<u32>,
+    /// Per file ordinal: `(start, len)` of the file's contiguous node
+    /// block. Initial builds mint exactly one block per file; surgery
+    /// appends replacement blocks at the tail and tombstones old ones.
+    pub(crate) file_blocks: Vec<(u32, u32)>,
     pub(crate) node_index: FxHashMap<NodeKey, usize>,
     pub(crate) edges: Vec<(usize, usize, u8)>,
     pub(crate) edge_set: FxHashSet<(usize, usize, u8)>,
@@ -168,6 +184,8 @@ impl GraphBuilder {
             reverse_adj: Vec::with_capacity(expected_nodes),
             peer_pyi_to_py: FxHashMap::default(),
             external_nodes: FxHashMap::default(),
+            node_file: Vec::new(),
+            file_blocks: Vec::new(),
         }
     }
 
@@ -178,6 +196,7 @@ impl GraphBuilder {
         }
         let idx = self.nodes.len();
         self.nodes.push(node);
+        self.node_file.push(NO_FILE);
         self.node_index.insert(key, idx);
         self.forward_adj.push(Vec::new());
         self.reverse_adj.push(Vec::new());

--- a/runtime/src/io.rs
+++ b/runtime/src/io.rs
@@ -34,12 +34,20 @@ pub(crate) const MAGIC: &[u8; 8] = b"DEADCSTG";
 /// [`GraphFileBody`]; the loader rejects mismatched values outright
 /// (graphs are cheap to rebuild — no migration logic). Bumped 1 → 2
 /// when the flag registries were added to the body and edge flags
-/// narrowed to `u8`.
-pub(crate) const FORMAT_VERSION: u32 = 2;
+/// narrowed to `u8`; 2 → 3 when node paths moved behind the
+/// [`GraphFileBody::paths`] table indirection.
+pub(crate) const FORMAT_VERSION: u32 = 3;
 
 #[derive(Serialize, Deserialize)]
 struct GraphFileBody {
     metadata: GraphMetadataRecord,
+    /// Path table: every distinct node path, in first-encounter order
+    /// (assembled graphs write nodes file-contiguously, so this is the
+    /// build's file order). [`NodeRecord::path_idx`] indexes into it.
+    /// Besides deduplicating what was one owned string per node, the
+    /// table gives the file an explicit file-identity axis — the
+    /// foundation graph surgery keys per-file node blocks on.
+    paths: Vec<String>,
     nodes: Vec<NodeRecord>,
     edges: Vec<(u32, u32, u8)>,
     /// Node-flag registry (engine built-ins + plugin declarations) so a
@@ -105,7 +113,8 @@ struct GraphMetadataRecord {
 struct NodeRecord {
     fqname: String,
     kind: String,
-    path: String,
+    /// Index into [`GraphFileBody::paths`].
+    path_idx: u32,
     start_line: u32,
     start_column: u32,
     end_line: u32,
@@ -164,29 +173,6 @@ impl GraphMetadata {
     }
 }
 
-fn distinct_files_and_lines<I, F>(nodes: I, get: F) -> (u64, u64)
-where
-    I: IntoIterator,
-    F: Fn(&I::Item) -> (Option<String>, u32),
-{
-    use std::collections::HashMap;
-    let mut max_line: HashMap<String, u32> = HashMap::new();
-    for node in nodes {
-        let (path, end_line) = get(&node);
-        let Some(path) = path else { continue };
-        if path.is_empty() {
-            continue;
-        }
-        let slot = max_line.entry(path).or_insert(0);
-        if end_line > *slot {
-            *slot = end_line;
-        }
-    }
-    let files = max_line.len() as u64;
-    let lines: u64 = max_line.values().map(|v| *v as u64).sum();
-    (files, lines)
-}
-
 /// Write a project graph to `path`.
 ///
 /// `nodes` / `edges` are the same payload `NativeGraph` exposes —
@@ -208,6 +194,8 @@ pub(crate) fn write_graph(
     py: Python<'_>,
 ) -> PyResult<()> {
     let mut node_records: Vec<NodeRecord> = Vec::with_capacity(nodes.len());
+    let mut paths: Vec<String> = Vec::new();
+    let mut path_to_idx: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
     for node in &nodes {
         let n = node.borrow(py);
         let imports = if let Some(imp) = &n.imports {
@@ -220,10 +208,14 @@ pub(crate) fn write_graph(
         } else {
             None
         };
+        let path_idx = *path_to_idx.entry(n.path.clone()).or_insert_with(|| {
+            paths.push(n.path.clone());
+            (paths.len() - 1) as u32
+        });
         node_records.push(NodeRecord {
             fqname: n.fqname.clone(),
             kind: n.kind.to_string(),
-            path: n.path.clone(),
+            path_idx,
             start_line: n.start_line as u32,
             start_column: n.start_column as u32,
             end_line: n.end_line as u32,
@@ -233,9 +225,20 @@ pub(crate) fn write_graph(
         });
     }
 
-    let (file_count, line_count) = distinct_files_and_lines(&node_records, |n: &&NodeRecord| {
-        (Some(n.path.clone()), n.end_line)
-    });
+    // The path table IS the distinct-file set; per-file line counts
+    // fold over `path_idx` instead of re-hashing path strings.
+    let file_count = paths.iter().filter(|p| !p.is_empty()).count() as u64;
+    let mut max_line: Vec<u32> = vec![0; paths.len()];
+    for n in &node_records {
+        let slot = &mut max_line[n.path_idx as usize];
+        *slot = (*slot).max(n.end_line);
+    }
+    let line_count: u64 = paths
+        .iter()
+        .zip(&max_line)
+        .filter(|(p, _)| !p.is_empty())
+        .map(|(_, &l)| l as u64)
+        .sum();
 
     let created_at = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -251,6 +254,7 @@ pub(crate) fn write_graph(
             line_count,
             user_meta: meta,
         },
+        paths,
         nodes: node_records,
         edges,
         node_flag_registry: node_flag_registry
@@ -322,6 +326,7 @@ pub(crate) fn read_graph(
 
     let GraphFileBody {
         metadata,
+        paths,
         nodes,
         edges,
         node_flag_registry,
@@ -342,10 +347,20 @@ pub(crate) fn read_graph(
             }
             None => None,
         };
+        let path = paths
+            .get(rec.path_idx as usize)
+            .ok_or_else(|| {
+                PyValueError::new_err(format!(
+                    "{path:?}: node path_idx {} out of range ({} paths)",
+                    rec.path_idx,
+                    paths.len()
+                ))
+            })?
+            .clone();
         let node = SymbolNode {
             fqname: rec.fqname,
             kind,
-            path: rec.path,
+            path,
             start_line: rec.start_line as usize,
             start_column: rec.start_column as usize,
             end_line: rec.end_line as usize,

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -3,7 +3,6 @@
 //! Salsa-backed analysis context that the rest of the crate operates on.
 
 use std::str::FromStr;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use parking_lot::lock_api::RawRwLockRecursive;
@@ -347,15 +346,6 @@ pub(crate) fn build_project_graph(
     // classification) hits a warm salsa cache instead of paying
     // the ~100ms walk inline.
     let t_populate = std::time::Instant::now();
-    // Per-file node counts, captured during the fan-out: each worker
-    // records its file's node total at the file's (sorted) position.
-    // Prefix-summed into per-file global-index offsets below, so the
-    // assembly pass assigns each node a deterministic index
-    // (`offset[file] + local_idx`) instead of a serial running
-    // counter — the seam for a future parallel assembly.
-    let node_counts: Vec<AtomicUsize> = (0..project_files.len())
-        .map(|_| AtomicUsize::new(0))
-        .collect();
     {
         // Per-file work-stealing on rayon: pre-clone N salsa
         // snapshots into a bounded MPMC channel; each task pulls a
@@ -386,7 +376,6 @@ pub(crate) fn build_project_graph(
         // commit message for the hazard.
         let dist_db: ProjectDatabase = db.clone();
         let files_ref: &[File] = &project_files;
-        let counts_ref: &[AtomicUsize] = &node_counts;
         let per_file_ids_ref: &[crate::native_plugins::PerFilePluginId] = per_file_plugin_ids;
         let counters_ref = Arc::clone(counters);
         let run_populate = move || {
@@ -421,14 +410,7 @@ pub(crate) fn build_project_graph(
                         s.spawn(move |_| {
                             let local_db = db_rx.recv().expect("snapshot available");
                             local_db.attach(|local_db| {
-                                // Record this file's node count for the offset
-                                // prefix-sum. `nodes` and `refs` are parallel
-                                // arrays, so `nodes.len()` is exactly what the
-                                // assembly mint loop iterates for this file.
-                                counts_ref[file_idx].store(
-                                    file_to_nodes(local_db, file).nodes.len(),
-                                    Ordering::Relaxed,
-                                );
+                                let _ = file_to_nodes(local_db, file);
                                 let _ = file_to_refspecs(local_db, file);
                                 // Owned per-file facts for the project-wide
                                 // plugin queries. Warmed here, while the AST
@@ -491,18 +473,6 @@ pub(crate) fn build_project_graph(
     progress.imports.finish_and_clear();
     progress.references.finish_and_clear();
 
-    // Exclusive prefix-sum the per-file node counts into per-file
-    // global-index offsets: file `i`'s nodes occupy global indices
-    // `[offset[i], offset[i] + count[i])`. The running total after the
-    // last file is the exact graph node population, which sizes the
-    // builder's payload region.
-    let mut node_offsets: Vec<usize> = Vec::with_capacity(node_counts.len());
-    let mut total_nodes: usize = 0;
-    for count in &node_counts {
-        node_offsets.push(total_nodes);
-        total_nodes += count.load(Ordering::Relaxed);
-    }
-
     counters.start_phase(PHASE_ASSEMBLE, Some(project_files.len()));
 
     // Assembly pass: assign global graph node indices to each
@@ -522,8 +492,6 @@ pub(crate) fn build_project_graph(
         py,
         db,
         &project_files,
-        &node_offsets,
-        total_nodes,
         &peer_pyi_to_py,
         per_file_plugin_ids,
         counters,
@@ -693,45 +661,11 @@ fn assemble_graph<'db>(
     py: Python<'_>,
     db: &'db ProjectDatabase,
     project_files: &[File],
-    node_offsets: &[usize],
-    total_nodes: usize,
     peer_pyi_to_py: &FxHashMap<File, File>,
     per_file_plugin_ids: &[crate::native_plugins::PerFilePluginId],
     counters: &Arc<ProgressCounters>,
     reload_log: &ReloadLog,
 ) -> PyResult<AssembledGraph> {
-    // `total_nodes` and `node_offsets` come from the fan-out's per-file
-    // node-count prefix sum (see the populate phase). The exact total
-    // sizes the hashmaps that grow one-per-node (ref_to_global,
-    // global_index, decl_by_name_range) and skip rehashing entirely.
-    // Every file's index 0 is its synthetic module node and everything
-    // else is a decl, so `decls = nodes - 1` per file — an upper bound
-    // (star-statement nodes aren't decls either) that's fine for
-    // capacity reservation.
-    let total_decls = total_nodes.saturating_sub(project_files.len());
-
-    let mut builder = GraphBuilder::with_capacity(total_nodes);
-    // Pre-size the payload region so Pass 1 can place each node at its
-    // offset-derived global index instead of appending. The offsets
-    // partition [0, total_nodes), so every slot is written exactly once.
-    builder.prefill_payload_region(total_nodes);
-    let mut global_index: DeclIndex =
-        FxHashMap::with_capacity_and_hasher(total_decls, Default::default());
-    let mut module_nodes_by_file: FxHashMap<File, usize> =
-        FxHashMap::with_capacity_and_hasher(project_files.len(), Default::default());
-    // class_by_selection only sees class decls — typically a small
-    // fraction of all decls, so size to a modest fraction (1/4) to
-    // dodge initial growth without wasting space.
-    let mut class_by_selection: FxHashMap<(File, (u32, u32)), usize> =
-        FxHashMap::with_capacity_and_hasher(total_decls / 4 + 1, Default::default());
-    let mut decl_by_name_range: FxHashMap<(File, (u32, u32)), usize> =
-        FxHashMap::with_capacity_and_hasher(total_decls, Default::default());
-    let mut ref_to_global: FxHashMap<NodeRef, usize> =
-        FxHashMap::with_capacity_and_hasher(total_nodes, Default::default());
-    let mut local_to_global: FxHashMap<(File, u32), usize> =
-        FxHashMap::with_capacity_and_hasher(total_nodes, Default::default());
-    let mut all_warnings: Vec<String> = Vec::new();
-
     // Pass 1: node mint.
     //
     // Mirrors pass 2's shape so the alloc-heavy work runs without the
@@ -773,7 +707,8 @@ fn assemble_graph<'db>(
         twin_payload: Option<&'db FileNodes>,
     }
     let mut mints: Vec<FileMint<'db>> = Vec::with_capacity(project_files.len());
-    for (file_pos, &file) in project_files.iter().enumerate() {
+    let mut total_nodes: usize = 0;
+    for &file in project_files.iter() {
         let path_str = file_path_string(db, file);
         let is_stub = path_str.ends_with(".pyi");
         let twin_payload = if is_stub {
@@ -783,14 +718,61 @@ fn assemble_graph<'db>(
         } else {
             None
         };
+        let payload = file_to_nodes(db, file);
         mints.push(FileMint {
             file,
-            base: node_offsets[file_pos],
-            payload: file_to_nodes(db, file),
+            base: total_nodes,
+            payload,
             path_str,
             is_stub,
             twin_payload,
         });
+        total_nodes += payload.nodes.len();
+    }
+
+    // `total_nodes` is the running prefix sum over the per-file
+    // payload lengths the mints loop just walked — each file's nodes
+    // occupy the contiguous block `[base, base + len)`, which is also
+    // recorded on the builder (`file_blocks` / `node_file`) as the
+    // file-identity layer graph surgery operates on. The exact total
+    // sizes the hashmaps that grow one-per-node (ref_to_global,
+    // global_index, decl_by_name_range) and skip rehashing entirely.
+    // Every file's index 0 is its synthetic module node and everything
+    // else is a decl, so `decls = nodes - 1` per file — an upper bound
+    // (star-statement nodes aren't decls either) that's fine for
+    // capacity reservation.
+    let total_decls = total_nodes.saturating_sub(project_files.len());
+
+    let mut builder = GraphBuilder::with_capacity(total_nodes);
+    // Pre-size the payload region so Pass 1 can place each node at its
+    // offset-derived global index instead of appending. The offsets
+    // partition [0, total_nodes), so every slot is written exactly once.
+    builder.prefill_payload_region(total_nodes);
+    let mut global_index: DeclIndex =
+        FxHashMap::with_capacity_and_hasher(total_decls, Default::default());
+    let mut module_nodes_by_file: FxHashMap<File, usize> =
+        FxHashMap::with_capacity_and_hasher(project_files.len(), Default::default());
+    // class_by_selection only sees class decls — typically a small
+    // fraction of all decls, so size to a modest fraction (1/4) to
+    // dodge initial growth without wasting space.
+    let mut class_by_selection: FxHashMap<(File, (u32, u32)), usize> =
+        FxHashMap::with_capacity_and_hasher(total_decls / 4 + 1, Default::default());
+    let mut decl_by_name_range: FxHashMap<(File, (u32, u32)), usize> =
+        FxHashMap::with_capacity_and_hasher(total_decls, Default::default());
+    let mut ref_to_global: FxHashMap<NodeRef, usize> =
+        FxHashMap::with_capacity_and_hasher(total_nodes, Default::default());
+    let mut local_to_global: FxHashMap<(File, u32), usize> =
+        FxHashMap::with_capacity_and_hasher(total_nodes, Default::default());
+    let mut all_warnings: Vec<String> = Vec::new();
+
+    // File-identity layer: dense idx → owning-file ordinal plus the
+    // per-file contiguous block, recorded on the builder so graph
+    // surgery can tombstone/append per-file blocks without scanning.
+    builder.node_file = vec![crate::builder::NO_FILE; total_nodes];
+    for (ordinal, mint) in mints.iter().enumerate() {
+        let n = mint.payload.nodes.len();
+        builder.file_blocks.push((mint.base as u32, n as u32));
+        builder.node_file[mint.base..mint.base + n].fill(ordinal as u32);
     }
 
     // Pass 0: serial-only resolution prep — fetch the spec payloads
@@ -1235,7 +1217,7 @@ fn assemble_graph<'db>(
     // directly. Only `Binding`-role refs are eligible (one flag per
     // alias; a use through it resolves or drops silently).
     for (pos, payload) in spec_payloads.iter().enumerate() {
-        let base = node_offsets[pos];
+        let base = mints[pos].base;
         let ids = &spec_ids[pos];
         for (i, spec) in payload.specs.iter().enumerate() {
             let Target::Member(m) = &spec.target else {
@@ -1289,7 +1271,7 @@ fn assemble_graph<'db>(
                 .par_iter()
                 .enumerate()
                 .flat_map_iter(|(pos, payload)| {
-                    let base = node_offsets[pos];
+                    let base = mints[pos].base;
                     let ids = &spec_ids_ref[pos];
                     let file = project_files[pos];
                     payload.specs.iter().enumerate().flat_map(move |(i, spec)| {


### PR DESCRIPTION
## What

Steps 1–2 of the `re_materialize` graph-surgery series, one commit each.

### Commit 1 — graph-file path table (`FORMAT_VERSION` 2 → 3)

The `.dcg` body gains a **path table** (every distinct node path, first-encounter order — the build's file order) and `NodeRecord` stores a `u32 path_idx` instead of one owned `String` per node. Version-2 files are rejected outright, per the format's no-migration policy. Besides the dedup, the table gives the format an explicit file-identity axis; metadata `file_count`/`line_count` now fold over it, retiring `distinct_files_and_lines`. `SymbolNode.path` stays a plain string — no public-surface change.

### Commit 2 — builder file-identity layer; populate-side counting removed

`GraphBuilder` gains the in-memory layer surgery operates on:

- `node_file: Vec<u32>` — dense node idx → owning-file ordinal (`NO_FILE` sentinel for externals / plugin-minted nodes, maintained by every append path);
- `file_blocks: Vec<(u32, u32)>` — per-file contiguous `(start, len)` block.

Initial builds mint one block per file; surgery will **append replacement blocks at the tail and tombstone old ones**, so untouched files' dense ids — and therefore all their edges — never move or remap. Nothing new is serialized: per-node `path_idx` (commit 1) already makes blocks derivable on load. The packed `(file, local)` id exists only as in-memory bookkeeping, never in the format.

The populate fan-out's per-file node-count `AtomicUsize` array and offset prefix-sum are deleted — assembly's serial prefetch already fetches every payload, so the per-file bases fall out of a running sum over payload lengths right where pass 1 needs them.

## Verification

- Full suite green (713 passed) + `prek run --all-files`, after each commit.
- Edge/flag inventory bit-for-bit identical on both regression corpora and the smoke tree.
- Real `.dcg` round-trip (`build` → `analyze --graph`) on the 1500-file / 984k-edge corpus.

## Series

1. **(here)** path indirection in the file format
2. **(here)** in-memory file-identity layer (sparse-id groundwork)
3. `re_materialize` early-return on zero change
4. graph-surgery function (tombstone + append), in shadow against full assemble
5. drop the shadow

https://claude.ai/code/session_01KYNAs8Y9ctXsM1waLmXEaP