### PR TITLE
Per-file conversions: click (pure) + dispatch-app/discord.py handler detection

### DIFF
--- a/runtime/src/builder.rs
+++ b/runtime/src/builder.rs
@@ -717,49 +717,55 @@ pub(crate) fn apply_prepared_batch(
     // ``PyRef`` is not.
     let outputs_lock = ctx.borrow(py).outputs.clone();
     py.allow_threads(move || -> PyResult<()> {
+        use rayon::prelude::*;
         let mut outputs = outputs_lock.write();
         let outputs = outputs
             .as_mut()
             .ok_or_else(|| not_materialized("apply_prepared_batch"))?;
+        let len = outputs.builder.nodes.len();
+        // Split the batch: edges apply in registration order through
+        // `add_edge` (which dedups); flag ORs are gathered for a separate
+        // sorted pass. A plugin like pytest flags every testcase / fixture —
+        // millions of decls — and `nodes[idx].flags |= bits` at a random `idx`
+        // into the multi-GB node array is cache-miss-bound, so that scatter,
+        // not the OR, is the cost. Flag ORs are commutative and idempotent, so
+        // applying them sorted by index — a monotonic, prefetch-friendly
+        // sweep — is byte-identical to the in-order scatter.
+        let mut flag_ops: Vec<(usize, u32)> = Vec::new();
         for op in prepared {
-            apply_prepared(outputs, op)?;
+            match op {
+                PreparedOp::Edge {
+                    src_idx,
+                    dst_idx,
+                    flags,
+                } => {
+                    check_idx_in_range(len, src_idx, "PreparedOp::Edge", "src_idx")?;
+                    check_idx_in_range(len, dst_idx, "PreparedOp::Edge", "dst_idx")?;
+                    outputs.builder.add_edge(src_idx, dst_idx, flags);
+                }
+                PreparedOp::Entrypoint { decl_idx } => {
+                    check_idx_in_range(len, decl_idx, "PreparedOp::Entrypoint", "decl_idx")?;
+                    // Flag the decl itself an entrypoint seed — no synthetic
+                    // marker node, since reachability seeds off the flag, not
+                    // an edge from a marker.
+                    flag_ops.push((decl_idx, NODE_FLAG_ENTRYPOINT));
+                }
+                PreparedOp::FlagDecl { decl_idx, flags } => {
+                    check_idx_in_range(len, decl_idx, "PreparedOp::FlagDecl", "decl_idx")?;
+                    flag_ops.push((decl_idx, flags));
+                }
+            }
+        }
+        // Parallel sort, then a sequential OR sweep that walks the node array
+        // in index order (so consecutive flagged decls hit warm cache lines).
+        // The result is order-independent, so this stays byte-identical.
+        flag_ops.par_sort_unstable_by_key(|&(idx, _)| idx);
+        let nodes = &mut outputs.builder.nodes;
+        for (idx, bits) in flag_ops {
+            nodes[idx].flags |= bits;
         }
         Ok(())
     })
-}
-
-fn apply_prepared(
-    outputs: &mut crate::project::BuildOutputs,
-    prepared: PreparedOp,
-) -> PyResult<()> {
-    match prepared {
-        PreparedOp::Edge {
-            src_idx,
-            dst_idx,
-            flags,
-        } => {
-            let len = outputs.builder.nodes.len();
-            check_idx_in_range(len, src_idx, "PreparedOp::Edge", "src_idx")?;
-            check_idx_in_range(len, dst_idx, "PreparedOp::Edge", "dst_idx")?;
-            outputs.builder.add_edge(src_idx, dst_idx, flags);
-            Ok(())
-        }
-        PreparedOp::Entrypoint { decl_idx } => {
-            let len = outputs.builder.nodes.len();
-            check_idx_in_range(len, decl_idx, "PreparedOp::Entrypoint", "decl_idx")?;
-            // Flag the decl itself an entrypoint seed — no synthetic
-            // marker node, since reachability seeds off the flag, not
-            // an edge from a marker.
-            outputs.builder.nodes[decl_idx].flags |= NODE_FLAG_ENTRYPOINT;
-            Ok(())
-        }
-        PreparedOp::FlagDecl { decl_idx, flags } => {
-            let len = outputs.builder.nodes.len();
-            check_idx_in_range(len, decl_idx, "PreparedOp::FlagDecl", "decl_idx")?;
-            outputs.builder.nodes[decl_idx].flags |= flags;
-            Ok(())
-        }
-    }
 }
 
 /// Bounds-check a single index against the builder's current node

--- a/runtime/src/native_plugins.rs
+++ b/runtime/src/native_plugins.rs
@@ -647,6 +647,36 @@ impl<'db> FileContext<'db> {
             .collect()
     }
 
