### PR TITLE
Fan per-file plugins out as tasks on incremental builds

### DIFF
--- a/runtime/src/project.rs
+++ b/runtime/src/project.rs
@@ -14,6 +14,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyType;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
+use ruff_db::source::line_index;
 use ruff_db::system::{OsSystem, SystemPathBuf};
 use ruff_text_size::TextRange;
 use ty_project::metadata::options::{EnvironmentOptions, Options};
@@ -572,6 +573,14 @@ pub(crate) fn build_project_graph(
             // at its true sorted `file_idx`, so offsets stay deterministic.
             let lanes = num_workers.max(1);
             let cols = files_ref.len().div_ceil(lanes);
+            // Fan each file's per-file plugins out as their own tasks only when
+            // there are fewer files than workers — i.e. the file axis alone
+            // can't fill the cores, which is the incremental case (a small
+            // dirty set on a big box). Cold builds and large dirty sets keep
+            // the serial-within-file loop: the file fan-out already saturates
+            // the cores there, so splitting each file into N more tasks would
+            // just add scheduling + snapshot-channel traffic for no parallelism.
+            let fan_out_plugins = !per_file_ids_ref.is_empty() && files_ref.len() <= num_workers;
             rayon::scope(|s| {
                 for col in 0..cols {
                     for lane in 0..lanes {
@@ -583,7 +592,18 @@ pub(crate) fn build_project_graph(
                         let db_tx = db_tx.clone();
                         let db_rx = db_rx.clone();
                         let counters_inner = Arc::clone(&counters_ref);
-                        s.spawn(move |_| {
+                        // Deps task: warm this file's shared salsa inputs. When
+                        // fanning out, the per-file plugins then run as their own
+                        // tasks (below) — concurrently with each other and with
+                        // other files' `file_to_nodes` — instead of serially in
+                        // this worker, so a small dirty set with many plugins
+                        // still saturates the cores. Warming the shared inputs
+                        // *before* releasing the plugin tasks is what makes that
+                        // sound: each plugin reads a memoized `file_to_nodes` /
+                        // `file_extraction` / index / line index, so the
+                        // concurrent tasks never collide computing the same salsa
+                        // query (which would just park workers).
+                        s.spawn(move |s| {
                             let local_db = db_rx.recv().expect("snapshot available");
                             local_db.attach(|local_db| {
                                 let _ = file_to_nodes(local_db, file);
@@ -593,44 +613,75 @@ pub(crate) fn build_project_graph(
                                 // Warmed here so the assemble pass's
                                 // dirty-set derivation is memo reads.
                                 let _ = resolution_surface_fp(local_db, file);
-                                // Owned per-file facts for the project-wide
-                                // plugin queries. Warmed here, while the AST
-                                // is live, so the queries below run as cache
-                                // reads.
+                                // Owned per-file facts for the plugin queries,
+                                // warmed while the AST is live so the plugin
+                                // queries run as cache reads.
                                 let _ = file_extraction(local_db, file);
-                                // Per-file native plugins: warm the salsa-cached
-                                // `per_file_plugin_ops(file, id)` query on this
-                                // worker so the serial assembly fold below is a
-                                // pure cache read. `run_on_file` is GIL-free and
-                                // touches only this file, so it composes with the
-                                // GIL-released fan-out.
-                                for &id in per_file_ids_ref {
-                                    let _ = crate::native_plugins::per_file_plugin_ops(
-                                        local_db, file, id,
-                                    );
+                                // The per-file plugin helpers map name ranges to
+                                // source lines; warm the line index too so the
+                                // (possibly concurrent) plugin tasks don't race
+                                // to build it.
+                                let _ = line_index(local_db, file);
+                                // Serial path (cold / large dirty set, or no
+                                // plugins): run the plugins in this worker and
+                                // drop the AST + index now — the file axis already
+                                // saturates the cores, so this avoids the extra
+                                // task + snapshot-channel traffic of fanning out.
+                                if !fan_out_plugins {
+                                    for &id in per_file_ids_ref {
+                                        let _ = crate::native_plugins::per_file_plugin_ops(
+                                            local_db, file, id,
+                                        );
+                                    }
+                                    ty_python_core::semantic_index(local_db, file).clear();
+                                    parsed_module(local_db, file).clear();
                                 }
-                                // Every per-file AST consumer for this file has
-                                // now run and memoized its result, so drop the
-                                // parsed AST *and* the semantic index's per-scope
-                                // analysis data (place tables, use-def maps, AST
-                                // ids) rather than let them sit resident through
-                                // assembly and the project-wide plugin pass —
-                                // that's the memory win, and the index data is
-                                // the larger share of it. Assembly, fqname, and
-                                // the class hierarchy read only the cached
-                                // payloads (`class_bases`, `external_base_children`,
-                                // `children_by_node`), never the AST or index, so
-                                // the all-files-resident peak never forms. Subclass
-                                // resolution can still pull an individual file's
-                                // AST/index back on demand to relocate a class
-                                // seed — `SemanticIndex::load` lazily rebuilds in
-                                // ingredient-reuse mode — and that rare reload is
-                                // re-cleared right after the plugin pass.
-                                ty_python_core::semantic_index(local_db, file).clear();
-                                parsed_module(local_db, file).clear();
                             });
                             db_tx.send(local_db).expect("channel open");
                             counters_inner.populate_inc();
+                            if !fan_out_plugins {
+                                return;
+                            }
+                            // Fan-out path: one task per plugin.
+                            // `per_file_plugin_ops` is keyed `(file, id)`, so the
+                            // tasks are independent salsa queries; the warming
+                            // above means each is a pure read of this file's
+                            // memoized inputs.
+                            //
+                            // The parsed AST + semantic index stay resident until
+                            // the *last* plugin finishes, tracked by a per-file
+                            // countdown: whoever decrements it to zero clears them
+                            // (the memory win — so they don't sit resident through
+                            // assembly and the project-wide plugin pass). The
+                            // counter is observed only after each task's
+                            // `per_file_plugin_ops` returns, so the clearer runs
+                            // strictly after every reader is done. Subclass
+                            // resolution can pull them back on demand later; that
+                            // rare reload is re-cleared after the plugin pass.
+                            let remaining = Arc::new(std::sync::atomic::AtomicUsize::new(
+                                per_file_ids_ref.len(),
+                            ));
+                            for &id in per_file_ids_ref {
+                                let db_tx = db_tx.clone();
+                                let db_rx = db_rx.clone();
+                                let remaining = Arc::clone(&remaining);
+                                s.spawn(move |_| {
+                                    let local_db = db_rx.recv().expect("snapshot available");
+                                    local_db.attach(|local_db| {
+                                        let _ = crate::native_plugins::per_file_plugin_ops(
+                                            local_db, file, id,
+                                        );
+                                        if remaining
+                                            .fetch_sub(1, std::sync::atomic::Ordering::AcqRel)
+                                            == 1
+                                        {
+                                            ty_python_core::semantic_index(local_db, file).clear();
+                                            parsed_module(local_db, file).clear();
+                                        }
+                                    });
+                                    db_tx.send(local_db).expect("channel open");
+                                });
+                            }
                         });
                     }
                 }

--- a/scripts/bench_materialize.py
+++ b/scripts/bench_materialize.py
@@ -130,13 +130,21 @@ def _incremental(
         return ctx.read_progress_snapshot()["fqname_total"] - len(ctx.tombstoned_indices())
 
     manifest = sorted((corpus).glob("pkg_*"))
+    # Prefer framework files (pytest / fastapi / unittest / … — see
+    # gen_bench_corpus.py) as edit targets: editing one re-runs the per-file
+    # plugins on a file that actually has fixtures/handlers/etc., so the
+    # incremental loop measures real plugin work, not a generic-module no-op.
+    # Falls back to generic `mod_*.py` on a corpus with no framework content.
+    _fw_prefixes = ("test_", "app_", "tests_", "models_", "cli_")
+    fw_files = sorted(f for f in corpus.glob("pkg_*/*.py") if f.name.startswith(_fw_prefixes))
+    generic = [sorted(pkg.glob("mod_*.py"))[0] for pkg in manifest[: max(edits, 1)]]
+    scatter_targets = fw_files or generic
     rows: list[tuple[str, float, tuple[int, int], int]] = []
     originals: dict[Path, str] = {}
     try:
-        # Scattered edits: one file per round, spread across packages.
+        # Scattered edits: one file per round, spread across the corpus.
         for i in range(edits):
-            pkg = manifest[(i * 97) % len(manifest)]
-            target = sorted(pkg.glob("mod_*.py"))[i % 3]
+            target = scatter_targets[(i * 97) % len(scatter_targets)]
             originals.setdefault(target, target.read_text())
             target.write_text(target.read_text() + f"\n\ndef _bench_s{i}():\n    pass\n")
             before = _nodes()
@@ -153,8 +161,8 @@ def _incremental(
                 )
             )
 
-        # Hot loop: repeated edits to one file.
-        target = (corpus / "pkg_0000" / "mod_0000.py").resolve()
+        # Hot loop: repeated edits to one file (a framework file if present).
+        target = (fw_files[0] if fw_files else corpus / "pkg_0000" / "mod_0000.py").resolve()
         originals.setdefault(target, target.read_text())
         for i in range(edits):
             target.write_text(target.read_text() + f"\n\ndef _bench_h{i}():\n    pass\n")
@@ -194,8 +202,10 @@ def main() -> None:
     parser.add_argument(
         "--plugins",
         choices=("none", "all"),
-        default="none",
-        help="Run with no plugins (pure build) or the full built-in set.",
+        default="all",
+        help="Run with the full built-in plugin set (default) or none (pure "
+        "build). Only meaningful against a corpus generated with "
+        "--framework-fraction > 0; otherwise every plugin early-outs.",
     )
     parser.add_argument(
         "--count",

--- a/scripts/gen_bench_corpus.py
+++ b/scripts/gen_bench_corpus.py
@@ -132,6 +132,116 @@ def _module_source(
     return "\n".join(lines) + "\n"
 
 
+# Framework flavors woven into the corpus so the per-file plugins have real
+# work to do — decorators to extract, fixtures / handlers / constructions to
+# find, subclass bases to walk — instead of every plugin hitting its
+# import/decorator early-out on a barren generic tree. Each framework file is
+# *additive* (written alongside the generic modules, importing its generic
+# sibling so it still resolves and mints an edge), so the generic import graph
+# that carries the node/edge scale is untouched. Third-party frameworks
+# (fastapi / flask / pytest / click) needn't be installed — the plugins match
+# the import + decorator syntactically — while `unittest` / `__init_subclass__`
+# resolve first-party, so their subclass walks fire too.
+FRAMEWORK_FLAVORS = (
+    "pytest",
+    "fastapi",
+    "flask",
+    "unittest",
+    "init_subclass",
+    "mock_patch",
+    "click",
+)
+
+# Flavors that need a `test_*.py` filename (pytest collection) — also the ones
+# whose package gets a `conftest.py`.
+_TEST_FLAVORS = frozenset({"pytest", "mock_patch"})
+
+
+def _framework_file(flavor: str, p: int, m: int) -> tuple[str, str]:
+    """``(filename, source)`` for one additive framework file for module
+    ``(p, m)``. Deterministic in ``(flavor, p, m)``; imports the generic
+    sibling so the body's call resolves to a real cross-file edge."""
+    uid = f"{p:04d}_{m:04d}"
+    head = [f"from pkg_{p:04d} import mod_{m:04d} as _i0", ""]
+    call = ["    _i0.fn_0()"]
+    meth = ["        _i0.fn_0()"]
+    body: list[str] = []
+    if flavor == "pytest":
+        name = f"test_x{uid}.py"
+        body += ["import pytest", ""]
+        body += ["@pytest.fixture", f"def fix_{uid}():", f"    return {m}", ""]
+        body += [
+            f'@pytest.fixture(name="alias_{uid}")',
+            f"def make_{uid}():",
+            "    return object()",
+            "",
+        ]
+        body += [f"def test_uses_{uid}(fix_{uid}, alias_{uid}):", *call, ""]
+        body += [f"class TestGroup_{uid}:", f"    def test_method(self, fix_{uid}):", *meth, ""]
+    elif flavor == "fastapi":
+        name = f"app_{uid}.py"
+        body += ["from fastapi import FastAPI", "", "app = FastAPI()", ""]
+        for h, verb in enumerate(("get", "post", "put")):
+            body += [f'@app.{verb}("/r_{uid}_{h}")', f"def handler_{uid}_{h}():", *call, ""]
+    elif flavor == "flask":
+        name = f"app_{uid}.py"
+        body += ["from flask import Flask", "", "app = Flask(__name__)", ""]
+        for h in range(2):
+            body += [f'@app.route("/r_{uid}_{h}")', f"def view_{uid}_{h}():", *call, ""]
+        body += ["def create_app():", "    return Flask(__name__)", "", "made = create_app()", ""]
+        body += [f'@made.route("/m_{uid}")', f"def made_view_{uid}():", *call, ""]
+    elif flavor == "unittest":
+        name = f"tests_{uid}.py"
+        body += ["import unittest", "", f"class Test_{uid}(unittest.TestCase):"]
+        body += ["    def test_a(self):", *meth]
+        body += ["    def test_b(self):", *meth, ""]
+        body += ["def setUpModule():", "    pass", "", "def tearDownModule():", "    pass", ""]
+    elif flavor == "init_subclass":
+        name = f"models_{uid}.py"
+        body += [
+            f"class Base_{uid}:",
+            "    registry = []",
+            "    def __init_subclass__(cls, **kwargs):",
+            "        super().__init_subclass__(**kwargs)",
+            f"        Base_{uid}.registry.append(cls)",
+            "",
+        ]
+        for s in range(2):
+            body += [f"class Sub_{uid}_{s}(Base_{uid}):", "    def run(self):", *meth, ""]
+    elif flavor == "mock_patch":
+        name = f"test_p{uid}.py"
+        body += [
+            f"def test_patches_{uid}(monkeypatch):",
+            f'    monkeypatch.setattr("pkg_{p:04d}.mod_{m:04d}.fn_0", None)',
+            *call,
+            "",
+        ]
+    elif flavor == "click":
+        name = f"cli_{uid}.py"
+        body += ["import click", "", "cli = click.Group()", ""]
+        body += ["@cli.command()", f"def cmd_{uid}_0():", *call, ""]
+        body += ["@cli.group()", f"def sub_{uid}():", "    pass", ""]
+        body += [f"@sub_{uid}.command()", f"def cmd_{uid}_1():", *call, ""]
+    else:  # pragma: no cover - guarded by FRAMEWORK_FLAVORS
+        raise ValueError(flavor)
+    return name, "\n".join(head + body) + "\n"
+
+
+# conftest.py for a package containing pytest/mock_patch files: a couple of
+# shared fixtures, so `@pytest.fixture` resolution + the conftest-decl rule fire.
+_CONFTEST_SRC = (
+    "import pytest\n\n"
+    "@pytest.fixture\n"
+    "def shared_fix():\n"
+    "    return 1\n\n"
+    '@pytest.fixture(name="shared_alias")\n'
+    "def make_shared():\n"
+    "    return object()\n\n"
+    "def conftest_helper():\n"
+    "    return 2\n"
+)
+
+
 def generate(
     out: Path,
     *,
@@ -140,18 +250,27 @@ def generate(
     decls_per_module: int,
     imports_per_module: int,
     calls_per_decl: int,
+    framework_fraction: float,
     clean: bool,
 ) -> dict[str, object]:
     if clean and out.exists():
         shutil.rmtree(out)
     out.mkdir(parents=True, exist_ok=True)
 
+    # Stride that selects ~`framework_fraction` of modules to also get an
+    # additive framework file; flavors round-robin across the selected set so
+    # every plugin gets a proportional share. Deterministic in the indices.
+    stride = round(1 / framework_fraction) if framework_fraction > 0 else 0
     files = 0
+    framework_files = 0
+    flavor_counts: dict[str, int] = {f: 0 for f in FRAMEWORK_FLAVORS}
+    selected = 0
     for p in range(packages):
         pkg = out / f"pkg_{p:04d}"
         pkg.mkdir(exist_ok=True)
         (pkg / "__init__.py").write_text("")
         files += 1
+        pkg_needs_conftest = False
         for m in range(modules_per_package):
             src = _module_source(
                 p,
@@ -164,6 +283,20 @@ def generate(
             )
             (pkg / f"mod_{m:04d}.py").write_text(src)
             files += 1
+            gi = p * modules_per_package + m
+            if stride and gi % stride == 0:
+                flavor = FRAMEWORK_FLAVORS[selected % len(FRAMEWORK_FLAVORS)]
+                selected += 1
+                name, fsrc = _framework_file(flavor, p, m)
+                (pkg / name).write_text(fsrc)
+                files += 1
+                framework_files += 1
+                flavor_counts[flavor] += 1
+                if flavor in _TEST_FLAVORS:
+                    pkg_needs_conftest = True
+        if pkg_needs_conftest:
+            (pkg / "conftest.py").write_text(_CONFTEST_SRC)
+            files += 1
 
     manifest = {
         "packages": packages,
@@ -171,6 +304,9 @@ def generate(
         "decls_per_module": decls_per_module,
         "imports_per_module": imports_per_module,
         "calls_per_decl": calls_per_decl,
+        "framework_fraction": framework_fraction,
+        "framework_files": framework_files,
+        "framework_flavors": flavor_counts,
         "files": files,
     }
     (out / "_manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
@@ -201,6 +337,17 @@ def main() -> None:
         "The default (2) yields ~103 edges/file (~5.2 edges/node).",
     )
     parser.add_argument(
+        "--framework-fraction",
+        type=float,
+        default=0.0,
+        help="Fraction (0..1) of modules that also get an additive framework "
+        "file — a pytest fixture/test module, fastapi/flask app, unittest "
+        "TestCase, __init_subclass__ base, monkeypatch test, or click group "
+        "(round-robin) — plus a conftest.py per package with pytest files. "
+        "These give the per-file plugins real work; the generic import graph "
+        "(node/edge scale) is untouched. Default 0 reproduces the plain tree.",
+    )
+    parser.add_argument(
         "--no-clean",
         dest="clean",
         action="store_false",
@@ -216,6 +363,7 @@ def main() -> None:
         decls_per_module=args.decls_per_module,
         imports_per_module=args.imports_per_module,
         calls_per_decl=args.calls_per_decl,
+        framework_fraction=args.framework_fraction,
         clean=args.clean,
     )
     elapsed = time.perf_counter() - start


### PR DESCRIPTION
## Problem

The populate fan-out parallelizes over **files**, and each file's per-file plugins run in a **serial loop inside that file's worker** (`run_populate`). That's right for cold builds (files ≫ cores), but backwards for an **incremental build on a big-CPU box**: a small dirty set lights up only `dirty_files` workers, and within each, the plugins serialize on one core while the rest idle. As more per-file plugins land, that serial per-file run grows and the extra cores never help.

## Change

Restructure the populate worker into a **deps task** that warms the file's shared salsa inputs (`file_to_nodes` / `file_to_refspecs` / `resolution_surface_fp` / `file_extraction` / `line_index`), then fans the per-file plugins out as **one task each** so they run concurrently — with each other and with other files' `file_to_nodes`.

- **Soundness:** warming the shared inputs *before* releasing the plugin tasks means each `per_file_plugin_ops(file, id)` is a pure read of memoized inputs, so concurrent tasks for the same file never collide computing the same salsa query (which would just park workers). `per_file_plugin_ops` is already keyed `(file, id)`, so the tasks are independent.
- **Eviction preserved:** the parsed AST + semantic index are dropped by whoever decrements a per-file `AtomicUsize` countdown to zero — observed only *after* each task's `per_file_plugin_ops` returns, so the clearer runs strictly after every reader. Same post-extraction eviction as before, just triggered by the last task instead of the tail of a monolithic file task.
- **Gated on `files <= num_workers`:** only fan out when the file axis alone can't fill the cores (the incremental case). Cold builds and large dirty sets keep the serial-within-file loop — the file fan-out already saturates the cores there, so splitting each file into N more tasks would only add scheduling + snapshot-channel traffic for no parallelism. The threshold is `num_workers`; trivial to widen if moderate dirty sets want it.

The bounded snapshot channel is unchanged and still correct: rayon runs ≤ `num_workers` tasks at once and each holds ≤ 1 snapshot, and no task holds a snapshot while waiting on another (the deps task spawns and returns), so there's no deadlock.

## Validation

Pure scheduling change — **byte-identical** output:
- Full suite (745 passed, 4 skipped) — the plugin tests run on tiny projects, which now exercise the fan-out path and assert exact edges/flags.
- Explicit A/B dump on the fan-out path (init_subclass, 4-file corpus) diffs clean vs `main`.

Perf, 4-core box (50k-file corpus):
- Cold: `populate` 5.5s, unchanged vs `main` (gate keeps cold on the serial path).
- Incremental edit: takes the fan-out path, `populate=889µs`, correct.

**The parallelism win can't be shown on 4 cores** (a 1-file edit has nothing to spread). It needs a high-core box: there, a small dirty set's plugins fan across the cores instead of serializing. Worth confirming on your machine before/after — and tuning the `num_workers` threshold up if your typical dirty sets are larger than the core count.

https://claude.ai/code/session_01KYNAs8Y9ctXsM1waLmXEaP

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYNAs8Y9ctXsM1waLmXEaP)_