### PR TITLE
Add a synthetic at-scale corpus generator + materialize benchmark

### DIFF
--- a/scripts/bench_materialize.py
+++ b/scripts/bench_materialize.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+"""Time ``Analysis(corpus).materialize_all()`` on a generated corpus.
+
+Pair with ``scripts/gen_bench_corpus.py``. Reports total wall time, the
+per-phase breakdown the rust build already tracks (enumerate / populate /
+assemble / fqname index / plugins), node + edge counts, and peak RSS, so
+the build is hill-climbable phase by phase.
+
+The per-phase numbers come from ``ctx.read_progress_snapshot()`` (atomic
+counters the build stamps as it runs) -- free to read, no allocation.
+Exact node/edge counts come from the same snapshot when present and fall
+back to ``len(ctx.nodes())`` / ``len(ctx.edges())`` only when ``--count``
+is passed (those allocate the full Python lists -- many GB at full scale,
+so they default off).
+
+``--incremental`` additionally times a zero-change rescan and a
+one-file-change re_materialize on the same ctx. NOTE: the corpus must
+live OUTSIDE this repo (see gen_bench_corpus.py) or the rescan re-roots
+at the repo and rebuilds the wrong file set; this script resolves the
+path to absolute, but it cannot move it out of a nesting project.
+
+Usage::
+
+    uv run python scripts/gen_bench_corpus.py --out /tmp/c --packages 4 \\
+        --modules-per-package 8
+    uv run python scripts/bench_materialize.py --corpus /tmp/c --count
+
+    # full-scale cold + incremental, with the rust per-phase line
+    DEAD_CST_TIMING=1 uv run python scripts/bench_materialize.py \\
+        --corpus ~/.cache/dead-cst-bench/corpus --incremental
+"""
+
+from __future__ import annotations
+
+import argparse
+import resource
+import statistics
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _bench_common import file_count, require_native  # noqa: E402
+
+from dead_cst import Analysis  # noqa: E402
+from dead_cst import _native as native  # noqa: E402
+
+# read_progress_snapshot phases, in build order, with the snapshot key
+# prefix each one stamps its elapsed-microseconds / item-total under.
+_PHASES = [
+    ("enumerate", "enum"),
+    ("populate", "populate"),
+    ("assemble", "assemble"),
+    ("fqname idx", "fqname"),
+    ("plugins", "plugins"),
+]
+
+
+def _maxrss_bytes() -> int:
+    """Peak resident set size of this process. ``ru_maxrss`` is bytes on
+    macOS and kilobytes on Linux."""
+    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return rss if sys.platform == "darwin" else rss * 1024
+
+
+def _all_builtin_plugins() -> list:
+    # Mirror the set bench_parallel_plugins.py uses; resolved through the
+    # native registry the CLI drives.
+    names = [
+        "main_block",
+        "init_subclass",
+        "server_config",
+        "unittest",
+        "flask",
+        "fastapi",
+        "typer",
+        "cyclopts",
+        "slack_bolt",
+        "fastmcp",
+        "celery",
+        "click",
+        "mock_patch",
+        "discordpy",
+        "pytest",
+        "project_scripts",
+        "dynamic_import_fallback",
+    ]
+    return [native._builtin_native_plugin(n) for n in names]
+
+
+def _cold_build(corpus: Path, plugins: list) -> tuple[float, Analysis, native.ProjectContext]:
+    analysis = Analysis(corpus, plugins=plugins)
+    start = time.perf_counter()
+    ctx = analysis.materialize_all()
+    wall = time.perf_counter() - start
+    return wall, analysis, ctx
+
+
+def _incremental(
+    analysis: Analysis, ctx: native.ProjectContext, corpus: Path
+) -> tuple[float, float, int, int]:
+    """Time two re_materialize passes on the already-built ctx and prove
+    the edit registered.
+
+    Zero-change: an explicit rescan with nothing touched on disk -- a
+    pure salsa cache hit for per-file work (the assemble + fqname passes
+    still rebuild the whole graph from cached per-file outputs).
+
+    One-file change: append a top-level decl to one module, then
+    ``detect_changes()`` + re_materialize. NOTE: a targeted
+    ``ChangeEvent.changed(path)`` does *not* invalidate the file in this
+    ty integration (verified -- the node count doesn't move); only the
+    rescan path (which ``detect_changes`` returns) picks edits up, so
+    salsa re-parses just the changed file under a full-project re-stat.
+
+    Returns ``(zero_s, one_s, nodes_before, nodes_after)``; the node
+    delta proves the edit took. Restores the file afterwards."""
+
+    def _nodes() -> int:
+        return ctx.read_progress_snapshot()["fqname_total"]
+
+    # Zero-change: force a rebuild with nothing actually modified.
+    t = time.perf_counter()
+    analysis.re_materialize([native.ChangeEvent.rescan()])
+    zero = time.perf_counter() - t
+    nodes_before = _nodes()
+
+    # One-file change: append a fresh top-level decl, then autodetect.
+    target = (corpus / "pkg_0000" / "mod_0000.py").resolve()
+    original = target.read_text()
+    try:
+        target.write_text(original + "\n\ndef _bench_touch():\n    pass\n")
+        t = time.perf_counter()
+        analysis.re_materialize(ctx.detect_changes())
+        one = time.perf_counter() - t
+        nodes_after = _nodes()
+    finally:
+        target.write_text(original)
+    return zero, one, nodes_before, nodes_after
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--corpus", type=Path, required=True, help="Generated corpus dir.")
+    parser.add_argument("--repeats", type=int, default=1, help="Timed runs; reports best.")
+    parser.add_argument(
+        "--plugins",
+        choices=("none", "all"),
+        default="none",
+        help="Run with no plugins (pure build) or the full built-in set.",
+    )
+    parser.add_argument(
+        "--count",
+        action="store_true",
+        help="Also materialize ctx.nodes()/edges() for an exact count "
+        "(allocates the full lists -- many GB at full scale).",
+    )
+    parser.add_argument(
+        "--incremental",
+        action="store_true",
+        help="After the cold build, time a zero-change rescan and a "
+        "one-file-change re_materialize on the same ctx.",
+    )
+    args = parser.parse_args()
+
+    require_native()
+    if not args.corpus.is_dir():
+        sys.exit(f"ERROR: corpus dir not found: {args.corpus}")
+    # Resolve to absolute: a relative root makes ty's rescan re-walk
+    # rediscover zero files, so an incremental re_materialize silently
+    # rebuilds to an empty graph. Absolute roots are unaffected.
+    args.corpus = args.corpus.resolve()
+
+    files = file_count(args.corpus)
+    plugins = _all_builtin_plugins() if args.plugins == "all" else []
+
+    walls: list[float] = []
+    analysis: Analysis | None = None
+    ctx: native.ProjectContext | None = None
+    for i in range(args.repeats):
+        wall, analysis, ctx = _cold_build(args.corpus, plugins)
+        walls.append(wall)
+        print(f"  cold run {i + 1}/{args.repeats}: {wall:.2f}s", flush=True)
+
+    assert ctx is not None
+    # Capture the cold-build counters before any re_materialize resets them.
+    snap = ctx.read_progress_snapshot()
+    best = min(walls)
+
+    zero_wall = one_wall = None
+    nodes_before = nodes_after = 0
+    if args.incremental:
+        assert analysis is not None
+        zero_wall, one_wall, nodes_before, nodes_after = _incremental(analysis, ctx, args.corpus)
+        print(f"  zero-change re_materialize:     {zero_wall:.2f}s", flush=True)
+        print(
+            f"  one-file-change re_materialize: {one_wall:.2f}s "
+            f"(nodes {nodes_before:,} -> {nodes_after:,})",
+            flush=True,
+        )
+
+    peak = _maxrss_bytes()
+
+    # Counts: the fqname phase walks every node, so fqname_total is the
+    # node count (free). No phase counts edges, so an exact edge total
+    # needs --count (which allocates the full edge list).
+    nodes = snap.get("fqname_total") or 0
+    edges = 0
+    if args.count:
+        nodes = len(ctx.nodes())
+        edges = len(ctx.edges())
+
+    print(f"\n  corpus      {args.corpus}")
+    print(f"  files       {files:,}")
+    print(f"  nodes       {nodes:,}{'' if args.count else '  (fqname_total; --count for exact)'}")
+    if args.count:
+        print(f"  edges       {edges:,}")
+        print(f"  nodes/file  {nodes / files:.1f}")
+        print(f"  edges/file  {edges / files:.1f}")
+    print(f"  plugins     {args.plugins}")
+    print(f"  peak RSS    {peak / 1e9:.2f} GB")
+    print(f"  best wall   {best:.2f}s  (median {statistics.median(walls):.2f}s of {args.repeats})")
+    if files and best:
+        print(f"  throughput  {files / best:,.0f} files/s")
+    if zero_wall is not None:
+        print(f"  re_mat 0chg {zero_wall:.2f}s  ({best / zero_wall:.1f}x faster than cold)")
+        delta = nodes_after - nodes_before
+        print(
+            f"  re_mat 1chg {one_wall:.2f}s  ({best / one_wall:.1f}x faster than cold; "
+            f"+{delta} node{'s' if delta != 1 else ''} from the edit)"
+        )
+
+    print("\n  per-phase (best-effort, from last run's snapshot):")
+    print(f"    {'phase':<12}{'elapsed':>10}{'items':>14}")
+    for label, key in _PHASES:
+        us = snap.get(f"{key}_elapsed_us", 0)
+        total = snap.get(f"{key}_total", 0)
+        print(f"    {label:<12}{us / 1e6:>9.2f}s{total:>14,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gen_bench_corpus.py
+++ b/scripts/gen_bench_corpus.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python
+"""Generate a synthetic Python corpus for at-scale materialize benchmarks.
+
+The goal is a *reproducible*, *tunable* tree that drives the rust build
+(parse -> ty resolve -> assemble -> fqname index) at a chosen node/edge
+scale, so ``scripts/bench_materialize.py`` can time it and Claude can
+hill-climb the numbers.
+
+Layout: a flat set of importable top-level packages under one root::
+
+    corpus/
+      pkg_0000/__init__.py
+      pkg_0000/mod_0000.py
+      pkg_0000/mod_0001.py
+      ...
+      pkg_0599/mod_0332.py
+      _manifest.json
+
+The root is on ty's search path (``Analysis`` keeps ``project_root``
+there), so every ``from pkg_XXXX import mod_YYYY`` resolves and each call
+into an imported module mints a cross-file reachability edge. That is
+what makes the edge count scale with ``--calls-per-decl`` rather than
+collapsing to import-alias edges only.
+
+Output is a pure function of the knobs (no RNG that affects structure),
+so the same flags always produce byte-identical files -- a regenerate is
+a no-op for salsa and for diffing.
+
+Examples::
+
+    # tiny, for calibrating the node/edge yield of the template
+    uv run python scripts/gen_bench_corpus.py --out /tmp/c --packages 4 \\
+        --modules-per-package 8
+
+    # full target -- the defaults are calibrated to hit it: ~200k files
+    # in 600 packages, ~4.0M nodes, ~20.8M edges (~19.8 nodes/file,
+    # ~104 edges/file). Plan for ~15 GB of RAM and a few minutes.
+    uv run python scripts/gen_bench_corpus.py \\
+        --out ~/.cache/dead-cst-bench/corpus \\
+        --packages 600 --modules-per-package 333
+
+IMPORTANT: generate the corpus OUTSIDE the dead-cst repo (e.g. under
+``~/.cache``, not ``target/``). ty's rescan-based re_materialize re-runs
+project discovery and walks up to the nearest ``pyproject.toml``; a
+corpus nested inside this repo gets re-rooted at the repo on rescan and
+the incremental rebuild sees the wrong file set (silently empty / tiny).
+A corpus outside any project rebuilds correctly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import time
+from pathlib import Path
+
+
+def _import_targets(
+    p: int, m: int, packages: int, modules: int, count: int
+) -> list[tuple[int, int]]:
+    """Pick ``count`` distinct ``(pkg, module)`` import targets for module
+    ``(p, m)``, never itself. Roughly half same-package siblings (cheap,
+    in-tree resolution) and half cross-package (stresses ty's module
+    resolver across the search path). Deterministic in the indices."""
+    targets: list[tuple[int, int]] = []
+    seen = {(p, m)}
+    for k in range(count):
+        if k % 2 == 0 and modules > 1:
+            # same-package sibling, strided so it isn't always m+1
+            tm = (m + 1 + k * 7) % modules
+            tp = p
+        else:
+            # cross-package, spread across the whole corpus
+            tp = (p + 1 + k * 13) % packages
+            tm = (m + k * 5) % modules
+        # nudge off any collision (incl. self) deterministically
+        guard = 0
+        while (tp, tm) in seen and guard < modules:
+            tm = (tm + 1) % modules
+            guard += 1
+        seen.add((tp, tm))
+        targets.append((tp, tm))
+    return targets
+
+
+def _module_source(
+    p: int,
+    m: int,
+    packages: int,
+    modules: int,
+    decls: int,
+    imports: int,
+    calls: int,
+) -> str:
+    """Render one module: ``imports`` aliased module imports followed by
+    ``decls`` top-level decls (functions, with ~1 in 5 a class). Every
+    function/method body makes ``calls`` cross-module calls through the
+    aliases, each to a function that is guaranteed to exist in the target
+    (all modules share the same decl layout)."""
+    fn_idx = [d for d in range(decls) if d % 5 != 4]  # the rest are classes
+    if not fn_idx:
+        fn_idx = [0]
+
+    targets = _import_targets(p, m, packages, modules, imports)
+    lines: list[str] = []
+    for k, (tp, tm) in enumerate(targets):
+        lines.append(f"from pkg_{tp:04d} import mod_{tm:04d} as _i{k}")
+    lines.append("")
+
+    n_imports = len(targets)
+    for d in range(decls):
+        if d % 5 == 4:
+            lines.append(f"class C_{d}:")
+            lines.append("    def run(self):")
+            for c in range(calls):
+                k = (d * 3 + c) % n_imports if n_imports else 0
+                t = fn_idx[(d + c) % len(fn_idx)]
+                lines.append(f"        _i{k}.fn_{t}()")
+            if calls == 0:
+                lines.append("        pass")
+        else:
+            lines.append(f"def fn_{d}():")
+            for c in range(calls):
+                k = (d * 3 + c) % n_imports if n_imports else 0
+                t = fn_idx[(d + c) % len(fn_idx)]
+                lines.append(f"    _i{k}.fn_{t}()")
+            if calls == 0:
+                lines.append("    pass")
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def generate(
+    out: Path,
+    *,
+    packages: int,
+    modules_per_package: int,
+    decls_per_module: int,
+    imports_per_module: int,
+    calls_per_decl: int,
+    clean: bool,
+) -> dict[str, object]:
+    if clean and out.exists():
+        shutil.rmtree(out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    files = 0
+    for p in range(packages):
+        pkg = out / f"pkg_{p:04d}"
+        pkg.mkdir(exist_ok=True)
+        (pkg / "__init__.py").write_text("")
+        files += 1
+        for m in range(modules_per_package):
+            src = _module_source(
+                p,
+                m,
+                packages,
+                modules_per_package,
+                decls_per_module,
+                imports_per_module,
+                calls_per_decl,
+            )
+            (pkg / f"mod_{m:04d}.py").write_text(src)
+            files += 1
+
+    manifest = {
+        "packages": packages,
+        "modules_per_package": modules_per_package,
+        "decls_per_module": decls_per_module,
+        "imports_per_module": imports_per_module,
+        "calls_per_decl": calls_per_decl,
+        "files": files,
+    }
+    (out / "_manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    return manifest
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--out", type=Path, required=True, help="Corpus output directory.")
+    parser.add_argument("--packages", type=int, default=600)
+    parser.add_argument("--modules-per-package", type=int, default=333)
+    parser.add_argument(
+        "--decls-per-module",
+        type=int,
+        default=13,
+        help="Top-level decls per module (~1 in 5 is a class) -- the main "
+        "node-count knob. nodes/file ~= 1 module + imports + decls. The "
+        "default (13, with 6 imports) yields ~19.8 nodes/file.",
+    )
+    parser.add_argument("--imports-per-module", type=int, default=6)
+    parser.add_argument(
+        "--calls-per-decl",
+        type=int,
+        default=2,
+        help="Cross-module calls per decl body -- the main edge-count knob. "
+        "The default (2) yields ~103 edges/file (~5.2 edges/node).",
+    )
+    parser.add_argument(
+        "--no-clean",
+        dest="clean",
+        action="store_false",
+        help="Write into an existing dir instead of wiping it first.",
+    )
+    args = parser.parse_args()
+
+    start = time.perf_counter()
+    manifest = generate(
+        args.out,
+        packages=args.packages,
+        modules_per_package=args.modules_per_package,
+        decls_per_module=args.decls_per_module,
+        imports_per_module=args.imports_per_module,
+        calls_per_decl=args.calls_per_decl,
+        clean=args.clean,
+    )
+    elapsed = time.perf_counter() - start
+    print(f"wrote {manifest['files']:,} files to {args.out} in {elapsed:.1f}s")
+    print(f"knobs: {json.dumps(manifest)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Tooling to hill-climb build performance at a controlled, reproducible scale — a synthetic corpus generator plus a materialize benchmark. No library/runtime changes.

- **`scripts/gen_bench_corpus.py`** — writes a deterministic tree of importable top-level packages whose modules import + call across each other, so the **edge** count scales with real cross-file reachability (not just import-alias edges). Knobs (`--packages`, `--modules-per-package`, `--decls-per-module`, `--imports-per-module`, `--calls-per-decl`) tune the yield; defaults are calibrated to **~200k files / ~4.0M nodes / ~20.8M edges** at `600 × 333`.
- **`scripts/bench_materialize.py`** — times `Analysis(corpus).materialize_all()`, reports node/edge counts + peak RSS, and breaks the build down **per phase** via `read_progress_snapshot()`. `--incremental` also times a zero-change rescan and a one-file-change `re_materialize` on the same ctx (proving the edit registered via the node delta). Pair with `DEAD_CST_TIMING=1` for the rust per-phase line. `--plugins all` to include the built-in plugin pass.

## Measured (full scale, 600×333, no plugins)
- files 200,400 · nodes 3,996,600 · edges 20,779,200
- cold ~120–155s wall (**populate is ~86%** — parse + ty resolve), assemble ~16s, fqname ~4s; peak RSS ~14 GB
- zero-change re_materialize ~40s, one-file ~40s — i.e. **`assemble`/`fqname` fully rebuild every time** (not incremental); they're the incremental floor, not re-parsing

## Notes for users (also in the script docstrings)
- **Generate the corpus outside this repo** (default `~/.cache/dead-cst-bench/corpus`). A rescan-based `re_materialize` re-runs ty project discovery and walks up to the nearest `pyproject.toml`; nested in `target/`, it re-roots at the repo and rebuilds the wrong file set. The runner resolves the path to absolute but can't move it out of a nesting project.
- Generated corpora are not committed.

## Test plan
- [x] `uv run ruff check` / `ruff format --check` clean on both scripts.
- [x] Ran end-to-end at tiny / medium / full scale (cold + `--incremental`); node/edge counts and per-phase timings as above.
- [ ] N/A — tooling only, no package code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)