+    /// Per-file twin of `find_handler_decorators`: `(owner name, file-local
+    /// idx)` for every decl carrying an `@<owner>.<attr>(...)` decorator whose
+    /// `attr` is one of `decorator_attrs` — one row per distinct owner in
+    /// source order. Reads the salsa-cached `decorator_rows` directly.
+    fn handler_decorators_local(&self, decorator_attrs: &[&str]) -> Vec<(String, u32)> {
+        let facts = crate::file_extraction::file_extraction(self.db, self.file);
+        let attrs: rustc_hash::FxHashSet<&str> = decorator_attrs.iter().copied().collect();
+        let by_range = self.name_range_to_local();
+        let mut out: Vec<(String, u32)> = Vec::new();
+        for (rk, descriptors) in &facts.decorator_rows {
+            let Some(&local) = by_range.get(rk) else {
+                continue;
+            };
+            let mut seen_owners: rustc_hash::FxHashSet<&str> = rustc_hash::FxHashSet::default();
+            for desc in descriptors {
+                let [attr] = desc.attrs.as_slice() else {
+                    continue;
+                };
+                if !attrs.contains(attr.as_str()) {
+                    continue;
+                }
+                if !seen_owners.insert(desc.root_name.as_str()) {
+                    continue;
+                }
+                out.push((desc.root_name.to_string(), local));
+            }
+        }
+        out
+    }
+
     /// Visit every call site in this file (decl-owned and module-scope),
     /// yielding the *file-local* owner index (module-scope → 0). The per-file
     /// twin of [`for_each_call_site`](crate::project) keyed on local indices.
