### PR TITLE
build-plugin-host: derive the compile closure from cargo's crate graph (ship all SVHs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ two versions.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`bundle-plugin-host` ships every distinct SVH unit the runtime binds.** The
+  plugin-compile closure was gathered by globbing the (reused, never-cleaned)
+  cargo deps dir and deduping by `(crate, kind)` keeping the newest by mtime —
+  but mtime is not a faithful proxy for "the SVH the runtime dylib bound", so
+  the closure could omit the exact unit a plugin needs (the plugin then failed
+  `rustc`'s `-L` crate resolution against the shipped runtime), and it collapsed
+  crates the graph compiles at more than one SVH. The closure is now derived
+  from cargo's `compiler-artifact` stream (`--message-format=json`) — the exact
+  set of units the crate graph compiled, every distinct SVH retained, with no
+  stale copies (so the old dedup's bloat concern doesn't arise). The runtime
+  dylib, the dynamic `_native`, and libstd are still excluded (they ship in the
+  base `dead_cst` wheel).
+
 ## [0.14.0] - 2026-06-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ two versions.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-09
+
 ### Added
 
 - **Incremental cross-file resolution on `re_materialize`.** The assemble
@@ -61,6 +63,30 @@ two versions.
 
 ### Changed
 
+- **Per-file plugins run in one salsa query per file.** The per-file plugin
+  pass was keyed `(file, plugin)` — one salsa query, and one memo entry, per
+  plugin per file — so its bookkeeping grew `O(files × plugins)`. It's now
+  keyed `(file, set_id)`, where `set_id` interns the registered per-file
+  plugin set: a single query per file runs the whole set (the per-plugin loop
+  is plain Rust, free of salsa), so per-build memo work is `O(files)`
+  regardless of plugin count. Identical plugin sets share a `set_id` and so
+  their cache entries; different sets key separately. Output unchanged.
+- **`click`, and the dispatch-app / discord.py handler detection, moved to the
+  per-file pass.** `click` became a pure per-file plugin (its group→handler
+  wiring is entirely file-local). The dispatch-app family (flask / fastapi /
+  typer / cyclopts / slack_bolt / fastmcp / celery) and discord.py now emit
+  their `@<owner>.<verb>` handlers as per-file facts and resolve them
+  project-wide, so the handler walk rides the salsa cache instead of
+  rescanning every file each build; the cross-file construction / subclass /
+  factory work stays in the project-wide pass. Output unchanged.
+- **Sorted flag fold in the plugin apply.** The project-wide plugin-op fold
+  applied flag ORs in registration order, scattering writes across the node
+  array — cache-miss-bound when a plugin like `pytest` flags millions of
+  testcases / fixtures, where the random scatter (not the OR) dominates. Flag
+  ORs are now gathered, sorted by node index, and applied in one monotonic,
+  prefetch-friendly sweep; they're commutative + idempotent, so the result is
+  byte-identical, and edges still fold in registration order through
+  `add_edge`.
 - **Project-wide plugins moved onto per-file facts + a project-wide resolve.**
   The `pytest`, `init_subclass`, `unittest`, and `mock_patch` built-ins are
   now *dual-mode*: their file-local observations (test/fixture/conftest
@@ -346,8 +372,6 @@ two versions.
   `edge_flag_registry()`, `default_seed_mask()`, `node_flag(name)`, and
   `edge_flag(name)`, and `GraphMetadata` carries both tables. (`PLUGIN_API_EPOCH`
   bumped 1→2; `FORMAT_VERSION` bumped 1→2 — old graph files are rejected.)
-
-### Changed
 
 - **`re_materialize` early-returns on zero change.** `apply_changes` now
   reports whether any salsa revision advanced; when explicit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "dead-cst-native"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "dead-cst-runtime",
  "pyo3",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "dead-cst-runtime"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bincode",
  "compact_str",
@@ -977,7 +977,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "main_block_plugin"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "dead-cst-runtime",
  "pyo3",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "per_file_decorated"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "dead-cst-runtime",
  "pyo3",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "per_file_main_block"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "dead-cst-runtime",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["vendor"]
 
 [package]
 name = "dead-cst-native"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 publish = false
 

--- a/examples/main_block_plugin/Cargo.toml
+++ b/examples/main_block_plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "main_block_plugin"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 publish = false
 

--- a/examples/per_file_decorated/Cargo.toml
+++ b/examples/per_file_decorated/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "per_file_decorated"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 publish = false
 

--- a/examples/per_file_main_block/Cargo.toml
+++ b/examples/per_file_main_block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "per_file_main_block"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 publish = false
 

--- a/plugin-host/pyproject.toml
+++ b/plugin-host/pyproject.toml
@@ -7,7 +7,7 @@ name = "dead-cst-plugin-host"
 # Must match the `dead-cst` version exactly — the runtime ABI fingerprint
 # (rustc commit + version) is checked when a plugin loads. The publish
 # workflow keeps these in lockstep.
-version = "0.13.0"
+version = "0.14.0"
 description = "Prebuilt dead-cst dependency closure for compiling native plugins."
 readme = "README.md"
 license = "MIT"

--- a/python/dead_cst/cli.py
+++ b/python/dead_cst/cli.py
@@ -565,18 +565,6 @@ def _dylib_name(stem: str) -> str:
 _PLUGIN_EXTERN_CRATES = ("serde_json", "regex")
 
 
-def _crate_key(filename: str) -> str:
-    """Crate name from a cargo ``deps/`` artifact filename, dropping the SVH
-    suffix: ``libserde_json-1a2b3c4d.rlib`` (or ``.dylib`` / ``.so`` for a
-    proc-macro) -> ``serde_json``. Cargo names every dep artifact
-    ``lib<crate>-<hash>.<ext>``, so strip the ``lib`` prefix, the extension, and
-    the trailing ``-<hash>``."""
-    stem = filename.rsplit(".", 1)[0]
-    if stem.startswith("lib"):
-        stem = stem[3:]
-    return stem.rsplit("-", 1)[0]
-
-
 def _prefer_dynamic_link_args(std_lib: Path) -> list[str]:
     """The ``-Wl,...`` linker args (without the ``-C link-arg=`` prefix) that
     make a ``prefer-dynamic`` artifact defer host symbols and find libstd + its
@@ -632,9 +620,61 @@ def _materialize_dep_closure(dep_dir: Path) -> Path:
     return staging
 
 
-def _build_runtime_from_source(root: Path, *, release: bool, std_lib: Path) -> Path:
+def _cargo_artifact_files(cargo_json_stdout: str) -> list[Path]:
+    """Every output file cargo reported via ``compiler-artifact`` messages in a
+    ``cargo build --message-format=json`` stream. This is the exact set of
+    compiled units in the build's crate graph — every distinct SVH artifact,
+    deduped by the graph itself rather than guessed by mtime — so the shipped
+    closure binds the same SVHs the runtime dylib does. Fresh (cached) units
+    still report their ``filenames``, so this is correct over a reused (not
+    cleaned) target dir."""
+    files: list[Path] = []
+    for line in cargo_json_stdout.splitlines():
+        try:
+            msg = json.loads(line)
+        except ValueError:
+            continue  # non-JSON line on stdout (shouldn't occur) — be lenient
+        if msg.get("reason") == "compiler-artifact":
+            files.extend(Path(f) for f in (msg.get("filenames") or []))
+    return files
+
+
+def _closure_units(
+    artifacts: Iterable[Path], *, dylib_suffix: str, excluded: set[str]
+) -> list[Path]:
+    """The plugin-compile closure drawn from a set of cargo artifacts: every
+    dependency ``.rlib`` plus proc-macro dylib, with **every distinct SVH unit
+    kept**. No ``(crate, kind)`` dedup — that could drop the exact SVH the
+    runtime dylib bound (mtime is not a faithful proxy for "what binds"), and it
+    collapses crates the graph legitimately compiles at more than one SVH, so
+    `rustc`'s ``-L`` search for the runtime's transitive deps would fail to find
+    a match. The runtime dylib, the dynamic ``_native``, and libstd are excluded
+    (they ship in the base ``dead_cst`` wheel); ``.rmeta`` / ``.d`` and other
+    non-link outputs fall out by suffix. Distinct SVHs have distinct filenames,
+    so they're all retained; identical paths are deduped."""
+    seen: set[Path] = set()
+    out: list[Path] = []
+    for entry in artifacts:
+        if entry in seen:
+            continue
+        seen.add(entry)
+        is_proc_macro = (
+            entry.suffix == dylib_suffix
+            and entry.name not in excluded
+            and not entry.name.startswith("libstd-")
+        )
+        if entry.suffix == ".rlib" or is_proc_macro:
+            out.append(entry)
+    return out
+
+
+def _build_runtime_from_source(
+    root: Path, *, release: bool, std_lib: Path
+) -> tuple[Path, list[Path]]:
     """Build the runtime dylib + dep metadata (+ the dynamic ``_native``) from a
-    source checkout into ``target/plugin-host``; return the deps dir."""
+    source checkout into ``target/plugin-host``; return ``(deps_dir, artifacts)``
+    where ``artifacts`` is every file cargo's crate graph compiled (see
+    [`_cargo_artifact_files`])."""
     if shutil.which("cargo") is None:
         raise typer.BadParameter(
             "cargo not found on PATH; needed to build the runtime from source."
@@ -660,14 +700,20 @@ def _build_runtime_from_source(root: Path, *, release: bool, std_lib: Path) -> P
         "CARGO_TARGET_DIR": str(target_dir),
         "RUSTFLAGS": " ".join(["-C prefer-dynamic", *(f"-C link-arg={arg}" for arg in link_args)]),
     }
-    cmd = ["cargo", "build", "-p", "dead-cst-native"] + (["--release"] if release else [])
+    # `--message-format=json`: capture cargo's `compiler-artifact` stream so the
+    # closure is derived from the actual crate graph (every SVH unit), not by
+    # globbing the reused deps dir and guessing with mtime. Progress + warnings
+    # still flow to stderr; the JSON rides stdout.
+    cmd = ["cargo", "build", "-p", "dead-cst-native", "--message-format=json"] + (
+        ["--release"] if release else []
+    )
     typer.echo(f"$ {' '.join(cmd)}  (prefer-dynamic, dylib-only runtime)", err=True)
     try:
         manifest.write_text(dylib_only)
-        subprocess.run(cmd, cwd=root, env=env, check=True)
+        proc = subprocess.run(cmd, cwd=root, env=env, check=True, stdout=subprocess.PIPE, text=True)
     finally:
         manifest.write_text(original)
-    return deps_dir
+    return deps_dir, _cargo_artifact_files(proc.stdout)
 
 
 @app.command(name="build-plugin")
@@ -878,7 +924,7 @@ def bundle_plugin_host(
 
     std_lib = _host_std_lib()
     suffix = _dylib_suffix()
-    deps_dir = _build_runtime_from_source(root, release=release, std_lib=std_lib)
+    deps_dir, artifacts = _build_runtime_from_source(root, release=release, std_lib=std_lib)
 
     if output is not None:
         bundle = output.resolve()
@@ -898,29 +944,16 @@ def bundle_plugin_host(
     # `dead_cst` wheel. (.rmeta are skipped: redundant with the .rlib, which
     # embed metadata, and would nearly double the payload.)
     #
-    # Dedup by (crate, kind): cargo's deps/ accumulates multiple SVH-suffixed
-    # artifacts per crate across incremental rebuilds (this target dir is reused,
-    # not cleaned, to keep rebuilds fast). Ship exactly one per (crate, kind) —
-    # the newest, which is the set this build's runtime dylib actually binds
-    # against (mtime is a faithful proxy right after a successful build).
-    # Without this, stale copies (e.g. a second `regex` rlib) leak in and bloat
-    # the wheel — and a `--extern <crate>` glob in `build-plugin` could pick the
-    # wrong SVH.
+    # The set is derived from cargo's `compiler-artifact` stream (every unit the
+    # crate graph compiled), NOT by globbing the reused deps dir. That ships
+    # *every distinct SVH unit per crate* and nothing stale: the previous
+    # `(crate, kind)` + newest-mtime dedup could ship a different SVH than the
+    # runtime dylib bound (so a plugin built against the closure failed `rustc`'s
+    # `-L` crate resolution), and it collapsed crates the graph compiles at more
+    # than one SVH. The graph also has no stale copies, so the bloat the old
+    # dedup guarded against doesn't arise.
     excluded = {_dylib_name("dead_cst_runtime"), _dylib_name("dead_cst_native")}
-    newest: dict[tuple[str, str], Path] = {}
-    for entry in deps_dir.iterdir():
-        if not entry.is_file():
-            continue
-        is_proc_macro = (
-            entry.suffix == suffix
-            and entry.name not in excluded
-            and not entry.name.startswith("libstd-")
-        )
-        if entry.suffix == ".rlib" or is_proc_macro:
-            key = (_crate_key(entry.name), entry.suffix)
-            cur = newest.get(key)
-            if cur is None or entry.stat().st_mtime > cur.stat().st_mtime:
-                newest[key] = entry
+    units = _closure_units(artifacts, dylib_suffix=suffix, excluded=excluded)
     # Store each artifact xz-compressed (`<name>.xz`). A wheel is a zip, and the
     # raw `.rlib` closure deflates to ~107 MB — over PyPI's 100 MB/file cap. The
     # bulk is `lib.rmeta` crate metadata embedded in each rlib, which can't be
@@ -930,7 +963,7 @@ def bundle_plugin_host(
     n_files = 0
     raw_bytes = 0
     xz_bytes = 0
-    for entry in newest.values():
+    for entry in units:
         dest = bundle / f"{entry.name}.xz"
         with (
             open(entry, "rb") as fsrc,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dead-cst-runtime"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 publish = false
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,8 @@ import typer
 from typer.testing import CliRunner
 
 from dead_cst.cli import (
-    _crate_key,
+    _cargo_artifact_files,
+    _closure_units,
     _materialize_dep_closure,
     _rel_path,
     app,
@@ -153,28 +154,61 @@ def test_rel_path_outside_root_returned_unchanged():
 
 
 # ---------------------------------------------------------------------------
-# _crate_key (plugin-host closure dedup)
+# plugin-host closure derivation (_cargo_artifact_files / _closure_units)
 # ---------------------------------------------------------------------------
 
 
-def test_crate_key_strips_lib_prefix_ext_and_svh():
-    # rlib, proc-macro dylib, and .so all reduce to the bare crate name.
-    assert _crate_key("libserde_json-1a2b3c4d5e6f7a8b.rlib") == "serde_json"
-    assert _crate_key("libserde_derive-9f8e7d6c.dylib") == "serde_derive"
-    assert _crate_key("libregex-abc123.so") == "regex"
-
-
-def test_crate_key_preserves_underscores_in_crate_name():
-    # Only the trailing `-<hash>` segment is dropped; internal `_` stays.
-    assert _crate_key("libregex_automata-deadbeefcafef00d.rlib") == "regex_automata"
-
-
-def test_crate_key_collapses_distinct_svh_of_same_crate():
-    # The dedup invariant: two SVH-distinct artifacts of one crate (the stale
-    # leftover scenario `bundle-plugin-host` must collapse) map to one key.
-    assert _crate_key("libregex-1111111111111111.rlib") == _crate_key(
-        "libregex-2222222222222222.rlib"
+def test_cargo_artifact_files_collects_compiler_artifact_filenames():
+    # The compiler-artifact stream — fresh and dirty units both report
+    # `filenames`; non-artifact reasons and non-JSON noise are ignored.
+    stream = "\n".join(
+        [
+            json.dumps({"reason": "compiler-artifact", "filenames": ["/d/libregex-aaaa.rlib"]}),
+            json.dumps(
+                {
+                    "reason": "compiler-artifact",
+                    "fresh": True,
+                    "filenames": ["/d/libserde-bbbb.rlib"],
+                }
+            ),
+            json.dumps({"reason": "compiler-message", "message": {"rendered": "warning"}}),
+            json.dumps({"reason": "build-finished", "success": True}),
+            "not json",
+        ]
     )
+    assert _cargo_artifact_files(stream) == [
+        Path("/d/libregex-aaaa.rlib"),
+        Path("/d/libserde-bbbb.rlib"),
+    ]
+
+
+def test_closure_units_keeps_every_distinct_svh_per_crate():
+    # The fix: two SVH-distinct rlibs of one crate are BOTH shipped (the old
+    # (crate, kind) + mtime dedup dropped one — possibly the one that binds).
+    artifacts = [
+        Path("/d/libregex-1111111111111111.rlib"),
+        Path("/d/libregex-2222222222222222.rlib"),
+    ]
+    kept = _closure_units(artifacts, dylib_suffix=".so", excluded=set())
+    assert kept == artifacts
+
+
+def test_closure_units_filters_kinds_and_excludes_wheel_shipped():
+    suffix = ".so"
+    excluded = {"libdead_cst_runtime.so", "dead_cst_native.so"}
+    artifacts = [
+        Path("/d/libregex-aaaa.rlib"),  # dep rlib -> keep
+        Path("/d/libserde_derive-bbbb.so"),  # proc-macro dylib -> keep
+        Path("/d/libdead_cst_runtime.so"),  # runtime dylib -> excluded
+        Path("/d/dead_cst_native.so"),  # _native -> excluded
+        Path("/d/libstd-cccc.so"),  # libstd -> excluded by prefix
+        Path("/d/libregex-aaaa.rmeta"),  # metadata-only -> dropped by suffix
+        Path("/d/libregex-aaaa.rlib"),  # duplicate path -> deduped
+    ]
+    assert _closure_units(artifacts, dylib_suffix=suffix, excluded=excluded) == [
+        Path("/d/libregex-aaaa.rlib"),
+        Path("/d/libserde_derive-bbbb.so"),
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -722,7 +722,7 @@ dev = [
 
 [[package]]
 name = "dead-cst-plugin-host"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "plugin-host" }
 
 [[package]]


### PR DESCRIPTION
Fix for 0.14.1.

## Bug

`bundle-plugin-host` built the plugin-compile closure by globbing the reused (never-cleaned) cargo `deps/` dir and deduping by `(crate, kind)`, keeping the newest by **mtime**, assuming "newest == the SVH the runtime dylib binds." That's wrong:

- **mtime isn't a faithful proxy for the bound SVH** — a later unrelated rebuild can touch a stale unit, so the dedup can ship a *different* SVH than the runtime dylib actually references.
- **It collapses crates the graph compiles at more than one SVH** to a single unit.

Either way the shipped closure can omit a unit `rustc` needs, so a plugin built against it fails `-L` crate resolution against the shipped runtime.

## Fix

Derive the closure from cargo's **`compiler-artifact` stream** (`cargo build --message-format=json`) — the exact set of units the runtime's crate graph compiled, **every distinct SVH retained**, deduped by the graph itself rather than guessed by mtime. The graph reports only this build's units, so there are no stale copies either — the dedup's original anti-bloat purpose is moot. The runtime dylib, the dynamic `_native`, and libstd stay excluded (they ship in the base `dead_cst` wheel).

`_build_runtime_from_source` now captures cargo's JSON on stdout (progress/warnings still flow to stderr) and returns `(deps_dir, artifacts)`.

## Code

- New pure helpers, each unit-tested:
  - `_cargo_artifact_files(stdout)` — parse the `compiler-artifact` filenames (fresh units report theirs too, so it's correct over a reused target dir).
  - `_closure_units(artifacts, …)` — filter to dep `.rlib` + proc-macro dylib, **keep all SVHs** (no `(crate, kind)` dedup), exclude the wheel-shipped runtime / `_native` / libstd.
- Removed the now-dead `_crate_key` (its only use was the deleted dedup) and its tests.

`ty` + `ruff` clean; full `test_cli.py` (37) green.

## ⚠️ Stacking / sequencing — read before merging

This branch is cut from **`claude/release-0.14.0`** (the 0.14.0 release-prep branch), so a PR against `main` shows **two commits**: the 0.14.0 version bump + changelog finalize, *and* this fix. The CHANGELOG entry is filed under the post-0.14.0 `[Unreleased]` (→ 0.14.1), and the version bump to 0.14.1 is intentionally **not** here (per "never hand-edit a version on a non-release commit").

Cleaner options: merge `claude/release-0.14.0` (→ 0.14.0) first and retarget this PR's base to it so only the fix shows; or merge both and cut 0.14.0, then bump 0.14.1 when you tag.

## Not verified here

I could **not** run `bundle-plugin-host` end-to-end (it needs the pinned prefer-dynamic toolchain + a full runtime build, macOS/Linux-gated), so the JSON-parsing and closure-filtering are covered by unit tests but the live build path wants a check on your release machine.

https://claude.ai/code/session_01KYNAs8Y9ctXsM1waLmXEaP

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYNAs8Y9ctXsM1waLmXEaP)_