### PR TITLE
bench: weave framework patterns into the corpus so plugins do real work

### DIFF
--- a/scripts/bench_materialize.py
+++ b/scripts/bench_materialize.py
@@ -130,13 +130,21 @@ def _incremental(
         return ctx.read_progress_snapshot()["fqname_total"] - len(ctx.tombstoned_indices())
 
     manifest = sorted((corpus).glob("pkg_*"))
+    # Prefer framework files (pytest / fastapi / unittest / … — see
+    # gen_bench_corpus.py) as edit targets: editing one re-runs the per-file
+    # plugins on a file that actually has fixtures/handlers/etc., so the
+    # incremental loop measures real plugin work, not a generic-module no-op.
+    # Falls back to generic `mod_*.py` on a corpus with no framework content.
+    _fw_prefixes = ("test_", "app_", "tests_", "models_", "cli_")
+    fw_files = sorted(f for f in corpus.glob("pkg_*/*.py") if f.name.startswith(_fw_prefixes))
+    generic = [sorted(pkg.glob("mod_*.py"))[0] for pkg in manifest[: max(edits, 1)]]
+    scatter_targets = fw_files or generic
     rows: list[tuple[str, float, tuple[int, int], int]] = []
     originals: dict[Path, str] = {}
     try:
-        # Scattered edits: one file per round, spread across packages.
+        # Scattered edits: one file per round, spread across the corpus.
         for i in range(edits):
-            pkg = manifest[(i * 97) % len(manifest)]
-            target = sorted(pkg.glob("mod_*.py"))[i % 3]
+            target = scatter_targets[(i * 97) % len(scatter_targets)]
             originals.setdefault(target, target.read_text())
             target.write_text(target.read_text() + f"\n\ndef _bench_s{i}():\n    pass\n")
             before = _nodes()
@@ -153,8 +161,8 @@ def _incremental(
                 )
             )
 
-        # Hot loop: repeated edits to one file.
-        target = (corpus / "pkg_0000" / "mod_0000.py").resolve()
+        # Hot loop: repeated edits to one file (a framework file if present).
+        target = (fw_files[0] if fw_files else corpus / "pkg_0000" / "mod_0000.py").resolve()
         originals.setdefault(target, target.read_text())
         for i in range(edits):
             target.write_text(target.read_text() + f"\n\ndef _bench_h{i}():\n    pass\n")