@@ -1264,7 +1294,7 @@ impl NativePlugin {
     /// group declared in one file may collect handlers registered in another.
     #[staticmethod]
     fn click() -> Self {
-        Self::project_wide(Arc::new(ClickPluginImpl))
+        Self::dual_mode(Arc::new(ClickPluginImpl))
     }
 
     /// Native `MockPatchPlugin` (port of `dead_cst.contrib.mock_patch`).
@@ -2621,6 +2651,15 @@ pub mod plugin_api {
             self.inner.classes_defining_method(method_name)
         }
 
+        /// `(owner name, file-local idx)` for `@<owner>.<attr>(...)`-decorated
+        /// decls whose `attr` is one of `decorator_attrs`.
+        pub(crate) fn handler_decorators_local(
+            &self,
+            decorator_attrs: &[&str],
+        ) -> Vec<(String, u32)> {
+            self.inner.handler_decorators_local(decorator_attrs)
+        }
+
         /// `(local owner, literal)` for calls to `name` imported from one of
         /// `modules`, taking the `arg_index` positional string literal.
         pub(crate) fn calls_to_imported_local(
@@ -3535,95 +3574,67 @@ const CLICK_SUBGROUP_DECORATOR: &str = "group";
 
 pub(crate) struct ClickPluginImpl;
 
-impl plugin_api::ExternalPlugin for ClickPluginImpl {
-    fn name(&self) -> &str {
-        "click"
-    }
-
-    fn run(
-        &self,
-        ctx: &plugin_api::PluginCtx<'_>,
-        ops: &mut plugin_api::PluginOps,
-    ) -> Result<(), plugin_api::PluginError> {
-        // Cheap import-presence guard (`has_imports_of("click")`).
-        if !ctx.has_imports_of("click") {
-            return Ok(());
+impl plugin_api::PerFilePlugin for ClickPluginImpl {
+    fn run_on_file(&self, file: &plugin_api::PluginFileCtx<'_>, ops: &mut plugin_api::FileOps) {
+        // Cheap import-presence guard.
+        if !file.imports_any_module(&["click"]) {
+            return;
         }
 
-        // --- Phase 1: gather indices. ---
+        // --- Phase 1: gather file-local indices. ---
 
         // Groups via `@click.group` / `@click.Group`-decorated decls.
-        let group_decls: Vec<usize> = ctx.decorated_decls(&["click"], &CLICK_GROUP_DECORATORS);
-
+        let group_decls = file.decorated_decls(&["click"], &CLICK_GROUP_DECORATORS);
         // Groups via `X = click.Group(...)` constructions.
-        let group_ctors: Vec<usize> = ctx.constructions(&["click"], &["Group"]);
-
+        let group_ctors = file.constructions(&["click"], &["Group"]);
         // No groups => no wiring to do (the fixpoint would no-op anyway).
         if group_decls.is_empty() && group_ctors.is_empty() {
-            return Ok(());
+            return;
         }
 
         // Handlers: `@<owner>.{command,group,result_callback}(...)`.
-        let handlers: Vec<(String, usize)> = ctx.handler_decorators(&CLICK_REGISTRATION_DECORATORS);
-
+        let handlers = file.handler_decorators_local(&CLICK_REGISTRATION_DECORATORS);
         // Subgroup links: handlers decorated specifically with
-        // `@<owner>.group(...)`. Wiring such a handler promotes it to a
-        // group so its own `@<handler>.command()` handlers wire next pass.
-        let subgroup_links: FxHashSet<(usize, String)> = ctx
-            .handler_decorators(&[CLICK_SUBGROUP_DECORATOR])
+        // `@<owner>.group(...)`. Wiring such a handler promotes it to a group
+        // so its own `@<handler>.command()` handlers wire next pass.
+        let subgroup_links: FxHashSet<(u32, String)> = file
+            .handler_decorators_local(&[CLICK_SUBGROUP_DECORATOR])
             .into_iter()
             .map(|(owner, idx)| (idx, owner))
             .collect();
 
-        // --- Phase 2: resolve paths/fqnames + run the group->handler
-        // fixpoint. Pre-fetch (path, simple name) for every group + handler
-        // node up front so the loop needs no random node access. ---
+        // --- Phase 2: group->handler fixpoint. Everything is keyed within
+        // this one file, so the old `(path, name)` key reduces to the simple
+        // name (path is constant), and every wired edge is file-local. ---
 
-        // groups_by_owner: (path, simple name) -> [group idx, ...].
-        let group_idxs: Vec<usize> = group_decls
-            .iter()
-            .chain(group_ctors.iter())
-            .copied()
-            .collect();
-        let mut groups_by_owner: FxHashMap<(String, String), Vec<usize>> = FxHashMap::default();
-        for nv in ctx.nodes_at(&group_idxs) {
-            let simple = simple_name(&nv.fqname).to_string();
-            groups_by_owner
-                .entry((nv.path, simple))
-                .or_default()
-                .push(nv.idx);
+        // Local idx -> simple name, for every node in the file.
+        let nodes = file.nodes();
+        let simple_of = |idx: u32| -> String {
+            nodes
+                .get(idx as usize)
+                .map(|n| simple_name(&n.fqname).to_string())
+                .unwrap_or_default()
+        };
+
+        // groups_by_name: simple name -> [group local idx, ...].
+        let mut groups_by_name: FxHashMap<String, Vec<u32>> = FxHashMap::default();
+        for &g in group_decls.iter().chain(group_ctors.iter()) {
+            groups_by_name.entry(simple_of(g)).or_default().push(g);
         }
 
-        // decorated_idx -> (path, simple name) for every handler decl.
-        let handler_idxs: Vec<usize> = handlers.iter().map(|(_, idx)| *idx).collect();
-        let handler_attr: FxHashMap<usize, (String, String)> = ctx
-            .nodes_at(&handler_idxs)
-            .into_iter()
-            .map(|nv| {
-                let simple = simple_name(&nv.fqname).to_string();
-                (nv.idx, (nv.path, simple))
-            })
-            .collect();
-
         // Fixpoint: wire each handler to its owning group(s); a newly wired
-        // subgroup handler becomes a group, exposing its own handlers on the
-        // next pass. `emitted` dedups edges so the loop terminates once no
-        // new group is discovered. Verbatim port of `ClickPlugin.run`'s loop.
-        let mut emitted: FxHashSet<(usize, usize)> = FxHashSet::default();
+        // subgroup handler becomes a group, exposing its own handlers next
+        // pass. `emitted` dedups edges so the loop terminates once no new group
+        // is discovered. Verbatim port of `ClickPlugin.run`'s loop.
+        let mut emitted: FxHashSet<(u32, u32)> = FxHashSet::default();
         let mut changed = true;
         while changed {
             changed = false;
             for (owner_name, decorated_idx) in &handlers {
-                let Some((path, decorated_simple)) = handler_attr.get(decorated_idx).cloned()
-                else {
-                    continue;
-                };
-                // Snapshot the owner's group idxs: the insert below may
-                // mutate `groups_by_owner`, and the dedup + outer loop make
-                // deferring a same-pass insertion to the next pass
-                // fixpoint-equivalent.
-                let Some(owner_idxs) = groups_by_owner.get(&(path.clone(), owner_name.clone()))
-                else {
+                // Snapshot the owner's group idxs: the insert below may mutate
+                // `groups_by_name`, and the dedup + outer loop make deferring a
+                // same-pass insertion to the next pass fixpoint-equivalent.
+                let Some(owner_idxs) = groups_by_name.get(owner_name) else {
                     continue;
                 };
                 for owner_idx in owner_idxs.clone() {
@@ -3632,8 +3643,8 @@ impl plugin_api::ExternalPlugin for ClickPluginImpl {
                     }
                     ops.add_edge(owner_idx, *decorated_idx, 0);
                     if subgroup_links.contains(&(*decorated_idx, owner_name.clone())) {
-                        groups_by_owner
-                            .entry((path.clone(), decorated_simple.clone()))
+                        groups_by_name
+                            .entry(simple_of(*decorated_idx))
                             .or_default()
                             .push(*decorated_idx);
                         changed = true;
@@ -3641,8 +3652,16 @@ impl plugin_api::ExternalPlugin for ClickPluginImpl {
                 }
             }
         }
+    }
+}
 
-        Ok(())
+impl plugin_api::ExternalPlugin for ClickPluginImpl {
+    fn name(&self) -> &str {
+        "click"
+    }
+
+    fn per_file(&self) -> Option<&dyn plugin_api::PerFilePlugin> {
+        Some(self)
     }
 }
 

--- a/runtime/src/native_plugins.rs
+++ b/runtime/src/native_plugins.rs
@@ -549,13 +549,12 @@ impl<'db> FileContext<'db> {
     /// `decl_by_name_range`'s per-file restriction: the decl rows in
     /// [`file_extraction`] (`decorator_rows`, `function_params`, …) are keyed
     /// by the same `name_range`, so this is the local-space join table.
-    fn name_range_to_local(&self) -> rustc_hash::FxHashMap<(u32, u32), u32> {
-        self.nodes()
-            .iter()
-            .enumerate()
-            .filter(|(_, n)| !matches!(n.kind, NodeKind::Module | NodeKind::Import))
-            .map(|(i, n)| (n.name_range, i as u32))
-            .collect()
+    ///
+    /// Delegates to the salsa-cached [`decl_name_range_to_local`] so the many
+    /// per-file plugins (and the several helpers a single plugin calls) share
+    /// one computation per file rather than each rebuilding the map.
+    fn name_range_to_local(&self) -> &'db rustc_hash::FxHashMap<(u32, u32), u32> {
+        decl_name_range_to_local(self.db, self.file)
     }
 
     /// Per-file twin of `find_decorated_decls(extract_args = true)`: file-local
@@ -1055,6 +1054,26 @@ fn per_file_set(set_id: u32) -> Option<Arc<[PerFilePluginId]>> {
         .sets
         .get(set_id as usize)
         .map(Arc::clone)
+}
+
+/// `name_range → file-local idx` for every non-module / non-import node,
+/// salsa-cached. Several per-file plugins — and several helpers within one
+/// plugin — need this join table (to map a [`file_extraction`] row's range
+/// key to a file-local index); caching it here means the per-file pass builds
+/// it once per file and every consumer reads the memo, instead of each
+/// rebuilding an O(nodes) map. Re-runs only when ``file_to_nodes`` changes.
+#[salsa::tracked(returns(ref), heap_size = ruff_memory_usage::heap_size)]
+pub(crate) fn decl_name_range_to_local(
+    db: &dyn ProjectDb,
+    file: File,
+) -> rustc_hash::FxHashMap<(u32, u32), u32> {
+    file_to_nodes(db, file)
+        .nodes
+        .iter()
+        .enumerate()
+        .filter(|(_, n)| !matches!(n.kind, NodeKind::Module | NodeKind::Import))
+        .map(|(i, n)| (n.name_range, i as u32))
+        .collect()
 }
 
 /// Run one per-file plugin (configless builtin, configured builtin, or

--- a/runtime/src/native_plugins.rs
+++ b/runtime/src/native_plugins.rs
@@ -677,6 +677,40 @@ impl<'db> FileContext<'db> {
         out
     }
 
+    /// Per-file twin of `find_handler_decorators_via`: `(owner name, file-local
+    /// idx)` for every decl carrying a two-level `@<owner>.<via_attr>.<attr>(...)`
+    /// decorator whose `attr` is one of `decorator_attrs` — one row per distinct
+    /// owner in source order.
+    fn handler_decorators_via_local(
+        &self,
+        via_attr: &str,
+        decorator_attrs: &[&str],
+    ) -> Vec<(String, u32)> {
+        let facts = crate::file_extraction::file_extraction(self.db, self.file);
+        let attrs: rustc_hash::FxHashSet<&str> = decorator_attrs.iter().copied().collect();
+        let by_range = self.name_range_to_local();
+        let mut out: Vec<(String, u32)> = Vec::new();
+        for (rk, descriptors) in &facts.decorator_rows {
+            let Some(&local) = by_range.get(rk) else {
+                continue;
+            };
+            let mut seen_owners: rustc_hash::FxHashSet<&str> = rustc_hash::FxHashSet::default();
+            for desc in descriptors {
+                let [via, outer] = desc.attrs.as_slice() else {
+                    continue;
+                };
+                if via.as_str() != via_attr || !attrs.contains(outer.as_str()) {
+                    continue;
+                }
+                if !seen_owners.insert(desc.root_name.as_str()) {
+                    continue;
+                }
+                out.push((desc.root_name.to_string(), local));
+            }
+        }
+        out
+    }
+
     /// Visit every call site in this file (decl-owned and module-scope),
     /// yielding the *file-local* owner index (module-scope → 0). The per-file
     /// twin of [`for_each_call_site`](crate::project) keyed on local indices.
@@ -1313,7 +1347,7 @@ impl NativePlugin {
     /// may live in different files; Cog subclasses span files).
     #[staticmethod]
     fn discordpy() -> Self {
-        Self::project_wide(Arc::new(DiscordPyPluginImpl))
+        Self::dual_mode(Arc::new(DiscordPyPluginImpl))
     }
 
     /// Native `PytestPlugin` (port of `dead_cst.contrib.pytest`). Seed
@@ -1427,7 +1461,7 @@ impl NativePlugin {
     /// Wrap a [`DispatchAppConfig`] in a project-wide native plugin. Shared by
     /// the per-framework factories and the custom `dispatch_app` factory.
     fn from_dispatch_config(name: String, config: DispatchAppConfig) -> Self {
-        Self::project_wide(Arc::new(DispatchAppPluginImpl { name, config }))
+        Self::dual_mode(Arc::new(DispatchAppPluginImpl { name, config }))
     }
 }
 
@@ -2660,6 +2694,17 @@ pub mod plugin_api {
             self.inner.handler_decorators_local(decorator_attrs)
         }
 
+        /// `(owner name, file-local idx)` for two-level
+        /// `@<owner>.<via_attr>.<attr>(...)`-decorated decls.
+        pub(crate) fn handler_decorators_via_local(
+            &self,
+            via_attr: &str,
+            decorator_attrs: &[&str],
+        ) -> Vec<(String, u32)> {
+            self.inner
+                .handler_decorators_via_local(via_attr, decorator_attrs)
+        }
+
         /// `(local owner, literal)` for calls to `name` imported from one of
         /// `modules`, taking the `arg_index` positional string literal.
         pub(crate) fn calls_to_imported_local(
@@ -3210,6 +3255,36 @@ impl DispatchAppPluginImpl {
         }
         false
     }
+
+    /// Per-instance topic for this framework's `@<owner>.<reg_decorator>`
+    /// handler facts. Namespaced by `self.name` (one instance per framework)
+    /// so flask's handlers never bleed into fastapi's resolve.
+    fn handler_topic(&self) -> String {
+        format!("dispatch/{}/handler", self.name)
+    }
+}
+
+impl plugin_api::PerFilePlugin for DispatchAppPluginImpl {
+    fn run_on_file(&self, file: &plugin_api::PluginFileCtx<'_>, ops: &mut plugin_api::FileOps) {
+        // Detecting `@<owner>.<reg_decorator>(...)` handlers is a pure
+        // syntactic, file-local read — publish one fact per handler, pinned to
+        // the decorated decl, value = the owner (receiver) name. The
+        // project-wide `run` reconstructs the handler list and does the
+        // cross-file wiring (subclass-expanded constructions, factory walk).
+        // No import gate here: the old plugin gated the *whole* pass on a
+        // project-level `is_active`, so a handler in a file that doesn't itself
+        // import the framework must still surface — `run` applies that gate.
+        let reg_ref: Vec<&str> = self
+            .config
+            .registration_decorators
+            .iter()
+            .map(String::as_str)
+            .collect();
+        let topic = self.handler_topic();
+        for (owner, local) in file.handler_decorators_local(&reg_ref) {
+            ops.emit_fact(topic.clone(), Some(local), owner);
+        }
+    }
 }
 
 /// Trailing path component (`Path(path).name`) for the celery shared-task
@@ -3228,6 +3303,20 @@ fn simple_name(fqname: &str) -> &str {
 impl plugin_api::ExternalPlugin for DispatchAppPluginImpl {
     fn name(&self) -> &str {
         &self.name
+    }
+
+    fn declare_topics(&self) -> Vec<crate::topic_registry::TopicSpec> {
+        vec![crate::topic_registry::TopicSpec {
+            name: self.handler_topic(),
+            description: "A `@<owner>.<registration_decorator>(...)` handler decl, pinned \
+                          to the decorated decl, value = the owner (receiver) name; the \
+                          project-wide pass wires it to its owning app instance."
+                .to_string(),
+        }]
+    }
+
+    fn per_file(&self) -> Option<&dyn plugin_api::PerFilePlugin> {
+        Some(self)
     }
 
     fn run(
@@ -3309,13 +3398,17 @@ impl plugin_api::ExternalPlugin for DispatchAppPluginImpl {
             }
         }
 
-        // handlers: `@<owner>.<reg_decorator>(...)`-decorated functions.
-        let reg_ref: Vec<&str> = cfg
-            .registration_decorators
-            .iter()
-            .map(String::as_str)
-            .collect();
-        let handlers: Vec<(String, usize)> = ctx.handler_decorators(&reg_ref);
+        // handlers: `@<owner>.<reg_decorator>(...)`-decorated functions,
+        // reconstructed from the per-file facts (value = owner name, pinned to
+        // the decorated decl) the salsa-cached per-file pass published.
+        let handlers: Vec<(String, usize)> = match ctx.topic(&self.handler_topic()) {
+            Some(handle) => ctx
+                .facts_for_topic(handle)
+                .into_iter()
+                .filter_map(|fact| fact.decl_idx.map(|idx| (fact.value, idx)))
+                .collect(),
+            None => Vec::new(),
+        };
 
         // factory_reachers (seed + factory): union of every factory decl's
         // direct predecessors. Inverts step 6's question (is this var's
@@ -3800,11 +3893,46 @@ const DISCORD_BOT_DECORATORS: [&str; 10] = [
 const DISCORD_TREE_DECORATORS: [&str; 2] = ["command", "context_menu"];
 const DISCORD_COG_BASES: [&str; 2] = ["discord.ext.commands.Cog", "discord.ext.commands.GroupCog"];
 
+/// Topic carrying discord.py handler decls — both single-attr `@<bot>.<verb>`
+/// and two-level `@<bot>.tree.<verb>` slash commands (the project-wide pass
+/// wires both identically). Value = the owner (bot) name, pinned to the
+/// decorated decl.
+const DISCORD_TOPIC_HANDLER: &str = "discord/handler";
+
 pub(crate) struct DiscordPyPluginImpl;
+
+impl plugin_api::PerFilePlugin for DiscordPyPluginImpl {
+    fn run_on_file(&self, file: &plugin_api::PluginFileCtx<'_>, ops: &mut plugin_api::FileOps) {
+        // Handler-decorator detection is syntactic + file-local. Publish one
+        // fact per handler (single-attr and two-level alike); the project-wide
+        // `run` reconstructs the list and wires each to its bot var (which the
+        // cross-file Bot/Client construction walk discovers). No import gate —
+        // `run`'s project-level discord-presence check applies it.
+        for (owner, local) in file.handler_decorators_local(&DISCORD_BOT_DECORATORS) {
+            ops.emit_fact(DISCORD_TOPIC_HANDLER, Some(local), owner);
+        }
+        for (owner, local) in file.handler_decorators_via_local("tree", &DISCORD_TREE_DECORATORS) {
+            ops.emit_fact(DISCORD_TOPIC_HANDLER, Some(local), owner);
+        }
+    }
+}
 
 impl plugin_api::ExternalPlugin for DiscordPyPluginImpl {
     fn name(&self) -> &str {
         "DiscordPyPlugin"
+    }
+
+    fn declare_topics(&self) -> Vec<crate::topic_registry::TopicSpec> {
+        vec![crate::topic_registry::TopicSpec {
+            name: DISCORD_TOPIC_HANDLER.to_string(),
+            description: "A discord.py `@<bot>.<verb>` / `@<bot>.tree.<verb>` handler decl, \
+                          pinned to the decorated decl, value = the bot (owner) name."
+                .to_string(),
+        }]
+    }
+
+    fn per_file(&self) -> Option<&dyn plugin_api::PerFilePlugin> {
+        Some(self)
     }
 
     fn run(
@@ -3850,11 +3978,18 @@ impl plugin_api::ExternalPlugin for DiscordPyPluginImpl {
         let client_names_ref: Vec<&str> = client_names.iter().map(String::as_str).collect();
         bot_var_idxs.extend(ctx.constructions(&["discord"], &client_names_ref));
 
-        // 2 + 3. Handler decorators: single-attr `@<bot>.<verb>` and
-        // two-level `@<bot>.tree.<verb>` slash commands.
-        let bot_handlers: Vec<(String, usize)> = ctx.handler_decorators(&DISCORD_BOT_DECORATORS);
-        let tree_handlers: Vec<(String, usize)> =
-            ctx.handler_decorators_via("tree", &DISCORD_TREE_DECORATORS);
+        // 2 + 3. Handler decorators (single-attr `@<bot>.<verb>` and two-level
+        // `@<bot>.tree.<verb>` slash commands), reconstructed from the per-file
+        // facts the salsa-cached per-file pass published. Both shapes share one
+        // topic — the wiring below treats them identically.
+        let handlers: Vec<(String, usize)> = match ctx.topic(DISCORD_TOPIC_HANDLER) {
+            Some(handle) => ctx
+                .facts_for_topic(handle)
+                .into_iter()
+                .filter_map(|fact| fact.decl_idx.map(|idx| (fact.value, idx)))
+                .collect(),
+            None => Vec::new(),
+        };
 
         // 4. Cog subclasses + their files; module setup/teardown hooks.
         let mut cogs_by_path: FxHashMap<String, Vec<usize>> = FxHashMap::default();
@@ -3920,17 +4055,13 @@ impl plugin_api::ExternalPlugin for DiscordPyPluginImpl {
         }
 
         // Wire single-attr + two-level handler decorators to their bot.
-        let handler_idxs: Vec<usize> = bot_handlers
-            .iter()
-            .chain(tree_handlers.iter())
-            .map(|(_, idx)| *idx)
-            .collect();
+        let handler_idxs: Vec<usize> = handlers.iter().map(|(_, idx)| *idx).collect();
         let handler_paths: FxHashMap<usize, String> = handler_idxs
             .iter()
             .copied()
             .zip(ctx.node_paths(&handler_idxs))
             .collect();
-        for (owner, decorated_idx) in bot_handlers.iter().chain(tree_handlers.iter()) {
+        for (owner, decorated_idx) in &handlers {
             let Some(path) = handler_paths.get(decorated_idx) else {
                 continue;
             };

--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -2105,65 +2105,96 @@ fn assemble_graph<'db>(
     // translation below; flags apply to freshly minted blocks only
     // (clean files carry theirs in the restored base flags); facts are
     // derived state, rebuilt from every file's ops each pass.
+    //
+    // The per-fact work — `file_path_string`, the topic/value `to_string`s,
+    // the `Fact` alloc — is fanned out across the snapshot pool, one job per
+    // file that emitted any op; the cheap, order-sensitive reduce (OR the
+    // flags onto disjoint blocks, push facts into `topic_facts`) stays serial
+    // in `pos` order so the output is byte-identical to the serial loop.
     let mut topic_facts: FxHashMap<String, Vec<crate::native_plugins::plugin_api::Fact>> =
         FxHashMap::default();
     if per_file_set_id.is_some() {
+        use crate::native_plugins::plugin_api::Fact;
         use crate::native_plugins::FileLocalOp;
-        for (pos, ops) in plugin_ops.iter().enumerate() {
-            let mint = &mints[pos];
-            let len = mint.payload.nodes.len();
-            let to_global =
-                |local: u32| ((local as usize) < len).then_some(mint.base + local as usize);
-            let mut file_path: Option<String> = None;
-            for op in ops.iter() {
-                match op {
-                    FileLocalOp::Edge { .. } => {}
-                    FileLocalOp::Entrypoint { decl_local_idx } => {
-                        if !mint.fill {
-                            continue;
+        type Applied = (Vec<(usize, u32)>, Vec<(String, Fact)>);
+        let op_positions: Vec<usize> = (0..n_files)
+            .filter(|&pos| !plugin_ops[pos].is_empty())
+            .collect();
+        // Fresh snapshot pool: the assemble-wide `pool` was moved into the
+        // resolve arm. Cheap (a handful of snapshot clones).
+        let plugin_pool = DbPool::new(db);
+        let mints_ref = &mints;
+        let plugin_ops_ref = &plugin_ops;
+        let applied: Vec<Applied> = py.allow_threads(|| {
+            run_job(&plugin_pool, &op_positions, |ldb, &pos| {
+                let ops = plugin_ops_ref[pos];
+                let mint = &mints_ref[pos];
+                let len = mint.payload.nodes.len();
+                let to_global =
+                    |local: u32| ((local as usize) < len).then_some(mint.base + local as usize);
+                let mut flag_writes: Vec<(usize, u32)> = Vec::new();
+                let mut facts: Vec<(String, Fact)> = Vec::new();
+                let mut file_path: Option<String> = None;
+                for op in ops {
+                    match op {
+                        FileLocalOp::Edge { .. } => {}
+                        FileLocalOp::Entrypoint { decl_local_idx } => {
+                            if mint.fill {
+                                if let Some(idx) = to_global(*decl_local_idx) {
+                                    flag_writes.push((idx, NODE_FLAG_ENTRYPOINT));
+                                }
+                            }
                         }
-                        if let Some(decl_idx) = to_global(*decl_local_idx) {
-                            builder.nodes[decl_idx].flags |= NODE_FLAG_ENTRYPOINT;
+                        FileLocalOp::FlagDecl {
+                            decl_local_idx,
+                            flags,
+                        } => {
+                            if mint.fill {
+                                if let Some(idx) = to_global(*decl_local_idx) {
+                                    flag_writes.push((idx, *flags));
+                                }
+                            }
                         }
-                    }
-                    FileLocalOp::FlagDecl {
-                        decl_local_idx,
-                        flags,
-                    } => {
-                        if !mint.fill {
-                            continue;
+                        FileLocalOp::Fact {
+                            topic,
+                            decl_local_idx,
+                            value,
+                        } => {
+                            // A fact that pinned a decl is dropped when that
+                            // decl doesn't resolve to a global node — same
+                            // lenient contract as edge/flag ops.
+                            let decl_idx = match decl_local_idx {
+                                Some(local) => match to_global(*local) {
+                                    Some(global) => Some(global),
+                                    None => continue,
+                                },
+                                None => None,
+                            };
+                            let path = file_path
+                                .get_or_insert_with(|| file_path_string(ldb, mint.file))
+                                .clone();
+                            facts.push((
+                                topic.to_string(),
+                                Fact {
+                                    path,
+                                    decl_idx,
+                                    value: value.to_string(),
+                                },
+                            ));
                         }
-                        if let Some(decl_idx) = to_global(*decl_local_idx) {
-                            builder.nodes[decl_idx].flags |= flags;
-                        }
-                    }
-                    FileLocalOp::Fact {
-                        topic,
-                        decl_local_idx,
-                        value,
-                    } => {
-                        // A fact that pinned a decl is dropped when that
-                        // decl doesn't resolve to a global node — same
-                        // lenient contract as edge/flag ops.
-                        let decl_idx = match decl_local_idx {
-                            Some(local) => match to_global(*local) {
-                                Some(global) => Some(global),
-                                None => continue,
-                            },
-                            None => None,
-                        };
-                        let path = file_path
-                            .get_or_insert_with(|| file_path_string(db, mint.file))
-                            .clone();
-                        topic_facts.entry(topic.to_string()).or_default().push(
-                            crate::native_plugins::plugin_api::Fact {
-                                path,
-                                decl_idx,
-                                value: value.to_string(),
-                            },
-                        );
                     }
                 }
+                (flag_writes, facts)
+            })
+        });
+        // Serial reduce in `pos` order (op_positions is ascending), so the
+        // fact order — and thus the build — matches the serial loop exactly.
+        for (flag_writes, facts) in applied {
+            for (idx, bits) in flag_writes {
+                builder.nodes[idx].flags |= bits;
+            }
+            for (topic, fact) in facts {
+                topic_facts.entry(topic).or_default().push(fact);
             }
         }
     }


### PR DESCRIPTION
Follow-up to #303, continuing to move project-wide plugin work onto the salsa-cached per-file pass. Three commits, each byte-identical to `main` (A/B-verified on cross-file corpora).

## 1. `click` → pure per-file (no project-wide resolve)

Click turned out to be entirely file-local: its group→handler wiring looks up groups by the group's `(path, simple name)` and matches handlers on the handler's own `path`, so the old project-wide `run` *never wired anything across files*. The whole gather + subgroup fixpoint moves verbatim into a per-file pass — no facts, no resolve, just file-local edges — and rides the salsa cache (reused for a clean file on `re_materialize`). The old version re-ran `handler_decorators` / `constructions` / a full `nodes_at` fetch over the whole project every build.

## 2 + 3. `DispatchApp` (flask/fastapi/typer/cyclopts/slack_bolt/fastmcp/celery) + `DiscordPy` → handler detection per-file

The expensive, **syntactic + file-local** handler-decorator walk (`handler_decorators`, which re-scanned every file's decorators each build) moves into the salsa-cached per-file pass, emitted as facts the project-wide `run` reads back. The genuinely cross-file work **stays** in `run` — that's where it belongs:

- the subclass-expanded app-construction walk (`find_subclasses_of_fqn` → `constructions`),
- the whole-project variable index (`vars_by_file`),
- the factory-promotion predecessor walk (`direct_predecessors`).

Details:
- **DispatchApp**: each framework instance emits `@<owner>.<registration_decorator>(...)` handlers under a **per-framework** topic (`dispatch/<name>/handler`, namespaced by the instance name so flask's handlers never reach fastapi's resolve), pinned to the decorated decl, value = owner name. `run` reconstructs the handler list and does the unchanged step-5 wiring + step-6 factory promotion. No per-file import gate: the old pass gated the whole plugin on a project-level `is_active`, which `run` still applies, so a handler in a file that doesn't itself import the framework still surfaces.
- **DiscordPy**: single-attr `@<bot>.<verb>` and two-level `@<bot>.tree.<verb>` handlers emit under one `discord/handler` topic (they wire identically); `run` reconstructs and wires them to the Bot/Client vars the cross-file construction walk discovers.

New per-file helpers: `handler_decorators_local` and `handler_decorators_via_local` (twins of `find_handler_decorators[_via]`, keyed on file-local indices).

### Why only handler detection for the dispatch family

Their dominant per-build cost (the whole-project var index, the subclass-expanded construction walk, the factory predecessor walk) is **irreducibly cross-file** and has to stay in `run`. Handler detection is the one cleanly file-local, salsa-cacheable piece — so that's what moves.

## Validation

- **Byte-identical to `main`** on: a click corpus (nested groups, `@main.group()` subgroup-promotion fixpoint, `click.Group(...)` constructions, a same-named owner in another file that must *not* wire); a flask+typer+celery corpus (direct construction, subclass app, `create_app()` factory chain promoted via step 6, typer dispatch-mode); a discord.py corpus (bot + client handlers, tree slash command, Cog subclasses, setup/teardown hooks, `load_extension`).
- Full suite (745) + all plugin tests green; `prek` clean. No public API or CLI change.

## Not converted (deliberately)

`ProjectScripts` (reads `pyproject.toml`, not file-AST) and `DynamicImportFallback` (operates on the edge set) don't fit the per-file model. `ExplicitEntrypoint` is cleanly per-file-able but needs `project_root` + regex-compile plumbing for config-gated, modest value — left out.

https://claude.ai/code/session_01KYNAs8Y9ctXsM1waLmXEaP