### PR TITLE
Release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ two versions.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-09
+
 ### Added
 
 - **Incremental cross-file resolution on `re_materialize`.** The assemble
@@ -61,6 +63,30 @@ two versions.
 
 ### Changed
 
+- **Per-file plugins run in one salsa query per file.** The per-file plugin
+  pass was keyed `(file, plugin)` — one salsa query, and one memo entry, per
+  plugin per file — so its bookkeeping grew `O(files × plugins)`. It's now
+  keyed `(file, set_id)`, where `set_id` interns the registered per-file
+  plugin set: a single query per file runs the whole set (the per-plugin loop
+  is plain Rust, free of salsa), so per-build memo work is `O(files)`
+  regardless of plugin count. Identical plugin sets share a `set_id` and so
+  their cache entries; different sets key separately. Output unchanged.
+- **`click`, and the dispatch-app / discord.py handler detection, moved to the
+  per-file pass.** `click` became a pure per-file plugin (its group→handler
+  wiring is entirely file-local). The dispatch-app family (flask / fastapi /
+  typer / cyclopts / slack_bolt / fastmcp / celery) and discord.py now emit
+  their `@<owner>.<verb>` handlers as per-file facts and resolve them
+  project-wide, so the handler walk rides the salsa cache instead of
+  rescanning every file each build; the cross-file construction / subclass /
+  factory work stays in the project-wide pass. Output unchanged.
+- **Sorted flag fold in the plugin apply.** The project-wide plugin-op fold
+  applied flag ORs in registration order, scattering writes across the node
+  array — cache-miss-bound when a plugin like `pytest` flags millions of
+  testcases / fixtures, where the random scatter (not the OR) dominates. Flag
+  ORs are now gathered, sorted by node index, and applied in one monotonic,
+  prefetch-friendly sweep; they're commutative + idempotent, so the result is
+  byte-identical, and edges still fold in registration order through
+  `add_edge`.
 - **Project-wide plugins moved onto per-file facts + a project-wide resolve.**
   The `pytest`, `init_subclass`, `unittest`, and `mock_patch` built-ins are
   now *dual-mode*: their file-local observations (test/fixture/conftest
@@ -346,8 +372,6 @@ two versions.
   `edge_flag_registry()`, `default_seed_mask()`, `node_flag(name)`, and
   `edge_flag(name)`, and `GraphMetadata` carries both tables. (`PLUGIN_API_EPOCH`
   bumped 1→2; `FORMAT_VERSION` bumped 1→2 — old graph files are rejected.)
-
-### Changed
 
 - **`re_materialize` early-returns on zero change.** `apply_changes` now
   reports whether any salsa revision advanced; when explicit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "dead-cst-native"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "dead-cst-runtime",
  "pyo3",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "dead-cst-runtime"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bincode",
  "compact_str",
@@ -977,7 +977,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "main_block_plugin"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "dead-cst-runtime",
  "pyo3",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "per_file_decorated"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "dead-cst-runtime",
  "pyo3",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "per_file_main_block"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "dead-cst-runtime",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["vendor"]
 
 [package]
 name = "dead-cst-native"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 publish = false
 

--- a/examples/main_block_plugin/Cargo.toml
+++ b/examples/main_block_plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "main_block_plugin"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 publish = false
 

--- a/examples/per_file_decorated/Cargo.toml
+++ b/examples/per_file_decorated/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "per_file_decorated"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 publish = false
 

--- a/examples/per_file_main_block/Cargo.toml
+++ b/examples/per_file_main_block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "per_file_main_block"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 publish = false
 

--- a/plugin-host/pyproject.toml
+++ b/plugin-host/pyproject.toml
@@ -7,7 +7,7 @@ name = "dead-cst-plugin-host"
 # Must match the `dead-cst` version exactly — the runtime ABI fingerprint
 # (rustc commit + version) is checked when a plugin loads. The publish
 # workflow keeps these in lockstep.
-version = "0.13.0"
+version = "0.14.0"
 description = "Prebuilt dead-cst dependency closure for compiling native plugins."
 readme = "README.md"
 license = "MIT"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dead-cst-runtime"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 publish = false
 

--- a/uv.lock
+++ b/uv.lock
@@ -722,7 +722,7 @@ dev = [
 
 [[package]]
 name = "dead-cst-plugin-host"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "plugin-host" }
 
 [[package]]


### PR DESCRIPTION
Bump every crate/package version 0.13.0 -> 0.14.0 (dead-cst-native, which
maturin reads for the wheel; dead-cst-runtime; the plugin examples; and
dead-cst-plugin-host, which must match dead-cst exactly for the runtime
ABI-fingerprint check) and refresh Cargo.lock + uv.lock.

Finalize the changelog: roll [Unreleased] into [0.14.0] - 2026-06-09 with a
fresh empty [Unreleased] on top, merge the two duplicate `### Changed`
subsections into one, and document the late-cycle perf work that lacked
entries:
* per-file plugins coalesced into one salsa query per file (keyed on an
  interned set id) — O(files) memo work instead of O(files x plugins);
* click made pure per-file, and dispatch-app / discord.py handler detection
  moved to per-file facts;
* sorted flag fold in the project-wide plugin apply (kills the cache-miss
  scatter when a plugin flags millions of decls).

https://claude.ai/code/session_01KYNAs8Y9ctXsM1waLmXEaP