@@ -194,8 +202,10 @@ def main() -> None:
     parser.add_argument(
         "--plugins",
         choices=("none", "all"),
-        default="none",
-        help="Run with no plugins (pure build) or the full built-in set.",
+        default="all",
+        help="Run with the full built-in plugin set (default) or none (pure "
+        "build). Only meaningful against a corpus generated with "
+        "--framework-fraction > 0; otherwise every plugin early-outs.",
     )
     parser.add_argument(
         "--count",

--- a/scripts/gen_bench_corpus.py
+++ b/scripts/gen_bench_corpus.py
@@ -132,6 +132,116 @@ def _module_source(
     return "\n".join(lines) + "\n"
 
 
+# Framework flavors woven into the corpus so the per-file plugins have real
+# work to do — decorators to extract, fixtures / handlers / constructions to
+# find, subclass bases to walk — instead of every plugin hitting its
+# import/decorator early-out on a barren generic tree. Each framework file is
+# *additive* (written alongside the generic modules, importing its generic
+# sibling so it still resolves and mints an edge), so the generic import graph
+# that carries the node/edge scale is untouched. Third-party frameworks
+# (fastapi / flask / pytest / click) needn't be installed — the plugins match
+# the import + decorator syntactically — while `unittest` / `__init_subclass__`
+# resolve first-party, so their subclass walks fire too.
+FRAMEWORK_FLAVORS = (
+    "pytest",
+    "fastapi",
+    "flask",
+    "unittest",
+    "init_subclass",
+    "mock_patch",
+    "click",
+)
+
+# Flavors that need a `test_*.py` filename (pytest collection) — also the ones
+# whose package gets a `conftest.py`.
+_TEST_FLAVORS = frozenset({"pytest", "mock_patch"})
+
+
+def _framework_file(flavor: str, p: int, m: int) -> tuple[str, str]:
+    """``(filename, source)`` for one additive framework file for module
+    ``(p, m)``. Deterministic in ``(flavor, p, m)``; imports the generic
+    sibling so the body's call resolves to a real cross-file edge."""
+    uid = f"{p:04d}_{m:04d}"
+    head = [f"from pkg_{p:04d} import mod_{m:04d} as _i0", ""]
+    call = ["    _i0.fn_0()"]
+    meth = ["        _i0.fn_0()"]
+    body: list[str] = []
+    if flavor == "pytest":
+        name = f"test_x{uid}.py"
+        body += ["import pytest", ""]
+        body += ["@pytest.fixture", f"def fix_{uid}():", f"    return {m}", ""]
+        body += [
+            f'@pytest.fixture(name="alias_{uid}")',
+            f"def make_{uid}():",
+            "    return object()",
+            "",
+        ]
+        body += [f"def test_uses_{uid}(fix_{uid}, alias_{uid}):", *call, ""]
+        body += [f"class TestGroup_{uid}:", f"    def test_method(self, fix_{uid}):", *meth, ""]
+    elif flavor == "fastapi":
+        name = f"app_{uid}.py"
+        body += ["from fastapi import FastAPI", "", "app = FastAPI()", ""]
+        for h, verb in enumerate(("get", "post", "put")):
+            body += [f'@app.{verb}("/r_{uid}_{h}")', f"def handler_{uid}_{h}():", *call, ""]
+    elif flavor == "flask":
+        name = f"app_{uid}.py"
+        body += ["from flask import Flask", "", "app = Flask(__name__)", ""]
+        for h in range(2):
+            body += [f'@app.route("/r_{uid}_{h}")', f"def view_{uid}_{h}():", *call, ""]
+        body += ["def create_app():", "    return Flask(__name__)", "", "made = create_app()", ""]
+        body += [f'@made.route("/m_{uid}")', f"def made_view_{uid}():", *call, ""]
+    elif flavor == "unittest":
+        name = f"tests_{uid}.py"
+        body += ["import unittest", "", f"class Test_{uid}(unittest.TestCase):"]
+        body += ["    def test_a(self):", *meth]
+        body += ["    def test_b(self):", *meth, ""]
+        body += ["def setUpModule():", "    pass", "", "def tearDownModule():", "    pass", ""]
+    elif flavor == "init_subclass":
+        name = f"models_{uid}.py"
+        body += [
+            f"class Base_{uid}:",
+            "    registry = []",
+            "    def __init_subclass__(cls, **kwargs):",
+            "        super().__init_subclass__(**kwargs)",
+            f"        Base_{uid}.registry.append(cls)",
+            "",
+        ]
+        for s in range(2):
+            body += [f"class Sub_{uid}_{s}(Base_{uid}):", "    def run(self):", *meth, ""]
+    elif flavor == "mock_patch":
+        name = f"test_p{uid}.py"
+        body += [
+            f"def test_patches_{uid}(monkeypatch):",
+            f'    monkeypatch.setattr("pkg_{p:04d}.mod_{m:04d}.fn_0", None)',
+            *call,
+            "",
+        ]
+    elif flavor == "click":
+        name = f"cli_{uid}.py"
+        body += ["import click", "", "cli = click.Group()", ""]
+        body += ["@cli.command()", f"def cmd_{uid}_0():", *call, ""]
+        body += ["@cli.group()", f"def sub_{uid}():", "    pass", ""]
+        body += [f"@sub_{uid}.command()", f"def cmd_{uid}_1():", *call, ""]
+    else:  # pragma: no cover - guarded by FRAMEWORK_FLAVORS
+        raise ValueError(flavor)
+    return name, "\n".join(head + body) + "\n"
+
+
+# conftest.py for a package containing pytest/mock_patch files: a couple of
+# shared fixtures, so `@pytest.fixture` resolution + the conftest-decl rule fire.
+_CONFTEST_SRC = (
+    "import pytest\n\n"
+    "@pytest.fixture\n"
+    "def shared_fix():\n"
+    "    return 1\n\n"
+    '@pytest.fixture(name="shared_alias")\n'
+    "def make_shared():\n"
+    "    return object()\n\n"
+    "def conftest_helper():\n"
+    "    return 2\n"
+)
+
+
 def generate(
     out: Path,
     *,
@@ -140,18 +250,27 @@ def generate(
     decls_per_module: int,
     imports_per_module: int,
     calls_per_decl: int,
+    framework_fraction: float,
     clean: bool,
 ) -> dict[str, object]:
     if clean and out.exists():
         shutil.rmtree(out)
     out.mkdir(parents=True, exist_ok=True)
 
+    # Stride that selects ~`framework_fraction` of modules to also get an
+    # additive framework file; flavors round-robin across the selected set so
+    # every plugin gets a proportional share. Deterministic in the indices.
+    stride = round(1 / framework_fraction) if framework_fraction > 0 else 0
     files = 0
+    framework_files = 0
+    flavor_counts: dict[str, int] = {f: 0 for f in FRAMEWORK_FLAVORS}
+    selected = 0
     for p in range(packages):
         pkg = out / f"pkg_{p:04d}"
         pkg.mkdir(exist_ok=True)
         (pkg / "__init__.py").write_text("")
         files += 1
+        pkg_needs_conftest = False
         for m in range(modules_per_package):
             src = _module_source(
                 p,
@@ -164,6 +283,20 @@ def generate(
             )
             (pkg / f"mod_{m:04d}.py").write_text(src)
             files += 1
+            gi = p * modules_per_package + m
+            if stride and gi % stride == 0:
+                flavor = FRAMEWORK_FLAVORS[selected % len(FRAMEWORK_FLAVORS)]
+                selected += 1
+                name, fsrc = _framework_file(flavor, p, m)
+                (pkg / name).write_text(fsrc)
+                files += 1
+                framework_files += 1
+                flavor_counts[flavor] += 1
+                if flavor in _TEST_FLAVORS:
+                    pkg_needs_conftest = True
+        if pkg_needs_conftest:
+            (pkg / "conftest.py").write_text(_CONFTEST_SRC)
+            files += 1
 
     manifest = {
         "packages": packages,
@@ -171,6 +304,9 @@ def generate(
         "decls_per_module": decls_per_module,
         "imports_per_module": imports_per_module,
         "calls_per_decl": calls_per_decl,
+        "framework_fraction": framework_fraction,
+        "framework_files": framework_files,
+        "framework_flavors": flavor_counts,
         "files": files,
     }
     (out / "_manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
@@ -201,6 +337,17 @@ def main() -> None:
         "The default (2) yields ~103 edges/file (~5.2 edges/node).",
     )
     parser.add_argument(
+        "--framework-fraction",
+        type=float,
+        default=0.0,
+        help="Fraction (0..1) of modules that also get an additive framework "
+        "file — a pytest fixture/test module, fastapi/flask app, unittest "
+        "TestCase, __init_subclass__ base, monkeypatch test, or click group "
+        "(round-robin) — plus a conftest.py per package with pytest files. "
+        "These give the per-file plugins real work; the generic import graph "
+        "(node/edge scale) is untouched. Default 0 reproduces the plain tree.",
+    )
+    parser.add_argument(
         "--no-clean",
         dest="clean",
         action="store_false",
@@ -216,6 +363,7 @@ def main() -> None:
         decls_per_module=args.decls_per_module,
         imports_per_module=args.imports_per_module,
         calls_per_decl=args.calls_per_decl,
+        framework_fraction=args.framework_fraction,
         clean=args.clean,
     )
     elapsed = time.perf_counter() - start


### PR DESCRIPTION
The synthetic bench corpus is purely generic (`from pkg import mod as _i; _i.fn()`), so every per-file plugin hits its import/decorator early-out and returns an empty op list in microseconds — and `bench_materialize.py` runs plugins **off** by default. The net effect: plugin cost and plugin-scaling numbers were being measured against code the plugins never react to.

This makes the harness exercise the plugins.

## `gen_bench_corpus.py`

New `--framework-fraction F` (0..1): F of modules also get an **additive** framework file, round-robin across:

- pytest — `@pytest.fixture` + tests taking fixtures as params (+ a `conftest.py` per pytest package);
- fastapi / flask — `app = FastAPI()` / `Flask(__name__)`, `@app.get`/`@app.route` handlers, a `create_app()` factory + `made = create_app()`;
- unittest — `TestCase` subclasses + `setUpModule`/`tearDownModule`;
- `__init_subclass__` — a base + subclasses (first-party, so the subclass walk resolves);
- mock_patch — a `monkeypatch.setattr("pkg.mod.fn", …)` test;
- click — a group + commands (incl. a subgroup).

The files are **additive** — each imports its generic sibling, so the generic import graph that carries the node/edge scale is untouched, and a third-party framework needn't be installed (the plugins match import + decorator syntactically; `unittest` / `__init_subclass__` resolve first-party so their subclass walks fire). `F=0` reproduces the old tree byte-for-byte. The manifest records the fraction + per-flavor counts.

## `bench_materialize.py`

- `--plugins` now defaults to `all` (only meaningful with framework content; documented).
- The incremental edit loop prefers framework files, so a dirty file actually re-runs the per-file plugins instead of editing a generic no-op module.

## Verified

On a tiny all-flavor corpus, the plugins now do real work — flag 30 nodes (testcase/fixture/entrypoint), emit `INIT_SUBCLASS` edges — and the project-wide plugin pass reports real per-plugin costs (`fastapi`/`flask`/`unittest` in the ms on 39 files) instead of µs noise. `ruff` clean.

Generate a framework-rich corpus at scale with e.g. `--framework-fraction 0.15`.

https://claude.ai/code/session_01KYNAs8Y9ctXsM1waLmXEaP

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYNAs8Y9ctXsM1waLmXEaP)_